### PR TITLE
docs: Add info card for ODBC JoinPushDown behavior

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/odbc.md
+++ b/spiceaidocs/docs/components/data-connectors/odbc.md
@@ -18,9 +18,7 @@ datasets:
 
 :::info
 
-The Spice Runtime combines queries with `JOIN`s to multiple ODBC datasets that share the same `odbc_connection_string`. This allows the runtime to execute queries with multiple joins directly on the ODBC connection, instead of performing a full table scan and joining on the local runtime client.
-
-To take advantage of this, ensure the ODBC connection string is the same for the same datbase/connection.
+For the best `JOIN` performance, ensure all ODBC datasets from the same database are configured with the exact same `odbc_connection_string` in Spice.
 
 :::
 

--- a/spiceaidocs/docs/components/data-connectors/odbc.md
+++ b/spiceaidocs/docs/components/data-connectors/odbc.md
@@ -16,6 +16,14 @@ datasets:
       odbc_connection_string: Driver={Foo Driver};Host=db.foo.net;Param=Value
 ```
 
+:::info
+
+The Spice Runtime combines queries with `JOIN`s to multiple ODBC datasets that share the same `odbc_connection_string`. This allows the runtime to execute queries with multiple joins directly on the ODBC connection, instead of performing a full table scan and joining on the local runtime client.
+
+To take advantage of this, ensure the ODBC connection string is the same for the same datbase/connection.
+
+:::
+
 ## Configuration
 
 In addition to the connection string, the following [arrow_odbc builder parameters](https://docs.rs/arrow-odbc/latest/arrow_odbc/struct.OdbcReaderBuilder.html) are exposed as params:


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds an info card about the behavior of `JoinPushDown` with ODBC connections that share the same connection string.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Part of [https://github.com/spiceai/spiceai/issues/1931](https://github.com/spiceai/spiceai/issues/1931)
