### PR TITLE
DuckDB: remove nested lists acceleration support limitation

### DIFF
--- a/spiceaidocs/docs/components/data-accelerators/duckdb.md
+++ b/spiceaidocs/docs/components/data-accelerators/duckdb.md
@@ -36,12 +36,6 @@ datasets:
 
 :::warning[Limitations]
 
-- The DuckDB accelerator does not support nested lists, or structs with nested structs/lists [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
-  - Supported:
-    - `SELECT {'x': 1, 'y': 2, 'z': 3}`
-  - Unsupported:
-    - `SELECT [['duck', 'goose', 'heron'], ['frog', 'toad']]`
-    - `SELECT {'x': [1, 2, 3]}`
 - The DuckDB accelerator does not support enum, dictionary, or map [field types](https://duckdb.org/docs/sql/data_types/overview). For example:
   - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`


### PR DESCRIPTION
## 🗣 Description

DuckDB: remove nested lists acceleration support limitation. Support is added in RC.3

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
