### PR TITLE
Add a deployment comment only if the workflow is running on the PR branch

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -50,6 +50,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add deploy comment to PR
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Fix build_and_publish workflow when it is triggered on push to trunk