### PR TITLE
docs: Release stable accelerators

### DIFF
--- a/website/docs/components/data-accelerators/duckdb.md
+++ b/website/docs/components/data-accelerators/duckdb.md
@@ -40,6 +40,7 @@ datasets:
   - Unsupported:
     - `SELECT MAP(['key1', 'key2', 'key3'], [10, 20, 30])`
 - The DuckDB accelerator does not support `Decimal256` (76 digits), as it exceeds DuckDB's maximum Decimal width of 38 digits.
+- Using the DuckDB accelerator with `on_zero_results: use_source` does not support using filters on binary columns when the query results in using the source connection, like `WHERE col_blob <> ''`. Cast the binary to another data type instead, like `WHERE CAST(col_blob AS TEXT) <> ''`.
 - Updating a dataset with DuckDB acceleration while the Spice Runtime is running (hot-reload) will cause the DuckDB accelerator query federation to disable until the Runtime is restarted.
 
 :::

--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -30,8 +30,8 @@ Supported Data Accelerators include:
 
 | Name       | Description                     | Status            | Engine Modes     |
 | ---------- | ------------------------------- | ----------------- | ---------------- |
-| `arrow`    | In-Memory Arrow Records         | Release Candidate | `memory`         |
-| `duckdb`   | Embedded [DuckDB][duckdb]       | Release Candidate | `memory`, `file` |
+| `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
+| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file` |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate | N/A              |
 | `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds a limitation for DuckDB about on zero results behavior with blobs
* Releases Arrow and DuckDB accelerators to Stable