### PR TITLE
Update datasets.md with more details on the behavior of refresh_check…

### DIFF
--- a/spiceaidocs/docs/reference/spicepod/datasets.md
+++ b/spiceaidocs/docs/reference/spicepod/datasets.md
@@ -180,7 +180,7 @@ Optional. How to refresh the dataset. The following values are supported:
 
 ## `acceleration.refresh_check_interval`
 
-Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not included, the accelerator will not refresh after it initially loads data.
+Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not defined, the accelerator will not refresh after it initially loads data.
 
 See [Duration](../duration/index.md)
 

--- a/spiceaidocs/docs/reference/spicepod/datasets.md
+++ b/spiceaidocs/docs/reference/spicepod/datasets.md
@@ -180,7 +180,7 @@ Optional. How to refresh the dataset. The following values are supported:
 
 ## `acceleration.refresh_check_interval`
 
-Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used.
+Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not included, the accelerator will not refresh after it initially loads data.
 
 See [Duration](../duration/index.md)
 


### PR DESCRIPTION
…_interval when its not provided.

## 🗣 Description

Documentation update on refresh_check_interval. When not provided, the accelerator never refreshes.  This is by design.  

