### PR TITLE
fix: dataset load parallelism

### DIFF
--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -79,7 +79,7 @@ The name of the secret store. This is used to reference the store in the secret 
 
 This configuration setting determines the maximum number of datasets that can be loaded in parallel during startup.
 
-By default, the maximum number of parallel datasets is effectively unlimited (minimum value `536870911`).
+By default, the maximum number of parallel datasets is effectively unlimited.
 
 ### `runtime.results_cache`
 

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -75,9 +75,11 @@ The name of the secret store. This is used to reference the store in the secret 
 
 ## `runtime`
 
-### `runtime.num_of_parallel_loading_at_start_up`
+### `runtime.dataset_load_parallelism`
 
-This configuration setting determines the maximum number of datasets that can be loaded in parallel during startup. This parallel loading capability accelerates Spice's startup process when multiple datasets are configured.
+This configuration setting determines the maximum number of datasets that can be loaded in parallel during startup.
+
+By default, the maximum number of parallel datasets is effectively unlimited (minimum value `536870911`).
 
 ### `runtime.results_cache`
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* The parameter `num_of_parallel_loading_at_start_up` has renamed to `dataset_load_parallelism`