### PR TITLE
docs: Cron schedules and workers

### DIFF
--- a/website/docs/cli/reference/trace.md
+++ b/website/docs/cli/reference/trace.md
@@ -28,6 +28,7 @@ spice trace [task] [flags]
 - `tool_use::sql_query`
 - `tool_use::memory`
 - `vector_search`
+- `scheduled_worker`
 
 These tasks are from the `task` column in the Spice SQL `runtime.task_history` table.
 

--- a/website/docs/components/workers/index.md
+++ b/website/docs/components/workers/index.md
@@ -16,21 +16,35 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
+    type: load_balance
     description: |
       Distributes requests between 'foo' and 'bar' models in a round-robin fashion.
-    models:
-      - from: foo
-      - from: bar
+    load_balance:
+      routing:
+        - from: foo
+        - from: bar
   - name: fallback
+    type: load_balance
     description: |
       Attempts 'bar' first, then 'foo', then 'baz' if previous models fail.
-    models:
-      - from: foo
-        order: 2
-      - from: bar
-        order: 1
-      - from: baz
-        order: 3
+    load_balance:
+      routing:
+        - from: foo
+          order: 2
+        - from: bar
+          order: 1
+        - from: baz
+          order: 3
+  - name: weighted
+    type: load_balance
+    description: |
+      Routes 80% of traffic to 'foo'.
+    load_balance:
+      routing:
+        - from: foo
+          weight: 4
+        - from: bar
+          weight: 1
 ```
 
 ## Use-Cases

--- a/website/docs/components/workers/index.md
+++ b/website/docs/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'foo' and 'bar' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: foo
         - from: bar
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'bar' first, then 'foo', then 'baz' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: baz
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'foo'.
     load_balance:

--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -420,7 +420,7 @@ datasets:
       refresh_cron: "0 12 * * 1-5"
 ```
 
-This configuration will refresh `taxi_trips` data at midday every weekday. For more information about cron schedules, see to the [cron schedule reference](/docs/reference/cron.md).
+This configuration will refresh `taxi_trips` data at midday every weekday. For more information about cron schedules, see the [cron schedule reference](/docs/reference/cron.md).
 
 ## Refresh Retries
 

--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -422,6 +422,8 @@ datasets:
 
 This configuration will refresh `taxi_trips` data at midday every weekday. For more information about cron schedules, see the [cron schedule reference](/docs/reference/cron.md).
 
+The `refresh_cron` parameter cannot be specified in conjunction with a `refresh_check_interval` parameter.
+
 ## Refresh Retries
 
 |                                      |                  |

--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -398,6 +398,30 @@ date: Thu, 11 Apr 2024 20:11:18 GMT
 On-demand refresh always initiates a new refresh, terminating any in-progress refresh for the dataset.
 :::
 
