### PR TITLE
docs: Clarify DuckDB type limitations

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -37,8 +37,11 @@ datasets:
 :::warning[Limitations]
 
 - The DuckDB accelerator does not support nested lists, or structs with nested structs/lists [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
+  - Supported:
+    - `SELECT {'x': 1, 'y': 2, 'z': 3}`
   - Unsupported:
     - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
+    - `SELECT {'x': [1, 2, 3]}`
 - The DuckDB accelerator does not support enum, dictionary, or map [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
   - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`

--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -36,18 +36,14 @@ datasets:
 
 :::warning[Limitations]
 
-- The DuckDB accelerator does not support schemas with [field types](https://duckdb.org/docs/sql/data_types/overview): nested arrays/lists, UTF8/string arrays/lists, boolean arrays/lists, structs, nested structs or map fields. For example:
-  - Supported:
-    - `SELECT [1, 2, 3];`
-    - `SELECT ['1992-09-20 11:30:00.123456789', 'epoch'::TIMESTAMP]`
+- The DuckDB accelerator does not support nested lists, or structs with nested structs/lists [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
   - Unsupported:
     - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
-    - `SELECT {'x': 1, 'y': 2, 'z': 3}`
+- The DuckDB accelerator does not support enum, dictionary, or map [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
+  - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
-    - `SELECT ['duck', 'goose', 'heron'];`
-    - `SELECT [true, false];`
 - The DuckDB accelerator does not support `Decimal256` (76 digits), as it exceeds DuckDB's maximum Decimal width of 38 digits.
-- Updating a dataset with DuckDB acceleration while the Spice Runtime is running (hot-reload) will cause DuckDB accelerator query federation to disable until the Runtime is restarted.
+- Updating a dataset with DuckDB acceleration while the Spice Runtime is running (hot-reload) will cause the DuckDB accelerator query federation to disable until the Runtime is restarted.
 
 :::
 

--- a/spiceaidocs/docs/components/data-connectors/duckdb.md
+++ b/spiceaidocs/docs/components/data-connectors/duckdb.md
@@ -83,3 +83,16 @@ SELECT * FROM 'todos.json';
 -- As a DuckDB function
 SELECT * FROM read_json('todos.json');
 ```
+
+:::warning[Limitations]
+
+- The DuckDB connector does not support nested lists, or structs with nested structs/lists [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
+  - Unsupported:
+    - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
+- The DuckDB connector does not support enum, dictionary, or map [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
+  - Unsupported:
+    - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
+- The DuckDB connector does not support `Decimal256` (76 digits), as it exceeds DuckDB's maximum Decimal width of 38 digits.
+- Updating a dataset with a DuckDB connector while the Spice Runtime is running (hot-reload) will cause the DuckDB connector query federation to disable until the Runtime is restarted.
+
+:::

--- a/spiceaidocs/docs/components/data-connectors/duckdb.md
+++ b/spiceaidocs/docs/components/data-connectors/duckdb.md
@@ -96,6 +96,5 @@ SELECT * FROM read_json('todos.json');
   - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
 - The DuckDB connector does not support `Decimal256` (76 digits), as it exceeds DuckDB's maximum Decimal width of 38 digits.
-- Updating a dataset with a DuckDB connector while the Spice Runtime is running (hot-reload) will cause the DuckDB connector query federation to disable until the Runtime is restarted.
 
 :::

--- a/spiceaidocs/docs/components/data-connectors/duckdb.md
+++ b/spiceaidocs/docs/components/data-connectors/duckdb.md
@@ -87,8 +87,11 @@ SELECT * FROM read_json('todos.json');
 :::warning[Limitations]
 
 - The DuckDB connector does not support nested lists, or structs with nested structs/lists [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
+  - Supported:
+    - `SELECT {'x': 1, 'y': 2, 'z': 3}`
   - Unsupported:
     - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
+    - `SELECT {'x': [1, 2, 3]}`
 - The DuckDB connector does not support enum, dictionary, or map [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
   - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

For DuckDB accelerator and connector:
* Removes UTF8 lists and boolean lists from the limitations, as they are supported
* Removes simple structs from the limitations, as they are supported
* Adds enums to the list of unsupported data types