### PR TITLE
Standardise file format docs. Add docs about document tables

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/file.md
+++ b/spiceaidocs/docs/components/data-connectors/file.md
@@ -9,19 +9,7 @@ import TabItem from '@theme/TabItem';
 
 The File Data Connector enables federated SQL queries on files stored by locally accessible filesystems. It supports querying individual files or entire directories, where all child files within the directory will be loaded and queried.
 
-File formats are specified using the `file_format` parameter in the `params` section. File formats currently supported are:
-
-| Name                                          | Parameter               | Supported |
-| --------------------------------------------- | ----------------------- | --------- |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        |
-| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   |
-| JSON                                          | `file_format: json`     | Roadmap   |
-| Markdown                                      | `file_format: markdown` | Roadmap   |
-| Text                                          | `file_format: txt`      | Roadmap   |
-| PDF                                           | `file_format: pdf`      | Roadmap   |
-
-File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](/reference/file_format)
+File formats are specified using the `file_format` parameter, as described in [Object Store File Formats](/components/data-connectors/index.md#object-store-file-formats).
 
 Example `spicepod.yml`
 

--- a/spiceaidocs/docs/components/data-connectors/ftp.md
+++ b/spiceaidocs/docs/components/data-connectors/ftp.md
@@ -19,9 +19,7 @@ If a folder is provided, all child Parquet/CSV files will be loaded.
 
     The connection to FTP can be configured by providing the following params:
 
-    - `file_format`: Specifies the data file format. Required if the format cannot be inferred by from the `from` path.
-      - `parquet`: Parquet file format.
-      - `csv`: CSV file format.
+    - `file_format`: Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](/components/data-connectors/index.md#object-store-file-formats).
     - `ftp_port`: Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`
     - `ftp_user`: The username for the FTP server. E.g. `ftp_user: my-ftp-user`
     - `ftp_pass`: The password for the FTP server. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -35,7 +35,7 @@ Currently supported Data Connectors include:
 ## Object Store File Formats
 For data connectors that are object store compatible, if a folder is provided, the file format must be specified with `params.file_format`.
 
-For individual files, the file format will be inferred, and `params.file_format` is unnecessary.
+If a file is provided, the file format will be inferred, and `params.file_format` is unnecessary.
 
 File formats currently supported are:
 

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -41,15 +41,15 @@ File formats currently supported are:
 
 | Name                                          | Parameter               | Supported | Is Document Format |
 | --------------------------------------------- | ----------------------- | --------- | ------------------ |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        | ❌                |
-| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        | ❌                |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   | ❌                |
-| JSON                                          | `file_format: json`     | Roadmap   | ❌                |
-| Microsoft Excel                               | `file_format: xlsx`     | Roadmap   | ❌                |
-| Markdown                                      | `file_format: md`       | Roadmap   | ✅                |
-| Text                                          | `file_format: txt`      | Roadmap   | ✅                |
-| PDF                                           | `file_format: pdf`      | Roadmap   | ✅                |
-| Microsoft Word                                | `file_format: doc`      | Roadmap   | ✅                |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        | ❌                 |
+| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        | ❌                 |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   | ❌                 |
+| JSON                                          | `file_format: json`     | Roadmap   | ❌                 |
+| Microsoft Excel                               | `file_format: xlsx`     | Roadmap   | ❌                 |
+| Markdown                                      | `file_format: md`       | ✅        | ✅                 |
+| Text                                          | `file_format: txt`      | ✅        | ✅                 |
+| PDF                                           | `file_format: pdf`      | Roadmap   | ✅                 |
+| Microsoft Word                                | `file_format: doc`      | Roadmap   | ✅                 |
 
 File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](/reference/file_format)
 

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -11,24 +11,95 @@ Data Connectors provide connections to databases, data warehouses, and data lake
 
 Currently supported Data Connectors include:
 
-| Name            | Description | Status | Protocol/Format                     | Refresh Modes    | Supports Inserts |
-| --------------- | ----------- | ------ | ----------------------------------- | ---------------- | ---------------- |
-| `databricks`    | Databricks  | Alpha  | Spark Connect <br/> S3 / Delta Lake | `full`           | ❌               |
-| `delta_lake`    | Delta Lake  | Alpha  | Delta Lake                          | `full`           | ❌               |
-| `postgres`      | PostgreSQL  | Alpha  |                                     | `full`           | ❌               |
-| `spiceai`       | Spice.ai    | Alpha  | Arrow Flight                        | `append`, `full` | ✅               |
-| `s3`            | S3          | Alpha  | Parquet, CSV                        | `full`           | ❌               |
-| `dremio`        | Dremio      | Alpha  | Arrow Flight SQL                    | `full`           | ❌               |
-| `flightsql`     | FlightSQL   | Alpha  | Arrow Flight SQL                    | `full`           | ❌               |
-| `snowflake`     | Snowflake   | Alpha  | Arrow                               | `full`           | ❌               |
-| `mysql`         | MySQL       | Alpha  |                                     | `full`           | ❌               |
-| `clickhouse`    | Clickhouse  | Alpha  |                                     | `full`           | ❌               |
-| `spark`         | Spark       | Alpha  | Spark Connect                       | `full`           | ❌               |
-| `ftp`, `sftp`   | FTP/SFTP    | Alpha  | Parquet, CSV                        | `full`           | ❌               |
-| `graphql`       | GraphQL     | Alpha  | GraphQL                             | `full`           | ❌               |
-| `github`        | GitHub      | Alpha  | GraphQL, REST                       | `full`           | ❌               |
-| `odbc`          | ODBC        | Alpha  | ODBC                                | `full`           | ❌               |
-| `http`, `https` | HTTP(s)     | Alpha  | Parquet, CSV                        | `full`           | ❌               |
+| Name            | Description | Status | Protocol/Format                     | Refresh Modes    | Supports Inserts | Supports Documents |
+| --------------- | ----------- | ------ | ----------------------------------- | ---------------- | ---------------- | ------------------ |
+| `clickhouse`    | Clickhouse  | Alpha  |                                     | `full`           | ❌               | ❌                |
+| `databricks`    | Databricks  | Alpha  | Spark Connect <br/> S3 / Delta Lake | `full`           | ❌               | ❌                |
+| `delta_lake`    | Delta Lake  | Alpha  | Delta Lake                          | `full`           | ❌               | ❌                |
+| `dremio`        | Dremio      | Alpha  | Arrow Flight SQL                    | `full`           | ❌               | ❌                |
+| `file`          | File        | Alpha  | Parquet, CSV                        | `full`           | ❌               | ✅                |
+| `flightsql`     | FlightSQL   | Alpha  | Arrow Flight SQL                    | `full`           | ❌               | ❌                |
+| `ftp`, `sftp`   | FTP/SFTP    | Alpha  | Parquet, CSV                        | `full`           | ❌               | ✅                |
+| `graphql`       | GraphQL     | Alpha  | GraphQL                             | `full`           | ❌               | ❌                |
+| `github`        | GitHub      | Alpha  | GraphQL, REST                       | `full`           | ❌               | ❌                |
+| `http`, `https` | HTTP(s)     | Alpha  | Parquet, CSV                        | `full`           | ❌               | ❌                |
+| `mysql`         | MySQL       | Alpha  |                                     | `full`           | ❌               | ❌                |
+| `odbc`          | ODBC        | Alpha  | ODBC                                | `full`           | ❌               | ❌                |
+| `postgres`      | PostgreSQL  | Alpha  |                                     | `full`           | ❌               | ❌                |
+| `snowflake`     | Snowflake   | Alpha  | Arrow                               | `full`           | ❌               | ❌                |
+| `spiceai`       | Spice.ai    | Alpha  | Arrow Flight                        | `append`, `full` | ✅               | ❌                |
+| `s3`            | S3          | Alpha  | Parquet, CSV                        | `full`           | ❌               | ✅                |
+| `sharepoint`    | SharePoint  | Alpha  |                                     | `full`           | ❌               | ✅                |
+| `spark`         | Spark       | Alpha  | Spark Connect                       | `full`           | ❌               | ❌                |
+
+## Object Store File Formats
+For data connectors that are object store compatible, if a folder is provided, the file format must be specified with `params.file_format`. This is unnecessary for a single file.
+
+File formats currently supported are:
+
+| Name                                          | Parameter               | Supported | Is Document Format |
+| --------------------------------------------- | ----------------------- | --------- | ------------------ |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        | ❌                |
+| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        | ❌                |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   | ❌                |
+| JSON                                          | `file_format: json`     | Roadmap   | ❌                |
+| Microsoft Excel                               | `file_format: xlsx`     | Roadmap   | ❌                |
+| Markdown                                      | `file_format: md`       | Roadmap   | ✅                |
+| Text                                          | `file_format: txt`      | Roadmap   | ✅                |
+| PDF                                           | `file_format: pdf`      | Roadmap   | ✅                |
+| Microsoft Word                                | `file_format: doc`      | Roadmap   | ✅                |
+
+File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](/reference/file_format)
+
+If a format is a document format, each file will be treated as a document, as per [document support](#document-support) below.
+
+### Document Support
+If a Data Connector supports documents, when the appropriate file format is specified (see [above](#object-store-file-formats)), each file will be treated as a row in the table, with the contents of the file within the `content` column. Additional columns will exist, dependent on the data connector.
+
+#### Example
+Consider a local filesystem
+```shell
+>>> ls -la
+total 232
+drwxr-sr-x@ 22 jeadie  staff    704 30 Jul 13:12 .
+drwxr-sr-x@ 18 jeadie  staff    576 30 Jul 13:12 ..
+-rw-r--r--@  1 jeadie  staff   1329 15 Jan  2024 DR-000-Template.md
+-rw-r--r--@  1 jeadie  staff   4966 11 Aug  2023 DR-001-Dremio-Architecture.md
+-rw-r--r--@  1 jeadie  staff   2307 28 Jul  2023 DR-002-Data-Completeness.md
+```
+
+And the spicepod
+```yaml
+datasets:
+    - name: my_documents
+      from: file:docs/decisions/
+      params:
+        file_format: md
+```
+A Document table will be created.
+```shell
+>>> SELECT * FROM my_documents LIMIT 3
++--------------------------------------------------------------------------------+--------------------------------------------------+
+| location                                                                       | content                                          |
++--------------------------------------------------------------------------------+--------------------------------------------------+
+| Users/jeadie/Github/data-platform/docs/decisions/DR-000-Template.md            | # DR-000: DR Template                            |
+|                                                                                | **Date:** <>                                     |
+|                                                                                | **Decision Makers:**                             |                                            |
+|                                                                                | - @<>                                            |
+|                                                                                | - @<>                                            |
+|                                                                                | ...                                              |
+| Users/jeadie/Github/data-platform/docs/decisions/DR-001-Dremio-Architecture.md | # DR-001: Add "Cached" Dremio Dataset            |
+|                                                                                |                                                  |
+|                                                                                | ## Context                                       |
+|                                                                                |                                                  |
+|                                                                                | We use [Dremio](https://www.dremio.com/) to p... |
+| Users/jeadie/Github/data-platform/docs/decisions/DR-002-Data-Completeness.md   | # DR-002: Append-Only Data Completeness          |
+|                                                                                |                                                  |
+|                                                                                | ## Context                                       |
+|                                                                                |                                                  |
+|                                                                                | Our Ethereum append-only dataset is incomple...  |
++--------------------------------------------------------------------------------+--------------------------------------------------+
+```
 
 ## Data Connector Docs
 

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -79,26 +79,26 @@ datasets:
 A Document table will be created.
 ```shell
 >>> SELECT * FROM my_documents LIMIT 3
-+--------------------------------------------------------------------------------+--------------------------------------------------+
-| location                                                                       | content                                          |
-+--------------------------------------------------------------------------------+--------------------------------------------------+
-| Users/jeadie/Github/data-platform/docs/decisions/DR-000-Template.md            | # DR-000: DR Template                            |
-|                                                                                | **Date:** <>                                     |
-|                                                                                | **Decision Makers:**                             |                                            |
-|                                                                                | - @<>                                            |
-|                                                                                | - @<>                                            |
-|                                                                                | ...                                              |
-| Users/jeadie/Github/data-platform/docs/decisions/DR-001-Dremio-Architecture.md | # DR-001: Add "Cached" Dremio Dataset            |
-|                                                                                |                                                  |
-|                                                                                | ## Context                                       |
-|                                                                                |                                                  |
-|                                                                                | We use [Dremio](https://www.dremio.com/) to p... |
-| Users/jeadie/Github/data-platform/docs/decisions/DR-002-Data-Completeness.md   | # DR-002: Append-Only Data Completeness          |
-|                                                                                |                                                  |
-|                                                                                | ## Context                                       |
-|                                                                                |                                                  |
-|                                                                                | Our Ethereum append-only dataset is incomple...  |
-+--------------------------------------------------------------------------------+--------------------------------------------------+
++----------------------------------------------------+--------------------------------------------------+
+| location                                           | content                                          |
++----------------------------------------------------+--------------------------------------------------+
+| Users/docs/decisions/DR-000-Template.md            | # DR-000: DR Template                            |
+|                                                    | **Date:** <>                                     |
+|                                                    | **Decision Makers:**                             |
+|                                                    | - @<>                                            |
+|                                                    | - @<>                                            |
+|                                                    | ...                                              |
+| Users/docs/decisions/DR-001-Dremio-Architecture.md | # DR-001: Add "Cached" Dremio Dataset            |
+|                                                    |                                                  |
+|                                                    | ## Context                                       |
+|                                                    |                                                  |
+|                                                    | We use [Dremio](https://www.dremio.com/) to p... |
+| Users/docs/decisions/DR-002-Data-Completeness.md   | # DR-002: Append-Only Data Completeness          |
+|                                                    |                                                  |
+|                                                    | ## Context                                       |
+|                                                    |                                                  |
+|                                                    | Our Ethereum append-only dataset is incomple...  |
++----------------------------------------------------+--------------------------------------------------+
 ```
 
 ## Data Connector Docs

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -33,7 +33,9 @@ Currently supported Data Connectors include:
 | `spark`         | Spark       | Alpha  | Spark Connect                       | `full`           | ❌               | ❌                |
 
 ## Object Store File Formats
-For data connectors that are object store compatible, if a folder is provided, the file format must be specified with `params.file_format`. This is unnecessary for a single file.
+For data connectors that are object store compatible, if a folder is provided, the file format must be specified with `params.file_format`.
+
+For individual files, the file format will be inferred, and `params.file_format` is unnecessary.
 
 File formats currently supported are:
 

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -11,17 +11,7 @@ The S3 Data Connector enables federated SQL query on files stored in S3 or S3-co
 
 If a folder is provided, all child files will be loaded.
 
-File formats are specified using the `file_format` parameter in the `params` section. File formats currently supported are:
-
-| Name                                          | Parameter               | Supported |
-| --------------------------------------------- | ----------------------- | --------- |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet`  | ✅        |
-| [CSV](/reference/file_format.md#csv)          | `file_format: csv`      | ✅        |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg`  | Roadmap   |
-| JSON                                          | `file_format: json`     | Roadmap   |
-| Markdown                                      | `file_format: markdown` | Roadmap   |
-| Text                                          | `file_format: txt`      | Roadmap   |
-| PDF                                           | `file_format: pdf`      | Roadmap   |
+File formats are specified using the `file_format` parameter, as described in [Object Store File Formats](/components/data-connectors/index.md#object-store-file-formats).
 
 Example `spicepod.yml`:
 


### PR DESCRIPTION
## 🗣 Description
 - Add docs to standardise how we describe `params.file_format`.
 - Add basic docs about `document tables`. 