### PR TITLE
Update postgres params descriptions

### DIFF
--- a/spiceaidocs/docs/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/data-accelerators/postgres/index.md
@@ -25,6 +25,11 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_user`: The username to connect with.
 - `pg_pass_key`: The secret key containing the password to connect with.
 - `pg_pass`: The plain-text password to connect with, ignored if `pg_pass_key` is provided.
+- `pg_sslmode`: Optional parameter, specifies the SSL/TLS behavior for the connection, supported values:
+  - `prefer`: (default) This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
+  - `required`: This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.
+  - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
+- `pg_insecure`: Optional parameter, Allows TLS connectivity to servers with invalid/expired certificates.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.
 
@@ -36,10 +41,12 @@ datasets:
       engine: postgres
       params:
         pg_host: localhost
-        pg_port: 5432
+        pg_port: '5432'
         pg_db: my_database
         pg_user: my_user
         pg_pass_key: my_secret
+        pg_sslmode: required
+        pg_insecure: 'true'
 ```
 
 Additionally, an `engine_secret` may be provided when configuring a PostgreSQL data store to allow for using a different secret store to specify the password for a dataset using PostgreSQL as both the data source and data store.
@@ -50,7 +57,7 @@ datasets:
     name: my_dataset
     params:
       pg_host: localhost
-      pg_port: 5432
+      pg_port: '5432'
       pg_db: data_store
       pg_user: my_user
       pg_pass_key: my_secret
@@ -59,7 +66,7 @@ datasets:
       engine_secret: pg_backend
       params:
         pg_host: localhost
-        pg_port: 5433
+        pg_port: '5433'
         pg_db: data_store
         pg_user: my_user
         pg_pass_key: my_secret

--- a/spiceaidocs/docs/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/data-accelerators/postgres/index.md
@@ -26,7 +26,7 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_pass_key`: The secret key containing the password to connect with.
 - `pg_pass`: The plain-text password to connect with, ignored if `pg_pass_key` is provided.
 - `pg_sslmode`: Optional parameter, specifies the SSL/TLS behavior for the connection, supported values:
-  - `prefer`: (default) This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
+  - `prefer`: (default) This mode will try to establish a secure SSL connection if possible, but will still connect if the server does not support SSL.
   - `required`: This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.
   - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
 - `pg_insecure`: Optional parameter, Allows TLS connectivity to servers with invalid/expired certificates.

--- a/spiceaidocs/docs/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/data-connectors/postgres/index.md
@@ -28,6 +28,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: (default) This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
   - `required`: This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.
   - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
+- `pg_insecure`: Optional parameter, Allows TLS connectivity to servers with invalid/expired certificates.
 
 Configuration `params` are provided either in the top level `dataset` for a dataset source and federated SQL query, or in the `acceleration` section for a data store.
 
@@ -41,6 +42,8 @@ datasets:
       pg_db: my_database
       pg_user: my_user
       pg_pass_key: my_secret
+      pg_sslmode: required
+      pg_insecure: 'true'
 ```
 
 Additionally, an `engine_secret` may be provided when configuring a PostgreSQL data store to allow for using a different secret store to specify the password for a dataset using PostgreSQL as both the data source and data store.


### PR DESCRIPTION
- added `pg_insecure` param
- updated `pg_port` in examples to be string value for consistency