### PR TITLE
Change required to require in pg_sslmode

### DIFF
--- a/spiceaidocs/docs/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/data-accelerators/postgres/index.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: 'PostgreSQL Data Accelerator'
-sidebar_label: 'PostgreSQL Data Accelerator'
-description: 'PostgreSQL Data Accelerator Documentation'
+title: "PostgreSQL Data Accelerator"
+sidebar_label: "PostgreSQL Data Accelerator"
+description: "PostgreSQL Data Accelerator Documentation"
 ---
 
 To use PostgreSQL as Data Accelerator, specify `postgres` as the `engine` for acceleration.
@@ -27,7 +27,7 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_pass`: The plain-text password to connect with, ignored if `pg_pass_key` is provided.
 - `pg_sslmode`: Optional parameter, specifies the SSL/TLS behavior for the connection, supported values:
   - `prefer`: (default) This mode will try to establish a secure SSL connection if possible, but will still connect if the server does not support SSL.
-  - `required`: This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.
+  - `require`: This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.
   - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
 - `pg_insecure`: Optional parameter, Allows TLS connectivity to servers with invalid/expired certificates.
 
@@ -46,7 +46,7 @@ datasets:
         pg_user: my_user
         pg_pass_key: my_secret
         pg_sslmode: required
-        pg_insecure: 'true'
+        pg_insecure: "true"
 ```
 
 Additionally, an `engine_secret` may be provided when configuring a PostgreSQL data store to allow for using a different secret store to specify the password for a dataset using PostgreSQL as both the data source and data store.

--- a/spiceaidocs/docs/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/data-accelerators/postgres/index.md
@@ -1,8 +1,8 @@
 ---
 type: docs
-title: "PostgreSQL Data Accelerator"
-sidebar_label: "PostgreSQL Data Accelerator"
-description: "PostgreSQL Data Accelerator Documentation"
+title: 'PostgreSQL Data Accelerator'
+sidebar_label: 'PostgreSQL Data Accelerator'
+description: 'PostgreSQL Data Accelerator Documentation'
 ---
 
 To use PostgreSQL as Data Accelerator, specify `postgres` as the `engine` for acceleration.
@@ -46,7 +46,7 @@ datasets:
         pg_user: my_user
         pg_pass_key: my_secret
         pg_sslmode: required
-        pg_insecure: "true"
+        pg_insecure: 'true'
 ```
 
 Additionally, an `engine_secret` may be provided when configuring a PostgreSQL data store to allow for using a different secret store to specify the password for a dataset using PostgreSQL as both the data source and data store.


### PR DESCRIPTION
The parameter supported is `require` instead of `required`, correct the spelling