### PR TITLE
docs: Promote DuckDB Accelerator, MySQL Connector

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/index.md
+++ b/spiceaidocs/docs/components/data-accelerators/index.md
@@ -30,10 +30,10 @@ Supported Data Accelerators include:
 
 | Engine Name                       | Description             | Status | Engine Modes     |
 | --------------------------------- | ----------------------- | ------ | ---------------- |
-| [`arrow`](./arrow.md)             | In-Memory Arrow Records | Alpha  | `memory`         |
-| [`duckdb`](./duckdb.md)           | Embedded DuckDB         | Alpha  | `memory`, `file` |
-| [`sqlite`](./sqlite.md)           | Embedded SQLite         | Alpha  | `memory`, `file` |
+| [`duckdb`](./duckdb.md)           | Embedded DuckDB         | Beta   | `memory`, `file` |
 | [`postgres`](./postgres/index.md) | Attached PostgreSQL     | Beta   |                  |
+| [`arrow`](./arrow.md)             | In-Memory Arrow Records | Alpha  | `memory`         |
+| [`sqlite`](./sqlite.md)           | Embedded SQLite         | Alpha  | `memory`, `file` |
 
 ## Data Types
 

--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -13,26 +13,26 @@ Currently supported Data Connectors include:
 
 | Name            | Description   | Status | Protocol/Format                     | Refresh Modes               | Supports [Ingestion](https://docs.spiceai.org/features/data-ingestion) | Supports Documents |
 | --------------- | ------------- | ------ | ----------------------------------- | --------------------------- | ------------------ | ------------------ |
-| `abfs`          | Azure BlobFS  | Alpha  | Parquet, CSV                        | `append`, `full`            | Roadmap            | ✅                 |
-| `clickhouse`    | Clickhouse    | Alpha  |                                     | `append`, `full`            | ❌                 | ❌                 |
+| `mysql`         | MySQL         | Release Candidate   |                                     | `append`, `full`            | Roadmap            | ❌                 |
 | `databricks`    | Databricks    | Beta   | Spark Connect <br/> S3 / Delta Lake | `append`, `full`            | Roadmap            | ❌                 |
-| `debezium`      | Debezium      | Alpha  | CDC, Kafka                          | `append`, `full`, `changes` | ❌                 | ❌                 |
 | `delta_lake`    | Delta Lake    | Beta   | Delta Lake                          | `append`, `full`            | Roadmap            | ❌                 |
-| `dremio`        | Dremio        | Alpha  | Arrow Flight SQL                    | `append`, `full`            | ❌                 | ❌                 |
-| `file`          | File          | Alpha   | Parquet, CSV                        | `append`, `full`            | Roadmap            | ✅                 |
 | `flightsql`     | FlightSQL     | Beta   | Arrow Flight SQL                    | `append`, `full`            | ❌                 | ❌                 |
-| `ftp`, `sftp`   | FTP/SFTP      | Alpha  | Parquet, CSV                        | `append`, `full`            | ❌                 | ✅                 |
 | `github`        | GitHub        | Beta   | GraphQL, REST                       | `append`, `full`            | ❌                 | ❌                 |
-| `graphql`       | GraphQL       | Alpha  | GraphQL                             | `append`, `full`            | ❌                 | ❌                 |
-| `http`, `https` | HTTP(s)       | Alpha  | Parquet, CSV                        | `append`, `full`            | ❌                 | ❌                 |
-| `mssql`         | MS SQL Server | Alpha  | Tabular Data Stream (TDS)           | `append`, `full`            | ❌                 | ❌                 |
-| `mysql`         | MySQL         | Beta   |                                     | `append`, `full`            | Roadmap            | ❌                 |
 | `odbc`          | ODBC          | Beta  |                                     | `append`, `full`            | ❌                 | ❌                 |
 | `postgres`      | PostgreSQL    | Beta   |                                     | `append`, `full`            | Roadmap            | ❌                 |
 | `s3`            | S3            | Beta   | Parquet, CSV                        | `append`, `full`            | Roadmap            | ✅                 |
+| `spiceai`       | Spice.ai      | Beta   | Arrow Flight                        | `append`, `full`            | ✅                 | ❌                 |
+| `abfs`          | Azure BlobFS  | Alpha  | Parquet, CSV                        | `append`, `full`            | Roadmap            | ✅                 |
+| `clickhouse`    | Clickhouse    | Alpha  |                                     | `append`, `full`            | ❌                 | ❌                 |
+| `debezium`      | Debezium      | Alpha  | CDC, Kafka                          | `append`, `full`, `changes` | ❌                 | ❌                 |
+| `dremio`        | Dremio        | Alpha  | Arrow Flight SQL                    | `append`, `full`            | ❌                 | ❌                 |
+| `file`          | File          | Alpha   | Parquet, CSV                        | `append`, `full`            | Roadmap            | ✅                 |
+| `ftp`, `sftp`   | FTP/SFTP      | Alpha  | Parquet, CSV                        | `append`, `full`            | ❌                 | ✅                 |
+| `graphql`       | GraphQL       | Alpha  | GraphQL                             | `append`, `full`            | ❌                 | ❌                 |
+| `http`, `https` | HTTP(s)       | Alpha  | Parquet, CSV                        | `append`, `full`            | ❌                 | ❌                 |
+| `mssql`         | MS SQL Server | Alpha  | Tabular Data Stream (TDS)           | `append`, `full`            | ❌                 | ❌                 |
 | `sharepoint`    | SharePoint    | Alpha  |                                     | `append`, `full`            | ❌                 | ✅                 |
 | `snowflake`     | Snowflake     | Alpha  | Arrow                               | `append`, `full`            | Roadmap            | ❌                 |
-| `spiceai`       | Spice.ai      | Beta   | Arrow Flight                        | `append`, `full`            | ✅                 | ❌                 |
 | `spark`         | Spark         | Alpha  | Spark Connect                       | `append`, `full`            | ❌                 | ❌                 |
 
 ## Object Store File Formats


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Promotes DuckDB Accelerator to Beta
* Promotes MySQL Connector to RC
* Re-organizes table to display connectors/accelerators ordered by release status (RC->Beta->Alpha)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
