### PR TITLE
Document accelerated tables refresh retry

### DIFF
--- a/spiceaidocs/docs/data-accelerators/data-refresh.md
+++ b/spiceaidocs/docs/data-accelerators/data-refresh.md
@@ -188,3 +188,29 @@ date: Thu, 11 Apr 2024 20:11:18 GMT
 A retention policy automatically removes data from accelerated datasets with a temporal column that exceeds the defined retention period, optimizing resource utilization.
 
 The policy is set using the [`acceleration.retention_check_enabled`](/reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](/reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](/reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](/reference/spicepod/datasets#time_column) and [`time_format`](/reference/spicepod/datasets#time_format) dataset parameters.
+
+## Refresh Retries
+
+By default, accelerated datasets attempt to retry data refreshes on transient errors (connectivity issues, compute warehouse goes idle, etc.) using [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_sequence) backoff strategy. This behavior can be adjusted with the [`acceleration.refresh_retry_enabled`](/reference/spicepod/datasets#accelerationrefresh_retry_enabled) and [`acceleration.rrefresh_retry_max_attempts`](/reference/spicepod/datasets#accelerationrefresh_retry_max_attempts) parameters.
+
+Example: Disable rertries
+
+```yaml
+datasets:
+  - from: spice.ai/eth.recent_blocks
+    name: eth_recent_blocks
+    acceleration:
+      refresh_retry_enabled: false
+      refresh_check_interval: 30s
+```
+
+Example: Limit retries to a maximum of 10 attempts
+
+```yaml
+datasets:
+  - from: spice.ai/eth.recent_blocks
+    name: eth_recent_blocks
+    acceleration:
+      refresh_retry_max_attempts: 10
+      refresh_check_interval: 30s
+```

--- a/spiceaidocs/docs/reference/spicepod/datasets.md
+++ b/spiceaidocs/docs/reference/spicepod/datasets.md
@@ -183,6 +183,16 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration/index.md)
 
+## `acceleration.refresh_retry_enabled`
+
+Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.
+
+Retries utilize a [Fibonacci backoff strategy](https://en.wikipedia.org/wiki/Fibonacci_sequence). To disable refresh retries, set `refresh_retry_enabled: false`.
+
+## `acceleration.refresh_retry_max_attempts`
+
+Optional. Defines the maximum number of retry attempts when refresh retries are enabled. The default is undefined, allowing for unlimited attempts.
+
 ## `acceleration.params`
 
 Optional. Parameters to pass to the acceleration engine. The parameters are specific to the acceleration engine used.


### PR DESCRIPTION
Document refresh retry behavior and `refresh_retry_enabled`/`refresh_retry_max_attempts` params.

‼️Should be merged only if we merge/include ⁠[Enable retries for accelerated table refresh](https://github.com/spiceai/spiceai/pull/1762/) to 0.14.1-alpha release.

<img width="883" alt="image" src="https://github.com/spiceai/docs/assets/981580/c9b4672c-8948-4652-a740-06f8a3c3dda1">
