### PR TITLE
Update taxi_trips demo query

### DIFF
--- a/spiceaidocs/docs/getting-started/index.md
+++ b/spiceaidocs/docs/getting-started/index.md
@@ -111,29 +111,29 @@ sql> show tables;
 Query took: 0.004728897 seconds
 ```
 
-Enter a query to display the most expensive tax trips:
+Enter a query to display the longest taxi trips:
 
 ```
-sql> SELECT trip_distance_mi, fare_amount FROM taxi_trips ORDER BY fare_amount LIMIT 10;
+sql> SELECT trip_distance_mi, total_amount FROM taxi_trips ORDER BY trip_distance_mi DESC LIMIT 10;
 ```
 
 Output:
 
 ```
-+------------------+-------------+
-| trip_distance_mi | fare_amount |
-+------------------+-------------+
-| 1.1              | 7.5         |
-| 6.1              | 23.0        |
-| 0.6              | 4.5         |
-| 16.7             | 52.0        |
-| 11.3             | 37.5        |
-| 1.1              | 6.0         |
-| 5.3              | 18.5        |
-| 1.3              | 7.0         |
-| 1.0              | 7.0         |
-| 3.5              | 17.5        |
-+------------------+-------------+
++------------------+--------------+
+| trip_distance_mi | total_amount |
++------------------+--------------+
+| 191.9            | 3.0          |
+| 189.2            | 63.0         |
+| 163.8            | 93.64        |
+| 122.4            | 160.0        |
+| 104.0            | 3.0          |
+| 69.7             | 213.58       |
+| 64.8             | 280.83       |
+| 60.0             | 350.12       |
+| 53.9             | 0.0          |
+| 53.3             | 5.33         |
++------------------+--------------+
 
 Query took: 0.002458976 seconds
 ```


### PR DESCRIPTION
Fixes https://github.com/spicehq/spiceai/issues/166

1. Fixes ordering (DESC)
2. Updates query from the most expensive taxi trips to the longest taxi trips as most distances for most expensive trips are zero (see below)
```
sql> SELECT trip_distance_mi, fare_amount FROM taxi_trips ORDER BY fare_amount DESC LIMIT 10;
+------------------+-------------+
| trip_distance_mi | fare_amount |
+------------------+-------------+
| 0.0              | 310.0       |
| 0.0              | 280.0       |
| 64.8             | 275.0       |
| 60.0             | 256.5       |
| 0.0              | 250.0       |
| 0.0              | 175.0       |
| 0.0              | 171.0       |
| 25.7             | 163.0       |
| 122.4            | 160.0       |
| 0.5              | 156.0       |
+------------------+-------------+ 
```
PR with similar change to Spice Readme: 
https://github.com/spiceai/spiceai/pull/948