### PR TITLE
Document trace verbosity flags (`-v`, `-vv`)

### DIFF
--- a/spiceaidocs/docs/cli/tracing.md
+++ b/spiceaidocs/docs/cli/tracing.md
@@ -1,37 +1,53 @@
 ---
 title: 'Configuring Trace Levels'
 sidebar_label: 'Trace Levels'
-description: 'Documentation on how to configure Spice.ai OSS trace levels'
+description: 'Configuring Spice.ai OSS trace output verbosity levels'
 pagination_prev: null
 ---
 
-Trace verbosity is controlled by the `SPICED_LOG` environment variable.
+Output trace verbosity is controlled by the `SPICED_LOG` environment variable and verbosity flags (`-v`, `-vv`).
 
-### Default Trace Levels
+### Default
 
-The default level is `INFO` for these components:
+The default trace level is `INFO`, suitable for general information about the system.
 
 ```bash
-SPICED_LOG="task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO"
+SPICED_LOG="task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,reqwest_retry::middleware=off,WARN"
 ```
 
 ### Enabling Debug Mode
 
-To enable debug mode, which provides detailed logs, use:
+Use the `-v` CLI flag to enable detailed logs, useful for debugging.
 
 ```bash
-SPICED_LOG="DEBUG" spice run
+spice run -v
+spiced -v
 ```
 
-For the most verbose logging, set the trace level to `TRACE`:
+This sets `SPICED_LOG` to `DEBUG` level:
 
 ```bash
-SPICED_LOG="TRACE" spice run
+SPICED_LOG="task_history=DEBUG,spiced=DEBUG,runtime=DEBUG,secrets=DEBUG,data_components=DEBUG,cache=DEBUG,extensions=DEBUG,spice_cloud=DEBUG,llms=DEBUG,DEBUG" spice run
+```
+
+### Enabling Trace Mode
+
+Use the `-vv` CLI flag to enable the most detailed logs, typically for in-depth troubleshooting.
+
+```bash
+spice run -vv
+spiced -vv
+```
+
+This sets `SPICED_LOG` to `TRACE` level:
+
+```bash
+SPICED_LOG="task_history=TRACE,spiced=TRACE,runtime=TRACE,secrets=TRACE,data_components=TRACE,cache=TRACE,extensions=TRACE,spice_cloud=TRACE,llms=TRACE,TRACE" spice run
 ```
 
 ### Granular Configuration
 
-For specific components, adjust the trace levels as needed:
+For specific component trace configuration, adjust the trace levels as needed:
 
 ```bash
 SPICED_LOG="spiced=INFO,runtime=DEBUG,data_components=WARN,cache=WARN" spice run


### PR DESCRIPTION
## 🗣 Description

Document trace verbosity flags (`-v`, `-vv`)

