### PR TITLE
Trigger Algolia search reindex on gh-pages built event and manually

### DIFF
--- a/.github/workflows/trigger_search_reindex.yml
+++ b/.github/workflows/trigger_search_reindex.yml
@@ -1,0 +1,19 @@
+name: Trigger Search Reindex
+
+on:
+  push:
+    branches:
+      - trunk
+
+  pull_request:
+    branches:
+      - trunk
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Search Reindex
+        run: |
+          curl -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}" \
+            --user "${{ secrets.ALGOLIA_USER_ID }}":"${{ secrets.ALGOLIA_TOKEN }}"

--- a/.github/workflows/trigger_search_reindex.yml
+++ b/.github/workflows/trigger_search_reindex.yml
@@ -1,19 +1,20 @@
-name: Trigger Search Reindex
+name: Trigger Algolia Search Reindex
 
 on:
-  push:
-    branches:
-      - trunk
+  workflow_dispatch:
 
-  pull_request:
-    branches:
-      - trunk
+  # trigger automatically when gh-pages is built
+  page_build:
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Search Reindex
+      - name: Wait for gh-page cache update
+        if: github.event_name == 'page_build' && github.event.build.status == 'built'
+        run: sleep 60
+
+      - name: Trigger search reindex
         run: |
           curl -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex" \
             --user "${{ secrets.ALGOLIA_USER_ID }}":"${{ secrets.ALGOLIA_TOKEN }}"

--- a/.github/workflows/trigger_search_reindex.yml
+++ b/.github/workflows/trigger_search_reindex.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - name: Trigger Search Reindex
         run: |
-          curl -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}" \
+          curl -X POST "https://crawler.algolia.com/api/1/crawlers/${{ secrets.ALGOLIA_CRAWLER_ID }}/reindex" \
             --user "${{ secrets.ALGOLIA_USER_ID }}":"${{ secrets.ALGOLIA_TOKEN }}"


### PR DESCRIPTION
Will call Algolia crawler webhook, to reindex docs. Can be run manually or automatically after each successful gh-pages build