### PR TITLE
Improve the Ready State documentation

### DIFF
--- a/spiceaidocs/docs/api/http/ready.md
+++ b/spiceaidocs/docs/api/http/ready.md
@@ -1,0 +1,49 @@
+---
+title: 'GET /v1/ready'
+sidebar_label: 'GET /v1/ready'
+sidebar_position: 1
+description: 'HTTP Readiness API'
+---
+
+Spice indicates when all datasets have finished loading and is ready to accept queries by returning a 200 status code on the `/v1/ready` endpoint. Before this endpoint returns a 200 status code, queries may return an error. The behavior for when an accelerated dataset is considered ready is configurable via the `ready_state` parameter, see [Data Refresh](/components/data-accelerators/data-refresh#ready-state) for more details.
+
+Example request:
+
+```shell
+curl -i "127.0.0.1:8090/v1/ready"
+```
+
+Ready response:
+
+```bash
+HTTP/1.1 200 OK
+content-type: text/plain; charset=utf-8
+content-length: 5
+date: Sat, 02 Nov 2024 07:37:14 GMT
+
+Ready
+```
+
+Not ready response:
+
+```bash
+HTTP/1.1 503 Service Unavailable
+content-type: text/plain; charset=utf-8
+content-length: 9
+date: Sat, 02 Nov 2024 07:44:55 GMT
+
+Not Ready
+```
+
+## Readiness Probe
+
+In production deployments, the `/v1/ready` endpoint can be used as a [readiness probe](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/#readiness-probe) for a Spice deployment to ensure traffic is routed to the Spice runtime only after all datasets have finished loading.
+
+Example Kubernetes readiness probe:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /v1/ready
+    port: 8090
+```

--- a/spiceaidocs/docs/components/data-accelerators/arrow.md
+++ b/spiceaidocs/docs/components/data-accelerators/arrow.md
@@ -2,7 +2,7 @@
 title: 'In-Memory Arrow Data Accelerator'
 sidebar_label: 'In-Memory Arrow Data Accelerator'
 description: 'In-Memory Arrow Data Accelerator Documentation'
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 The In-Memory Arrow Data Accelerator is the default data accelerator in Spice. It uses Apache Arrow to store data in-memory for fast access and query performance.

--- a/spiceaidocs/docs/components/data-accelerators/data-refresh.md
+++ b/spiceaidocs/docs/components/data-accelerators/data-refresh.md
@@ -50,6 +50,26 @@ When using `mode: append`, if late arriving data or clock-skew needs to be accou
 
 Datasets configured with acceleration `refresh_mode: changes` require a [Change Data Capture (CDC)](/features/cdc/index.md) supported data connector. Initial CDC support in Spice is supported by the [Debezium data connector](/components/data-connectors/debezium.md).
 
+## Ready State
+
+By default, Spice will return an error for queries against an accelerated dataset that is still loading its initial data. The endpoint [`/v1/ready`](/api/http/ready) is used in production deployments to control when queries are sent to the Spice runtime.
+
+The ready state for an accelerated dataset can be configured using the [`ready_state`](/reference/spicepod/datasets#accelerationready_state) parameter in the acceleration configuration.
+
+- `ready_state: on_load`: Default. The dataset is considered ready after the initial load of the accelerated data. For file-based accelerated datasets that have existing data, this will be ready immediately. Queries against this dataset before the data is loaded will return an error.
+- `ready_state: on_registration`: The dataset is considered ready when the dataset is registered in Spice, even before the initial data is loaded. Queries against this dataset before the data is loaded will automatically fallback to the federated source. Once the data is loaded, queries will be served from the acceleration.
+
+Example:
+
+```yaml
+datasets:
+  - from: s3://my_bucket/my_dataset
+    name: my_dataset
+    acceleration:
+      enabled: true
+      ready_state: on_load # or on_registration
+```
+
 ## Filtered Refresh
 
 Typically only a working subset of an entire dataset is used in an application or dashboard. Use these features to filter refresh data, creating a smaller subset for faster processing and to reduce the data transferred and stored locally.

--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -2,7 +2,7 @@
 title: 'DuckDB Data Accelerator'
 sidebar_label: 'DuckDB Data Accelerator'
 description: 'DuckDB Data Accelerator Documentation'
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 To use DuckDB as Data Accelerator, specify `duckdb` as the `engine` for acceleration.

--- a/spiceaidocs/docs/components/data-accelerators/sqlite.md
+++ b/spiceaidocs/docs/components/data-accelerators/sqlite.md
@@ -2,7 +2,7 @@
 title: 'SQLite Data Accelerator'
 sidebar_label: 'SQLite Data Accelerator'
 description: 'SQLite Data Accelerator Documentation'
-sidebar_position: 3
+sidebar_position: 4
 pagination_next: null
 ---
 


### PR DESCRIPTION
## 🗣 Description

Improves the documentation for the `ready_state` feature added in v0.19.4-beta.

Also re-orders the `Data Refresh` page to come first under the `Data Accelerators` section.

Adds documentation for the `/v1/ready` HTTP API.
