### PR TITLE
Add allow_http documentation to s3 connector

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -60,6 +60,7 @@ Example: `name: cool_dataset`
 - `s3_endpoint`: The S3 endpoint, or equivalent (e.g. MinIO endpoint), for the S3-compatible storage. Defaults to region endpoint. E.g. `s3_endpoint: https://my.minio.server`
 - `s3_region`: Region of the S3 bucket, if region specific. Default value is `us-east-1` E.g. `s3_region: us-east-1`
 - `client_timeout`: Specifies timeout for S3 operations. Default value is `30s` E.g. `client_timeout: 60s`
+- `allow_http`: Allow connection to `s3_endpoint` with `HTTP` protocol. Defaults to `false`
 - `hive_partitioning_enabled`: Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`
 
 More CSV related parameters can be configured, see [CSV Parameters](/reference/file_format.md#csv)
@@ -208,8 +209,9 @@ Create a dataset named `cool_dataset` from a Parquet file stored in MinIO.
 - from: s3://s3-bucket-name/path/to/parquet/cool_dataset.parquet
   name: cool_dataset
   params:
-    s3_endpoint: https://my.minio.server
+    s3_endpoint: http://my.minio.server
     s3_region: 'us-east-1' # Best practice for Minio
+    allow_http: true
 ```
 
 ### S3 Public Example

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -64,12 +64,13 @@ SELECT COUNT(*) FROM cool_dataset;
 | `s3_auth`                   | Authentication type. Options: `public`, `key` and `iam_role`. Defaults to `public` if `s3_key` and `s3_secret` are not provided, otherwise defaults to `key`. |
 | `s3_key`                    | Access key (e.g. `AWS_ACCESS_KEY_ID` for AWS)                                                                                                                 |
 | `s3_secret`                 | Secret key (e.g. `AWS_SECRET_ACCESS_KEY` for AWS)                                                                                                             |
+| `allow_http`                | Allow insecure HTTP connections to `s3_endpoint`. Defaults to `false`                                                                                         |
 
 For additional CSV parameters, see [CSV Parameters](/reference/file_format.md#csv)
 
 ## Authentication
 
-No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
+No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. For Kubernetes Service Accounts with assigned IAM roles, set s3_auth to iam_role. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
 
 Minimum IAM policy for S3 access:
 

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -210,7 +210,7 @@ Create a dataset named `cool_dataset` from a Parquet file stored in MinIO.
   name: cool_dataset
   params:
     s3_endpoint: http://my.minio.server
-    s3_region: 'us-east-1' # Best practice for Minio
+    s3_region: 'us-east-1' # Best practice for MinIO
     allow_http: true
 ```
 

--- a/spiceaidocs/docs/components/data-connectors/s3.md
+++ b/spiceaidocs/docs/components/data-connectors/s3.md
@@ -70,7 +70,7 @@ For additional CSV parameters, see [CSV Parameters](/reference/file_format.md#cs
 
 ## Authentication
 
-No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. For Kubernetes Service Accounts with assigned IAM roles, set s3_auth to iam_role. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
+No authentication is required for public endpoints. For private buckets, set s3_auth to key or iam_role. For Kubernetes Service Accounts with assigned IAM roles, set `s3_auth` to `iam_role`. If using iam_role, the [AWS IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) of the running instance is used.
 
 Minimum IAM policy for S3 access:
 


### PR DESCRIPTION
## 🗣 Description

* Add description for s3 connector `allow_http` parameter
* Improve MinIO example

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
