### PR TITLE
Add docs for `connection_pool_size`

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -20,6 +20,8 @@ datasets:
 
 The connection to PostgreSQL can be configured by providing the following `params`:
 
+<!-- When making changes to this list, also update components/data-connectors/postgres/index.md -->
+
 - `pg_host`: The hostname of the PostgreSQL server.
 - `pg_port`: The port of the PostgreSQL server.
 - `pg_db`: The name of the database to connect to.
@@ -27,11 +29,12 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_pass`: The password to connect with. Use the [secret replacement syntax](../../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_pg_pass}`.
 - `pg_sslmode`: Optional. Specifies the SSL/TLS behavior for the connection, supported values:
   - `verify-full`: (default) This mode requires an SSL connection, a valid root certificate, and the server host name to match the one specified in the certificate.
-  - `verify-ca`: This mode requires an SSL connection and a valid root certificate.
-  - `required`: This mode requires an SSL connection.
-  - `prefer`: This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
-  - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
+  - `verify-ca`: This mode requires a TLS connection and a valid root certificate.
+  - `require`: This mode requires a TLS connection.
+  - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
+  - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.
 

--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -34,7 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
-- `pg_connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
+- `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.
 

--- a/spiceaidocs/docs/components/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/components/data-connectors/postgres/index.md
@@ -18,6 +18,8 @@ datasets:
 
 The connection to PostgreSQL can be configured by providing the following `params`:
 
+<!-- When making changes to this list, also update components/data-accelerators/postgres/index.md -->
+
 - `pg_host`: The hostname of the PostgreSQL server.
 - `pg_port`: The port of the PostgreSQL server.
 - `pg_db`: The name of the database to connect to.
@@ -25,11 +27,12 @@ The connection to PostgreSQL can be configured by providing the following `param
 - `pg_pass`: The password to connect with. Use the [secret replacement syntax](../../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_pg_pass}`.
 - `pg_sslmode`: Optional. Specifies the SSL/TLS behavior for the connection, supported values:
   - `verify-full`: (default) This mode requires an SSL connection, a valid root certificate, and the server host name to match the one specified in the certificate.
-  - `verify-ca`: This mode requires an SSL connection and a valid root certificate.
-  - `require`: This mode requires an SSL connection.
-  - `prefer`: This mode will try to establish a secure SSL connection if possible, but will connect insecurely if the server does not support SSL.
-  - `disable`: This mode will not attempt to use an SSL connection, even if the server supports it.
+  - `verify-ca`: This mode requires a TLS connection and a valid root certificate.
+  - `require`: This mode requires a TLS connection.
+  - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
+  - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the top level `dataset` for a dataset source and federated SQL query, or in the `acceleration` section for a data store.
 

--- a/spiceaidocs/docs/components/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/components/data-connectors/postgres/index.md
@@ -32,7 +32,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
-- `pg_connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
+- `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the top level `dataset` for a dataset source and federated SQL query, or in the `acceleration` section for a data store.
 


### PR DESCRIPTION
## 🗣 Description

Add documentation for the `connection_pool_size` parameter in the Postgres Data Connector/Accelerator.
