### PR TITLE
Update Spark & Databricks docs

### DIFF
--- a/spiceaidocs/docs/data-connectors/databricks.md
+++ b/spiceaidocs/docs/data-connectors/databricks.md
@@ -24,7 +24,6 @@ Databricks as a connector for federated SQL query against Databricks using [Spar
   - `deltalake`: Query Delta Tables.
 - `databricks-cluster-id`: The ID of the compute cluster in Databricks to use for the query. Only valid when `mode` is `spark_connect`.
 - `databricks_use_ssl`: If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.
-  - `false`: Connect to Databricks endpoint without TLS
 
 ### Auth
 

--- a/spiceaidocs/docs/data-connectors/databricks.md
+++ b/spiceaidocs/docs/data-connectors/databricks.md
@@ -24,7 +24,6 @@ Databricks as a connector for federated SQL query against Databricks using [Spar
   - `deltalake`: Query Delta Tables.
 - `databricks-cluster-id`: The ID of the compute cluster in Databricks to use for the query. Only valid when `mode` is `spark_connect`.
 - `databricks_use_ssl`: If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.
-  - `true`: Connect to Databricks endpoint with TLS
   - `false`: Connect to Databricks endpoint without TLS
 
 ### Auth

--- a/spiceaidocs/docs/data-connectors/databricks.md
+++ b/spiceaidocs/docs/data-connectors/databricks.md
@@ -12,9 +12,10 @@ Databricks as a connector for federated SQL query against Databricks using [Spar
 
 ## Configuration
 
-`spice login databricks` can be used to configure the Databricks access token for the Spice runtime. 
+`spice login databricks` can be used to configure the Databricks access token for the Spice runtime.
 
 ### Parameters
+
 - `endpoint`: The endpoint of the Databricks instance.
 - `mode`: The execution mode for querying against Databricks. The default is `spark_connect`. Possible values:
   - `spark_connect`: Use Spark Connect to query against Databricks.
@@ -22,6 +23,9 @@ Databricks as a connector for federated SQL query against Databricks using [Spar
 - `format`: The format of the data to query. The default is `deltalake`. Only valid when `mode` is `s3`. Possible values:
   - `deltalake`: Query Delta Tables.
 - `databricks-cluster-id`: The ID of the compute cluster in Databricks to use for the query. Only valid when `mode` is `spark_connect`.
+- `databricks_use_ssl`: The ssl configuration for the transport channel against Databricks. The default is `true`. Possible values:
+  - `true`: Connect to Databricks endpoint with TLS
+  - `false`: Connect to Databricks endpoint without TLS
 
 ### Auth
 
@@ -38,6 +42,7 @@ Check [Secrets Stores](/secret-stores) for more details.
     ```
 
     Learn more about [File Secret Store](/secret-stores/file).
+
   </TabItem>
   <TabItem value="env" label="Env">
     ```bash
@@ -53,11 +58,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: env
-    
+
     # <...>
     ```
 
     Learn more about [Env Secret Store](/secret-stores/env).
+
   </TabItem>
   <TabItem value="k8s" label="Kubernetes">
     ```bash
@@ -73,11 +79,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: kubernetes
-    
+
     # <...>
     ```
 
     Learn more about [Kubernetes Secret Store](/secret-stores/kubernetes).
+
   </TabItem>
   <TabItem value="keyring" label="Keyring">
     Add new keychain entry (macOS), with user and password in JSON string
@@ -96,11 +103,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: keyring
-    
+
     # <...>
     ```
 
     Learn more about [Keyring Secret Store](/secret-stores/keyring).
+
   </TabItem>
 </Tabs>
 

--- a/spiceaidocs/docs/data-connectors/databricks.md
+++ b/spiceaidocs/docs/data-connectors/databricks.md
@@ -23,7 +23,7 @@ Databricks as a connector for federated SQL query against Databricks using [Spar
 - `format`: The format of the data to query. The default is `deltalake`. Only valid when `mode` is `s3`. Possible values:
   - `deltalake`: Query Delta Tables.
 - `databricks-cluster-id`: The ID of the compute cluster in Databricks to use for the query. Only valid when `mode` is `spark_connect`.
-- `databricks_use_ssl`: The ssl configuration for the transport channel against Databricks. The default is `true`. Possible values:
+- `databricks_use_ssl`: If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.
   - `true`: Connect to Databricks endpoint with TLS
   - `false`: Connect to Databricks endpoint without TLS
 

--- a/spiceaidocs/docs/data-connectors/spark.md
+++ b/spiceaidocs/docs/data-connectors/spark.md
@@ -14,9 +14,9 @@ Apache Spark as a connector for federated SQL query against a Spark Cluster usin
 
 The Apache Spark Connector can be used in two ways: specifying a plaintext connection string using the `spark_remote` parameter or specifying a `spark_remote` secret. The connector will fail if both configurations are set.
 
-
 ### Parameters
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI
+
+- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
 
 ### Auth
 
@@ -31,6 +31,7 @@ Check [Secrets Stores](/secret-stores) for more details.
     ```
 
     Learn more about [File Secret Store](/secret-stores/file).
+
   </TabItem>
   <TabItem value="env" label="Env">
     ```bash
@@ -46,11 +47,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: env
-    
+
     # <...>
     ```
 
     Learn more about [Env Secret Store](/secret-stores/env).
+
   </TabItem>
   <TabItem value="k8s" label="Kubernetes">
     ```bash
@@ -66,11 +68,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: kubernetes
-    
+
     # <...>
     ```
 
     Learn more about [Kubernetes Secret Store](/secret-stores/kubernetes).
+
   </TabItem>
   <TabItem value="keyring" label="Keyring">
     Add new keychain entry (macOS), with user and password in JSON string
@@ -89,11 +92,12 @@ Check [Secrets Stores](/secret-stores) for more details.
 
     secrets:
       store: keyring
-    
+
     # <...>
     ```
 
     Learn more about [Keyring Secret Store](/secret-stores/keyring).
+
   </TabItem>
 </Tabs>
 
@@ -105,5 +109,4 @@ datasets:
     name: my_table
     params:
       spark_remote: sc://localhost
-    
 ```


### PR DESCRIPTION
- [x] Don't merge this before [Update Databricks to specify use_ssl = true in connection string #1406](https://github.com/spiceai/spiceai/pull/1406) is merged

* Add docs on databricks_use_ssl in Databricks data connector doc
* Add reference to spark connect client connection string doc in Spark data connector doc, which has details about use_ssl parameter in Spark