### PR TITLE
Include unsupported indexes and constraints to Arrow Data Connector limitations

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/arrow.md
+++ b/spiceaidocs/docs/components/data-accelerators/arrow.md
@@ -36,6 +36,7 @@ datasets:
 
 - The In-Memory Arrow Data Accelerator does not support persistent storage. Data is stored in-memory and will be lost when the Spice runtime is stopped.
 - The In-Memory Arrow Data Accelerator does not support `Decimal256` (76 digits), as it exceeds Arrow's maximum Decimal width of 38 digits.
+- The In-Memory Arrow Data Accelerator does not support [constraints](/features/data-acceleration/constraints) and [indexes](/features/data-acceleration/indexes).
 
 :::warning[Memory Considerations]
 


### PR DESCRIPTION
## 🗣 Description

Include unsupported indexes and constraints to Arrow Data Connector limitations

<img width="810" alt="image" src="https://github.com/user-attachments/assets/0c92218d-1cfd-45e4-a82f-8427b3bd189e">


## 🔨 Related Issues

Part of https://github.com/spiceai/spiceai/issues/3345
