### PR TITLE
Update the doc to use correct pg_sslmode param

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -50,7 +50,7 @@ datasets:
         pg_db: my_database
         pg_user: my_user
         pg_pass: ${secrets:my_pg_pass}
-        pg_sslmode: required
+        pg_sslmode: require
 ```
 
 Specify different secrets for a PostgreSQL source and acceleration:


### PR DESCRIPTION
## 🗣 Description

`pg_sslmode` param uses `require` instead of `required`. Fix the wrong value in the doc.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
