### PR TITLE
docs: Update DuckDB and SQLite accelerator limitations

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -36,7 +36,7 @@ datasets:
 
 :::warning[Limitations]
 
-- The DuckDB accelerator does not support schemas with [field types](https://duckdb.org/docs/sql/data_types/overview): nested arrays/lists, UTF8/string arrays/lists, structs or map fields. For example:
+- The DuckDB accelerator does not support schemas with [field types](https://duckdb.org/docs/sql/data_types/overview): nested arrays/lists, UTF8/string arrays/lists, structs, nested structs or map fields. For example:
   - Supported:
     - `SELECT [1, 2, 3];`
     - `SELECT ['1992-09-20 11:30:00.123456789', 'epoch'::TIMESTAMP]`
@@ -46,4 +46,7 @@ datasets:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
     - `SELECT ['duck', 'goose', 'heron'];`
 - The DuckDB accelerator does not support `Decimal256` (76 digits), as it exceeds DuckDB's maximum Decimal width of 38 digits.
+- The DuckDB accelerator does not support using the same `duckdb_file` for multiple accelerated datasets.
+- Updating a dataset with DuckDB acceleration while the Spice Runtime is running (hot-reload) will cause DuckDB accelerator query federation to disable until the Runtime is restarted.
+
 :::

--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -35,7 +35,10 @@ datasets:
         sqlite_file: /my/chosen/location/sqlite.db
 ```
 
-## Limitations
+:::warning[Limitations]
 
 - The SQLite accelerator only support arrow `Decimal128` and `Decimal256` for up to 16 precision, as SQLite REAL type conforms to the [IEEE 754 Binary-64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64) format which supports 16 decimal digits.
 - The SQLite accelerator don't support arrow `Interval` types, as [SQLite](https://www.sqlite.org/lang_datefunc.html) doesn't have a native interval type.
+- Updating a dataset with SQLite acceleration while the Spice Runtime is running (hot-reload) will cause SQLite accelerator query federation to disable until the Runtime is restarted.
+
+:::


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Documents the limitations for DuckDB where you cannot use the same `duckdb_file` accelerator file in multiple accelerators
* Documents the common limitation for accelerator federation during dataset hot-reload

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes https://github.com/spiceai/spiceai/issues/2326
* Closes https://github.com/spiceai/spiceai/issues/1864
