### PR TITLE
Update graphql docs with change from json_path to json_pointer

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/graphql.md
+++ b/spiceaidocs/docs/components/data-connectors/graphql.md
@@ -57,9 +57,11 @@ query: |
   }
 ```
 
-- `json_pointer`: The pointer to the JSON data in the response. E.g. `json_pointer: /data/some/nodes`
+- `json_pointer`: The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) pointing to the JSON data in the response.
 
-Example using GitHub GraphQL API using Bearer Auth:
+### Examples
+
+Example using the GitHub GraphQL API and Bearer Auth.  The following will use `json_pointer` to retrieve all of the nodes in starredRepositories:
 
 ```yaml
 from: graphql:https://api.github.com/graphql
@@ -67,6 +69,33 @@ name: stars
 params:
   auth_token: [github_token]
   json_pointer: /data/viewer/starredRepositories/nodes
+  query: |
+    {
+      viewer {
+        starredRepositories {
+          nodes {
+            name
+            stargazerCount
+            languages (first: 10) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+
+```
+
+ To get access to a specific node in starredRepositories, use the index in the `json_pointer`:
+
+```yaml
+from: graphql:https://api.github.com/graphql
+name: stars
+params:
+  auth_token: [github_token]
+  json_pointer: /data/viewer/starredRepositories/nodes/0
   query: |
     {
       viewer {

--- a/spiceaidocs/docs/components/data-connectors/graphql.md
+++ b/spiceaidocs/docs/components/data-connectors/graphql.md
@@ -28,7 +28,6 @@ datasets:
 
 - The GraphQL data connector does not support variables in the query.
 - Filter pushdown is not currently supported; however, when using the limit, the connector will request only the necessary data.
-- Acceleration of response nested data only works with `arrow` engine. Support for other engines is in progress.
 
 :::
 
@@ -58,7 +57,7 @@ query: |
   }
 ```
 
-- `json_pointer`: The path to the JSON data in the response. E.g. `json_pointer: /data/some/nodes`
+- `json_pointer`: The pointer to the JSON data in the response. E.g. `json_pointer: /data/some/nodes`
 
 Example using GitHub GraphQL API using Bearer Auth:
 


### PR DESCRIPTION
## 🗣 Description

The json_path parameter in the GraphQL was really a json_pointer.  The parameter name was changed to json_pointer and the logic was updated to follow the format of a json_pointer.  This is the documentation update that goes with it.

Also updated the doc to follow markdown best practices. 

Also fixes: #301 

## 🔨 Related Issues
https://github.com/spiceai/spiceai/pull/1930

