### PR TITLE
docs: Add info on duplicate column handling for GraphQL unnesting

### DIFF
--- a/spiceaidocs/docs/data-connectors/graphql.md
+++ b/spiceaidocs/docs/data-connectors/graphql.md
@@ -280,16 +280,21 @@ params:
     query {
       users {
         name
-        metadata {
-          name: email
+        emergency_contact {
+          name
         }
       }
     }
 ```
 
-To avoid this error, you should use [use aliases in your query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, we used an alias to induce the duplicate error in our query with `name: email`.
+This example would fail with a runtime error:
+```bash
+WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+```
 
-The example below is more complex where a query returns a person, their name, and their starships' name. We've used an alias to rename `starship.name` to `starshipName` when unnesting, to avoid the duplicate column error:
+Avoid, this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.
+
+The example below is more complex where a query returns a person, their name, and their starships' name. An alias is used to rename `starship.name` to `starshipName` when unnesting, to avoid the duplicate column error:
 ```yaml
 from: graphql:https://localhost
 name: stargazers

--- a/spiceaidocs/docs/data-connectors/graphql.md
+++ b/spiceaidocs/docs/data-connectors/graphql.md
@@ -294,7 +294,7 @@ WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name'
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.
 
-The example below is more complex where a query returns a person, their name, and their starships' name. An alias is used to rename `starship.name` to `starshipName` when unnesting, to avoid the duplicate column error:
+The example below uses a GraphQL alias to rename `emergency_contact.name` as `emergencyContactName`.
 ```yaml
 from: graphql:https://localhost
 name: stargazers
@@ -303,10 +303,10 @@ params:
   json_path: data.people
   query: |
     query {
-      people {
+      users {
         name
-        starship {
-          starshipName: name
+        emergency_contact {
+          emergencyContactName: name
         }
       }
     }

--- a/spiceaidocs/docs/data-connectors/graphql.md
+++ b/spiceaidocs/docs/data-connectors/graphql.md
@@ -289,41 +289,6 @@ params:
 
 The handling behavior of duplicate columns can be adjusted with the `unnest_duplicate_columns` parameter. If not specified, the value defaults to `error`.
 
-##### Renaming Duplicate Columns
-
-To retain all instances of duplicates, set the `unnest_duplicate_columns` parameter to `rename`.
-In this mode, unnesting will append a numeric counter to duplicate columns for the number of times the column has been seen.
-The counter is appended based on the order the keys are visited.
-
-Take the same example `spicepod.yml` query that would previously error, but with `rename` mode:
-```yaml
-from: graphql:https://localhost
-name: stargazers
-params:
-  unnest_depth: 2
-  unnest_duplicate_columns: rename
-  json_path: data.users
-  query: |
-    query {
-      users {
-        name
-        metadata {
-          name: email
-        }
-      }
-    }
-```
-
-An example query response in this mode would look like:
-```bash
-sql> select name_1, name_2 from users limit 1;
-+--------------+-------------------+
-| name_1       | name_2            |
-+--------------+-------------------+
-| example name | example@localhost |
-+--------------+-------------------+
-```
-
 ##### Overwriting Duplicate Columns
 
 To overwrite instances of duplicates, set the `unnest_duplicate_columns` parameter to `overwrite`.

--- a/spiceaidocs/docs/data-connectors/graphql.md
+++ b/spiceaidocs/docs/data-connectors/graphql.md
@@ -292,7 +292,7 @@ This example would fail with a runtime error:
 WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
 ```
 
-Avoid, this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.
+Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.
 
 The example below is more complex where a query returns a person, their name, and their starships' name. An alias is used to rename `starship.name` to `starshipName` when unnesting, to avoid the duplicate column error:
 ```yaml

--- a/spiceaidocs/docs/data-connectors/graphql.md
+++ b/spiceaidocs/docs/data-connectors/graphql.md
@@ -267,7 +267,7 @@ sql> select node from stargazers limit 1;
 
 #### Unnesting Duplicate Columns
 
-By default, if no `unnest_duplicate_columns` parameter is specified the Spice Runtime will error when a duplicate column is detected during unnesting.
+By default, the Spice Runtime will error when a duplicate column is detected during unnesting.
 
 For example, this example `spicepod.yml` query would fail due to `name` fields:
 ```yaml
@@ -287,38 +287,22 @@ params:
     }
 ```
 
-The handling behavior of duplicate columns can be adjusted with the `unnest_duplicate_columns` parameter. If not specified, the value defaults to `error`.
+To avoid this error, you should use [use aliases in your query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, we used an alias to induce the duplicate error in our query with `name: email`.
 
-##### Overwriting Duplicate Columns
-
-To overwrite instances of duplicates, set the `unnest_duplicate_columns` parameter to `overwrite`.
-In this mode, unnesting will overwrite the duplicate column with the latest seen column of the same key.
-
-Take the same example `spicepod.yml` query, but with `overwrite` mode:
+The example below is more complex where a query returns a person, their name, and their starships' name. We've used an alias to rename `starship.name` to `starshipName` when unnesting, to avoid the duplicate column error:
 ```yaml
 from: graphql:https://localhost
 name: stargazers
 params:
   unnest_depth: 2
-  unnest_duplicate_columns: overwrite
-  json_path: data.users
+  json_path: data.people
   query: |
     query {
-      users {
+      people {
         name
-        metadata {
-          name: email
+        starship {
+          starshipName: name
         }
       }
     }
-```
-
-An example query response in this mode would look like:
-```bash
-sql> select name from users limit 1;
-+-------------------+
-| name              |
-+-------------------+
-| example@localhost |
-+-------------------+
 ```


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds docs for the error behavior of duplicate columns in GraphQL unnesting, and adds an example for aliasing to workaround duplicates.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of [#1802](https://github.com/spiceai/spiceai/issues/1802)