### PR TITLE
docs: Add spicepod config docs for task_history

### DIFF
--- a/spiceaidocs/docs/reference/spicepod/index.md
+++ b/spiceaidocs/docs/reference/spicepod/index.md
@@ -171,6 +171,24 @@ runtime:
     key_file: /path/to/key.pem
 ```
 
+### `runtime.task_history`
+
+The task history section specifies runtime task history configuration.
+
+```yaml
+runtime:
+  task_history:
+    enabled: true
+    captured_output: truncated
+    retention_period: 8h
+    retention_check_interval: 15m
+```
+
+- `enabled` - optional, `true` by default.
+- `captured_output` - optional, what level of output is captured by the task history table. `truncated` by default. Possible values are `truncated`, or `none`.
+- `retention_period` - optional, how long records in the task history table should be retained. Default is `8h`, or 8 hours.
+- `retention_check_interval` - optional, how often should old records be checked for removal. Default is `15m`, or 15 minutes.
+
 ## `metadata`
 
 An optional `map` of metadata.


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds documentation for the `runtime.task_history` spicepod configuration

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* #404 will extend the `task_history` documentation in future, once https://github.com/spiceai/spiceai/issues/2639 is completed and `query_history` is replaced with `task_history`.
