### PR TITLE
Remove Forward/Back buttons for most docs pages

### DIFF
--- a/spiceaidocs/docs/acknowledgements/index.md
+++ b/spiceaidocs/docs/acknowledgements/index.md
@@ -3,6 +3,8 @@ title: Open Source Acknowledgements
 sidebar_label: Acknowledgements
 sidebar_position: 100
 description: 'Spice AI acknowledges the following open source projects for making this project possible:'
+pagination_prev: null
+pagination_next: null
 ---
 
 Spice AI acknowledges the following open source projects for making this project possible:

--- a/spiceaidocs/docs/cli/index.md
+++ b/spiceaidocs/docs/cli/index.md
@@ -3,6 +3,7 @@ title: 'Spice.ai OSS CLI documentation'
 sidebar_label: 'CLI'
 description: 'Detailed documentation on the Spice.ai OSS CLI'
 sidebar_position: 9
+pagination_prev: null
 ---
 
 The Spice CLI is a set of commands to create and manage Spicepods and interact with the Spice runtime.

--- a/spiceaidocs/docs/cli/reference/add.md
+++ b/spiceaidocs/docs/cli/reference/add.md
@@ -1,6 +1,8 @@
 ---
 title: "Add"
 sidebar_label: "add"
+pagination_prev: null
+pagination_next: null
 ---
 
 Add Spicepod - adds a Spicepod to the project

--- a/spiceaidocs/docs/cli/reference/completion.md
+++ b/spiceaidocs/docs/cli/reference/completion.md
@@ -1,6 +1,8 @@
 ---
 title: "Completion"
 sidebar_label: "completion"
+pagination_prev: null
+pagination_next: null
 ---
 
 Generate the autocompletion script for spice for the specified shell.

--- a/spiceaidocs/docs/cli/reference/dataset.md
+++ b/spiceaidocs/docs/cli/reference/dataset.md
@@ -1,6 +1,8 @@
 ---
 title: "dataset"
 sidebar_label: "dataset"
+pagination_prev: null
+pagination_next: null
 ---
 
 Dataset operations

--- a/spiceaidocs/docs/cli/reference/datasets.md
+++ b/spiceaidocs/docs/cli/reference/datasets.md
@@ -1,6 +1,8 @@
 ---
 title: "datasets"
 sidebar_label: "datasets"
+pagination_prev: null
+pagination_next: null
 ---
 
 Lists datasets loaded by the Spice runtime

--- a/spiceaidocs/docs/cli/reference/index.md
+++ b/spiceaidocs/docs/cli/reference/index.md
@@ -2,6 +2,7 @@
 title: "Spice.ai OSS CLI command reference"
 sidebar_label: "Spice CLI command reference"
 description: "Spice CLI command reference"
+pagination_next: null
 ---
 
 # spice

--- a/spiceaidocs/docs/cli/reference/init.md
+++ b/spiceaidocs/docs/cli/reference/init.md
@@ -1,6 +1,8 @@
 ---
 title: "init"
 sidebar_label: "init"
+pagination_prev: null
+pagination_next: null
 ---
 Initialize Spice app - initializes a new Spice app
 

--- a/spiceaidocs/docs/cli/reference/login.md
+++ b/spiceaidocs/docs/cli/reference/login.md
@@ -1,6 +1,8 @@
 ---
 title: "login"
 sidebar_label: "login"
+pagination_prev: null
+pagination_next: null
 ---
 
 Login to the Spice.ai Platform, or other services with sub-commands.

--- a/spiceaidocs/docs/cli/reference/models.md
+++ b/spiceaidocs/docs/cli/reference/models.md
@@ -1,6 +1,8 @@
 ---
 title: "models"
 sidebar_label: "models"
+pagination_prev: null
+pagination_next: null
 ---
 
 Lists models loaded by the Spice runtime

--- a/spiceaidocs/docs/cli/reference/pods.md
+++ b/spiceaidocs/docs/cli/reference/pods.md
@@ -1,6 +1,8 @@
 ---
 title: "pods"
 sidebar_label: "pods"
