### PR TITLE
docs: Update Windows install

### DIFF
--- a/website/docs/getting-started/index.mdx
+++ b/website/docs/getting-started/index.mdx
@@ -26,20 +26,23 @@ Download the latest version of Spice, connect to a dataset in S3, and ask questi
 
 <Tabs>
   <TabItem value="default" label="macOS, Linux, and WSL" default>
+    ### Install Script
+
     ```bash
     curl https://install.spiceai.org | /bin/bash
     ```
 
-    Or using `brew`:
+    ### Homebrew
 
     ```bash
     brew install spiceai/spiceai/spice
     ```
-
   </TabItem>
   <TabItem value="windows" label="Windows" default>
+    ### PowerShell Install Script
+
     ```bash
-    curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
+    iex ((New-Object System.Net.WebClient).DownloadString("https://install.spiceai.org/Install.ps1"))
     ```
   </TabItem>
 </Tabs>

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -32,7 +32,7 @@ For deployment options, such as to Kubernetes, see [`Deployment`](./deployment/i
     ### PowerShell Install Script
 
     ```bash
-    curl -L "https://install.spiceai.org/Install.ps1" -o Install.ps1 && PowerShell -ExecutionPolicy Bypass -File ./Install.ps1
+    iex ((New-Object System.Net.WebClient).DownloadString("https://install.spiceai.org/Install.ps1"))
     ```
 
   </TabItem>
@@ -68,6 +68,7 @@ Binaries for Linux, Windows, and macOS are available for download from GitHub at
     brew install protobuf
     ```
   </TabItem>
+
   <TabItem value="linux" label="Linux (Ubuntu)">
   1. Install system dependencies
     ```shell
@@ -96,6 +97,7 @@ Binaries for Linux, Windows, and macOS are available for download from GitHub at
       source $HOME/.cargo/env
     ```
   </TabItem>
+
 </Tabs>
 
 ### Build Spice OSS
@@ -131,13 +133,17 @@ The Spice CLI will automatically detect and download the appropriate runtime bin
 #### CUDA Support
 
 **Steps**:
+
 1. GPUs with Cuda compute capabilities < 7.5 are not supported (V100, Titan V, GTX 1000 series, ...).
 1. Ensure both Cuda and associated Nvidia drivers are installed. Requires CUDA version 12.2 or higher
 1. Ensure Nvidia binaries are in your path:
+
 ```shell
 export PATH=$PATH:/usr/local/cuda/bin
 ```
+
 1. Build Spice OSS with CUDA support:
+
 ```shell
 make install-with-models-cuda
 ```
@@ -147,12 +153,15 @@ This ensures CUDA devices are selected on model load, and CUDA-specifiy kernels 
 #### Metal Support
 
 **Steps**:
+
 1. Ensure you have Xcode installed.
+
 ```shell
 xcode-select --install
 ```
 
 1. Build Spice OSS with Metal support:
+
 ```shell
 make install-with-models-metal
 ```

--- a/website/src/components/molecules/install-options/install-options.tsx
+++ b/website/src/components/molecules/install-options/install-options.tsx
@@ -21,8 +21,7 @@ let allTabs = [
   {
     id: 'windows',
     name: 'Windows',
-    command: `# PowerShell Install Script
-iex ((New-Object System.Net.WebClient).DownloadString("https://install.spiceai.org/Install.ps1"))`
+    command: 'iex ((New-Object System.Net.WebClient).DownloadString("https://install.spiceai.org/Install.ps1"))'
   }
 ]
 

--- a/website/src/components/molecules/install-options/install-options.tsx
+++ b/website/src/components/molecules/install-options/install-options.tsx
@@ -21,7 +21,8 @@ let allTabs = [
   {
     id: 'windows',
     name: 'Windows',
-    command: 'Invoke-WebRequest -Uri "https://install.spiceai.org"'
+    command: `# PowerShell Install Script
+iex ((New-Object System.Net.WebClient).DownloadString("https://install.spiceai.org/Install.ps1"))`
   }
 ]
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the Windows installation instructions to use correct PowerShell installation commands

The previous commands failed in PowerShell, and were only valid for Command Prompt. The installation command on the homepage didn't even do anything.

* Closes #816 