### PR TITLE
Add OpenAI model example to AI Gateway documentation

### DIFF
--- a/spiceaidocs/docs/features/ai-gateway/index.md
+++ b/spiceaidocs/docs/features/ai-gateway/index.md
@@ -26,24 +26,14 @@ For detailed configuration and API usage, refer to the [API Documentation](/api)
 
 ### Example: Configuring an OpenAI Model
 
-To use a language model hosted on OpenAI (or compatible), specify the `openai` path in `from`. 
+To use a language model hosted on OpenAI (or compatible), specify the `openai` path and model ID in `from`.
 
-Specific the model ID in `from`.
-These parameters are specific to OpenAI models:
-
-| Param | Description | Default |
-| ----- | ----------- | ------- |
-| `openai_api_key` | The OpenAI API key.        | -                           |
-| `openai_org_id` | The OpenAI organization id. | -                           |
-| `openai_project_id` | The OpenAI project id.  | -                           |
-| `endpoint` | The OpenAI API base endpoint.    | `https://api.openai.com/v1` |
-
-Example configuration:
+Example `spicepod.yml`:
 
 ```yaml
 models:
-  - from: openai:gpt-4o
-    name: local_fs_model
+  - from: openai:gpt-4o-mini
+    name: openai
     params:
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
 
@@ -54,4 +44,4 @@ models:
       openai_api_key: ${ secrets:SPICE_GROQ_API_KEY }
 ```
 
-This example demonstrates how to configure an OpenAI model in the AI Gateway. The `from` field specifies the model source and ID, while the `params` field includes necessary parameters such as the API key and endpoint.
+For details, see [OpenAI (or Compatible) Language Models](/components/models/openai/index.md).

--- a/spiceaidocs/docs/features/ai-gateway/index.md
+++ b/spiceaidocs/docs/features/ai-gateway/index.md
@@ -44,4 +44,4 @@ models:
       openai_api_key: ${ secrets:SPICE_GROQ_API_KEY }
 ```
 
-For details, see [OpenAI (or Compatible) Language Models](/components/models/openai/index.md).
+For details, see [OpenAI (or Compatible) Language Models](/components/models/openai.md).

--- a/spiceaidocs/docs/features/ai-gateway/index.md
+++ b/spiceaidocs/docs/features/ai-gateway/index.md
@@ -23,3 +23,35 @@ Spice supports a variety of LLMs (see [Model Components](/components/models/inde
 - **System Prompts**: Customize system prompts and override defaults for [`v1/chat/completion`](/api/http/chat-completions.md).
 
 For detailed configuration and API usage, refer to the [API Documentation](/api).
+
+### Example: Configuring an OpenAI Model
+
+To use a language model hosted on OpenAI (or compatible), specify the `openai` path in `from`. 
+
+For a specific model, include it as the model ID in `from`. Defaults to `"gpt-3.5-turbo"`.
+These parameters are specific to OpenAI models:
+
+| Param | Description | Default |
+| ----- | ----------- | ------- |
+| `openai_api_key` | The OpenAI API key.        | -                           |
+| `openai_org_id` | The OpenAI organization id. | -                           |
+| `openai_project_id` | The OpenAI project id.  | -                           |
+| `endpoint` | The OpenAI API base endpoint.    | `https://api.openai.com/v1` |
+
+Example configuration:
+
+```yaml
+models:
+  - from: openai:gpt-4o
+    name: local_fs_model
+    params:
+      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
+
+  - from: openai:llama3-groq-70b-8192-tool-use-preview
+    name: groq-llama
+    params:
+      endpoint: https://api.groq.com/openai/v1
+      openai_api_key: ${ secrets:SPICE_GROQ_API_KEY }
+```
+
+This example demonstrates how to configure an OpenAI model in the AI Gateway. The `from` field specifies the model source and ID, while the `params` field includes necessary parameters such as the API key and endpoint.

--- a/spiceaidocs/docs/features/ai-gateway/index.md
+++ b/spiceaidocs/docs/features/ai-gateway/index.md
@@ -28,7 +28,7 @@ For detailed configuration and API usage, refer to the [API Documentation](/api)
 
 To use a language model hosted on OpenAI (or compatible), specify the `openai` path in `from`. 
 
-For a specific model, include it as the model ID in `from`. Defaults to `"gpt-3.5-turbo"`.
+Specific the model ID in `from`.
 These parameters are specific to OpenAI models:
 
 | Param | Description | Default |


### PR DESCRIPTION
Add an example of configuring an OpenAI model to the AI Gateway documentation page.

* Add a new section "Example: Configuring an OpenAI Model" to `spiceaidocs/docs/features/ai-gateway/index.md`
* Include a YAML configuration example for an OpenAI model
* Provide a brief explanation of the example and its parameters

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spiceai/docs?shareId=d6b92326-ac4f-442e-b1d0-2bc4ab2dcbd2).