### PR TITLE
Fix incorrect ref to self-updating CLI

### DIFF
--- a/spiceaidocs/content/en/cli/_index.md
+++ b/spiceaidocs/content/en/cli/_index.md
@@ -62,7 +62,7 @@ rm ~/.spice/bin/spice
 curl https://install.spiceai.org | /bin/bash
 ```
 
-v0.2.0-alpha will support a self-update command, see the [Spice.ai roadmap](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md) for more details.
+A future release will support a self-update command, see the [Spice.ai roadmap](https://github.com/spiceai/spiceai/blob/trunk/docs/ROADMAP.md) for more details.
 
 ## Uninstall
 


### PR DESCRIPTION
v0.2.0 doesn't include a self-updating CLI.  We should either say we will do it *sometime* in the future or refer to a specific future release.