### PR TITLE
Clarify behavior on in-flight refresh when on-demand refresh triggered

### DIFF
--- a/spiceaidocs/docs/data-accelerators/data-refresh.md
+++ b/spiceaidocs/docs/data-accelerators/data-refresh.md
@@ -193,6 +193,10 @@ date: Thu, 11 Apr 2024 20:11:18 GMT
 {"message":"Dataset refresh triggered for eth_recent_blocks."}
 ```
 
+:::warning[Note]
+On-demand refresh always initiates a new refresh, terminating any in-progress refresh for the dataset.
+:::
+
 ## Refresh Retries
 
 By default, accelerated datasets attempt to retry data refreshes on transient errors (connectivity issues, compute warehouse goes idle, etc.) using [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_sequence) backoff strategy. This behavior can be adjusted with the [`acceleration.refresh_retry_enabled`](/reference/spicepod/datasets#accelerationrefresh_retry_enabled) and [`acceleration.rrefresh_retry_max_attempts`](/reference/spicepod/datasets#accelerationrefresh_retry_max_attempts) parameters.

--- a/spiceaidocs/docs/data-accelerators/data-refresh.md
+++ b/spiceaidocs/docs/data-accelerators/data-refresh.md
@@ -193,12 +193,6 @@ date: Thu, 11 Apr 2024 20:11:18 GMT
 {"message":"Dataset refresh triggered for eth_recent_blocks."}
 ```
 
-## Retention Policy
-
-A retention policy automatically removes data from accelerated datasets with a temporal column that exceeds the defined retention period, optimizing resource utilization.
-
-The policy is set using the [`acceleration.retention_check_enabled`](/reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](/reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](/reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](/reference/spicepod/datasets#time_column) and [`time_format`](/reference/spicepod/datasets#time_format) dataset parameters.
-
 ## Refresh Retries
 
 By default, accelerated datasets attempt to retry data refreshes on transient errors (connectivity issues, compute warehouse goes idle, etc.) using [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_sequence) backoff strategy. This behavior can be adjusted with the [`acceleration.refresh_retry_enabled`](/reference/spicepod/datasets#accelerationrefresh_retry_enabled) and [`acceleration.rrefresh_retry_max_attempts`](/reference/spicepod/datasets#accelerationrefresh_retry_max_attempts) parameters.
@@ -224,3 +218,9 @@ datasets:
       refresh_retry_max_attempts: 10
       refresh_check_interval: 30s
 ```
+
+## Retention Policy
+
+A retention policy automatically removes data from accelerated datasets with a temporal column that exceeds the defined retention period, optimizing resource utilization.
+
+The policy is set using the [`acceleration.retention_check_enabled`](/reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](/reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](/reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](/reference/spicepod/datasets#time_column) and [`time_format`](/reference/spicepod/datasets#time_format) dataset parameters.


### PR DESCRIPTION
1. Clarify behavior on in-flight refresh when on-demand refresh triggered
2. Move Refresh Retries section so it goes after `Refresh On-Demand`