### PR TITLE
Fix the margin on the sidebar-nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     .cover-main span {
       color: white;
     }
-    .sidebar-nav h2 {
+    .sidebar-nav {
       margin-left: 10px;
     }
   </style>


### PR DESCRIPTION
Fixes the margin in the sidebar nav of the docs site.

<img width="274" alt="Screen Shot 2021-08-09 at 6 39 18 PM" src="https://user-images.githubusercontent.com/879445/128687130-950f4915-c427-42e0-ab95-2a1ebfd11c6d.png">
