### PR TITLE
Adding a limitations section for each accelerator

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -50,3 +50,11 @@ datasets:
 - Updating a dataset with DuckDB acceleration while the Spice Runtime is running (hot-reload) will cause DuckDB accelerator query federation to disable until the Runtime is restarted.
 
 :::
+
+:::warning[Memory Considerations]
+
+When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+
+To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+
+:::

--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -53,8 +53,8 @@ datasets:
 
 :::warning[Memory Considerations]
 
-When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+When accelerating a dataset using `mode: memory` (the default), some or all of the dataset is loaded into memory. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
 
-To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+In-memory limitations can be mitigated by storing acceleration data on disk, which is supported by [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) accelerators by specifying `mode: file`.
 
 :::

--- a/spiceaidocs/docs/components/data-accelerators/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/index.md
@@ -39,6 +39,14 @@ Supported Data Accelerators include:
 
 Data Accelerators may not support all possible Apache Arrow data types. For complete compatibility, see [specifications](/reference/datatypes.md).
 
+:::warning[Memory Considerations]
+
+When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+
+To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+
+:::
+
 ## Data Accelerator Docs
 
 import DocCardList from '@theme/DocCardList';

--- a/spiceaidocs/docs/components/data-accelerators/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/index.md
@@ -41,9 +41,9 @@ Data Accelerators may not support all possible Apache Arrow data types. For comp
 
 :::warning[Memory Considerations]
 
-When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+When accelerating a dataset using `mode: memory` (the default), some or all of the dataset is loaded into memory. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
 
-To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+In-memory limitations can be mitigated by storing acceleration data on disk, which is supported by [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) accelerators by specifying `mode: file`.
 
 :::
 

--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -78,3 +78,13 @@ datasets:
 :::warning[Limitations]
 
 - The Postgres federated queries may result in unexpected result types due to the difference in DataFusion and Postgres size increase rules. Please explicitly specify the expected output type of aggregation functions when writing query involving Postgres table in Spice. For example, rewrite `SUM(int_col)` into `CAST (SUM(int_col) as BIGINT`.
+
+:::
+
+:::warning[Memory Considerations]
+
+When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+
+To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+
+:::

--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -80,11 +80,3 @@ datasets:
 - The Postgres federated queries may result in unexpected result types due to the difference in DataFusion and Postgres size increase rules. Please explicitly specify the expected output type of aggregation functions when writing query involving Postgres table in Spice. For example, rewrite `SUM(int_col)` into `CAST (SUM(int_col) as BIGINT`.
 
 :::
-
-:::warning[Memory Considerations]
-
-When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
-
-To help alleviate these limitations, [`duckdb`](../duckdb.md) and [`sqlite`](../sqlite.md) have the option to spill the data onto the local disk.
-
-:::

--- a/spiceaidocs/docs/components/data-accelerators/postgres/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/postgres/index.md
@@ -85,6 +85,6 @@ datasets:
 
 When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
 
-To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+To help alleviate these limitations, [`duckdb`](../duckdb.md) and [`sqlite`](../sqlite.md) have the option to spill the data onto the local disk.
 
 :::

--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -46,8 +46,8 @@ datasets:
 
 :::warning[Memory Considerations]
 
-When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+When accelerating a dataset using `mode: memory` (the default), some or all of the dataset is loaded into memory. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
 
-To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+In-memory limitations can be mitigated by storing acceleration data on disk, which is supported by [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) accelerators by specifying `mode: file`.
 
 :::

--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -43,3 +43,11 @@ datasets:
 - Updating a dataset with SQLite acceleration while the Spice Runtime is running (hot-reload) will cause SQLite accelerator query federation to disable until the Runtime is restarted.
 
 :::
+
+:::warning[Memory Considerations]
+
+When accelerating a dataset some or all of the data will be put into memory. Ensure that you have enough memory for all of your datasets. Some overhead for the query engine will also be required as well, especially with multiple concurrent queries.
+
+To help alleviate these limitations, [`duckdb`](./duckdb.md) and [`sqlite`](./sqlite.md) have the option to spill the data onto the local disk.
+
+:::


### PR DESCRIPTION
## 🗣 Description

Adding a limitations section for each data accelerator. Each accelerator (including Arrow) has a section about the limitations, and links to `duckdb` and `sqlite` for accelerators that spill to disk.

## 🔨 Related Issues

- #370 

## 🤔 Concerns