### PR TITLE
Fix github token permissions in build_and_publish.yml

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -13,6 +13,8 @@ permissions:
   contents: write
 
 jobs:
+  permissions:
+    deployments: write
   deploy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -11,10 +11,9 @@ on:
 
 permissions:
   contents: write
+  deployments: write
 
 jobs:
-  permissions:
-    deployments: write
   deploy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

## 🗣 Description

Extended github token permissions to allow creating github deployment from wrangler action