### PR TITLE
Update SQLite limitations

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -38,9 +38,11 @@ datasets:
 
 :::warning[Limitations]
 
-- The SQLite accelerator only support arrow `Decimal128` and `Decimal256` for up to 16 precision, as SQLite REAL type conforms to the [IEEE 754 Binary-64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#IEEE_754_double-precision_binary_floating-point_format:_binary64) format which supports 16 decimal digits.
-- The SQLite accelerator don't support arrow `Interval` types, as [SQLite](https://www.sqlite.org/lang_datefunc.html) doesn't have a native interval type.
+- The SQLite accelerator doesn't support arrow `Interval` types, as [SQLite](https://www.sqlite.org/lang_datefunc.html) doesn't have a native interval type.
 - The SQLite accelerator only supports arrow `List` types of primitive data types; lists with structs are not supported.
+- The SQLite accelerator doesn't support advanced grouping features such as `ROLLUP` and `GROUPING`.
+- In SQLite, `CAST(value AS DECIMAL)` doesn't convert an integer to a floating-point value if the casted value is an integer. Operations like `CAST(1 AS DECIMAL) / CAST(2 AS DECIMAL)` will be treated as integer division, resulting in 0 instead of the expected 0.5.
+Use `FLOAT` to ensure conversion to a floating-point value: `CAST(1 AS FLOAT) / CAST(2 AS FLOAT)`.
 - Updating a dataset with SQLite acceleration while the Spice Runtime is running (hot-reload) will cause SQLite accelerator query federation to disable until the Runtime is restarted.
 
 :::


### PR DESCRIPTION
## 🗣 Description

Update SQLite limitations:
 - Remove Decimal limitations as no more actual
 - Add limitation related to unsupported grouping features `ROLLUP` and `GROUPING`

## 🔨 Related Issues

part of https://github.com/spiceai/spiceai/issues/3028

