### PR TITLE
Fix custom docs styles

### DIFF
--- a/spiceaidocs/assets/scss/_styles_project.scss
+++ b/spiceaidocs/assets/scss/_styles_project.scss
@@ -29,3 +29,9 @@ h3 code {
     display: none;
   }
 }
+
+.card-deck {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+}


### PR DESCRIPTION
Fixed custom styles:

- cards grid
![CleanShot 2024-03-15 at 11 00 59@2x](https://github.com/spiceai/docs/assets/827338/89b6a64c-fc8a-4197-a919-5f2170b0f5a8)

- proper highlight for code in section headers
![CleanShot 2024-03-15 at 11 01 08@2x](https://github.com/spiceai/docs/assets/827338/8409c460-0eb3-4af2-85ab-64cdc34da823)

