### PR TITLE
docs: Release Spice Cloud Catalog Beta

### DIFF
--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -27,7 +27,7 @@ Supported Catalog Connectors include:
 | `unity_catalog` | Unity Catalog           | Stable      | Delta Lake                   |
 | `databricks`    | Databricks              | Beta        | Spark Connect, S3/Delta Lake |
 | `iceberg`       | Apache Iceberg          | Beta        | Parquet                      |
-| `spice.ai`      | Spice.ai Cloud Platform | Alpha       | Arrow Flight                 |
+| `spice.ai`      | Spice.ai Cloud Platform | Beta        | Arrow Flight                 |
 | `glue`          | AWS Glue                | Coming Soon | JSON, Parquet, Iceberg       |
 
 ## Catalog Connector Docs

--- a/website/docs/components/catalogs/spiceai.md
+++ b/website/docs/components/catalogs/spiceai.md
@@ -19,6 +19,8 @@ Example:
 catalogs:
   - from: spice.ai:demo-org/tpch # Load tables from the `demo-org` organization's `tpch` app
     name: marketplace # Tables will be available in the "marketplace" catalog
+    params:
+      spiceai_api_key: ${secrets:SPICEAI_API_KEY} # Spice.ai API key to login to the organization and app
     include:
       - "tpch.part*" # include only the tables from the "tpch" schema and that start with "part"
       - "tpch.supplier" # also include the "supplier" table
@@ -156,3 +158,15 @@ include:
   - "tpch.part*" # Include all tables from the "tpch" schema that start with "part"
   - "tpch.supplier" # Include the "supplier" table from the "tpch" schema
 ```
+
+## `params`
+
+The following parameters are supported for configuring the connection to the Spice Cloud catalog/tables:
+
+| Parameter Name | Definition |
+|---------------|------------|
+| `spiceai_api_key` | Authorization API key from the Spice.ai Cloud Platform, used to login to the specified organization and app. |
+
+## Cookbook
+
+- A cookbook recipe to configure Spice Cloud as a catalog connector in Spice. [Spice Cloud Catalog Connector](https://github.com/spiceai/cookbook/tree/trunk/catalogs/spiceai#readme)


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the Spice Cloud Catalog docs to include a reference to the `spiceai_api_key` parameter
* Releases the Spice Cloud Catalog as Beta