### PR TITLE
Improve markdown quality by following best practices

### DIFF
--- a/spiceaidocs/docs/api/arrow-flight-sql/index.md
+++ b/spiceaidocs/docs/api/arrow-flight-sql/index.md
@@ -9,4 +9,4 @@ description: 'Query Spice using JDBC/ODBC/ADBC'
 
 Spice implements the Flight SQL protocol which enables querying the datasets configured in Spice via tools that support connecting via one of the Arrow Flight SQL drivers, such as [DBeaver](https://dbeaver.io), [Tableau](https://www.tableau.com/), or [Power BI](https://www.microsoft.com/en-us/power-platform/products/power-bi).
 
-<img src="https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/0a8bc474-03c3-4c1c-8003-d250cd52b300/public" />
+<img src="https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/0a8bc474-03c3-4c1c-8003-d250cd52b300/public" alt="arrow flight and spice" />

--- a/spiceaidocs/docs/cli/reference/add.md
+++ b/spiceaidocs/docs/cli/reference/add.md
@@ -7,15 +7,18 @@ pagination_next: null
 
 Add Spicepod - adds a Spicepod to the project
 
-### Usage:
+### Usage
+
 ```shell
 spice add [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+#### Flags
 
-### Examples:
+- `-h`, `--help`   Print this help message
+
+### Examples
+
 ```shell
 spice add spiceai/quickstart
 ```

--- a/spiceaidocs/docs/cli/reference/completion.md
+++ b/spiceaidocs/docs/cli/reference/completion.md
@@ -8,16 +8,20 @@ pagination_next: null
 Generate the autocompletion script for spice for the specified shell.
 See each sub-command's help for details on how to use the generated script.
 
-### Usage:
+### Usage
+
 ```shell
 spice completion [command]
 ```
-Available `command`s
-  - bash
-  - fish
-  - powershell
-  - zsh
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+Available `command`s
+
+- bash
+- fish
+- powershell
+- zsh
+
+#### Flags
+
+- `-h`, `--help`   Print this help message
   

--- a/spiceaidocs/docs/cli/reference/dataset.md
+++ b/spiceaidocs/docs/cli/reference/dataset.md
@@ -7,13 +7,16 @@ pagination_next: null
 
 Dataset operations
 
-### Usage:
+### Usage
+
 ```shell
 spice dataset [command]
 ```
 
 Available `command`s:
-  - `configure`:    Configure a dataset
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+- `configure`:    Configure a dataset
+
+#### Flags
+
+- `-h`, `--help`   Print this help message

--- a/spiceaidocs/docs/cli/reference/datasets.md
+++ b/spiceaidocs/docs/cli/reference/datasets.md
@@ -7,15 +7,18 @@ pagination_next: null
 
 Lists datasets loaded by the Spice runtime
 
-### Usage:
+### Usage
+
 ```shell
 spice datasets [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   help for datasets
+#### Flags
+
+- `-h`, `--help`   help for datasets
 
 ### Examples:
+
 ```shell
 >>> spice datasets
 

--- a/spiceaidocs/docs/cli/reference/index.md
+++ b/spiceaidocs/docs/cli/reference/index.md
@@ -5,15 +5,15 @@ description: "Spice CLI command reference"
 pagination_next: null
 ---
 
-# spice
+## spice
 
-## Usage
+### Usage
 
 ```bash
 spice [command] [--help]
 ```
 
-## Full Command Reference
+### Full Command Reference
 
 | Command                                            | Description                                                         |
 | -------------------------------------------------- | --------------------------------------------------------------------|
@@ -34,7 +34,7 @@ spice [command] [--help]
 | [upgrade](/cli/reference/upgrade)       | Upgrades the Spice CLI to the latest release                        |
 | [version](/cli/reference/version)       | Spice CLI version                                                   |
 
-## Command Flags
+### Command Flags
 
 All commands have a help flag **--help** or **-h** to print its usage documentation:
 

--- a/spiceaidocs/docs/cli/reference/init.md
+++ b/spiceaidocs/docs/cli/reference/init.md
@@ -6,18 +6,20 @@ pagination_next: null
 ---
 Initialize Spice app - initializes a new Spice app
 
-### Usage:
+### Usage
+
 ```shell
 spice init [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+#### Flags
+
+- `-h`, `--help`   Print this help message
 
 ### Examples:
+
 ```shell 
 spice init
 spice init <spice app name>
 spice init my_app
 ```
-

--- a/spiceaidocs/docs/cli/reference/login.md
+++ b/spiceaidocs/docs/cli/reference/login.md
@@ -7,21 +7,25 @@ pagination_next: null
 
 Login to the Spice.ai Platform, or other services with sub-commands.
 
-### Usage:
+### Usage
+
 ```shell
 spice login [command] [flags]
 ```
 
-### Flags:
-  - `-h`, `--help`         Print this help message
-  - `-k`, `--key` string   API key (for spice.ai)
+### Flags
 
-#### Available Commands:
-  - `databricks`  Login to a Databricks instance
-  - `dremio`      Login to a Dremio instance
-  - `s3`          Login to a s3 storage
+- `-h`, `--help`         Print this help message
+- `-k`, `--key` string   API key (for spice.ai)
 
-#### Examples:
+#### Available Commands
+
+- `databricks`  Login to a Databricks instance
+- `dremio`      Login to a Dremio instance
+- `s3`          Login to a s3 storage
+
+#### Examples
+
 ```shell
 spice login
 ```

--- a/spiceaidocs/docs/cli/reference/models.md
+++ b/spiceaidocs/docs/cli/reference/models.md
@@ -7,15 +7,18 @@ pagination_next: null
 
 Lists models loaded by the Spice runtime
 
-### Usage:
+### Usage
+
 ```shell 
 spice models [flags]
 ```
 
-#### Flags:
+#### Flags
+
   - `-h`, `--help`   help for models
 
-### Examples:
+### Examples
+
 ```shell
 >>> spice models
 

--- a/spiceaidocs/docs/cli/reference/pods.md
+++ b/spiceaidocs/docs/cli/reference/pods.md
@@ -6,15 +6,18 @@ pagination_next: null
 ---
 Lists Spicepods loaded by the Spice runtime
 
-### Usage:
-```shell 
+### Usage
+
+```shell
 spice pods [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   help for pods
+#### Flags
 
-### Examples:
+- `-h`, `--help`   help for pods
+
+### Examples
+
 ```shell 
 >>> spice pods
 
@@ -22,4 +25,3 @@ VERSION NAME        DATASETSCOUNT MODELSCOUNT DEPENDENCIESCOUNT
 v1beta1 demo        2             1           0
 v1beta1 another_pod 3             0           1
 ```
-

--- a/spiceaidocs/docs/cli/reference/refresh.md
+++ b/spiceaidocs/docs/cli/reference/refresh.md
@@ -7,22 +7,23 @@ pagination_next: null
 
 Refreshes an accelerated dataset loaded by the Spice runtime
 
-### Usage:
+### Usage
+
 ```shell
 spice refresh [dataset] [flags]
 ```
 
 `dataset` - an accelerated dataset name
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+#### Flags
 
-### Examples:
+- `-h`, `--help`   Print this help message
+
+### Examples
+
 ```shell 
 >>> spice refresh taxi_trips
 
 Refreshing dataset taxi_trips ...
 Dataset refresh triggered for taxi_trips.
 ```
-
-

--- a/spiceaidocs/docs/cli/reference/run.md
+++ b/spiceaidocs/docs/cli/reference/run.md
@@ -6,16 +6,18 @@ pagination_next: null
 ---
 Run Spice - starts the Spice runtime, installing if necessary
 
-### Usage:
+### Usage
+
 ```shell 
 spice run [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+#### Flags
 
-### Examples:
+- `-h`, `--help`   Print this help message
+
+### Examples
+
 ```shell
 spice run
 ```
-

--- a/spiceaidocs/docs/cli/reference/sql.md
+++ b/spiceaidocs/docs/cli/reference/sql.md
@@ -7,16 +7,19 @@ pagination_next: null
 
 Start an interactive SQL query session against the Spice runtime
 
-### Usage:
+### Usage
+
 ```shell 
 spice sql [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   Print this help message
+#### Flags
+
+- `-h`, `--help`   Print this help message
 
 
 ### Examples
+
 ```shell 
 $ spice sql
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/spiceaidocs/docs/cli/reference/status.md
+++ b/spiceaidocs/docs/cli/reference/status.md
@@ -7,14 +7,17 @@ pagination_next: null
 Spice runtime status
 
 ### Usage
+
 ```shell
 spice status [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   help for status
+#### Flags
 
-### Examples:
+- `-h`, `--help`   help for status
+
+### Examples
+
 ```shell 
 >>> spice status
 

--- a/spiceaidocs/docs/cli/reference/upgrade.md
+++ b/spiceaidocs/docs/cli/reference/upgrade.md
@@ -6,16 +6,18 @@ pagination_next: null
 ---
 Upgrades the Spice CLI to the latest release
 
-### Usage:
-```shell 
+### Usage
+
+```shell
 spice upgrade [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   help for upgrade
+#### Flags
 
-### Examples:
+- `-h`, `--help`   help for upgrade
+
+### Examples
+
 ```shell
 spice upgrade
 ```
-

--- a/spiceaidocs/docs/cli/reference/version.md
+++ b/spiceaidocs/docs/cli/reference/version.md
@@ -6,15 +6,18 @@ pagination_next: null
 ---
 Spice CLI version
 
-### Usage:
+### Usage
+
 ```shell 
 spice version [flags]
 ```
 
-#### Flags:
-  - `-h`, `--help`   help for version
+#### Flags
 
-### Examples:
+- `-h`, `--help`   help for version
+
+### Examples
+
 ```shell
 spice version
 ```

--- a/spiceaidocs/docs/clients/DBeaver/index.md
+++ b/spiceaidocs/docs/clients/DBeaver/index.md
@@ -15,7 +15,7 @@ pagination_next: null
 
 4. Launch DBeaver  
 
-5. In the DBeaver application menu bar, open the "Database" menu and choose: "Driver Manager":      
+5. In the DBeaver application menu bar, open the "Database" menu and choose: "Driver Manager":
 ![Driver manager menu option](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/691d1f83-c1d0-4ad8-ec8d-d8f37ccc9d00/public "Driver manager menu option")
 
 6. Click the "New" button on the right:
@@ -26,43 +26,42 @@ pagination_next: null
    1. Click the: "Add File" button
    1. Choose the "flight-sql-jdbc-driver-15.0.1.jar" jar file (the file downloaded in step 3 above) - and click "Open"
    ![Select jar file](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/19900f7a-f00f-473d-780e-4a28c2ecd800/public "Select jar file")
-   1. Close the Driver editor window with the blue "OK" button on the lower-right   
+   1. Close the Driver editor window with the blue "OK" button on the lower-right
 
-8. Enter the driver settings:   
-   1. Click the "Settings" tab   
-   1. In the "Driver Name" field - enter: ```Apache Arrow Flight SQL```   
+8. Enter the driver settings:
+   1. Click the "Settings" tab
+   1. In the "Driver Name" field - enter: ```Apache Arrow Flight SQL```
    1. In the "URL Template" field - enter: ```jdbc:arrow-flight-sql://{host}:{port}?useEncryption=false&disableCertificateVerification=true```
-   1. In the "Driver Type" drop-down box - choose: "SQLite"   
+   1. In the "Driver Type" drop-down box - choose: "SQLite"
    1. Select "No authentication"
    1. The driver manager "Edit Driver" window should look like this:
-   ![Driver Manager completed](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/20348c42-117b-4763-80d2-6e615b23ae00/public "Driver Manager completed")   
-   1. Click the blue "OK" button on the lower-right to save the driver   
+   ![Driver Manager completed](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/20348c42-117b-4763-80d2-6e615b23ae00/public "Driver Manager completed")
+   1. Click the blue "OK" button on the lower-right to save the driver
    1. Close the "Driver Manager" window by clicking the blue "Close" button on the lower-right.
 
-   
-9. Create a new Database Connection:   
-   1. In the DBeaver application menu bar, open the "Database" menu and choose: "New Database Connection":   
-   ![New Database Connection](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/acdf7251-4238-44ee-9639-0c557518da00/public "New Database Connection")   
-   1. In the "Connect to a database" window - type: ```Flight``` in the search bar   
-   1. Choose the ```Apache Arrow Flight SQL``` driver - the window should look like this:   
-   ![Connect to a database window](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/61cee5fe-dc75-4ac1-e558-eea3aff4c100/public "Connect to a database window")   
+9. Create a new Database Connection:
+   1. In the DBeaver application menu bar, open the "Database" menu and choose: "New Database Connection":
+   ![New Database Connection](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/acdf7251-4238-44ee-9639-0c557518da00/public "New Database Connection")
+   1. In the "Connect to a database" window - type: ```Flight``` in the search bar
+   1. Choose the ```Apache Arrow Flight SQL``` driver - the window should look like this:
+   ![Connect to a database window](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/61cee5fe-dc75-4ac1-e558-eea3aff4c100/public "Connect to a database window")
    1. Click the blue "Next >" button on the bottom of the window
-   1. On the next screen, the JDBC URL should be filled out already - just supply the Host (`localhost`) and Port (`50051`) values for the Spice runtime. The window should look like this:   
+   1. On the next screen, the JDBC URL should be filled out already - just supply the Host (`localhost`) and Port (`50051`) values for the Spice runtime. The window should look like this:
    ![Connect to a database window 2](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/2a2b2fdc-00db-49d3-5359-059b12342b00/public "Connect to a database window 2")
-   1. Click the "Test Connection" button - the window should look like this:   
-   ![Test Connection results](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/a3fc5f5f-a39f-47ce-7955-4b384ec1ae00/public "Test Connection results")   
+   1. Click the "Test Connection" button - the window should look like this:
+   ![Test Connection results](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/a3fc5f5f-a39f-47ce-7955-4b384ec1ae00/public "Test Connection results")
    1. Click the blue "OK" button to close the Connection test window
    1. Click the "Connection details (name, type, ...)" button on the right
    1. In the "General" section, enter: `Spice Runtime` for the "Connection name". It should look like this:
    ![Name the Database Connection](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/f6d04fe1-92a1-4082-d4ea-e9daacaca200/public)
-   1. Click the blue "Finish" button to save the connection   
+   1. Click the blue "Finish" button to save the connection
 
 10. Run a query:
-    1. Right-click on the Database Connection on the left - choose: "SQL Editor", and then: "Open SQL Console" as shown here:      
-    ![Open SQL Console](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/642a5885-9e3f-4dd7-ef43-72bfce27bb00/public "Open SQL Console")   
-    1. In the Console window - run a query - something like: ```SELECT * FROM taxi_trips;```   
-    1. Click the triangle button to execute the SQL statement - as shown below (or use keyboard shortcut: Ctrl+Enter):      
-    ![Execute SQL](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/2134e47b-a066-47e9-1d48-06352675f400/public "Execute SQL")   
+    1. Right-click on the Database Connection on the left - choose: "SQL Editor", and then: "Open SQL Console" as shown here:
+    ![Open SQL Console](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/642a5885-9e3f-4dd7-ef43-72bfce27bb00/public "Open SQL Console")
+    1. In the Console window - run a query - something like: ```SELECT * FROM taxi_trips;```
+    1. Click the triangle button to execute the SQL statement - as shown below (or use keyboard shortcut: Ctrl+Enter):
+    ![Execute SQL](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/2134e47b-a066-47e9-1d48-06352675f400/public "Execute SQL")
     1. See the query results as shown in this screenshot:
-    ![Query Results](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/0e9f3c0f-2e03-47f9-8d5e-65e078d7e900/public "Query Results")   
+    ![Query Results](https://imagedelivery.net/HyTs22ttunfIlvyd6vumhQ/0e9f3c0f-2e03-47f9-8d5e-65e078d7e900/public "Query Results")
     1. DBeaver is now configured to query the Spice runtime using SQL! 🎉

--- a/spiceaidocs/docs/clients/grafana/index.md
+++ b/spiceaidocs/docs/clients/grafana/index.md
@@ -38,11 +38,12 @@ global:
 ```
 
 ## Local Quickstart
+
 This tutorial creates and configures Grafana and Prometheus locally to scrape and display metrics from several Spice instances. It assumes:
     - Two Spice runtimes, `spiced-main` and `spiced-edge`, are running on `127.0.0.1:9091` and `127.0.0.1:9092` respectively.
 
-
 1. Create a `compose.yaml`:
+
     ```yaml
     version: "3"
     services:
@@ -62,7 +63,8 @@ This tutorial creates and configures Grafana and Prometheus locally to scrape an
         network_mode: "host"
     ```
 
-1. Create a `prometheus.yaml` to 
+1. Create a `prometheus.yaml` to
+
     ```yaml
     global:
     scrape_interval: 1s
@@ -76,6 +78,7 @@ This tutorial creates and configures Grafana and Prometheus locally to scrape an
     ```
 
 1. Add a prometheus as a source to grafana. Create a `.grafana/provisioning/datasources/prometheus.yml`
+
     ```yaml
     apiVersion: 1
 
@@ -86,12 +89,15 @@ This tutorial creates and configures Grafana and Prometheus locally to scrape an
         url: http://localhost:9090
         isDefault: true
     ```
+
 1. Run the Docker Compose
+
     ```bash
     docker-compose up
     ```
 
 1. Go to `http://localhost:3000/dashboard/import` and add the JSON from [monitoring/grafana-dashboard.json](https://github.com/spiceai/spiceai/blob/trunk/monitoring/grafana-dashboard.json).
 
-1. The dashboard will have data from the Spice runtimes. 
+1. The dashboard will have data from the Spice runtimes.
+
 <img src="/img/grafana/screenshot.png" />

--- a/spiceaidocs/docs/clients/jetbrains-datagrip/index.md
+++ b/spiceaidocs/docs/clients/jetbrains-datagrip/index.md
@@ -48,4 +48,3 @@ pagination_next: null
     ![Query Results](./img/datagrip-7.png "Query Results")
 
 DataGrip is now configured to query the Spice runtime using SQL! 🎉
-    

--- a/spiceaidocs/docs/clients/tableau/index.md
+++ b/spiceaidocs/docs/clients/tableau/index.md
@@ -10,7 +10,7 @@ pagination_next: null
 Use [Tableau](https://www.tableau.com/) to access, visualise and analyse datasets loaded in Spice.
 
 > The world's leading analytics platform. Tableau is the broadest and deepest end-to-end data and analytics platform. Ensure the responsible use of data and drive better business outcomes with fully integrated data management and governance, visual analytics and data storytelling, and collaboration – all with Salesforce’s industry-leading Einstein built right in.
-> 
+>
 > – [The Tableau platform](https://www.tableau.com/)
 
 ## Install Tableau Desktop
@@ -22,16 +22,17 @@ Download and install [Tableau Desktop](https://www.tableau.com/products/desktop/
 [JDBC](https://docs.oracle.com/javase/tutorial/jdbc/basics/index.html) (Java Database Connectivity) is a standard way to connect to, and interact with a database. The Flight SQL driver is a JDBC driver implementation that utilizes the underlying [Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) protocol, allowing any program that connects via JDBC to seamlessly connect and interact with databases that support Flight SQL. Because Spice supports Flight SQL, this driver acts as a bridge, enabling Tableau to establish a connection with Spice, execute queries, and retrieve data.
 
 1. **Download the Flight SQL JDBC driver**
- - Visit the [Flight SQL JDBC driver](https://central.sonatype.com/artifact/org.apache.arrow/flight-sql-jdbc-driver/) page
- - Select the **Versions** tab
- - Click **Browse**  next to the version you want to download
- - Click the `flight-sql-jdbc-driver-XX.XX.XX.jar` file (with only the `.jar` file extension) from the list of files to download the driver jar file
+
+- Visit the [Flight SQL JDBC driver](https://central.sonatype.com/artifact/org.apache.arrow/flight-sql-jdbc-driver/) page
+- Select the **Versions** tab
+- Click **Browse**  next to the version you want to download
+- Click the `flight-sql-jdbc-driver-XX.XX.XX.jar` file (with only the `.jar` file extension) from the list of files to download the driver jar file
 
 2. **Copy the downloaded jar file into the following directory based on your operating system**
- - Windows: `C:\Program Files\Tableau\Drivers`
- - Mac: `~/Library/Tableau/Drivers`
- - Linux: `/opt/tableau/tableau_driver/jdbc`
- - Start or restart Tableau
+
+- Windows: `C:\Program Files\Tableau\Drivers`
+- Mac: `~/Library/Tableau/Drivers`
+- Linux: `/opt/tableau/tableau_driver/jdbc` - Start or restart Tableau
 
 ## Configure a Spice connection
 

--- a/spiceaidocs/docs/components/catalogs/databricks.md
+++ b/spiceaidocs/docs/components/catalogs/databricks.md
@@ -31,15 +31,19 @@ catalogs:
 ```
 
 ## `from`
+
 The `from` field is used to specify the catalog provider. For Databricks, use `databricks:<catalog_name>`. The `catalog_name` is the name of the catalog in the Databricks Unity Catalog you want to connect to.
 
 ## `name`
+
 The `name` field is used to specify the name of the catalog in Spice. Tables from the Databricks catalog will be available in the schema with this name in Spice. The schema hierarchy of the external catalog is preserved in Spice.
 
 ## `include`
+
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
 ## `params`
+
 The `params` field is used to configure the connection to the Databricks Unity Catalog. The following parameters are supported:
 
 - `endpoint`: The Databricks workspace endpoint, e.g. `dbc-a12cd3e4-56f7.cloud.databricks.com`.
@@ -50,12 +54,15 @@ The `params` field is used to configure the connection to the Databricks Unity C
 - `databricks_use_ssl`: If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.
 
 ## `dataset_params`
+
 The `dataset_params` field is used to configure the dataset-specific parameters for the catalog. The following parameters are supported:
 
 ### Spark Connect parameters
+
 - `databricks_cluster_id`: The ID of the compute cluster in Databricks to use for the query. e.g. `1234-567890-abcde123`.
 
 ### Delta Lake parameters
+
 These settings can also be configured in the `databricks` secret. See the [Databricks Data Connector](/components/data-connectors/databricks.md) for more information on configuring the secret.
 
 #### AWS S3
@@ -66,6 +73,7 @@ These settings can also be configured in the `databricks` secret. See the [Datab
 - `aws_endpoint`: The endpoint for the S3 object store.
 
 #### Azure Blob
+
 Note: One of the following must be provided: `azure_storage_account_key`, `azure_storage_client_id` and `azure_storage_client_secret`, or `azure_storage_sas_key`.
 
 - `azure_storage_account_name`: The Azure Storage account name.

--- a/spiceaidocs/docs/components/catalogs/index.md
+++ b/spiceaidocs/docs/components/catalogs/index.md
@@ -28,9 +28,11 @@ Currently supported Catalog Connectors include:
 Catalog are configured using a Catalog Connector in the `catalogs` section of the Spicepod. See the specific Catalog Connector documentation for configuration details.
 
 ### `include`
+
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
 Example:
+
 ```yaml
 catalogs:
   - from: spiceai

--- a/spiceaidocs/docs/components/catalogs/spiceai.md
+++ b/spiceaidocs/docs/components/catalogs/spiceai.md
@@ -23,10 +23,13 @@ catalogs:
 ```
 
 ## `from`
+
 The `from` field is used to specify the catalog provider. For the Spice.ai catalog connector, use `spiceai`.
 
 ## `name`
+
 The `name` field is used to specify the name of the catalog in Spice. Tables from the Spice.ai built-in catalog will be available in the schema with this name in Spice.
 
 ## `include`
+
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.

--- a/spiceaidocs/docs/components/catalogs/unity-catalog.md
+++ b/spiceaidocs/docs/components/catalogs/unity-catalog.md
@@ -26,27 +26,31 @@ catalogs:
 ```
 
 ## `from`
+
 The `from` field is used to specify the catalog provider. For Unity Catalog, use `unity_catalog:<catalog_path>`. The `catalog_path` is the URL to the [`getCatalog`](https://github.com/unitycatalog/unitycatalog/blob/main/api/Apis/CatalogsApi.md) endpoint of the Unity Catalog API. It should be formatted as `https://<unity_catalog_host>/api/2.1/unity-catalog/catalogs/<catalog_name>`.
 
 ## `name`
+
 The `name` field is used to specify the name of the catalog in Spice. The schema hierarchy of the external catalog is preserved in Spice.
 
 ## `include`
+
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
 ## `dataset_params`
+
 The `dataset_params` field is used to configure the dataset-specific parameters for the catalog.
 
 These settings can also be configured in the `delta_lake` secret. See the [Delta Lake Data Connector](/components/data-connectors/delta-lake.md) for more information on configuring the secret.
 
-#### AWS S3
+### AWS S3
 
 - `aws_region`: The AWS region for the S3 object store.
 - `aws_access_key_id`: The access key ID for the S3 object store.
 - `aws_secret_access_key`: The secret access key for the S3 object store.
 - `aws_endpoint`: The endpoint for the S3 object store.
 
-#### Azure Blob
+### Azure Blob
 Note: One of the following must be provided: `azure_storage_account_key`, `azure_storage_client_id` and `azure_storage_client_secret`, or `azure_storage_sas_key`.
 
 - `azure_storage_account_name`: The Azure Storage account name.
@@ -56,6 +60,6 @@ Note: One of the following must be provided: `azure_storage_account_key`, `azure
 - `azure_storage_sas_key`: The shared access signature key for accessing the storage account.
 - `azure_storage_endpoint`: The endpoint for the Azure Blob storage account.
 
-#### Google Storage (GCS)
+### Google Storage (GCS)
 
 - `google_service_account`: Filesystem path to the Google service account JSON key file.

--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -45,4 +45,5 @@ datasets:
     - `SELECT {'x': 1, 'y': 2, 'z': 3}`
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
     - `SELECT ['duck', 'goose', 'heron'];`
+
 :::

--- a/spiceaidocs/docs/components/data-connectors/https.md
+++ b/spiceaidocs/docs/components/data-connectors/https.md
@@ -10,12 +10,14 @@ The HTTP(s) Data Connector enables federated SQL query against a variety of tabu
 The connector supports HTTP authentication via either `param` and/or `secrets`.
 
 ### Parameters
- - `http_port`: Optional. Port to create HTTP(s) connection over. Default: 80 and 443 for HTTP and HTTPS respectively.
- - `http_username`: Optional. Username to provide connection for HTTP basic authentication. Default: None.
- - `http_password`: Optional. Password to provide connection for HTTP basic authentication. Default: None.
- - `http_password_key`: Key of the secret that contains the value to use for `http_password`. Default: None.
+
+- `http_port`: Optional. Port to create HTTP(s) connection over. Default: 80 and 443 for HTTP and HTTPS respectively.
+- `http_username`: Optional. Username to provide connection for HTTP basic authentication. Default: None.
+- `http_password`: Optional. Password to provide connection for HTTP basic authentication. Default: None.
+- `http_password_key`: Key of the secret that contains the value to use for `http_password`. Default: None.
 
 ### Examples
+
 ```yaml
 datasets:
   - from: https://github.com/LAION-AI/audio-dataset/raw/7fd6ae3cfd7cde619f6bed817da7aa2202a5bc28/metadata/freesound/parquet/freesound_parquet.parquet
@@ -28,6 +30,7 @@ datasets:
 ```
 
 To use a secret for the HTTP password, for example, by env variable
+
 ```yaml
 datasets:
   - from: http://static_username@localhost/report.csv
@@ -38,6 +41,7 @@ datasets:
 ```
 
 With the associated secret set, for example:
+
 ```shell
 export SPICE_SECRET_HTTP_LOCAL_PASSWORD="BadPa$5w0rd"
 ```

--- a/spiceaidocs/docs/components/data-connectors/odbc.md
+++ b/spiceaidocs/docs/components/data-connectors/odbc.md
@@ -62,11 +62,9 @@ $ docker build -t spice-libsqliteodbc .
 
 Validate that the ODBC configuration was updated to reference the newly installed driver:
 
-
 :::warning[Note]
 Since `libsqliteodbc` is vendored by Debian, the package install hooks append the driver configuration to `/etc/odbcinst.ini`. When using a custom driver (e.g. [Databricks Simba](https://www.databricks.com/spark/odbc-drivers-download)), it is your responsibility to update `/etc/odbcinst.ini` to point at the location of the newly installed driver.
 :::
-
 
 ```bash
 $ docker run --entrypoint /bin/bash -it spice-libsqliteodbc
@@ -95,7 +93,7 @@ Setup=libsqlite3odbc.so
 UsageCount=1
 ```
 
-###### `test.db`
+### `test.db`
 
 To fully test the image, make an example SQLite database (`test.db`) and spicepod on your host:
 
@@ -109,7 +107,7 @@ sqlite> insert into spice_test values ("Hopper");
 sqlite> insert into spice_test values ("Linus");
 ```
 
-###### `spicepod.yaml`
+### `spicepod.yaml`
 
 Make sure that the `DRIVER` parameter matches the name of the driver section in `odbcinst.ini`.
 

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -170,4 +170,5 @@ Create a dataset named `taxi_trips` from a public S3 folder.
 :::warning[Limitations]
 
 - Only S3 authentication using `aws_access_key_id` and `aws_secret_access_key` is currently supported. Please [submit an issue](https://github.com/spiceai/spiceai/issues/new?template=feature_request.md) if you would like to see support for other authentication methods.
+
 :::

--- a/spiceaidocs/docs/components/data-connectors/snowflake.md
+++ b/spiceaidocs/docs/components/data-connectors/snowflake.md
@@ -161,4 +161,5 @@ datasets:
 
 1. Account identifier does not support the [Legacy account locator in a region format](https://docs.snowflake.com/en/user-guide/admin-account-identifier#format-2-legacy-account-locator-in-a-region). Use [Snowflake preferred name in organization format](https://docs.snowflake.com/en/user-guide/admin-account-identifier#format-1-preferred-account-name-in-your-organization).
 1. The connector supports password-based and [key-pair](https://docs.snowflake.com/en/user-guide/key-pair-auth) authentication.
+
 :::

--- a/spiceaidocs/docs/components/data-connectors/spiceai.md
+++ b/spiceaidocs/docs/components/data-connectors/spiceai.md
@@ -8,13 +8,16 @@ pagination_next: null
 The [Spice.ai](https://spice.ai/) Data Connector enables federated SQL query across datasets in the [Spice.ai Cloud Platform](https://docs.spice.ai/building-blocks/datasets).  Access to these datasets requires a free [Spice.ai account](https://spice.ai/login).
 
 ## Configuration
+
 ### Secrets
+
 Secrets will be automatically configured by using the `spice login` command and logging in with an active Spice AI account.
 
 - `key`: A Spice.ai API key.
 - `token`: An active personal access token that is configured when logging in to spice via `spice login` 
 
 ### Parameters
+
 - `from`: The Spice.ai dataset ID. For instance `spice.ai/eth.recent_blocks` or `spice.ai/eth.recent_traces`
 
 ## Example
@@ -25,6 +28,7 @@ Secrets will be automatically configured by using the `spice login` command and 
 ```
 
 ## Full Configuration Example
+
 ```yaml
 - from: spice.ai/eth.recent_blocks
   name: eth_recent_blocks
@@ -34,10 +38,13 @@ Secrets will be automatically configured by using the `spice login` command and 
 ```
 
 :::warning[Limitations]
-`refresh_mode: append` is supported for the following datasets: 
-* eth.recent_blocks
-* eth.recent_transactions
-* eth.recent_traces
+
+`refresh_mode: append` is supported for the following datasets:
+
+- eth.recent_blocks
+- eth.recent_transactions
+- eth.recent_traces
 
 All other datasets need to be configured with `refresh_mode: full`.
+
 :::

--- a/spiceaidocs/docs/features/data-ingestion/index.md
+++ b/spiceaidocs/docs/features/data-ingestion/index.md
@@ -33,6 +33,7 @@ Data Security: Assess data sensitivity and secure network connections between ed
 ### [Disk SMART](https://en.wikipedia.org/wiki/Self-Monitoring,_Analysis_and_Reporting_Technology)
 
 - Start Spice with the following dataset:
+
 ```yaml
 datasets:
   - from: spice.ai/coolorg/smart/datasets/drive_stats
@@ -45,6 +46,7 @@ datasets:
 ```
 
 - Start telegraf with the following config:
+
 ```
 [[inputs.smart]]
   attributes = true
@@ -58,5 +60,7 @@ datasets:
 SMART data will be available in the `smart_attribute_raw_value` dataset in Spice.ai OSS and replicated to the `coolorg.smart.drive_stats` dataset in Spice.ai Cloud.
 
 :::warning[Limitations]
+
 - Only Spice.ai replication is supported for now.
+
 :::

--- a/spiceaidocs/docs/features/federated-queries/index.md
+++ b/spiceaidocs/docs/features/federated-queries/index.md
@@ -185,4 +185,5 @@ To improve query performance, step 9 demonstrates the same query executed agains
 
 - **Query Performance:** Without acceleration, federated queries will be slower than local queries due to network latency and data transfer.
 - **Query Capabilities:** Not all SQL features and data types are supported across all data sources. More complex data type queries may not work as expected.
+
 :::

--- a/spiceaidocs/docs/features/local-acceleration/constraints.md
+++ b/spiceaidocs/docs/features/local-acceleration/constraints.md
@@ -51,6 +51,7 @@ Examples
         The following Spicepod is invalid because it specifies multiple `on_conflict` targets with `upsert`:
 
     :::danger[Invalid]
+
       ```yaml
       datasets:
 
@@ -66,11 +67,13 @@ Examples
         hash: upsert
         "(number, timestamp)": upsert
       ```
+
     :::
 
           The following Spicepod is valid because it specifies multiple `on_conflict` targets with `drop`, which is allowed:
 
     :::tip[Valid]
+
       ```yaml
       datasets:
 
@@ -86,6 +89,7 @@ Examples
         hash: drop
         "(number, timestamp)": drop
       ```
+
     :::
 
           The following Spicepod is invalid because it specifies multiple `on_conflict` targets with `upsert` and `drop`:
@@ -106,6 +110,7 @@ Examples
       hash: upsert
       "(number, timestamp)": drop
       ```
+
     :::
 
       </div>

--- a/spiceaidocs/docs/features/local-acceleration/indexes.md
+++ b/spiceaidocs/docs/features/local-acceleration/indexes.md
@@ -42,4 +42,5 @@ There are two types of indexes that can be specified in a Spicepod:
 :::warning[Limitations]
 
 - **Not supported for in-memory Arrow:** The default in-memory Arrow acceleration engine does not support indexes. Use [DuckDB](/components/data-accelerators/duckdb.md), [SQLite](/components/data-accelerators/duckdb.md), or [PostgreSQL](/components/data-accelerators/postgres/index.md) as the acceleration engine to enable indexing.
+
 :::

--- a/spiceaidocs/docs/sdks/golang/index.md
+++ b/spiceaidocs/docs/sdks/golang/index.md
@@ -5,7 +5,7 @@ pagination_prev: null
 pagination_next: null
 ---
 
-# Golang SDK for Spice.ai
+## Golang SDK for Spice.ai
 
 https://github.com/spiceai/gospice
 

--- a/spiceaidocs/docs/sdks/java/index.md
+++ b/spiceaidocs/docs/sdks/java/index.md
@@ -8,7 +8,7 @@ pagination_next: null
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Java SDK for Spice.ai
+## Java SDK for Spice.ai
 
 https://github.com/spiceai/spice-java
 

--- a/spiceaidocs/docs/sdks/javascript/index.md
+++ b/spiceaidocs/docs/sdks/javascript/index.md
@@ -8,7 +8,7 @@ pagination_next: null
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# JavaScript SDK for Spice.ai
+## JavaScript SDK for Spice.ai
 
 https://github.com/spiceai/spice.js
 

--- a/spiceaidocs/docs/sdks/python/index.md
+++ b/spiceaidocs/docs/sdks/python/index.md
@@ -5,7 +5,7 @@ pagination_prev: null
 pagination_next: null
 ---
 
-# Python SDK for Spice.ai
+## Python SDK for Spice.ai
 
 https://github.com/spiceai/spicepy
 

--- a/spiceaidocs/docs/sdks/rust/index.md
+++ b/spiceaidocs/docs/sdks/rust/index.md
@@ -5,7 +5,7 @@ pagination_prev: null
 pagination_next: null
 ---
 
-# Rust SDK for Spice.ai
+## Rust SDK for Spice.ai
 
 https://github.com/spiceai/spice-rs
 


### PR DESCRIPTION
## 🗣 Description

Our documentation doesn't always follow markdown best practices.  This updates most, but not all of the markdown in terms of whitespace, headings, and other similar best practices.  Not all standards could be completed.  For instance, we use HTML for tables, and this is an "avoid" practice.  In these cases, there were no changes.