+## Refresh Schedules
+
+|                             |                  |
+| --------------------------- | ---------------- |
+| Supported in `refresh_mode` | `full`, `append` |
+| Required                    | No               |
+| Default Value               | Unset            |
+
+The [`refresh_cron`](/docs/reference/spicepod/datasets#accelerationrefresh_cron) parameter supports specifying a cron schedule which controls when datasets refresh.
+
+Example:
+
+```yaml
+datasets:
+  - from: spice.ai/spiceai/quickstart/datasets/taxi_trips
+    name: taxi_trips
+    acceleration:
+      enabled: true
+      refresh_mode: full
+      refresh_cron: "0 12 * * 1-5"
+```
+
+This configuration will refresh `taxi_trips` data at midday every weekday. For more information about cron schedules, see to the [cron schedule reference](/docs/reference/cron.md).
+
 ## Refresh Retries
 
 |                                      |                  |

--- a/website/docs/reference/cron.md
+++ b/website/docs/reference/cron.md
@@ -6,11 +6,11 @@ pagination_next: null
 sidebar_position: 9
 ---
 
-The Spice Runtime uses the [`croner` Rust crate](https://github.com/hexagon/croner-rust?tab=readme-ov-file#pattern) for parsing cron expressions.
-
 The Runtime supports cron expressions with optional seconds, like `*/10 * * * * *` which evaluates to every 10th second (10, 20, 30, etc).
 
 Cron expressions in the Runtime evaluate according to the systems local time where the Runtime is running.
+
+The Spice Runtime uses the [`croner` Rust crate](https://github.com/hexagon/croner-rust?tab=readme-ov-file#pattern) for parsing cron expressions.
 
 ## Examples
 

--- a/website/docs/reference/cron.md
+++ b/website/docs/reference/cron.md
@@ -1,0 +1,45 @@
+---
+title: 'Cron Schedules'
+sidebar_label: 'Cron Schedules'
+pagination_prev: 'reference/index'
+pagination_next: null
+sidebar_position: 9
+---
+
+The Spice Runtime uses the [`croner` Rust crate](https://github.com/hexagon/croner-rust?tab=readme-ov-file#pattern) for parsing cron expressions.
+
+The Runtime supports cron expressions with optional seconds, like `*/10 * * * * *` which evaluates to every 10th second (10, 20, 30, etc).
+
+Cron expressions in the Runtime evaluate according to the systems local time where the Runtime is running.
+
+## Examples
+
+### At 1am every Monday
+
+```text
+0 1 * * 1
+```
+
+### At midday every weekday (Monday-Friday)
+
+```text
+0 12 * * 1-5
+```
+
+### Every hour, at 5 minutes past the hour
+
+```text
+5 * * * *
+```
+
+### Every 10 minutes
+
+```text
+*/10 * * * *
+```
+
+### Every 5 minutes at 30 seconds
+
+```text
+30 */5 * * * *
+```

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -240,9 +240,15 @@ Optional. How to refresh the dataset. The following values are supported:
 
 ## `acceleration.refresh_check_interval`
 
-Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not defined, the accelerator will not refresh after it initially loads data.
+Optional. How often data should be refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not defined, the accelerator will not refresh after it initially loads data. Cannot be specified in conjunction with a `refresh_cron`.
 
 See [Duration](../duration/index.md)
+
+## `acceleration.refresh_cron`
+
+Optional. Specifies a cron schedule which controls how often data is refreshed. For `append` datasets without a specific `time_column`, this config is not used. If not defined, the accelerator will not refresh after it initially loads data.
+
+See the [cron schedule reference](/docs/reference/cron.md).
 
 ## `acceleration.refresh_sql`
 

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -218,21 +218,25 @@ A Spicepod can contain one or more [workers](./workers.md) defining configurable
 ```yaml
 workers:
   - name: round-robin
+    type: load_balance
     description: |
       Distributes requests between 'foo' and 'bar' models in a round-robin fashion.
-    models:
-      - from: foo
-      - from: bar
+    load_balance:
+      routing:
+        - from: foo
+        - from: bar
   - name: fallback
+    type: load_balance
     description: |
       Attempts 'bar' first, then 'foo', then 'baz' if previous models fail.
-    models:
-      - from: foo
-        order: 2
-      - from: bar
-        order: 1
-      - from: baz
-        order: 3
+    load_balance:
+      routing:
+        - from: foo
+          order: 2
+        - from: bar
+          order: 1
+        - from: baz
+          order: 3
 ```
 
 For a complete specification of worker configuration, see the [Workers Reference](/docs/reference/spicepod/workers.md).

--- a/website/docs/reference/spicepod/workers.md
+++ b/website/docs/reference/spicepod/workers.md
@@ -15,29 +15,35 @@ Example:
 ```yaml
 workers:
   - name: round-robin
+    type: load_balance
     description: |
       Distributes requests between 'foo' and 'bar' models in a round-robin fashion.
-    models:
-      - from: foo
-      - from: bar
+    load_balance:
+      routing:
+        - from: foo
+        - from: bar
   - name: fallback
+    type: load_balance
     description: |
       Attempts 'bar' first, then 'foo', then 'baz' if previous models fail.
-    models:
-      - from: foo
-        order: 2
-      - from: bar
-        order: 1
-      - from: baz
-        order: 3
+    load_balance:
+      routing:
+        - from: foo
+          order: 2
+        - from: bar
+          order: 1
+        - from: baz
+          order: 3
   - name: weighted
+    type: load_balance
     description: |
       Routes 80% of traffic to 'foo'.
-    models:
-      - from: foo
-        order: 4
-      - from: bar
-        order: 1
+    load_balance:
+      routing:
+        - from: foo
+          weight: 4
+        - from: bar
+          weight: 1
 ```
 
 ### `name`
@@ -48,9 +54,17 @@ A unique identifier for this worker component.
 
 Additional details about the worker, useful for displaying to users and providing to LLM context.
 
-### `models` {#models}
+### `type`
 
-A list of model configurations that define how the model worker behaves.
+Determines how the worker can be configured, and what subset of compute traits are applicable.
+
+### `load_balance` 
+
+Applicable only for `.type: load_balance`. 
+
+### `load_balance.routing` 
+
+A list of model configurations that define how the load balancing behaves.
 
 The elements' structure uniquely determine the model worker algorithm. List elements should be of consistent type.
 
@@ -68,9 +82,10 @@ workers:
   - name: round-robin
     description: |
       Call models 'foo' & 'bar' in round robin.
-    models:
-      - from: foo
-      - from: bar
+    load_balance:
+      routing:
+        - from: foo
+        - from: bar
 ```
 
 The worker selects each model in turn for subsequent requests.
@@ -84,13 +99,35 @@ workers:
   - name: fallback
     description: |
       Call 'bar'. On error, call 'foo'. Failing that 'baz'.
-    models:
-      - from: foo
-        order: 2
-      - from: bar
-        order: 1
-      - from: baz
-        order: 3
+    load_balance:
+      routing:
+        - from: foo
+          order: 2
+        - from: bar
+          order: 1
+        - from: baz
+          order: 3
 ```
 
 The worker uses the models in increasing order, returning the first result that is not an error.
+
+
+#### Worker with weighted model routing
+
+Example
+
+```yaml
+workers:
+  - name: weighted
+    type: load_balance
+    description: |
+      Routes 80% of traffic to 'foo'.
+    load_balance:
+      routing:
+        - from: foo
+          weight: 4
+        - from: bar
+          weight: 1
+```
+
+The worker routes traffic to the models in accordance to the weighting (i.e. 80% to `foo`, 20% to `bar`).

--- a/website/docs/reference/spicepod/workers.md
+++ b/website/docs/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'foo' and 'bar' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: foo
         - from: bar
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'bar' first, then 'foo', then 'baz' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: baz
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'foo'.
     load_balance:
@@ -54,13 +51,46 @@ A unique identifier for this worker component.
 
 Additional details about the worker, useful for displaying to users and providing to LLM context.
 
-### `type`
+### `cron`
 
-Determines how the worker can be configured, and what subset of compute traits are applicable.
+Specifies a cron schedule to automatically run the worker at the specified times. The worker action controls the behavior of the schedule. See the [cron schedule reference](/docs/reference/cron.md) for more information on cron schedules.
+
+#### `cron` with a `load_balance` action
+
+When a `load_balance` action is specified with a cron schedule, the `params.prompt` parameter is used to automatically request a chat completion. When no `params.prompt` parameter is specified, the cron schedule is not activated.
+
+##### Worker with a round-robin balancer, that is automatically prompted on a schedule
+
+```yaml
+workers:
+  - name: round-robin
+    description: |
+      Call models 'foo' & 'bar' in round robin.
+    load_balance:
+      routing:
+        - from: foo
+        - from: bar
+    cron: "* * * * *" # every minute
+    params:
+      prompt: "What's the date today?"
+```
+
+#### `cron` with a `sql` action
+
+When a `sql` action is specified with a cron schedule, the worker runs the SQL at the specified scheduled times.
+
+##### Worker with a SQL action, that automatically executes on a schedule
+
+```yaml
+workers:
+  - name: sql-worker
+    cron: "* * * * *" # every minute
+    sql: "SELECT COUNT(*) FROM orders"
+```
 
 ### `load_balance` 
 
-Applicable only for `.type: load_balance`. 
+Specifies the configuration for a `load_balance` worker. When a `load_balance` section is present, other worker actions cannot be specified (e.g. `sql`).
 
 ### `load_balance.routing` 
 
@@ -131,3 +161,17 @@ workers:
 ```
 
 The worker routes traffic to the models in accordance to the weighting (i.e. 80% to `foo`, 20% to `bar`).
+
+### `sql`
+
+Specifies an SQL query action to run for this worker. When specified without a `cron` parameter, the worker does nothing.
+
+When this parameter is present, other worker actions cannot be specified (e.g. `load_balance`)
+
+### `params`
+
+Optional, additional parameters for the specified worker action.
+
+#### `params.prompt`
+
+Valid only when the `load_balance` worker action is specified with a `cron` schedule, otherwise ignored. The value specified by this parameter is used as the input to a new chat completion request on the specified `cron` schedule for the worker.


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Adds documentation for cron schedules for both workers and datasets
* Removes the `type` parameter from workers
* Documents the SQL worker action

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

* Closes #1023
* Closes #1020
* Closes #1017