### PR TITLE
Add missing `mode: file` to file based accelerator examples

### DIFF
--- a/spiceaidocs/docs/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/data-accelerators/duckdb.md
@@ -26,6 +26,7 @@ datasets:
     name: my_dataset
     acceleration:
       engine: duckdb
+      mode: file
       params:
         duckdb_file: /my/chosen/location/duckdb.db
 ```

--- a/spiceaidocs/docs/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/data-accelerators/sqlite.md
@@ -27,6 +27,7 @@ datasets:
     name: my_dataset
     acceleration:
       engine: sqlite
+      mode: file
       params:
         sqlite_file: /my/chosen/location/sqlite.db
 ```


### PR DESCRIPTION
closes #224 