### PR TITLE
Style tweaks for docs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -206,7 +206,7 @@ const config: Config = {
       },
     ],
     prism: {
-      theme: prismThemes.gruvboxMaterialDark,
+      theme: prismThemes.oneLight,
       darkTheme: prismThemes.gruvboxMaterialDark,
       additionalLanguages: ['bash', 'json', 'csharp'],
     },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -163,9 +163,9 @@ pre {
 }
 
 :root, [data-theme='light'] {
-  --ifm-color-primary: #c25e00;        /* base orange */
-  --ifm-color-primary-dark: #a85000;   /* darker orange */
-  --ifm-color-primary-darker: #9c4a00; /* even darker */
+  --ifm-color-primary: #EF5F00;        /* base orange */
+  --ifm-color-primary-dark: #CC4E00;   /* darker orange */
+  --ifm-color-primary-darker: #582D1D; /* even darker */
   --ifm-color-primary-darkest: #7d3d00;/* darkest orange */
   --ifm-color-primary-light: #cc6500;  /* light orange */
   --ifm-color-primary-lighter: #d66f00;/* lighter orange */

--- a/website/src/theme/Blog/Components/Author/Socials/index.tsx
+++ b/website/src/theme/Blog/Components/Author/Socials/index.tsx
@@ -1,0 +1,71 @@
+import type {ComponentType, ReactNode} from 'react';
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import type {Props} from '@theme/Blog/Components/Author/Socials';
+
+import Twitter from '@theme/Icon/Socials/Twitter';
+import GitHub from '@theme/Icon/Socials/GitHub';
+import X from '@theme/Icon/Socials/X';
+import StackOverflow from '@theme/Icon/Socials/StackOverflow';
+import LinkedIn from '@theme/Icon/Socials/LinkedIn';
+import DefaultSocialIcon from '@theme/Icon/Socials/Default';
+import Bluesky from '@theme/Icon/Socials/Bluesky';
+import Instagram from '@theme/Icon/Socials/Instagram';
+import Threads from '@theme/Icon/Socials/Threads';
+import Youtube from '@theme/Icon/Socials/YouTube';
+import Mastodon from '@theme/Icon/Socials/Mastodon';
+import Twitch from '@theme/Icon/Socials/Twitch';
+
+import styles from './styles.module.css';
+
+type SocialIcon = ComponentType<{className: string}>;
+
+type SocialPlatformConfig = {Icon: SocialIcon; label: string};
+
+const SocialPlatformConfigs: Record<string, SocialPlatformConfig> = {
+  twitter: {Icon: Twitter, label: 'Twitter'},
+  github: {Icon: GitHub, label: 'GitHub'},
+  stackoverflow: {Icon: StackOverflow, label: 'Stack Overflow'},
+  linkedin: {Icon: LinkedIn, label: 'LinkedIn'},
+  x: {Icon: X, label: 'X'},
+  bluesky: {Icon: Bluesky, label: 'Bluesky'},
+  instagram: {Icon: Instagram, label: 'Instagram'},
+  threads: {Icon: Threads, label: 'Threads'},
+  mastodon: {Icon: Mastodon, label: 'Mastodon'},
+  youtube: {Icon: Youtube, label: 'YouTube'},
+  twitch: {Icon: Twitch, label: 'Twitch'},
+};
+
+function getSocialPlatformConfig(platformKey: string): SocialPlatformConfig {
+  return (
+    SocialPlatformConfigs[platformKey] ?? {
+      Icon: DefaultSocialIcon,
+      label: platformKey,
+    }
+  );
+}
+
+function SocialLink({platform, link}: {platform: string; link: string}) {
+  const {Icon, label} = getSocialPlatformConfig(platform);
+  return (
+    <Link className={styles.authorSocialLink} href={link} title={label}>
+      <Icon className={clsx(styles.authorSocialLink)} />
+    </Link>
+  );
+}
+
+export default function BlogAuthorSocials({
+  author,
+}: {
+  author: Props['author'];
+}): ReactNode {
+  const entries = Object.entries(author.socials ?? {});
+  return (
+    <div className={styles.authorSocials}>
+      {entries.map(([platform, linkUrl]) => {
+        return <SocialLink key={platform} platform={platform} link={linkUrl} />;
+      })}
+    </div>
+  );
+}

--- a/website/src/theme/Blog/Components/Author/Socials/styles.module.css
+++ b/website/src/theme/Blog/Components/Author/Socials/styles.module.css
@@ -1,0 +1,32 @@
+:root {
+  --docusaurus-blog-social-icon-size: 1rem;
+}
+
+.authorSocials {
+  /*
+  This ensures that container takes height even if there's no social link
+  This keeps author names aligned even if only some have socials
+   */
+  height: var(--docusaurus-blog-social-icon-size);
+
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  line-height: 0;
+  overflow: hidden;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+
+.authorSocialLink {
+  height: var(--docusaurus-blog-social-icon-size);
+  width: var(--docusaurus-blog-social-icon-size);
+  line-height: 0;
+  margin-right: 0.4rem;
+}
+
+.authorSocialIcon {
+  width: var(--docusaurus-blog-social-icon-size);
+  height: var(--docusaurus-blog-social-icon-size);
+}

--- a/website/src/theme/Blog/Components/Author/index.tsx
+++ b/website/src/theme/Blog/Components/Author/index.tsx
@@ -1,0 +1,92 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import Link, {type Props as LinkProps} from '@docusaurus/Link';
+import AuthorSocials from '@theme/Blog/Components/Author/Socials';
+import type {Props} from '@theme/Blog/Components/Author';
+import Heading from '@theme/Heading';
+import styles from './styles.module.css';
+
+function MaybeLink(props: LinkProps): ReactNode {
+  if (props.href) {
+    return <Link {...props} />;
+  }
+  return <>{props.children}</>;
+}
+
+function AuthorTitle({title}: {title: string}) {
+  return (
+    <small className={styles.authorTitle} title={title}>
+      {title}
+    </small>
+  );
+}
+
+function AuthorName({name, as}: {name: string; as: Props['as']}) {
+  if (!as) {
+    return <span className={styles.authorName}>{name}</span>;
+  } else {
+    return (
+      <Heading as={as} className={styles.authorName}>
+        {name}
+      </Heading>
+    );
+  }
+}
+
+function AuthorBlogPostCount({count}: {count: number}) {
+  return <span className={clsx(styles.authorBlogPostCount)}>{count}</span>;
+}
+
+// Note: in the future we might want to have multiple "BlogAuthor" components
+// Creating different display modes with the "as" prop may not be the best idea
+// Explainer: https://kyleshevlin.com/prefer-multiple-compositions/
+// For now, we almost use the same design for all cases, so it's good enough
+export default function BlogAuthor({
+  as,
+  author,
+  className,
+  count,
+}: Props): ReactNode {
+  const {name, title, url, imageURL, email, page} = author;
+  const link =
+    page?.permalink || url || (email && `mailto:${email}`) || undefined;
+
+  return (
+    <div
+      className={clsx(
+        'avatar margin-bottom--lg margin-top--sm',
+        className,
+        styles[`author-as-${as}`],
+      )}>
+      {imageURL && (
+        <MaybeLink href={link} className="avatar__photo-link">
+          <img
+            className={clsx('avatar__photo', styles.authorImage)}
+            src={imageURL}
+            alt={name}
+          />
+        </MaybeLink>
+      )}
+
+      {(name || title) && (
+        <div className={clsx('avatar__intro', styles.authorDetails)}>
+          <div className="avatar__name">
+            {name && (
+              <MaybeLink href={link}>
+                <AuthorName name={name} as={as} />
+              </MaybeLink>
+            )}
+            {count !== undefined && <AuthorBlogPostCount count={count} />}
+          </div>
+          {!!title && <AuthorTitle title={title} />}
+
+          {/*
+            We always render AuthorSocials even if there's none
+            This keeps other things aligned with flexbox layout
+          */}
+          <AuthorSocials author={author} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/theme/Blog/Components/Author/styles.module.css
+++ b/website/src/theme/Blog/Components/Author/styles.module.css
@@ -1,0 +1,67 @@
+.authorImage {
+  --ifm-avatar-photo-size: 3.6rem;
+}
+
+.author-as-h1 .authorImage {
+  --ifm-avatar-photo-size: 7rem;
+}
+
+.author-as-h2 .authorImage {
+  --ifm-avatar-photo-size: 5.4rem;
+}
+
+.authorDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-around;
+}
+
+.authorName {
+  font-size: 1.1rem;
+  line-height: 1.1rem;
+  display: flex;
+  flex-direction: row;
+}
+
+.author-as-h1 .authorName {
+  font-size: 2.4rem;
+  line-height: 2.4rem;
+  display: inline;
+}
+
+.author-as-h2 .authorName {
+  font-size: 1.4rem;
+  line-height: 1.4rem;
+  display: inline;
+}
+
+.authorTitle {
+  font-size: 0.8rem;
+  line-height: 1rem;
+  display: -webkit-box;
+  overflow: hidden;
+  line-clamp: 1;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+
+.author-as-h1 .authorTitle {
+  font-size: 1.2rem;
+  line-height: 1.6rem;
+}
+
+.author-as-h2 .authorTitle {
+  font-size: 1rem;
+  line-height: 1.3rem;
+}
+
+.authorBlogPostCount {
+  background: var(--ifm-color-secondary);
+  color: var(--ifm-color-black);
+  font-size: 0.8rem;
+  line-height: 1.2;
+  border-radius: var(--ifm-global-radius);
+  padding: 0.1rem 0.4rem;
+  margin-left: 0.3rem;
+}


### PR DESCRIPTION
### Fixed primary orange theme color in light theme:

![CleanShot 2025-01-21 at 15 31 37@2x](https://github.com/user-attachments/assets/6cd704df-26fb-4ceb-aaf2-e11c6184cd93)

### Add space around author in blog

![CleanShot 2025-01-21 at 15 38 51@2x](https://github.com/user-attachments/assets/f15f6f9b-3696-44b6-ba71-276bc7dd3edc)

### Use `one light` theme for code box in light mode

![CleanShot 2025-01-21 at 15 44 36@2x](https://github.com/user-attachments/assets/3cfa42b1-c51d-4a54-b9f9-fa369332f4c4)
