### PR TITLE
Update file connector docs to clarify `file://` behavior

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/file.md
+++ b/spiceaidocs/docs/components/data-connectors/file.md
@@ -30,6 +30,7 @@ The `from` field for the File connector takes the form `file://path` where `path
 The dataset name. This will be used as the table name within Spice.
 
 Example:
+
 ```yaml
 datasets:
   - from: file://path/to/customer.parquet
@@ -84,7 +85,7 @@ In this example, `path` is an absolute path to the file on the filesystem.
 
 ```yaml
 datasets:
-  - from: file://path/to/customer.parquet
+  - from: file:///path/to/customer.parquet
     name: customer
     params:
       file_format: parquet
@@ -102,7 +103,7 @@ In this example, the path is relative to the directory where the `spicepod.yaml`
 
 ```yaml
 datasets:
-  - from: file:foo/yellow_tripdata_2024-01.parquet
+  - from: file://foo/yellow_tripdata_2024-01.parquet
     name: trip_data
     params:
       file_format: parquet

--- a/spiceaidocs/docs/reference/spicepod/datasets.md
+++ b/spiceaidocs/docs/reference/spicepod/datasets.md
@@ -60,12 +60,16 @@ acceleration:
 
 ## `from`
 
-The `from` field is a string that represents the Uniform Resource Identifier (URI) for the dataset. This URI is composed of two parts: a prefix indicating the Data Connector to use to connect to the dataset, and the path to the dataset within the source.
+The `from` field is a string that represents the Uniform Resource Identifier (URI) for the dataset. This URI is composed of two parts: a prefix indicating the Data Connector to use to connect to the dataset, a delimiter, and the path to the dataset within the source.
 
 The syntax for the `from` field is as follows:
 
 ```yaml
 from: <data_connector>:<path>
+# OR
+from: <data_connector>/<path>
+# OR
+from: <data_connector>://<path>
 ```
 
 Where:
@@ -89,6 +93,8 @@ Where:
   - [`graphql`](/components/data-connectors/graphql.md)
 
   If the Data Connector is not explicitly specified, it defaults to `spiceai`.
+
+- `<delimiter>`: The delimiter between the Data Connector and the path. Currently supported delimiters are `:`, `/`, and `://`. Some connectors place additional restrictions on the allowed delimiters to better conform to the expected syntax of the underlying data source, i.e. `s3://` is the only supported delimiter for the `s3` connector.
 
 - `<path>`: The path to the dataset within the source.
 


### PR DESCRIPTION
## 🗣 Description

Updates the documentation to clarify the behavior of `file://` wrt absolute/relative paths.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
