### PR TITLE
Fix k8s doc: `readynessProbe`-> `readinessProbe`

### DIFF
--- a/website/docs/deployment/kubernetes/index.md
+++ b/website/docs/deployment/kubernetes/index.md
@@ -125,7 +125,7 @@ In Kubernetes, this pod will not be marked as _Healthy_ until the `/health` endp
 The `/ready` endpoint indicates **whether or not the Spice datasets are ready**. This means that while `/health` might indicate that Spice is up and running, until `/ready` reports a status of `200`, your queries may return 0 results
 
 ```yaml
-readynessProbe:
+readinessProbe:
   httpGet:
     path: /v1/ready
     port: 8090


### PR DESCRIPTION
## 🗣 Description
 - Typo, should be readinessProbe.
 - See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes