### PR TITLE
Enable navbar.hideOnScroll

### DIFF
--- a/spiceaidocs/docs/index.md
+++ b/spiceaidocs/docs/index.md
@@ -34,7 +34,9 @@ Spice makes querying data by SQL across one or more data sources simple and fast
 
 **3. Faster data pipelines, machine learning training and inferencing.** Co-locate datasets in pipelines where the data is needed to minimize data-movement and improve query performance.
 
-⚠️ **DEVELOPER PREVIEW** Spice is under active **alpha** stage development and is not intended to be used in production until its **1.0-stable** release.
+:::warning[DEVELOPER PREVIEW]
+Spice is under active **alpha** stage development and is not intended to be used in production until its **1.0-stable** release.
+:::
 
 ### Connect with us
 

--- a/spiceaidocs/docusaurus.config.ts
+++ b/spiceaidocs/docusaurus.config.ts
@@ -64,6 +64,7 @@ const config: Config = {
         alt: 'Spice.ai logo',
         src: 'img/logo.svg',
       },
+      hideOnScroll: true,
       items: [
         {
           type: 'doc',


### PR DESCRIPTION
Enables the option `navbar.hideOnScroll` to automatically hide the navbar when scrolling down, and bring it back when scrolling up.

Also changes the developer preview warning to use the native admonition

<img width="718" alt="Screenshot 2024-03-26 at 4 02 10 PM" src="https://github.com/spiceai/docs/assets/879445/0ecb62c7-088f-4f24-8fba-a341aa031d1b">
