### PR TITLE
Rename spiceai data connector to spice.ai

### DIFF
--- a/spiceaidocs/docs/components/catalogs/index.md
+++ b/spiceaidocs/docs/components/catalogs/index.md
@@ -21,7 +21,7 @@ Currently supported Catalog Connectors include:
 | --------------- | ----------- | ------ | ----------------------------------- |
 | `databricks`    | Databricks  | Alpha  | Spark Connect <br/> S3 / Delta Lake | 
 | `unity_catalog`    | Unity Catalog  | Alpha  | Delta Lake                          | 
-| `spiceai`       | Spice.ai Cloud Platform    | Alpha  | Arrow Flight                        |
+| `spice.ai`       | Spice.ai Cloud Platform    | Alpha  | Arrow Flight                        |
 
 ## Catalog Connector Docs
 
@@ -35,7 +35,7 @@ Example:
 
 ```yaml
 catalogs:
-  - from: spiceai
+  - from: spice.ai
     name: spiceai
     include:
       - "tpch.*" # Include only the "tpch" tables.

--- a/spiceaidocs/docs/components/catalogs/spiceai.md
+++ b/spiceaidocs/docs/components/catalogs/spiceai.md
@@ -16,7 +16,7 @@ Create a [Spice.ai Cloud Platform](https://spice.ai) account and login with the 
 Example:
 ```yaml
 catalogs:
-  - from: spiceai
+  - from: spice.ai
     name: spicey # tables from the Spice.ai platform will be available in the "spicey" schema in Spice
     include:
       - "tpch.*" # include only the tables from the "tpch" schema

--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -9,7 +9,7 @@ To use DuckDB as Data Accelerator, specify `duckdb` as the `engine` for accelera
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: duckdb
@@ -25,7 +25,7 @@ Configuration `params` are provided in the `acceleration` section for a data sto
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: duckdb

--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -10,7 +10,7 @@ To use PostgreSQL as Data Accelerator, specify `postgres` as the `engine` for ac
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: postgres
@@ -40,7 +40,7 @@ Configuration `params` are provided either in the `acceleration` section of a da
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: postgres
@@ -57,7 +57,7 @@ Specify different secrets for a PostgreSQL source and acceleration:
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     params:
       pg_host: localhost

--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -10,7 +10,7 @@ To use SQLite as Data Accelerator, specify `sqlite` as the `engine` for accelera
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: sqlite
@@ -26,7 +26,7 @@ Configuration `params` are provided in the `acceleration` section of a dataset. 
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     acceleration:
       engine: sqlite

--- a/spiceaidocs/docs/components/data-connectors/postgres/index.md
+++ b/spiceaidocs/docs/components/data-connectors/postgres/index.md
@@ -66,7 +66,7 @@ Specify different secrets for a PostgreSQL source and acceleration:
 
 ```yaml
 datasets:
-  - from: spiceai:path.to.my_dataset
+  - from: spice.ai:path.to.my_dataset
     name: my_dataset
     params:
       pg_host: localhost

--- a/spiceaidocs/docs/components/secret-stores/keyring/index.md
+++ b/spiceaidocs/docs/components/secret-stores/keyring/index.md
@@ -34,7 +34,7 @@ And the secret can be referenced in parameters:
 
 ```yaml
 datasets:
-  - from: spiceai:eth.recent_blocks
+  - from: spice.ai:eth.recent_blocks
     name: blocks
     params:
       spiceai_api_key: ${keyring:spiceai_api_key} # ${secrets:spiceai_api_key} can also be used

--- a/spiceaidocs/docs/components/secret-stores/kubernetes/index.md
+++ b/spiceaidocs/docs/components/secret-stores/kubernetes/index.md
@@ -19,7 +19,7 @@ And the secret can be referenced in parameters:
 
 ```yaml
 datasets:
-  - from: spiceai:eth.recent_blocks
+  - from: spice.ai:eth.recent_blocks
     name: blocks
     params:
       spiceai_api_key: ${k8s:spiceai_api_key} # ${secrets:spiceai_api_key} can also be used to fallback to other secret stores

--- a/spiceaidocs/docs/reference/spicepod/catalogs.md
+++ b/spiceaidocs/docs/reference/spicepod/catalogs.md
@@ -14,7 +14,7 @@ Example:
 
 ```yaml
 catalogs:
-  - from: spiceai
+  - from: spice.ai
     name: spiceai
     include:
       - "tpch.*" # Include only the "tpch" tables.
@@ -36,7 +36,7 @@ Where:
 
   Currently supported catalog connectors:
 
-  - [`spiceai`](/components/catalogs/spiceai.md)
+  - [`spice.ai`](/components/catalogs/spiceai.md)
   - [`databricks`](/components/catalogs/databricks.md)
   - [`unity_catalog`](/components/catalogs/unity-catalog.md)
 
@@ -51,7 +51,7 @@ An alternative to adding the catalog definition inline in the `spicepod.yaml` fi
 **catalogs/sample/catalog.yaml**
 
 ```yaml
-from: spiceai
+from: spice.ai
 name: spiceai
 include:
   - "tpch.*" # Include only the "tpch" tables.


### PR DESCRIPTION
## 🗣 Description

Update docs according to: [Rename spiceai data connector to spice.ai](https://github.com/spiceai/spiceai/pull/2680)

~Currently Draft to merge after `0.18.3-beta` release~
