### PR TITLE
Add limitations for DuckDB field types

### DIFF
--- a/spiceaidocs/docs/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/data-accelerators/duckdb.md
@@ -31,11 +31,12 @@ datasets:
 ```
 
 ## Limitations
-- Does not support schemas with [field types](https://duckdb.org/docs/sql/data_types): nested arrays/lists, structs or map fields. For example:
+- Does not support schemas with [field types](https://duckdb.org/docs/sql/data_types): nested arrays/lists, UTF8/string arrays/lists, structs or map fields. For example:
   - Supported: 
     - `SELECT [1, 2, 3];`
-    - `SELECT ['duck', 'goose', NULL, 'heron'];`
+    - `SELECT ['1992-09-20 11:30:00.123456789', 'epoch'::TIMESTAMP]
   - Unsupported:
     - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
     - `SELECT {'x': 1, 'y': 2, 'z': 3}`
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
+    - `SELECT ['duck', 'goose', 'heron'];`

--- a/spiceaidocs/docs/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/data-accelerators/duckdb.md
@@ -29,3 +29,13 @@ datasets:
       params:
         duckdb_file: /my/chosen/location/duckdb.db
 ```
+
+## Limitations
+- Does not support schemas with [field types](https://duckdb.org/docs/sql/data_types): nested arrays/lists, structs or map fields. For example:
+  - Supported: 
+    - `SELECT [1, 2, 3];`
+    - `SELECT ['duck', 'goose', NULL, 'heron'];`
+  - Unsupported:
+    - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
+    - `SELECT {'x': 1, 'y': 2, 'z': 3}`
+    - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`


### PR DESCRIPTION
This is a limitation discovered in https://github.com/spiceai/spiceai/issues/873. The root cause shows that it also won't work for maps or structs.