+pagination_prev: null
+pagination_next: null
 ---
 Lists Spicepods loaded by the Spice runtime
 

--- a/spiceaidocs/docs/cli/reference/run.md
+++ b/spiceaidocs/docs/cli/reference/run.md
@@ -1,6 +1,8 @@
 ---
 title: "run"
 sidebar_label: "run"
+pagination_prev: null
+pagination_next: null
 ---
 Run Spice - starts the Spice runtime, installing if necessary
 

--- a/spiceaidocs/docs/cli/reference/sql.md
+++ b/spiceaidocs/docs/cli/reference/sql.md
@@ -1,6 +1,8 @@
 ---
 title: "sql"
 sidebar_label: "sql"
+pagination_prev: null
+pagination_next: null
 ---
 
 Start an interactive SQL query session against the Spice runtime

--- a/spiceaidocs/docs/cli/reference/status.md
+++ b/spiceaidocs/docs/cli/reference/status.md
@@ -1,6 +1,8 @@
 ---
 title: "status"
 sidebar_label: "status"
+pagination_prev: null
+pagination_next: null
 ---
 Spice runtime status
 

--- a/spiceaidocs/docs/cli/reference/upgrade.md
+++ b/spiceaidocs/docs/cli/reference/upgrade.md
@@ -1,6 +1,8 @@
 ---
 title: "upgrade"
 sidebar_label: "upgrade"
+pagination_prev: null
+pagination_next: null
 ---
 Upgrades the Spice CLI to the latest release
 

--- a/spiceaidocs/docs/cli/reference/version.md
+++ b/spiceaidocs/docs/cli/reference/version.md
@@ -1,6 +1,8 @@
 ---
 title: "version"
 sidebar_label: "version"
+pagination_prev: null
+pagination_next: null
 ---
 Spice CLI version
 

--- a/spiceaidocs/docs/clients/DBeaver/index.md
+++ b/spiceaidocs/docs/clients/DBeaver/index.md
@@ -3,6 +3,8 @@ title: "DBeaver"
 sidebar_label: "DBeaver"
 description: 'Configure DBeaver to query Spice via JDBC'
 sidebar_position: 2
+pagination_prev: 'clients/index'
+pagination_next: null
 ---
 
 1. Start the Spice runtime with a dataset loaded. Follow the [quickstart guide](/getting-started) to get started.

--- a/spiceaidocs/docs/clients/arrow-flight-sql/index.md
+++ b/spiceaidocs/docs/clients/arrow-flight-sql/index.md
@@ -3,6 +3,8 @@ title: "Arrow Flight SQL"
 sidebar_label: "Arrow Flight SQL"
 sidebar_position: 1
 description: "Query Spice using JDBC/ODBC/ADBC"
