### PR TITLE
Spark: add port number to example configuration

### DIFF
--- a/spiceaidocs/docs/data-connectors/spark.md
+++ b/spiceaidocs/docs/data-connectors/spark.md
@@ -108,5 +108,5 @@ datasets:
   - from: spark:spiceai.datasets.my_awesome_table
     name: my_table
     params:
-      spark_remote: sc://localhost
+      spark_remote: sc://localhost:15002
 ```


### PR DESCRIPTION
Spark requires spark_remote to have port number, otherwise it crashes: https://github.com/spiceai/spiceai/issues/1469

Updating example so it does not crash