### PR TITLE
Measurements and categories update

### DIFF
--- a/spiceaidocs/content/en/reference/pod/_index.md
+++ b/spiceaidocs/content/en/reference/pod/_index.md
@@ -180,7 +180,7 @@ dataspaces:
 
 ### `dataspaces[*].measurements`
 
-The measurements to create in the dataspace. If these measurements are not populated by either a data connector or through the API, they will use the default value of `0.0`. Each field must be a `float`.
+The measurements to create in the dataspace. Each field must be a `float`.
 
 ### `dataspaces[*].measurements[*].name`
 
@@ -216,17 +216,17 @@ Used to select which field in the data source to map to this measurement name. D
 In the source data:
 
 ```csv
-time,bal
+time,my_balance
 100,10
 200,20
 ```
 
-This would "select" the `bal` column and place it into `balance` to be used by Spice.ai
+This would "select" the `my_balance` column and place it into `balance` to be used by Spice.ai
 
 ```yaml
 measurements:
   - name: balance
-    selector: bal
+    selector: my_balance
 ```
 
 ### `dataspaces[*].measurements[*].fill`
@@ -240,7 +240,7 @@ Used to specify how to treat missing data. Possible values are `previous` or `no
 In the source data:
 
 ```csv
-time,bal
+time,balance
 100,10
 125,
 150,15
@@ -252,14 +252,14 @@ The following manifest:
 
 ```yaml
 measurements:
-  - name: bal
+  - name: balance
     fill: previous
 ```
 
 would produce this data to the AI Engine:
 
 ```csv
-time,bal
+time,balance
 100,10
 125,10
 150,15
@@ -273,7 +273,7 @@ Process categorical data. Categorical data is a group or collection of discrete 
 
 Some examples of categorical data include: colors, star ratings, brands, programming languages, age group, hair color, grades, etc.
 
-Define categorical collections in the Spicepod manifest by the categories` node. Specify each category with a `name` and a list of discrete `values.`
+Define categorical collections in the Spicepod manifest by the `categories` node. Specify each category with a `name` and a list of discrete `values.`
 
 **Example**
 

--- a/spiceaidocs/content/en/reference/pod/_index.md
+++ b/spiceaidocs/content/en/reference/pod/_index.md
@@ -209,7 +209,7 @@ measurements:
 
 ### `dataspaces[*].measurements[*].selector`
 
-Used to select which field in the data source to map to this measurement name. Defaults to `name` if not provided.
+Used to select which field in the data source to map to this measurement name. Defaults to the measurement name if not provided.
 
 **Example**
 
@@ -269,11 +269,11 @@ time,bal
 
 ### `dataspaces[*].categories`
 
-Process categorical data in your data source. Categorical data is any data that can come from a finite number of values.
+Process categorical data. Categorical data is a group or collection of discrete strings.
 
-Some examples of categorical data include: colors, ratings, brands, programming languages, age group, hair color, grades, etc.
+Some examples of categorical data include: colors, star ratings, brands, programming languages, age group, hair color, grades, etc.
 
-To specify categorical data in your data source, use the `categories` node and specify the `values` that can appear in the category `name`.
+Define categorical collections in the Spicepod manifest by the categories` node. Specify each category with a `name` and a list of discrete `values.`
 
 **Example**
 
@@ -295,11 +295,11 @@ dataspaces:
 
 ### `dataspaces[*].categories[*].name`
 
-The `name` of the category. This will be the field that appears in the data source.
+Both the category name and the dataspace observation field name.
 
 ### `dataspaces[*].categories[*].selector`
 
-Used to select which field in the data source to map to this measurement name. Defaults to `name` if not provided.
+Selects the source data field mapped to the data space field. Defaults to `name` if not provided.
 
 **Example**
 
@@ -311,7 +311,7 @@ time,color_rainbow
 200,blue
 ```
 
