### PR TITLE
docs: Fix embeddings release status

### DIFF
--- a/website/docs/components/embeddings/index.md
+++ b/website/docs/components/embeddings/index.md
@@ -20,9 +20,9 @@ Spice supports various model sources and formats to provide embedding components
 
 | Name                | Description                                  | Status            | ML Format(s) | LLM Format(s)\*                 |
 | ------------------- | -------------------------------------------- | ----------------- | ------------ | ------------------------------- |
+| [`file`][file]      | Local filesystem                             | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
+| [`huggingface`][hf] | Models hosted on HuggingFace                 | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
 | [`openai`][openai]  | OpenAI (or compatible) LLM endpoint          | Release Candidate | -            | OpenAI-compatible HTTP endpoint |
-| [`file`][file]      | Local filesystem                             | RC                | ONNX         | GGUF, GGML, SafeTensor          |
-| [`huggingface`][hf] | Models hosted on HuggingFace                 | RC                | ONNX         | GGUF, GGML, SafeTensor          |
 | [`azure`][azure]    | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 
 [file]: /components/embeddings/local.md


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates embeddings status to use the standard `Release Candidate` instead of `RC`
* Makes the embeddings status table ordered by status, then alphabetically