### PR TITLE
docs: Reorder connector table

### DIFF
--- a/spiceaidocs/docs/components/data-connectors/index.md
+++ b/spiceaidocs/docs/components/data-connectors/index.md
@@ -15,6 +15,7 @@ Currently supported Data Connectors include:
 | ---------------------------------- | ------------------------- | ----------------- | ------------------------- | --------------------------- | ------------------------------- | ------------------ |
 | `duckdb`                           | DuckDB                    | Release Candidate |                           | `append`, `full`            | ❌                              | ❌                 |
 | `github`                           | GitHub                    | Release Candidate | GraphQL, REST             | `append`, `full`            | ❌                              | ❌                 |
+| `graphql`                          | GraphQL                   | Release Candidate | GraphQL                   | `append`, `full`            | ❌                              | ❌                 |
 | `mysql`                            | MySQL                     | Release Candidate |                           | `append`, `full`            | Roadmap                         | ❌                 |
 | `postgres`                         | PostgreSQL                | Release Candidate |                           | `append`, `full`            | Roadmap                         | ❌                 |
 | `s3`                               | S3                        | Release Candidate | Parquet, CSV              | `append`, `full`            | Roadmap                         | ✅                 |
@@ -32,7 +33,6 @@ Currently supported Data Connectors include:
 | `dremio`                           | Dremio                    | Alpha             | Arrow Flight SQL          | `append`, `full`            | ❌                              | ❌                 |
 | `file`                             | File                      | Alpha             | Parquet, CSV              | `append`, `full`            | Roadmap                         | ✅                 |
 | `ftp`, `sftp`                      | FTP/SFTP                  | Alpha             | Parquet, CSV              | `append`, `full`            | ❌                              | ✅                 |
-| `graphql`                          | GraphQL                   | Release Candidate | GraphQL                   | `append`, `full`            | ❌                              | ❌                 |
 | `http`, `https`                    | HTTP(s)                   | Alpha             | Parquet, CSV              | `append`, `full`            | ❌                              | ❌                 |
 | `localpod`                         | Local dataset replication | Alpha             |                           | `append`, `full`            | ❌                              | ✅                 |
 | `sharepoint`                       | SharePoint                | Alpha             |                           | `append`, `full`            | ❌                              | ✅                 |


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Moves the GraphQL connector to be properly ordered in alphabetical order by release status