### PR TITLE
remove the nested path limitation on s3 parquet connector

### DIFF
--- a/spiceaidocs/docs/data-connectors/s3.md
+++ b/spiceaidocs/docs/data-connectors/s3.md
@@ -158,6 +158,4 @@ Create a dataset named `taxi_trips` from a public S3 folder.
 
 ## Limitations
 
-- Automatic discovery of nested paths are not yet supported. Only Parquet files in the root of the endpoint path will be loaded.
-
 - Only S3 authentication using `aws_access_key_id` and `aws_secret_access_key` is currently supported. Please [submit an issue](https://github.com/spiceai/spiceai/issues/new?template=feature_request.md) if you would like to see support for other authentication methods.


### PR DESCRIPTION
Remove the nested path limitation.

The csv change is not added as it was mainly a proof of concept of the listing table pattern. We need to work on the bigger change of the doc once it's properly designed/signed off by PM on the CSV object store path.