### PR TITLE
Update OpenAI docs to match data connector format

### DIFF
--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -7,26 +7,72 @@ sidebar_position: 1
 
 To use a language model hosted on OpenAI (or compatible), specify the `openai` path in the `from` field.
 
-For a specific model, include it as the model ID in the `from` field (see example below). The default model is `gpt-3.5-turbo`.
-
-These parameters are specific to OpenAI models:
-
-| Param               | Description                   | Default                     |
-| ------------------- | ----------------------------- | --------------------------- |
-| `openai_api_key`    | The OpenAI API key.           | -                           |
-| `openai_org_id`     | The OpenAI organization ID.   | -                           |
-| `openai_project_id` | The OpenAI project ID.        | -                           |
-| `endpoint`          | The OpenAI API base endpoint. | `https://api.openai.com/v1` |
-
-Example:
+For a specific model, include it as the model ID in the `from` field (see example below). The default model is `gpt-4o-mini`.
 
 ```yaml
 models:
-  - from: openai:gpt-4o
+  - from: openai:gpt-4o-mini
     name: openai_model
     params:
-      openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
+      openai_api_key: ${ secrets:OPENAI_API_KEY } # Required for official OpenAI models
+      tools: auto # Optional. Connect the model to datasets via SQL query/vector search tools
+      system_prompt: "You are a helpful assistant." # Optional.
+
+      # Optional parameters
+      endpoint: https://api.openai.com/v1 # Override to use a compatible provider (i.e. NVidia NIM)
+      openai_org_id: ${ secrets:OPENAI_ORG_ID }
+      openai_project_id: ${ secrets:OPENAI_PROJECT_ID }
+
+      # Override default chat completion request parameters
+      openai_temperature: 0.1
+      openai_response_format: { "type": "json_object" }
 ```
+
+## Configuration
+
+### `from`
+
+The `from` field takes the form `openai:model_id` where `model_id` is the model ID of the OpenAI model, valid model IDs are found in the `{endpoint}/v1/models` API response.
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $OPENAI_API_KEY" https://api.openai.com/v1/models
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-4o-mini",
+      "object": "model",
+      "created": 1727389042,
+      "owned_by": "system"
+    },
+...
+}
+```
+
+### `name`
+
+The model name. This will be used as the model ID within Spice and Spice's endpoints (i.e. `http://localhost:8090/v1/models`). This can be set to the same value as the model ID in the `from` field.
+
+### `params`
+
+| Param               | Description                   | Default                     |
+| ------------------- | ----------------------------- | --------------------------- |
+| `endpoint`          | The OpenAI API base endpoint. Can be overridden to use a compatible provider (i.e. NVidia NIM). | `https://api.openai.com/v1` |
+| `tools`             | Which [tools] should be made available to the model. Set to `auto` to use all available tools. | -    |
+| `system_prompt`     | An additional system prompt used for all chat completions to this model. | -    |
+| `openai_api_key`    | The OpenAI API key.           | -                           |
+| `openai_org_id`     | The OpenAI organization ID.   | -                           |
+| `openai_project_id` | The OpenAI project ID.        | -                           |
+| `openai_temperature` | Set the default temperature to use on chat completions.  | 0.0                         |
+| `openai_response_format` | An object specifying the format that the model must output, see [structured outputs].  | -                           |
+
+[tools]: ../../features/large-language-models/tools.md
+[structured outputs]: https://platform.openai.com/docs/guides/structured-outputs
 
 ## Supported OpenAI Compatible Providers
 
@@ -48,6 +94,21 @@ models:
       endpoint: https://api.groq.com/openai/v1
       openai_api_key: ${ secrets:SPICE_GROQ_API_KEY }
 ```
+
+### NVidia NIM
+
+NVidia NIM models are OpenAI compatible endpoints. Use the following configuration:
+
+```yaml
+models:
+  - from: openai:my_nim_model_id
+    name: my_nim_model
+    params:
+      endpoint: https://my_nim_host.com/v1
+      openai_api_key: ${ secrets:SPICE_NIM_API_KEY }
+```
+
+View the Spice cookbook for an example of setting up NVidia NIM with Spice [here](https://github.com/spiceai/cookbook/tree/trunk/nvidia-nim/ec2).
 
 ### Parasail
 

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -68,7 +68,7 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 | `openai_api_key`    | The OpenAI API key.           | -                           |
 | `openai_org_id`     | The OpenAI organization ID.   | -                           |
 | `openai_project_id` | The OpenAI project ID.        | -                           |
-| `openai_temperature` | Set the default temperature to use on chat completions.  | 0.0                         |
+| `openai_temperature` | Set the default temperature to use on chat completions.  | -                           |
 | `openai_response_format` | An object specifying the format that the model must output, see [structured outputs].  | -                           |
 
 [tools]: ../../features/large-language-models/tools.md

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -62,7 +62,7 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 
 | Param               | Description                   | Default                     |
 | ------------------- | ----------------------------- | --------------------------- |
-| `endpoint`          | The OpenAI API base endpoint. Can be overridden to use a compatible provider (i.e. NVidia NIM). | `https://api.openai.com/v1` |
+| `endpoint`          | The OpenAI API base endpoint. Can be overridden to use a compatible provider (i.e. Nvidia NIM). | `https://api.openai.com/v1` |
 | `tools`             | Which [tools] should be made available to the model. Set to `auto` to use all available tools. | -    |
 | `system_prompt`     | An additional system prompt used for all chat completions to this model. | -    |
 | `openai_api_key`    | The OpenAI API key.           | -                           |


### PR DESCRIPTION
## 🗣 Description

Improves the OpenAI model docs to be in a similar format to the data connector docs, with a comprehensive example at the top, with documentation for each item in the YAML object (i.e. `from`, `name`, `params`). Add the `tools` into the default example.
