### PR TITLE
docs: Update models grading

### DIFF
--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -60,16 +60,17 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 
 ### `params`
 
-| Param                    | Description                   | Default                     |
-| ------------------------ | ----------------------------- | --------------------------- |
-| `endpoint`               | The OpenAI API base endpoint. Can be overridden to use a compatible provider (i.e. Nvidia NIM). | `https://api.openai.com/v1` |
-| `tools`                  | Which [tools] should be made available to the model. Set to `auto` to use all available tools. | -    |
-| `system_prompt`          | An additional system prompt used for all chat completions to this model. | -    |
-| `openai_api_key`         | The OpenAI API key.           | -                           |
-| `openai_org_id`          | The OpenAI organization ID.   | -                           |
-| `openai_project_id`      | The OpenAI project ID.        | -                           |
-| `openai_temperature`     | Set the default temperature to use on chat completions.  | -                           |
-| `openai_response_format` | An object specifying the format that the model must output, see [structured outputs].  | -                           |
+| Param                     | Description                                                                                        | Default                     |
+| ------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------- |
+| `endpoint`                | The OpenAI API base endpoint. Can be overridden to use a compatible provider (i.e. Nvidia NIM).    | `https://api.openai.com/v1` |
+| `tools`                   | Which [tools] should be made available to the model. Set to `auto` to use all available tools.     | -                           |
+| `system_prompt`           | An additional system prompt used for all chat completions to this model.                           | -                           |
+| `openai_api_key`          | The OpenAI API key.                                                                                | -                           |
+| `openai_org_id`           | The OpenAI organization ID.                                                                        | -                           |
+| `openai_project_id`       | The OpenAI project ID.                                                                             | -                           |
+| `openai_temperature`      | Set the default temperature to use on chat completions.                                            | -                           |
+| `openai_response_format`  | An object specifying the format that the model must output, see [structured outputs].              | -                           |
+| `openai_reasoning_effort` | For reasoning models, like `o1`, this parameter specifies the reasoning effort used for the model. | -                           |
 
 [tools]: ../../features/large-language-models/tools.md
 [structured outputs]: https://platform.openai.com/docs/guides/structured-outputs

--- a/website/docs/reference/models.md
+++ b/website/docs/reference/models.md
@@ -9,7 +9,7 @@ This document presents the evaluation report for various Large-Language-Models (
 
 For more details on how model grades are evaluated in Spice, refer to the [model grading criteria](https://github.com/spiceai/spiceai/blob/f6039123028209e20469b342791fa85d52b7771e/docs/criteria/models/grading.md).
 
-| Model                                           | Spice Grade | Model Provider | Context Window<br/ >Max Output Tokens | Chat Completion | Response Format<br />(Structued Outputs) | Tools | Recursive<br />Tool Calling | Reasoning | Streaming | Evaluation Date | Spice Version |
+| Model                                           | Spice Grade | Model Provider | Context Window<br/ >Max Output Tokens | Chat Completion | Response Format<br />(Structued Outputs) | Tools | Recursive<br />Tool Calling | Reasoning | Streaming | Model Release Date | Spice Version |
 | ----------------------------------------------- | ----------- | -------------- | ------------------------------------- | --------------- | ---------------------------------------- | ----- | --------------------------- | --------- | --------- | --------------- | ------------- |
 | `o3-mini-2025-01-31 (Reasoning effort: high)`   | **A**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2025-01-31      | v1.0.2        |
 | `o3-mini-2025-01-31 (Reasoning effort: medium)` | **B**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2025-01-31      | v1.0.2        |

--- a/website/docs/reference/models.md
+++ b/website/docs/reference/models.md
@@ -1,7 +1,7 @@
 ---
 title: 'Models Grade Report'
 description: 'Spice AI graded Large-Language-Model (LLM) evaluation report'
-sidebar_label: 'Report'
+sidebar_label: 'Models Grade Report'
 sidebar_position: 4
 ---
 
@@ -14,9 +14,9 @@ For more details on how model grades are evaluated in Spice, refer to the [model
 | `o3-mini-2025-01-31 (Reasoning effort: high)`   | **A**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2025-01-31      | v1.0.2        |
 | `o3-mini-2025-01-31 (Reasoning effort: medium)` | **B**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2025-01-31      | v1.0.2        |
 | `o3-mini-2025-01-31 (Reasoning effort: low)`    | **C**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2025-01-31      | v1.0.2        |
-| `o1-2024-12-17 (Reasoning effort: high)`        | **A**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2024-12-17      | v1.0.2        |
-| `o1-2024-12-17 (Reasoning effort: medium)`      | **A**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2024-12-17      | v1.0.2        |
-| `o1-2024-12-17 (Reasoning effort: low)`         | **C**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ✅        | 2024-12-17      | v1.0.2        |
+| `o1-2024-12-17 (Reasoning effort: high)`        | **C**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ❌        | 2024-12-17      | v1.0.2        |
+| `o1-2024-12-17 (Reasoning effort: medium)`      | **C**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ❌        | 2024-12-17      | v1.0.2        |
+| `o1-2024-12-17 (Reasoning effort: low)`         | **C**       | `openai`       | 200k tokens<br/ >100k tokens          | ✅              | ✅                                       | ✅    | ✅                          | ✅        | ❌        | 2024-12-17      | v1.0.2        |
 | `gpt-4o-2024-08-06`                             | **B**       | `openai`       | 128k tokens<br/ >16384 tokens         | ✅              | ✅                                       | ✅    | ✅                          | ❌        | ✅        | 2024-08-06      | v1.0.2        |
 | `claude-3-5-sonnet-20241022`                    | **C**       | `anthropic`    | 200k tokens<br/ >8192 tokens          | ✅              | ❌                                       | ✅    | ✅                          | ❌        | ✅        | 2024-10-22      | v1.0.2        |
 | `grok-2-1212`                                   | Ungraded    | `xai`          | −                                     | ✅              | −                                        | −     | −                           | ❌        | −         | Not Available   | v1.0.2        |


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* The `o1` models do not support streaming. They cannot be higher than grade C.
* Adds the `openai_reasoning_effort` parameter to OpenAI model provider documentation