### PR TITLE
Add Query history reference

### DIFF
--- a/spiceaidocs/docs/api/http/ml-predict.md
+++ b/spiceaidocs/docs/api/http/ml-predict.md
@@ -1,5 +1,5 @@
 ---
-title: POST /v1/predict'
+title: 'POST /v1/predict'
 sidebar_label: 'POST /v1/predict'
 description: ''
 sidebar_position: 10

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -1,0 +1,45 @@
+---
+title: "Query History"
+sidebar_label: "Query History"
+pagination_prev: 'reference/index'
+pagination_next: null
+sidebar_position: 6
+---
+
+The Spice runtime stores information about completed queries in the `spice.runtime.query_history` table. Each query executed has a row in this table, and the data is retained for one day. Use a `SELECT` query to return information about each query as shown in this example:
+
+```sql
+SELECT
+  *
+FROM
+  *
+spice.runtime.query_history
+LIMIT
+  100;
+```
+
+## Columns in spice.runtime.query_history
+
+| Column Name       | Data Type                   | Description |
+|-------------------|-----------------------------|-------------|
+| query_id          | Utf8                        | The unique identifier of the SQL query. |
+| schema            | Utf8                        | The Schema of the tables queried.       |
+| sql               | Utf8                        | The query text of the SQL statment.     |
+| nsql              | Utf8                        | Optional. If the query was generated through the natural langauge to sql api, the natural language text of the query. |
+| start_time        | Timestamp(Nanosecond, None) | The query execution start time (UTC).    |
+| end_time          | Timestamp(Nanosecond, None) | The query execution end time (UTC).          |
+| execution_time    | Float32                     | The total execution time in seconds.          |
+| execution_status  | Int8                        | The [status code](query_history.md#execution-status-codes) returned from query execution.     |
+| rows_produced     | UInt64                      | The total number of rows returned from the query.           |
+| results_cache_hit | Boolean                     | True if the result from the query was returned from the results cache, otherwise false.          |
+| error_message     | Utf8                        | The error message that was returned        |
+
+### Execution Status Codes
+
+| Value | Status           | Description |
+|-------|-----------------------|-------------|
+| 0     | Success               | The query completed with no errors. |
+| -10   | Syntax Error          | The SQL query text provided has a syntax error.  For instance, a misspeled SQL statement was in the query. |
+| -20   | Query Planning Error  | An error occurred while mapping the SQL query to a query plan. For instance, attempting to call a function that does not exist, or providing a query with unsupported types. |
+| -30   | Query Execution Error | An error occurred during en execution due to a malformed input. For instance, passing malformed arguments to a SQL method. |
+| -120  | Internal Error        | An internal error occurred within Spice. |

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -23,7 +23,7 @@ LIMIT
 | Column Name       | Data Type                   | Description |
 |-------------------|-----------------------------|-------------|
 | query_id          | Utf8                        | The unique identifier of the SQL query. |
-| schema            | Utf8                        | The Schema of the tables queried.       |
+| schema            | Utf8                        | The Schema of the query result.       |
 | sql               | Utf8                        | The query text of the SQL statment.     |
 | nsql              | Utf8                        | Optional. If the query was generated through the natural langauge to sql api, the natural language text of the query. |
 | start_time        | Timestamp(Nanosecond, None) | The query execution start time (UTC).    |

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -25,7 +25,7 @@ LIMIT
 | query_id          | Utf8                        | The unique identifier of the SQL query. |
 | schema            | Utf8                        | The Schema of the query result.       |
 | sql               | Utf8                        | The query text of the SQL statement.     |
-| nsql              | Utf8                        | Optional. If the query was generated through the natural language to sql api, the natural language text of the query. |
+| nsql              | Utf8                        | Optional. If the query was generated through the natural language to SQL api, the natural language text of the query. |
 | start_time        | Timestamp(Nanosecond, None) | The query execution start time (UTC).    |
 | end_time          | Timestamp(Nanosecond, None) | The query execution end time (UTC).          |
 | execution_time    | Float32                     | The total execution time in seconds.          |

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -24,8 +24,8 @@ LIMIT
 |-------------------|-----------------------------|-------------|
 | query_id          | Utf8                        | The unique identifier of the SQL query. |
 | schema            | Utf8                        | The Schema of the query result.       |
-| sql               | Utf8                        | The query text of the SQL statment.     |
-| nsql              | Utf8                        | Optional. If the query was generated through the natural langauge to sql api, the natural language text of the query. |
+| sql               | Utf8                        | The query text of the SQL statement.     |
+| nsql              | Utf8                        | Optional. If the query was generated through the natural language to sql api, the natural language text of the query. |
 | start_time        | Timestamp(Nanosecond, None) | The query execution start time (UTC).    |
 | end_time          | Timestamp(Nanosecond, None) | The query execution end time (UTC).          |
 | execution_time    | Float32                     | The total execution time in seconds.          |
@@ -39,7 +39,7 @@ LIMIT
 | Value | Status           | Description |
 |-------|-----------------------|-------------|
 | 0     | Success               | The query completed with no errors. |
-| -10   | Syntax Error          | The SQL query text provided has a syntax error.  For instance, a misspeled SQL statement was in the query. |
+| -10   | Syntax Error          | The SQL query text provided has a syntax error.  For instance, a misspelled SQL statement was in the query. |
 | -20   | Query Planning Error  | An error occurred while mapping the SQL query to a query plan. For instance, attempting to call a function that does not exist, or providing a query with unsupported types. |
-| -30   | Query Execution Error | An error occurred during en execution due to a malformed input. For instance, passing malformed arguments to a SQL method. |
+| -30   | Query Execution Error | An error occurred during an execution due to a malformed input. For instance, passing malformed arguments to a SQL method. |
 | -120  | Internal Error        | An internal error occurred within Spice. |

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -31,7 +31,7 @@ LIMIT
 | execution_time    | Float32                     | The total execution time in seconds.          |
 | execution_status  | Int8                        | The [status code](query_history.md#execution-status-codes) returned from query execution.     |
 | rows_produced     | UInt64                      | The total number of rows returned from the query.           |
-| results_cache_hit | Boolean                     | True if the result from the query was returned from the results cache, otherwise false.          |
+| results_cache_hit | Boolean                     | True if the result of the query was returned from the results cache, otherwise, false.          |
 | error_message     | Utf8                        | The error message that was returned        |
 
 ### Execution Status Codes

--- a/spiceaidocs/docs/reference/query_history.md
+++ b/spiceaidocs/docs/reference/query_history.md
@@ -12,7 +12,6 @@ The Spice runtime stores information about completed queries in the `spice.runti
 SELECT
   *
 FROM
-  *
 spice.runtime.query_history
 LIMIT
   100;
@@ -23,23 +22,23 @@ LIMIT
 | Column Name       | Data Type                   | Description |
 |-------------------|-----------------------------|-------------|
 | query_id          | Utf8                        | The unique identifier of the SQL query. |
-| schema            | Utf8                        | The Schema of the query result.       |
+| schema            | Utf8                        | The schema of the query result.       |
 | sql               | Utf8                        | The query text of the SQL statement.     |
-| nsql              | Utf8                        | Optional. If the query was generated through the natural language to SQL api, the natural language text of the query. |
+| nsql              | Utf8                        | Optional. If the query was generated through the natural language to SQL API, the natural language text of the query. |
 | start_time        | Timestamp(Nanosecond, None) | The query execution start time (UTC).    |
 | end_time          | Timestamp(Nanosecond, None) | The query execution end time (UTC).          |
 | execution_time    | Float32                     | The total execution time in seconds.          |
 | execution_status  | Int8                        | The [status code](query_history.md#execution-status-codes) returned from query execution.     |
 | rows_produced     | UInt64                      | The total number of rows returned from the query.           |
 | results_cache_hit | Boolean                     | True if the result of the query was returned from the results cache, otherwise, false.          |
-| error_message     | Utf8                        | The error message that was returned        |
+| error_message     | Utf8                        | The error message that was returned.        |
 
 ### Execution Status Codes
 
 | Value | Status           | Description |
 |-------|-----------------------|-------------|
 | 0     | Success               | The query completed with no errors. |
-| -10   | Syntax Error          | The SQL query text provided has a syntax error.  For instance, a misspelled SQL statement was in the query. |
+| -10   | Syntax Error          | The SQL query text provided has a syntax error. For instance, a misspelled SQL statement was in the query. |
 | -20   | Query Planning Error  | An error occurred while mapping the SQL query to a query plan. For instance, attempting to call a function that does not exist, or providing a query with unsupported types. |
-| -30   | Query Execution Error | An error occurred during an execution due to a malformed input. For instance, passing malformed arguments to a SQL method. |
+| -30   | Query Execution Error | An error occurred during execution due to a malformed input. For instance, passing malformed arguments to a SQL method. |
 | -120  | Internal Error        | An internal error occurred within Spice. |

--- a/spiceaidocs/docs/reference/sql/index.md
+++ b/spiceaidocs/docs/reference/sql/index.md
@@ -2,7 +2,7 @@
 title: "SQL Reference"
 sidebar_label: "SQL Reference"
 pagination_prev: 'reference/index'
-sidebar_position: 6
+sidebar_position: 7
 pagination_next: null
 ---
 

--- a/spiceaidocs/docs/reference/sql/select.md
+++ b/spiceaidocs/docs/reference/sql/select.md
@@ -1,8 +1,9 @@
 ---
 title: "SELECT"
 sidebar_label: "SELECT"
-pagination_prev: 'reference/index'
+pagination_prev: 'reference/sql/index'
 pagination_next: null
+sidebar_position: 1
 ---
 
 :::info


### PR DESCRIPTION
## 🗣 Description

We have had query_history available in our spice.runtime.query_history table for some time, but no public documentation for reference.  Add reference for our query history so users can take advantage of the query history and access historical queries in the runtime.

