### PR TITLE
Clarify that postgres doesn't support inserts yet

### DIFF
--- a/spiceaidocs/docs/data-connectors/index.md
+++ b/spiceaidocs/docs/data-connectors/index.md
@@ -14,7 +14,7 @@ Currently supported Data Connectors include:
 | Name         | Description | Status       | Protocol/Format  | Refresh Modes    | Supports Inserts |
 | ------------ | ----------- | ------------ | ---------------- | ---------------- | ---------------- |
 | `databricks` | Databricks  | Alpha        | Delta Lake       | `full`           | ❌               |
-| `postgres`   | PostgreSQL  | Alpha        |                  | `full`           | ✅               |
+| `postgres`   | PostgreSQL  | Alpha        |                  | `full`           | ❌               |
 | `spiceai`    | Spice.ai    | Alpha        | Arrow Flight     | `append`, `full` | ✅               |
 | `s3`         | S3          | Alpha        | Parquet          | `full`           | ❌               |
 | `dremio`     | Dremio      | Alpha        | Arrow Flight SQL | `full`           | ❌               |


### PR DESCRIPTION
The PostgreSQL Data Connector doesn't support inserts yet. It is technically capable (which is probably how this got included) but it isn't wired up to expose the correct interface.

This will get cleaned up as part of my re-architecture PR - but until then, will correct the docs to be accurate.