### PR TITLE
Document Spice in-memory LRU caching

### DIFF
--- a/spiceaidocs/docs/features/caching/index.md
+++ b/spiceaidocs/docs/features/caching/index.md
@@ -7,7 +7,7 @@ pagination_prev: null
 pagination_next: null
 ---
 
-Spice supports in-memory LRU caching of query results, which can be enabled as follows. This can be used to prevent many redundant queries within a small time period and improve overall performance.
+Spice supports in-memory LRU caching of query results.  This can improve performance for redundant queries over a small period of time.
 
 ```yaml
 version: v1beta1

--- a/spiceaidocs/docs/features/caching/index.md
+++ b/spiceaidocs/docs/features/caching/index.md
@@ -26,5 +26,5 @@ runtime:
 - `item_expire` - optional, cache entry expiration time, 1 second by default.
 
 :::warning[Limitations]
-- Caching of Arrow Flight queries is not currently supported (coming soon).
+- Results caching for Arrow Flight queries is not currently supported (coming soon).
 :::

--- a/spiceaidocs/docs/features/caching/index.md
+++ b/spiceaidocs/docs/features/caching/index.md
@@ -1,0 +1,30 @@
+---
+title: 'Results Caching'
+sidebar_label: 'Results Caching'
+description: 'Learn how to use Spice in-memory caching of query results'
+sidebar_position: 5
+pagination_prev: null
+pagination_next: null
+---
+
+Spice supports in-memory LRU caching of query results, which can be enabled as follows. This can be used to prevent many redundant queries within a small time period and improve overall performance.
+
+```yaml
+version: v1beta1
+kind: Spicepod
+name: app
+
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 128mb
+    item_expire: 1s
+```
+
+- `enabled` - optional, `true` by default (if there is a non-empty `results_cache` section defined)
+- `cache_max_size` - optional, maximum cache size. Default is `128MB`
+- `item_expire` - optional, cache entry expiration time, 1 second by default.
+
+:::warning[Limitations]
+- Caching of Arrow Flight queries is not currently supported (coming soon).
+:::

--- a/spiceaidocs/docs/features/caching/index.md
+++ b/spiceaidocs/docs/features/caching/index.md
@@ -7,7 +7,11 @@ pagination_prev: null
 pagination_next: null
 ---
 
-Spice supports in-memory LRU caching of query results.  This can improve performance for redundant queries over a small period of time.
+Spice supports in-memory caching of query results.
+
+Results caching can help improve performance for bursts of requests and for non-accelerated results such as refresh data returned [on zero results](/data-accelerators/data-refresh.md#behavior-on-zero-results).
+
+Results caching employs a [least-recently-used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#LRU) cache replacement policy with the ability to specific an item expiry duration which defaults to 1-second.
 
 ```yaml
 version: v1beta1

--- a/spiceaidocs/docs/reference/spicepod/index.md
+++ b/spiceaidocs/docs/reference/spicepod/index.md
@@ -43,6 +43,24 @@ secrets:
   store: env
 ```
 
+## `runtime` 
+
+### `results_cache`
+
+The results cache section specifies runtime cache configuration. [Learn more](/features/caching).
+
+```yaml
+runtime:
+  results_cache:
+    enabled: true
+    cache_max_size: 128mb
+    item_expire: 1s
+```
+
+- `enabled` - optional, `true` by default (if there is a non-empty `results_cache` section defined)
+- `cache_max_size` - optional, maximum cache size. Default is `128MB`
+- `item_expire` - optional, cache entry expiration time, 1 second by default.
+
 ## `metadata`
 
 An optional `map` of metadata.


### PR DESCRIPTION
Document Spice in-memory LRU caching

<img width="892" alt="image" src="https://github.com/spiceai/docs/assets/981580/74d4a039-74fb-4b5f-9231-583d87f0d189">

YAML section

<img width="741" alt="image" src="https://github.com/spiceai/docs/assets/981580/7c5edeaa-5d7c-4091-9dcb-0145ae141e7c">
