### PR TITLE
Document federated pushdown limitations for Postgres connector & accelerator

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -74,3 +74,7 @@ datasets:
         pg_user: two_user_two_furious
         pg_pass: ${secrets:pg2_pass}
 ```
+
+:::warning[Limitations]
+
+- The Postgres federated queries may result in unexpected result types due to the difference in DataFusion and Postgres size increase rules. Please explicitly specify the expected output type of aggregation functions when writing query involving Postgres table in Spice. For example, rewrite `SUM(int_col)` into `CAST (SUM(int_col) as BIGINT`.

--- a/spiceaidocs/docs/components/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/components/data-connectors/postgres/index.md
@@ -83,3 +83,7 @@ datasets:
         pg_user: two_user_two_furious
         pg_pass: ${secrets:pg2_pass}
 ```
+
+:::warning[Limitations]
+
+- The Postgres federated queries may result in unexpected result types due to the difference in DataFusion and Postgres size increase rules. Please explicitly specify the expected output type of aggregation functions when writing query involving Postgres table in Spice. For example, rewrite `SUM(int_col)` into `CAST (SUM(int_col) as BIGINT`.


### PR DESCRIPTION
## 🗣 Description

Document federated pushdown limitations for Postgres connector & accelerator, which is caused by different size increase rules in DataFusion and Postgres.

## 🔨 Related Issues

- https://github.com/spiceai/spiceai/issues/2727

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