-This would "select" the `color_rainbow` column and place it into `color` to be used by Spice.ai
+The data field `color_rainbow` is selected as the mapped source data for the data space observation field `color.`
 
 ```yaml
 categories:
@@ -321,13 +321,13 @@ categories:
 
 ### `dataspaces[*].categories[*].values`
 
-The set of possible categorical values that will be accepted by Spice.ai for the category `name`.
+Specifies the list of discrete category `name` values.
 
-Any values appearing in the data source that do not appear in this list will be ignored.
+Unspecified values in source data are ignored and are not included in the dataspace observations.
 
 ### `dataspaces[*].tags`
 
-A list of tags. Each item is a string value. If this value appears in the data source, it will be sent to the AI Engine in the observation.
+Specifies the list of tags. Each item is a string value. Unspecified tags in source data are ignored and are not included in the dataspace observations.
 
 **Example**
 
@@ -342,7 +342,7 @@ dataspaces:
 
 ### `dataspaces[*].data`
 
-Used to specify the external data source (configured with `connector` and `processor`) to use to populate the dataspace.
+Defines the data `connector` and data `processor` for the dataspace.
 
 If this section is omitted, the data should be provided through the [observations API]({{<ref api>}}).
 

--- a/spiceaidocs/content/en/reference/pod/samples-gardener.md
+++ b/spiceaidocs/content/en/reference/pod/samples-gardener.md
@@ -17,7 +17,7 @@ params:
 dataspaces:
   - from: sensors
     name: garden
-    fields:
+    measurements:
       - name: temperature
       - name: moisture
     data:
@@ -36,8 +36,8 @@ actions:
 training:
   rewards:
     - reward: close_valve
+      # Reward keeping moisture content above 25%
       with: |
-        # Reward keeping moisture content above 25%
         if new_state.sensors_garden_moisture > 0.25:
           reward = 200
 
@@ -50,8 +50,8 @@ training:
             reward = reward * 2
 
     - reward: open_valve_half
+      # Reward watering when needed, more heavily if the garden is more dried out
       with: |
-        # Reward watering when needed, more heavily if the garden is more dried out
         if new_state.sensors_garden_moisture < 0.25:
           reward = 100 * (0.25 - new_state.sensors_garden_moisture)
 
@@ -61,8 +61,8 @@ training:
           reward = -50 * (new_state.sensors_garden_moisture - 0.25)
 
     - reward: open_valve_full
+      # Reward watering when needed, more heavily if the garden is more dried out
       with: |
-        # Reward watering when needed, more heavily if the garden is more dried out
         if new_state.sensors_garden_moisture < 0.25:
           reward = 200 * (0.25 - new_state.sensors_garden_moisture)
 

--- a/spiceaidocs/content/en/reference/pod/samples-serverops.md
+++ b/spiceaidocs/content/en/reference/pod/samples-serverops.md
@@ -28,7 +28,7 @@ dataspaces:
           field: usage_idle
       processor:
         name: flux-csv
-    fields:
+    measurements:
       # "usage_idle" measures the percentage of time the CPU is idle
       # Higher values indicate less CPU usage
       - name: usage_idle
@@ -52,8 +52,8 @@ training:
 
   rewards:
     - reward: perform_maintenance
+      # Reward when cpu usage is low and stable
       with: |
-        # Reward when cpu usage is low and stable
         if cpu_usage_new < high_cpu_usage_threshold:
           # The lower the cpu usage, the higher the reward
           reward = high_cpu_usage_threshold - cpu_usage_new
@@ -68,11 +68,11 @@ training:
           reward = high_cpu_usage_threshold - cpu_usage_new
 
     - reward: preload_cache
+      # Reward when cpu usage is low and rising
+      # Is the cpu usage high now, and was the cpu usage low previously?
+      # If so, previous state was a better time to preload,
+      # so give a negative reward based on the change
       with: |
-        # Reward when cpu usage is low and rising
-        # Is the cpu usage high now, and was the cpu usage low previously?
-        # If so, previous state was a better time to preload,
-        # so give a negative reward based on the change
         if cpu_usage_new > high_cpu_usage_threshold and cpu_usage_delta > 25:
           reward = -cpu_usage_delta
 
@@ -81,9 +81,9 @@ training:
           reward = high_cpu_usage_threshold - cpu_usage_new
 
     - reward: do_nothing
+      # Reward doing nothing under high cpu usage
+      # The higher the cpu usage, the higher the reward
       with: |
-        # Reward doing nothing under high cpu usage
-        # The higher the cpu usage, the higher the reward
         if cpu_usage_new > high_cpu_usage_threshold:
           reward = high_cpu_usage_threshold - cpu_usage_new
 

--- a/spiceaidocs/static/openapi/spiceai.yaml
+++ b/spiceaidocs/static/openapi/spiceai.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.3"
 info:
   description: ""
-  version: "0.1.1-alpha"
+  version: "0.3.0-alpha"
   title: "Spice.ai"
 servers:
   - url: http://localhost:8000/api/v0.1


### PR DESCRIPTION
- Add documentation for `fill` parameter
- Update samples to showcase new manifest schema (`fields` -> `measurements`)
- Update the reference documentation to explain the new `measurements` and `categories` nodes.
- Add documentation for `tags`

Closes #59 

Note: should not be merged until v0.3 is released.