### PR TITLE
Add TLS documentation

### DIFF
--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -15,7 +15,7 @@ A valid TLS certificate and private key in the [PEM](https://en.wikipedia.org/wi
 
 ## Via command line arguments
 
-Use the `--tls` flag to enable TLS. The `--tls-certificate-file` and `--tls-key-file` flags are used to specify the paths to the certificate and private key files.
+Use the `--tls-*` flags to enable TLS. The `--tls-certificate-file` and `--tls-key-file` flags are used to specify the paths to the certificate and private key files.
 
 ```bash
 spiced --tls --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
@@ -26,13 +26,13 @@ Alternatively, the `--tls-certificate` and `--tls-key` flags can be used to spec
 ```bash
 export TLS_CERT=$(cat /path/to/cert.pem)
 export TLS_KEY=$(cat /path/to/key.pem)
-spiced --tls --tls-certificate "$TLS_CERT" --tls-key "$TLS_KEY"
+spiced --tls-certificate "$TLS_CERT" --tls-key "$TLS_KEY"
 ```
 
 The arguments can also be passed to `spice run` to enable TLS.
 
 ```bash
-spice run -- --tls --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
+spice run -- --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
 ```
 
 Note that `--` is used to separate the `spice run` arguments from the Spice runtime arguments.

--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -1,0 +1,88 @@
+---
+title: 'TLS: Transport Layer Security'
+sidebar_label: 'TLS'
+sidebar_position: 2
+description: 'TLS Endpoint Documentation'
+pagination_prev: null
+pagination_next: null
+---
+
+[TLS](https://www.cloudflare.com/learning/ssl/transport-layer-security-tls/) (Transport Layer Security) is a cryptographic protocol that secures communication over a network. Learn how Spice can be configured to use TLS on all of its endpoints.
+
+## Pre-requisites
+
+A valid TLS certificate and private key in the [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) format are required. Follow the [TLS Sample](https://github.com/spiceai/samples/tree/trunk/tls) to generate these for testing.
+
+## Via command line arguments
+
+Use the `--tls` flag to enable TLS. The `--tls-certificate-file` and `--tls-key-file` flags are used to specify the paths to the certificate and private key files.
+
+```bash
+spiced --tls --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
+```
+
+Alternatively, the `--tls-certificate` and `--tls-key` flags can be used to specify the certificate and private key directly.
+
+```bash
+export TLS_CERT=$(cat /path/to/cert.pem)
+export TLS_KEY=$(cat /path/to/key.pem)
+spiced --tls --tls-certificate "$TLS_CERT" --tls-key "$TLS_KEY"
+```
+
+The arguments can also be passed to `spice run` to enable TLS.
+
+```bash
+spice run -- --tls --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
+```
+
+Note that `--` is used to separate the `spice run` arguments from the Spice runtime arguments.
+
+## Via spicepod.yaml
+
+The `runtime` configuration can be added to the root `spicepod.yaml` to enable TLS.
+
+```yaml
+runtime:
+  tls:
+    # Using filesystem paths
+    certificate_file: /path/to/cert.pem
+    key_file: /path/to/key.pem
+```
+
+```yaml
+runtime:
+  tls:
+    # Specify the certificate and key directly
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
+
+```yaml
+runtime:
+  tls:
+    # The certificate and key can also come from secrets
+    certificate: ${secrets:tls_cert}
+    key: ${secrets:tls_key}
+```
+
+For more information on using secrets, see the [Secret Stores](../../components/secret-stores/index.md) documentation.
+
+:::info
+
+Spice will only configure the endpoints based on the initial configuration it starts up with. Changing the parameters at runtime in the spicepod will have no effect.
+
+:::
+
+## Output
+
+The output shows TLS is enabled and which certificate is being used.
+
+```bash
+INFO runtime: All endpoints secured with TLS using certificate: CN=spiced.localhost, OU=IT, O=Widgets, Inc., L=Seattle, S=Washington, C=US
+```

--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -86,3 +86,37 @@ The output shows TLS is enabled and which certificate is being used.
 ```bash
 INFO runtime: All endpoints secured with TLS using certificate: CN=spiced.localhost, OU=IT, O=Widgets, Inc., L=Seattle, S=Washington, C=US
 ```
+
+## Using the Spice CLI
+
+When TLS is enabled, the Spice CLI can connect to the Spice runtime using the `--tls-root-certificate-file` flag. This flag is used to specify the path to the root certificate file that can be used to verify the Spice runtime's certificate.
+
+`spice sql`
+
+```bash
+spice sql --tls-root-certificate-file /path/to/root.pem
+```
+
+`spice status`
+
+```bash
+spice status --tls-root-certificate-file /path/to/root.pem
+```
+
+`spice datasets`
+
+```bash
+spice datasets --tls-root-certificate-file /path/to/root.pem
+```
+
+`spice models`
+
+```bash
+spice models --tls-root-certificate-file /path/to/root.pem
+```
+
+`spice catalogs`
+
+```bash
+spice catalogs --tls-root-certificate-file /path/to/root.pem
+```

--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -75,7 +75,7 @@ For more information on using secrets, see the [Secret Stores](../../components/
 
 :::info
 
-Spice will only configure the endpoints based on the initial configuration it starts up with. Changing the parameters at runtime in the spicepod will have no effect.
+Spice configures endpoints based on its configuration at startup. Changing parameters while Spice is running will have no effect.
 
 :::
 

--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -96,27 +96,3 @@ When TLS is enabled, the Spice CLI can connect to the Spice runtime using the `-
 ```bash
 spice sql --tls-root-certificate-file /path/to/root.pem
 ```
-
-`spice status`
-
-```bash
-spice status --tls-root-certificate-file /path/to/root.pem
-```
-
-`spice datasets`
-
-```bash
-spice datasets --tls-root-certificate-file /path/to/root.pem
-```
-
-`spice models`
-
-```bash
-spice models --tls-root-certificate-file /path/to/root.pem
-```
-
-`spice catalogs`
-
-```bash
-spice catalogs --tls-root-certificate-file /path/to/root.pem
-```

--- a/spiceaidocs/docs/api/tls/index.md
+++ b/spiceaidocs/docs/api/tls/index.md
@@ -18,7 +18,7 @@ A valid TLS certificate and private key in the [PEM](https://en.wikipedia.org/wi
 Use the `--tls-*` flags to enable TLS. The `--tls-certificate-file` and `--tls-key-file` flags are used to specify the paths to the certificate and private key files.
 
 ```bash
-spiced --tls --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
+spiced --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
 ```
 
 Alternatively, the `--tls-certificate` and `--tls-key` flags can be used to specify the certificate and private key directly.

--- a/spiceaidocs/docs/cli/reference/catalogs.md
+++ b/spiceaidocs/docs/cli/reference/catalogs.md
@@ -10,8 +10,12 @@ Lists [catalogs](/components/catalogs) loaded by the Spice runtime
 ### Usage
 
 ```shell
-spice catalogs
+spice catalogs [flags]
 ```
+
+#### Flags
+
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 
 ### Example
 

--- a/spiceaidocs/docs/cli/reference/datasets.md
+++ b/spiceaidocs/docs/cli/reference/datasets.md
@@ -15,6 +15,7 @@ spice datasets [flags]
 
 #### Flags
 
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `-h`, `--help`   help for datasets
 
 ### Examples:

--- a/spiceaidocs/docs/cli/reference/models.md
+++ b/spiceaidocs/docs/cli/reference/models.md
@@ -15,7 +15,8 @@ spice models [flags]
 
 #### Flags
 
-  - `-h`, `--help`   help for models
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-h`, `--help`   help for models
 
 ### Examples
 

--- a/spiceaidocs/docs/cli/reference/pods.md
+++ b/spiceaidocs/docs/cli/reference/pods.md
@@ -14,6 +14,7 @@ spice pods [flags]
 
 #### Flags
 
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `-h`, `--help`   help for pods
 
 ### Examples

--- a/spiceaidocs/docs/cli/reference/refresh.md
+++ b/spiceaidocs/docs/cli/reference/refresh.md
@@ -17,6 +17,7 @@ spice refresh [dataset] [flags]
 
 #### Flags
 
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `-h`, `--help`   Print this help message
 
 ### Examples

--- a/spiceaidocs/docs/cli/reference/run.md
+++ b/spiceaidocs/docs/cli/reference/run.md
@@ -10,14 +10,37 @@ Run Spice - starts the Spice runtime, installing if necessary
 
 ```shell 
 spice run [flags]
+spice run [flags] -- [spiced flags]
 ```
 
 #### Flags
 
 - `-h`, `--help`   Print this help message
 
+#### Spiced Flags
+
+Flags that are passed to the `spiced` runtime directly.
+
+- `--http`  Configure runtime HTTP address [default: 127.0.0.1:8090]
+- `--flight` Configure runtime Flight address [default: 127.0.0.1:50051]
+- `--open_telemetry` Configure runtime OpenTelemetry address [default: 127.0.0.1:50052]
+- `--tls-certificate`   The TLS PEM-encoded certificate
+- `--tls-certificate-file`  Path to the TLS PEM-encoded certificate file
+- `--tls-key`   The TLS PEM-encoded key
+- `--tls-key-file`   Path to the TLS PEM-encoded key file
+
 ### Examples
 
 ```shell
 spice run
+```
+
+```shell
+# Expose the HTTP server on all interfaces
+spice run -- --http 0.0.0.0:8090
+```
+
+```shell
+# Expose the HTTP & Flight servers on all interfaces with TLS
+spice run -- --http 0.0.0.0:8090 --flight 0.0.0.0:50051 --tls-certificate-file /path/to/cert.pem --tls-key-file /path/to/key.pem
 ```

--- a/spiceaidocs/docs/cli/reference/sql.md
+++ b/spiceaidocs/docs/cli/reference/sql.md
@@ -15,6 +15,7 @@ spice sql [flags]
 
 #### Flags
 
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `-h`, `--help`   Print this help message
 
 

--- a/spiceaidocs/docs/cli/reference/status.md
+++ b/spiceaidocs/docs/cli/reference/status.md
@@ -14,6 +14,7 @@ spice status [flags]
 
 #### Flags
 
+- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `-h`, `--help`   help for status
 
 ### Examples

--- a/spiceaidocs/docs/reference/spicepod/index.md
+++ b/spiceaidocs/docs/reference/spicepod/index.md
@@ -68,11 +68,11 @@ The name of the secret store. This is used to reference the store in the secret 
 
 ## `runtime`
 
-### `num_of_parallel_loading_at_start_up`
+### `runtime.num_of_parallel_loading_at_start_up`
 
 This configuration setting determines the maximum number of datasets that can be loaded in parallel during startup. This parallel loading capability accelerates Spice's startup process when multiple datasets are configured.
 
-### `results_cache`
+### `runtime.results_cache`
 
 The results cache section specifies runtime cache configuration. [Learn more](/features/caching).
 
@@ -89,6 +89,74 @@ runtime:
 - `cache_max_size` - optional, maximum cache size. Default is `128MiB`
 - `eviction_policy` - optional, cache replacement policy when the cached data reaches the `cache_max_size`. Default is `lru` - [least-recently-used (LRU)](https://en.wikipedia.org/wiki/Cache_replacement_policies#LRU)
 - `item_ttl` - optional, cache entry expiration time, 1 second by default.
+
+### `runtime.tls`
+
+The TLS section specifies the configuration for enabling Transport Layer Security (TLS) for all endpoints exposed by the runtime. [Learn more about enabling TLS](/api/tls).
+
+#### `runtime.tls.certificate`
+
+The TLS certificate to use for securing the runtime endpoints. The certificate can also come from [secrets](/components/secret-stores).
+
+```yaml
+runtime:
+  tls:
+    ...
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+```
+
+```yaml
+runtime:
+  tls:
+    ...
+    certificate: ${secrets:tls_cert}
+```
+
+#### `runtime.tls.certificate_file`
+
+The path to the TLS PEM-encoded certificate file. Only one of `certificate` or `certificate_file` must be used.
+
+```yaml
+runtime:
+  tls:
+    ...
+    certificate_file: /path/to/cert.pem
+```
+
+#### `runtime.tls.key`
+
+The TLS key to use for securing the runtime endpoints. The key can also come from [secrets](/components/secret-stores).
+
+```yaml
+runtime:
+  tls:
+    ...
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
+
+```yaml
+runtime:
+  tls:
+    ...
+    key: ${secrets:tls_key}
+```
+
+#### `runtime.tls.key_file`
+
+The path to the TLS PEM-encoded key file. Only one of `key` or `key_file` must be used.
+
+```yaml
+runtime:
+  tls:
+    ...
+    key_file: /path/to/key.pem
+```
 
 ## `metadata`
 

--- a/spiceaidocs/docs/reference/spicepod/index.md
+++ b/spiceaidocs/docs/reference/spicepod/index.md
@@ -94,6 +94,8 @@ runtime:
 
 The TLS section specifies the configuration for enabling Transport Layer Security (TLS) for all endpoints exposed by the runtime. [Learn more about enabling TLS](/api/tls).
 
+In addition to configuring TLS via the manifest, TLS can also be configured via `spiced` command line arguments using the `--tls-certificate`/`--tls-certificate-file` and `--tls-key`/`--tls-key-file` flags.
+
 #### `runtime.tls.certificate`
 
 The TLS certificate to use for securing the runtime endpoints. The certificate can also come from [secrets](/components/secret-stores).


### PR DESCRIPTION
## 🗣 Description

Adds documentation on how to enable TLS on the runtime endpoints.

## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/2071
