### PR TITLE
add `spice install` to cli reference

### DIFF
--- a/spiceaidocs/docs/cli/reference/install.md
+++ b/spiceaidocs/docs/cli/reference/install.md
@@ -1,0 +1,23 @@
+---
+title: "install"
+sidebar_label: "install"
+pagination_prev: null
+pagination_next: null
+---
+Download and install the latest version of the Spice runtime.
+
+### Usage
+
+```shell
+spice install [flags]
+```
+
+#### Flags
+
+- `-h`, `--help`   Print this help message
+
+### Examples:
+
+```shell 
+spice install
+```


### PR DESCRIPTION
## 🗣 Description
- Add basic reference docs for the `spice install` command to the CLI reference.

## 🔨 Related Issues
- Code change: https://github.com/spiceai/spiceai/pull/2090
