### PR TITLE
Initial docs for the OpenAI Responses API

### DIFF
--- a/website/docs/components/models/azure.md
+++ b/website/docs/components/models/azure.md
@@ -14,8 +14,8 @@ To use a language model hosted on Azure OpenAI, specify the `azure` path in the 
 | `azure_deployment_name` | The name of the model deployment.                                                   | Model name |
 | `endpoint`              | The Azure OpenAI resource endpoint, e.g., `https://resource-name.openai.azure.com`. | -          |
 | `azure_entra_token`     | The Azure Entra token for authentication.                                           | -          |
-| `azure_openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 | `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` |
+| `azure_openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 
 
 Only one of `azure_api_key` or `azure_entra_token` can be provided for model configuration.
@@ -33,8 +33,8 @@ models:
       azure_api_key: ${ secrets:SPICE_AZURE_API_KEY }
 
       # Responses API configuration
-      azure_openai_responses_tools: web_search
       responses_api: enabled
+      azure_openai_responses_tools: web_search
 ```
 
 Refer to the [Azure OpenAI Service models](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models) for more details on available models and configurations.

--- a/website/docs/components/models/azure.md
+++ b/website/docs/components/models/azure.md
@@ -14,7 +14,7 @@ To use a language model hosted on Azure OpenAI, specify the `azure` path in the 
 | `azure_deployment_name` | The name of the model deployment.                                                   | Model name |
 | `endpoint`              | The Azure OpenAI resource endpoint, e.g., `https://resource-name.openai.azure.com`. | -          |
 | `azure_entra_token`     | The Azure Entra token for authentication.                                           | -          |
-| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` |
+| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `disabled` |
 | `azure_openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 
 

--- a/website/docs/components/models/azure.md
+++ b/website/docs/components/models/azure.md
@@ -14,6 +14,9 @@ To use a language model hosted on Azure OpenAI, specify the `azure` path in the 
 | `azure_deployment_name` | The name of the model deployment.                                                   | Model name |
 | `endpoint`              | The Azure OpenAI resource endpoint, e.g., `https://resource-name.openai.azure.com`. | -          |
 | `azure_entra_token`     | The Azure Entra token for authentication.                                           | -          |
+| `azure_openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
+| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` |
+
 
 Only one of `azure_api_key` or `azure_entra_token` can be provided for model configuration.
 

--- a/website/docs/components/models/azure.md
+++ b/website/docs/components/models/azure.md
@@ -31,6 +31,10 @@ models:
       azure_api_version: 2024-08-01-preview
       azure_deployment_name: gpt-4o-mini
       azure_api_key: ${ secrets:SPICE_AZURE_API_KEY }
+
+      # Responses API configuration
+      azure_openai_responses_tools: web_search
+      responses_api: enabled
 ```
 
 Refer to the [Azure OpenAI Service models](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models) for more details on available models and configurations.

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -76,7 +76,7 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 | `openai_response_format`  | An object specifying the format that the model must output, see [structured outputs].              | -                           |
 | `openai_reasoning_effort` | For reasoning models, like `o1`, this parameter specifies the reasoning effort used for the model. | -                           |
 | `openai_usage_tier`       | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
-| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` by default if `endpoint` is set to `https://api.openai.com/v1`. Disabled by default for all other values of `endpoint`. |
+| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint using [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses). When using OpenAI-compatible providers, ensure the provider supports OpenAI's Responses API. | `disabled` |
 | `openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 
 [tools]: ../../features/large-language-models/tools.md

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -76,8 +76,8 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 | `openai_response_format`  | An object specifying the format that the model must output, see [structured outputs].              | -                           |
 | `openai_reasoning_effort` | For reasoning models, like `o1`, this parameter specifies the reasoning effort used for the model. | -                           |
 | `openai_usage_tier`       | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
-| `openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 | `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` by default if `endpoint` is set to `https://api.openai.com/v1`. Disabled by default for all other values of `endpoint`. |
+| `openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 
 [tools]: ../../features/large-language-models/tools.md
 [structured outputs]: https://platform.openai.com/docs/guides/structured-outputs

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -76,7 +76,7 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 | `openai_response_format`  | An object specifying the format that the model must output, see [structured outputs].              | -                           |
 | `openai_reasoning_effort` | For reasoning models, like `o1`, this parameter specifies the reasoning effort used for the model. | -                           |
 | `openai_usage_tier`       | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
-| `openai_responses_tools`  | The [hosted tools](https://platform.openai.com/docs/guides/tools) to allowlist when invoking the model from the `/v1/responses` endpoint: `code_interpreter` or `web_search`. These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. | -                           |
+| `openai_responses_tools`  | Comma-separated list of OpenAI-hosted tools exposed via the Responses API for this model.  These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. Supported tools: `code_interpreter`, `web_search`. | -                           |
 | `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` by default if `endpoint` is set to `https://api.openai.com/v1`. Disabled by default for all other values of `endpoint`. |
 
 [tools]: ../../features/large-language-models/tools.md

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -26,6 +26,10 @@ models:
       # Override default chat completion request parameters
       openai_temperature: 0.1
       openai_response_format: { 'type': 'json_object' }
+
+      # OpenAI Responses API configuration
+      responses_api: enabled
+      openai_responses_tools: web_search, code_interpreter
 ```
 
 ## Configuration
@@ -71,7 +75,9 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 | `openai_temperature`      | Set the default temperature to use on chat completions.                                            | -                           |
 | `openai_response_format`  | An object specifying the format that the model must output, see [structured outputs].              | -                           |
 | `openai_reasoning_effort` | For reasoning models, like `o1`, this parameter specifies the reasoning effort used for the model. | -                           |
-| `openai_usage_tier` | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1` |
+| `openai_usage_tier`       | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
+| `openai_responses_tools`  | The [hosted tools](https://platform.openai.com/docs/guides/tools) to allowlist when invoking the model from the `/v1/responses` endpoint: `code_interpreter` or `web_search`. These hosted tools are **not** available from the `/v1/chat/completions` HTTP endpoint. | -                           |
+| `responses_api`           | `enabled` or `disabled`. Whether to enable invoking this model from the `/v1/responses` HTTP endpoint | `enabled` by default if `endpoint` is set to `https://api.openai.com/v1`. Disabled by default for all other values of `endpoint`. |
 
 [tools]: ../../features/large-language-models/tools.md
 [structured outputs]: https://platform.openai.com/docs/guides/structured-outputs


### PR DESCRIPTION
## 🗣 Description
- See title
- The docs for the `/v1/responses` endpoint are auto-generated

## 🔨 Related Issues
- Closes https://github.com/spiceai/spiceai/issues/6761