### PR TITLE
Update docs to include `s3_auth` parameter for the S3 Data Connector

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -23,8 +23,8 @@ datasets:
       s3_key: ${secrets:S3_KEY}
       s3_secret: ${secrets:S3_SECRET}
   # Using IAM roles
-  - from: s3://s3-bucket-name/path/to/parquet/cool_dataset.parquet
-    name: cool_dataset
+  - from: s3://s3-bucket-name/path/to/parquet/cool_dataset2.parquet
+    name: cool_dataset2
     params:
       s3_auth: iam_role
   # Using a public bucket

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -13,6 +13,27 @@ Support for Iceberg and other file-formats are on the roadmap.
 
 If a folder is provided, all child Parquet/CSV files will be loaded.
 
+```yaml
+datasets:
+  # Using access keys
+  - from: s3://s3-bucket-name/path/to/parquet/cool_dataset.parquet
+    name: cool_dataset
+    params:
+      s3_auth: key
+      s3_key: ${secrets:S3_KEY}
+      s3_secret: ${secrets:S3_SECRET}
+  # Using IAM roles
+  - from: s3://s3-bucket-name/path/to/parquet/cool_dataset.parquet
+    name: cool_dataset
+    params:
+      s3_auth: iam_role
+  # Using a public bucket
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
+    name: taxi_trips
+    params:
+      file_format: parquet
+```
+
 ## Dataset Schema Reference
 
 ### `from`
@@ -42,10 +63,11 @@ More CSV related parameters can be configured, see [CSV Parameters](/reference/f
 
 Not required for public endpoints. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_dremio_pass}`.
 
+- `s3_auth`: (Optional) The authentication method to use. Values are `public`, `key` and `iam_role`. Defaults to `public` if `s3_key` and `s3_secret` are not provided, otherwise defaults to `key`.
 - `s3_key`: The access key (e.g. `AWS_ACCESS_KEY_ID` for AWS)
 - `s3_secret`: The secret key (e.g. `AWS_SECRET_ACCESS_KEY` for AWS)
 
-For endpoints protected by access keys, `s3_key` and `s3_secret` are required.
+For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of currently running instance.
 
 <Tabs>
   <TabItem value="env" label="Env">
@@ -177,9 +199,3 @@ Create a dataset named `taxi_trips` from a public S3 folder.
   params:
     file_format: parquet
 ```
-
-:::warning[Limitations]
-
-- Only S3 authentication using `aws_access_key_id` and `aws_secret_access_key` is currently supported. Please [submit an issue](https://github.com/spiceai/spiceai/issues/new?template=feature_request.md) if you would like to see support for other authentication methods.
-
-:::

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -11,7 +11,7 @@ The S3 Data Connector enables federated SQL query across Parquet/CSV files store
 
 Support for Iceberg and other file-formats are on the roadmap.
 
-If a folder is provided, all child Parquet/CSV files will be loaded.
+If a folder is provided, all child Parquet/CSV files will be loaded. Specify `file_format: parquet` or `file_format: csv` in the `params` section.
 
 ```yaml
 datasets:

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -7,11 +7,23 @@ description: 'S3 Data Connector Documentation'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The S3 Data Connector enables federated SQL query across Parquet/CSV files stored in S3, or S3-compatible storage solutions (e.g. MinIO, Cloudflare R2).
+The S3 Data Connector enables federated SQL query on files stored in S3 or S3-compatible systems (e.g. MinIO, Cloudflare R2).
 
-Support for Iceberg and other file-formats are on the roadmap.
+If a folder is provided, all child files will be loaded.
 
-If a folder is provided, all child Parquet/CSV files will be loaded. Specify `file_format: parquet` or `file_format: csv` in the `params` section.
+File formats are specified using the `file_format` parameter in the `params` section. File formats currently supported are:
+
+| Name                                          | Parameter               | Supported |
+| --------------------------------------------- | ----------------------- | --------- |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        |
+| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   |
+| JSON                                          | `file_format: json`     | Roadmap   |
+| Markdown                                      | `file_format: markdown` | Roadmap   |
+| Text                                          | `file_format: txt`      | Roadmap   |
+| PDF                                           | `file_format: pdf`      | Roadmap   |
+
+Example `spicepod.yml`:
 
 ```yaml
 datasets:
@@ -22,11 +34,13 @@ datasets:
       s3_auth: key
       s3_key: ${secrets:S3_KEY}
       s3_secret: ${secrets:S3_SECRET}
+
   # Using AWS IAM roles
   - from: s3://s3-bucket-name/path/to/parquet/cool_dataset2.parquet
     name: cool_dataset2
     params:
       s3_auth: iam_role
+
   # Using a public bucket
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips
@@ -61,13 +75,13 @@ More CSV related parameters can be configured, see [CSV Parameters](/reference/f
 
 ## Auth
 
-Not required for public endpoints. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_dremio_pass}`.
+Optional for public endpoints. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_dremio_pass}`.
 
 - `s3_auth`: (Optional) The authentication method to use. Values are `public`, `key` and `iam_role`. Defaults to `public` if `s3_key` and `s3_secret` are not provided, otherwise defaults to `key`.
 - `s3_key`: The access key (e.g. `AWS_ACCESS_KEY_ID` for AWS)
 - `s3_secret`: The secret key (e.g. `AWS_SECRET_ACCESS_KEY` for AWS)
 
-For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of currently running instance.
+For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the currently running instance.
 
 <Tabs>
   <TabItem value="env" label="Env">

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -22,7 +22,7 @@ datasets:
       s3_auth: key
       s3_key: ${secrets:S3_KEY}
       s3_secret: ${secrets:S3_SECRET}
-  # Using IAM roles
+  # Using AWS IAM roles
   - from: s3://s3-bucket-name/path/to/parquet/cool_dataset2.parquet
     name: cool_dataset2
     params:


### PR DESCRIPTION
## 🗣 Description

Improves the docs for the new `s3_auth` parameter added in https://github.com/spiceai/spiceai/pull/2611
