### PR TITLE
Document memory limitation for databricks data connector (mode: delta_lake)

### DIFF
--- a/website/docs/components/data-connectors/databricks.md
+++ b/website/docs/components/data-connectors/databricks.md
@@ -192,6 +192,16 @@ The table below shows the Databricks (mode: delta_lake) data types supported, al
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](/docs/components/secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](/docs/components/secret-stores#using-secrets).
 
+## Limitations
+
+ :::warning[Performance Considerations]
+
+ When using the Databricks (mode: delta_lake) Data connector without acceleration, data is loaded into memory during query execution. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
+
+ Memory limitations can be mitigated by storing acceleration data on disk, which is supported by [`duckdb`](../data-accelerators/duckdb.md) and [`sqlite`](../data-accelerators/sqlite.md) accelerators by specifying `mode: file`.
+
+ :::
+
 ## Cookbook
 
 - A cookbook recipe to configure Databricks as data connector in Spice under `delta_lake` mode. [Spice on Databricks (mode: delta_lake)](https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake#readme)

--- a/website/docs/components/data-connectors/databricks.md
+++ b/website/docs/components/data-connectors/databricks.md
@@ -194,7 +194,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Limitations
 
- :::warning[Performance Considerations]
+ :::warning[Memory Considerations]
 
  When using the Databricks (mode: delta_lake) Data connector without acceleration, data is loaded into memory during query execution. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
 


### PR DESCRIPTION
## 🗣 Description

Document memory limitation for databricks data connector (mode: delta_lake)

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