+pagination_prev: 'clients/index'
+pagination_next: null
 ---
 
 Arrow Flight SQL is a protocol for interacting with SQL databases using the Arrow in-memory format and the Flight RPC framework. Spice implements the Flight SQL protocol which enables querying the datasets configured in Spice via tools that support connecting via one of the Arrow Flight SQL drivers, such as [DBeaver](https://dbeaver.io), [Tableau](https://www.tableau.com/), or [Power BI](https://www.microsoft.com/en-us/power-platform/products/power-bi).

--- a/spiceaidocs/docs/clients/http_api/index.md
+++ b/spiceaidocs/docs/clients/http_api/index.md
@@ -2,6 +2,8 @@
 title: "HTTP API"
 sidebar_label: "HTTP"
 description: 'Directly call the Spice runtime via HTTP requests'
+pagination_prev: 'clients/index'
+pagination_next: null
 ---
 
 import Tabs from '@theme/Tabs';

--- a/spiceaidocs/docs/clients/index.md
+++ b/spiceaidocs/docs/clients/index.md
@@ -4,3 +4,7 @@ sidebar_label: 'Clients and Tools'
 sidebar_position: 9
 description: 'Client and tools'
 ---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/clients/index.md
+++ b/spiceaidocs/docs/clients/index.md
@@ -3,6 +3,8 @@ title: 'Clients and Tools'
 sidebar_label: 'Clients and Tools'
 sidebar_position: 9
 description: 'Client and tools'
+pagination_prev: null
+pagination_next: null
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/spiceaidocs/docs/clients/superset/index.md
+++ b/spiceaidocs/docs/clients/superset/index.md
@@ -3,6 +3,8 @@ title: 'Apache Superset'
 sidebar_label: 'Apache Superset'
 sidebar_position: 10
 description: 'Use Apache Superset to query and visualize datasets loaded in Spice.'
+pagination_prev: 'clients/index'
+pagination_next: null
 ---
 
 import Tabs from '@theme/Tabs';

--- a/spiceaidocs/docs/clients/tableau/index.md
+++ b/spiceaidocs/docs/clients/tableau/index.md
@@ -3,6 +3,8 @@ title: 'Tableau'
 sidebar_label: 'Tableau'
 sidebar_position: 10
 description: 'Use Tableau to to access, visualise and analyse datasets loaded in Spice.'
+pagination_prev: 'clients/index'
+pagination_next: null
 ---
 
 Use [Tableau](https://www.tableau.com/) to access, visualise and analyse datasets loaded in Spice.

--- a/spiceaidocs/docs/data-accelerators/index.md
+++ b/spiceaidocs/docs/data-accelerators/index.md
@@ -3,6 +3,8 @@ title: 'Data Accelerators'
 sidebar_label: 'Data Accelerators'
 description: ''
 sidebar_position: 5
+pagination_prev: null
+pagination_next: null
 ---
 
 Data sourced by Data Connectors can be locally materialized and accelerated using a Data Accelerator.
@@ -30,3 +32,9 @@ Currently supported Data Accelerators include:
 | [`duckdb`](./duckdb.md)           | Embedded DuckDB         | Alpha  | `memory`, `file` |
 | [`sqlite`](./sqlite.md)           | Embedded SQLite         | Alpha  | `memory`, `file` |
 | [`postgres`](./postgres/index.md) | Attached PostgreSQL     | Alpha  |                  |
+
+## Data Accelerator Docs
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/data-accelerators/sqlite.md
@@ -2,6 +2,7 @@
 title: 'SQLite Data Accelerator'
 sidebar_label: 'SQLite Data Accelerator'
 description: 'SQLite Data Accelerator Documentation'
+pagination_next: null
 ---
 
 To use SQLite as Data Accelerator, specify `sqlite` as the `engine` for acceleration.

--- a/spiceaidocs/docs/data-connectors/databricks.md
+++ b/spiceaidocs/docs/data-connectors/databricks.md
@@ -2,6 +2,7 @@
 title: 'Databricks Data Connector'
 sidebar_label: 'Databricks Data Connector'
 description: 'Databricks Data Connector Documentation'
+pagination_prev: null
 ---
 
 import Tabs from '@theme/Tabs';

--- a/spiceaidocs/docs/data-connectors/index.md
+++ b/spiceaidocs/docs/data-connectors/index.md
@@ -3,6 +3,8 @@ title: 'Data Connectors'
 sidebar_label: 'Data Connectors'
 description: ''
 sidebar_position: 6
+pagination_prev: null
+pagination_next: null
 ---
 
 Data Connectors provide connections to databases, data warehouses, and data lakes for federated SQL queries and data replication.
@@ -20,3 +22,9 @@ Currently supported Data Connectors include:
 | `snowflake`  | Snowflake   | Coming soon! | Arrow Flight SQL | `full`           | ❌               |
 | `bigquery`   | BigQuery    | Coming soon! | Arrow Flight SQL | `full`           | ❌               |
 | `mysql`      | MySQL       | Coming soon! |                  | `full`           | ❌               |
+
+## Data Connector Docs
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/data-connectors/spiceai.md
+++ b/spiceaidocs/docs/data-connectors/spiceai.md
@@ -2,6 +2,7 @@
 title: 'Spice.ai Data Connector'
 sidebar_label: 'Spice.ai Data Connector'
 description: 'Spice.ai Data Connector Documentation'
+pagination_next: null
 ---
 
 The [Spice.ai](https://spice.ai/) Data Connector enables federated SQL query across datasets in the [Spice.ai Cloud Platform](https://docs.spice.ai/building-blocks/datasets).  Access to these datasets require a free [Spice.ai account](https://spice.ai/login).

--- a/spiceaidocs/docs/data-ingestion/index.md
+++ b/spiceaidocs/docs/data-ingestion/index.md
@@ -3,6 +3,8 @@ title: 'Data Ingestion'
 sidebar_label: 'Data Ingestion'
 description: ''
 sidebar_position: 4
+pagination_prev: null
+pagination_next: null
 ---
 
 

--- a/spiceaidocs/docs/federated-queries/index.md
+++ b/spiceaidocs/docs/federated-queries/index.md
@@ -3,4 +3,6 @@ title: 'Federated Queries'
 sidebar_label: 'Federated Queries'
 description: ''
 sidebar_position: 2
+pagination_prev: null
+pagination_next: null
 ---

--- a/spiceaidocs/docs/getting-started/index.md
+++ b/spiceaidocs/docs/getting-started/index.md
@@ -3,6 +3,7 @@ title: 'Getting started with Spice.ai OSS'
 sidebar_label: 'Getting started'
 sidebar_position: 1
 description: 'Get started with Spice in 5 minutes'
+pagination_next: null
 ---
 
 ### Follow these steps to get started with Spice.

--- a/spiceaidocs/docs/intelligent-applications/index.md
+++ b/spiceaidocs/docs/intelligent-applications/index.md
@@ -3,6 +3,8 @@ title: 'Intelligent Applications'
 sidebar_label: 'Intelligent Applications'
 sidebar_position: 10
 description: 'Building intelligent data and AI-driven applications with Spice.ai'
+pagination_prev: null
+pagination_next: null
 ---
 
 As described in the blog post [Making Apps That Learn and Adapt](https://blog.spiceai.org/posts/2021/11/05/making-apps-that-learn-and-adapt/) the long-term vision for Spice.ai is to enable developers to easily build, deploy, and operate intelligent data and AI-driven applications.

--- a/spiceaidocs/docs/local-acceleration/index.md
+++ b/spiceaidocs/docs/local-acceleration/index.md
@@ -3,6 +3,8 @@ title: 'Local Acceleration'
 sidebar_label: 'Local Acceleration'
 description: ''
 sidebar_position: 3
+pagination_prev: null
+pagination_next: null
 ---
 
 Datasets can be locally accelerated by the Spice runtime, pulling data from any [Data Connector](/data-connectors) and storing it locally in a [Data Accelerator](/data-accelerators) for faster access. Additionally, the data is kept up to date in realtime, so you always have the latest data locally for querying.

--- a/spiceaidocs/docs/machine-learning/index.md
+++ b/spiceaidocs/docs/machine-learning/index.md
@@ -3,6 +3,7 @@ title: 'Machine Learning'
 sidebar_label: 'Machine Learning'
 description: ''
 sidebar_position: 8
+pagination_prev: null
 ---
 
 :::warning[Early Preview]

--- a/spiceaidocs/docs/machine-learning/inference/index.md
+++ b/spiceaidocs/docs/machine-learning/inference/index.md
@@ -3,6 +3,8 @@ title: 'Machine Learning Inference'
 sidebar_label: 'Machine Learning Inference'
 description: ''
 sidebar_position: 2
+pagination_prev: 'machine-learning/model-deployment/index'
+pagination_next: null
 ---
 
 import Tabs from '@theme/Tabs';

--- a/spiceaidocs/docs/machine-learning/model-deployment/index.md
+++ b/spiceaidocs/docs/machine-learning/model-deployment/index.md
@@ -3,6 +3,7 @@ title: 'ML Model Deployment'
 sidebar_label: 'ML Model Deployment'
 description: ''
 sidebar_position: 1
+pagination_next: 'machine-learning/inference/index'
 ---
 
 Models can be loaded from a variety of sources: 
@@ -20,3 +21,8 @@ A model component, within a Spicepod, has the following format.
 | `datasets`        | Datasets that the model depends on for inference                    | 
 | `files` (HF only) | Specify an individual file within the HuggingFace repository to use | 
  
+## Model Source Docs
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/reference/index.md
+++ b/spiceaidocs/docs/reference/index.md
@@ -3,4 +3,10 @@ title: 'Spice.ai OSS Reference Docs'
 sidebar_label: 'Reference'
 sidebar_position: 11
 description: 'Reference documentation on the Spice API, CLI and Pod manifest syntax.'
+pagination_prev: null
+pagination_next: null
 ---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/reference/spicepod/models.md
+++ b/spiceaidocs/docs/reference/spicepod/models.md
@@ -2,6 +2,7 @@
 title: "Models"
 sidebar_label: "Models"
 description: 'Models YAML reference'
+pagination_next: null
 ---
 
 :::warning[Early Preview]

--- a/spiceaidocs/docs/reference/timestamp.md
+++ b/spiceaidocs/docs/reference/timestamp.md
@@ -1,6 +1,8 @@
 ---
 title: "Timestamps"
 sidebar_label: "Timestamps"
+pagination_prev: 'reference/index'
+pagination_next: null
 ---
 
 In Spice all timestamps are represented as an integer value denoting the number of seconds that have passed since the _Unix epoch_ in UTC time. The Unix epoch is defined as 1970-01-01T00:00:00Z.

--- a/spiceaidocs/docs/secret-stores/env/index.md
+++ b/spiceaidocs/docs/secret-stores/env/index.md
@@ -3,6 +3,7 @@ title: 'Environment Secret Store'
 sidebar_label: 'Environment Secret Store'
 sidebar_position: 1
 description: 'Environment Variables Secret Store Documentation'
+pagination_prev: null
 ---
 
 The `env` store type enables Spice to read secrets from environment variables. Environment variables should be formatted `SPICE_SECRET_<secret-name>_<secret-value-key>`.

--- a/spiceaidocs/docs/secret-stores/index.md
+++ b/spiceaidocs/docs/secret-stores/index.md
@@ -3,6 +3,8 @@ title: 'Secret Stores'
 sidebar_label: 'Secret Stores'
 description: ''
 sidebar_position: 7
+pagination_prev: null
+pagination_next: null
 ---
 
 A Secret Store is a location where `secret` objects are stored, used to store sensitive data, like passwords, tokens, secret keys.
@@ -18,7 +20,6 @@ secrets:
 
 ## Secret Stores
 
-- [Environment Secret Store](env/index.md)
-- [File Secret Store](file/index.md)
-- [Kubernetes Secret Store](kubernetes/index.md)
-- [Keyring Secret Store](keyring/index.md)
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/spiceaidocs/docs/secret-stores/keyring/index.md
+++ b/spiceaidocs/docs/secret-stores/keyring/index.md
@@ -3,6 +3,7 @@ title: 'Keyring Secret Store'
 sidebar_label: 'Keyring Secret Store'
 sidebar_position: 4
 description: 'Keyring Secret Store Documentation'
+pagination_next: null
 ---
 
 The `keyring` store enables Spice to access secrets from the secure/credential store of the host operating system:


### PR DESCRIPTION
Removes the Forward/Back button at the bottom of most docs pages, leaving it in for the docs pages that make sense.

Also uses the DocCardList component to build the following view for index pages:

```tsx
import DocCardList from '@theme/DocCardList';

<DocCardList />
```

![Screenshot 2024-03-28 at 11 06 48 AM](https://github.com/spiceai/docs/assets/879445/506e4ba6-5ccf-4024-aa8a-0805c47a8a3c)
