### PR TITLE
S3 doc improvement: Add the IAM policy requirement for S3 documentation

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -72,7 +72,25 @@ Optional for public endpoints. Use the [secret replacement syntax](../secret-sto
 - `s3_key`: The access key (e.g. `AWS_ACCESS_KEY_ID` for AWS)
 - `s3_secret`: The secret key (e.g. `AWS_SECRET_ACCESS_KEY` for AWS)
 
-For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the currently running instance.
+For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the currently running instance. The following IAM policy shows the least priviledge policy required for the S3 connector:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::yourcompany-bucketname-datasets"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::yourcompany-bucketname-datasets/*"
+    }
+  ]
+}
+```
 
 <Tabs>
   <TabItem value="env" label="Env">

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -25,7 +25,7 @@ datasets:
       s3_key: ${secrets:S3_KEY}
       s3_secret: ${secrets:S3_SECRET}
 
-  # Using AWS IAM roles
+  # Using IAM roles or Kubernetes service accounts with assigned IAM roles
   - from: s3://s3-bucket-name/path/to/parquet/cool_dataset2.parquet
     name: cool_dataset2
     params:
@@ -72,7 +72,7 @@ Optional for public endpoints. Use the [secret replacement syntax](../secret-sto
 - `s3_key`: The access key (e.g. `AWS_ACCESS_KEY_ID` for AWS)
 - `s3_secret`: The secret key (e.g. `AWS_SECRET_ACCESS_KEY` for AWS)
 
-For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the currently running instance. The following IAM policy shows the least priviledge policy required for the S3 connector:
+For non-public buckets, `s3_auth: key` or `s3_auth: iam_role` is required. `s3_auth: iam_role` will use the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the currently running instance. The following IAM policy shows the least privileged policy required for the S3 connector:
 
 ```json
 {


### PR DESCRIPTION
## 🗣 Description

- Add the least privileged IAM policy required for the S3 connector to the documentation.
- Add the instructions to use `s3_auth: iam_role` for Kubernetes service accounts 

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
