### PR TITLE
Move scarf pixel to the bottom, to fix layout

### DIFF
--- a/spiceaidocs/docusaurus.config.ts
+++ b/spiceaidocs/docusaurus.config.ts
@@ -33,16 +33,6 @@ const config: Config = {
     locales: ['en'],
   },
 
-  headTags: [
-    {
-      tagName: 'img',
-      attributes: {
-        referrerPolicy: 'no-referrer-when-downgrade',
-        src: 'https://static.scarf.sh/a.png?x-pxid=d13c8a61-d145-479a-92dc-6a231eddbb3e',
-      },
-    },
-  ],
-
   presets: [
     [
       'classic',

--- a/spiceaidocs/src/theme/Root.tsx
+++ b/spiceaidocs/src/theme/Root.tsx
@@ -1,0 +1,13 @@
+import React, { type PropsWithChildren } from "react";
+
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <>
+      {children}
+      <img
+        referrerPolicy="no-referrer-when-downgrade"
+        src="https://static.scarf.sh/a.png?x-pxid=d13c8a61-d145-479a-92dc-6a231eddbb3e"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Extended docs root wrapper to place scarf pixel to the bottom (using [root swizzling](https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root)), to remove unexpected offset from the top.

**Before**:

![CleanShot 2025-01-05 at 17 18 41@2x](https://github.com/user-attachments/assets/3b580e76-e21a-41a5-be66-6a7fb859382c)

**After**:

![CleanShot 2025-01-05 at 17 11 09@2x](https://github.com/user-attachments/assets/6f5e231a-ccc7-493a-9c75-f021e2f8a49c)
