### PR TITLE
Update `file_format` docs

### DIFF
--- a/spiceaidocs/docs/data-connectors/ftp.md
+++ b/spiceaidocs/docs/data-connectors/ftp.md
@@ -19,7 +19,7 @@ If a folder is provided, all child Parquet/CSV files will be loaded.
 
     The connection to FTP can be configured by providing the following params:
 
-    - `file_format`: Specifies the requested file format. Required if `from` is a folder path or doesn't have a file extension.
+    - `file_format`: Specifies the data file format. Required if the format cannot be inferred by from the `from` path.
       - `parquet`: Parquet file format.
       - `csv`: CSV file format.
     - `ftp_port`: Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`

--- a/spiceaidocs/docs/data-connectors/ftp.md
+++ b/spiceaidocs/docs/data-connectors/ftp.md
@@ -19,8 +19,8 @@ If a folder is provided, all child Parquet/CSV files will be loaded.
 
     The connection to FTP can be configured by providing the following params:
 
-    - `file_format`: Optional, specifies the requested file format.
-      - `parquet`: (default) Parquet file format.
+    - `file_format`: Specifies the requested file format. Required if `from` is a folder path or doesn't have a file extension.
+      - `parquet`: Parquet file format.
       - `csv`: CSV file format.
     - `ftp_port`: Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`
     - `ftp_user`: The username for the FTP server. E.g. `ftp_user: my-ftp-user`
@@ -59,6 +59,7 @@ If a folder is provided, all child Parquet/CSV files will be loaded.
       - from: sftp://remote-sftp-server.com/path/to/folder/
         name: my_dataset
         params:
+          file_format: csv
           sftp_port: 20
           sftp_user: my-sftp-user
           sftp_pass_key: my-sftp-password

--- a/spiceaidocs/docs/data-connectors/s3.md
+++ b/spiceaidocs/docs/data-connectors/s3.md
@@ -27,8 +27,11 @@ The dataset name.
 
 Example: `name: cool_dataset`
 
-### `params` (optional)
+### `params`
 
+- `file_format`: Specifies the requested file format. Required if `from` is a folder path or doesn't have a file extension.
+  - `parquet`: Parquet file format.
+  - `csv`: CSV file format.
 - `endpoint`: The S3 endpoint, or equivalent (e.g. MinIO endpoint), for the S3-compatible storage. Defaults to region endpoint. E.g. `endpoint: https://my.minio.server`
 - `region`: Region of the S3 bucket, if region specific. Default value is `us-east-1`  E.g. `region: us-east-1`
 - `timeout`: Specifies timeout for S3 operations. Default value is `30s` E.g. `timeout: 60s`
@@ -158,6 +161,8 @@ Create a dataset named `taxi_trips` from a public S3 folder.
 ```yaml
 - from: s3://spiceai-demo-datasets/taxi_trips/2024/
   name: taxi_trips
+  params:
+    file_format: parquet
 ```
 
 :::warning[Limitations]

--- a/spiceaidocs/docs/data-connectors/s3.md
+++ b/spiceaidocs/docs/data-connectors/s3.md
@@ -29,7 +29,7 @@ Example: `name: cool_dataset`
 
 ### `params`
 
-- `file_format`: Specifies the requested file format. Required if `from` is a folder path or doesn't have a file extension.
+- `file_format`: Specifies the data file format. Required if the format cannot be inferred by from the `from` path.
   - `parquet`: Parquet file format.
   - `csv`: CSV file format.
 - `endpoint`: The S3 endpoint, or equivalent (e.g. MinIO endpoint), for the S3-compatible storage. Defaults to region endpoint. E.g. `endpoint: https://my.minio.server`

--- a/spiceaidocs/docs/deployment/kubernetes/index.md
+++ b/spiceaidocs/docs/deployment/kubernetes/index.md
@@ -38,6 +38,8 @@ spicepod:
     - from: s3://spiceai-demo-datasets/taxi_trips/2024/
       name: taxi_trips
       description: Demo taxi trips in s3
+      params:
+        file_format: parquet
       acceleration:
         enabled: true
 ```
@@ -121,6 +123,8 @@ spicepod:
     - from: s3://spiceai-demo-datasets/taxi_trips/2024/
       name: taxi_trips
       description: Demo taxi trips in s3
+      params:
+        file_format: parquet
       acceleration:
         enabled: true
         # Uncomment to refresh the acceleration on a schedule


### PR DESCRIPTION
Update `file_format` param docs for csv and s3. Add in spicepod examples where it is required.