### PR TITLE
Update banner to v0.15.2-alpha and fix `spiceai` selector

### DIFF
--- a/spiceaidocs/docs/api/http/catalogs.md
+++ b/spiceaidocs/docs/api/http/catalogs.md
@@ -19,7 +19,7 @@ Response:
 ```json
 [
   {
-    "from": "spice.ai",
+    "from": "spiceai",
     "name": "spiceai"
   }
 ]

--- a/spiceaidocs/docs/cli/reference/catalogs.md
+++ b/spiceaidocs/docs/cli/reference/catalogs.md
@@ -19,5 +19,5 @@ spice catalogs
 >>> spice catalogs
 
 FROM    NAME     
-spice.ai spiceai 
+spiceai spiceai 
 ```

--- a/spiceaidocs/docs/components/catalogs/index.md
+++ b/spiceaidocs/docs/components/catalogs/index.md
@@ -21,7 +21,7 @@ Currently supported Catalog Connectors include:
 | --------------- | ----------- | ------ | ----------------------------------- |
 | `databricks`    | Databricks  | Alpha  | Spark Connect <br/> S3 / Delta Lake | 
 | `unity_catalog`    | Unity Catalog  | Alpha  | Delta Lake                          | 
-| `spice.ai`       | Spice.ai Cloud Platform    | Alpha  | Arrow Flight                        |
+| `spiceai`       | Spice.ai Cloud Platform    | Alpha  | Arrow Flight                        |
 
 ## Catalog Connector Docs
 
@@ -33,7 +33,7 @@ Use the `include` field to specify which tables to include from the catalog. The
 Example:
 ```yaml
 catalogs:
-  - from: spice.ai
+  - from: spiceai
     name: spiceai
     include:
       - "tpch.*" # Include only the "tpch" tables.

--- a/spiceaidocs/docs/components/catalogs/spiceai.md
+++ b/spiceaidocs/docs/components/catalogs/spiceai.md
@@ -16,7 +16,7 @@ Create a [Spice.ai Cloud Platform](https://spice.ai) account and login with the 
 Example:
 ```yaml
 catalogs:
-  - from: spice.ai
+  - from: spiceai
     name: spicey # tables from the Spice.ai platform will be available in the "spicey" schema in Spice
     include:
       - "tpch.*" # include only the tables from the "tpch" schema

--- a/spiceaidocs/docusaurus.config.ts
+++ b/spiceaidocs/docusaurus.config.ts
@@ -57,7 +57,7 @@ const config: Config = {
     // image: 'img/docusaurus-social-card.jpg',
     announcementBar: {
       content:
-        '<a href="https://github.com/spiceai/spiceai/releases/tag/v0.15.1-alpha">Spice.ai OSS v0.15.1-alpha</a> is now available! 🚀',
+        '<a href="https://github.com/spiceai/spiceai/releases/tag/v0.15.2-alpha">Spice.ai OSS v0.15.2-alpha</a> is now available! 🚀',
       backgroundColor: 'var(--announcement-bar-bg)',
       textColor: 'var(--announcement-bar-text)',
       isCloseable: true,


### PR DESCRIPTION
## 🗣 Description

Updates the banner to v0.15.2-alpha for the recent release.

Fixes the `spiceai` selector for the catalog connector to match the data connector.
