### PR TITLE
Update postgres index.md - "required" sslmode should be "require"

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/components/data-connectors/postgres/index.md
@@ -27,7 +27,7 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_sslmode`: Optional parameter, specifies the SSL/TLS behavior for the connection, supported values:
   - `verify-full`: (default) This mode requires an SSL connection, a valid root certificate, and the server host name to match the one specified in the certificate.
   - `verify-ca`: This mode requires an SSL connection and a valid root certificate.
-  - `required`: This mode requires an SSL connection.
+  - `require`: This mode requires an SSL connection.
   - `prefer`: This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
   - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.


### PR DESCRIPTION

## 🗣 Description
Docs say sslmode "required" is valid but its "require"

Verify here:
https://www.postgresql.org/docs/current/libpq-ssl.html

and verified in the datafusion table provider:
https://github.com/datafusion-contrib/datafusion-table-providers/blob/02081887de7b64dfd816ef86716f8b0853ae3196/src/sql/db_connection_pool/postgrespool.rs#L118

