### PR TITLE
Dataset example in reference incorrect

### DIFF
--- a/spiceaidocs/docs/reference/spicepod/index.md
+++ b/spiceaidocs/docs/reference/spicepod/index.md
@@ -74,7 +74,8 @@ A dataset defined inline.
 
 ```yaml
 datasets:
-  - name: spice.ai/eth.recent_blocks
+  - from: spice.ai/eth.recent_blocks
+    name: eth_blocks
     acceleration:
       enabled: true
       refresh_mode: full


### PR DESCRIPTION
I don't think the previous reference documentation was correct. Running it as a part of a spicepod results in no datasets, and spiced attempting to load a local file.
```bash
>>> spiced
2024-04-18T03:54:03.476499Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
thread 'tokio-runtime-worker' panicked at crates/runtime/src/dataconnector/localhost.rs:53:9:
not implemented: read_provider not yet implemented for localhost provider
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-04-18T03:54:03.476651Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
2024-04-18T03:54:03.479871Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:3000
^C2024-04-18T03:54:52.051280Z  INFO runtime: Goodbye!
```