### PR TITLE
Skip generated API commit and push on release branches

### DIFF
--- a/.github/workflows/updated_openapi.yml
+++ b/.github/workflows/updated_openapi.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Cancel workflow if source branch is release/*
+        run: |
+          if [[ "${{ github.head_ref }}" == release/* ]]; then
+            echo "Source branch is release/*, skipping workflow."
+            exit 0
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/updated_openapi.yml
+++ b/.github/workflows/updated_openapi.yml
@@ -10,13 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel workflow if source branch is release/*
-        run: |
-          if [[ "${{ github.head_ref }}" == release/* ]]; then
-            echo "Source branch is release/*, skipping workflow."
-            exit 0
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -52,7 +45,7 @@ jobs:
           git config --global user.email 'schema-bot@spice.ai'
 
       - name: Commit and push changes
-        if: env.CHANGES_FOUND == 'true'
+        if: env.CHANGES_FOUND == 'true'  && !startsWith(github.head_ref, 'release/')
         working-directory: website
         run: |
           git add docs/api/HTTP/


### PR DESCRIPTION
## 🗣 Description

This pull request adds logic to the `.github/workflows/updated_openapi.yml` workflow to automatically cancel the workflow if the source branch matches the `release/*` pattern. This helps prevent unnecessary workflow runs for release branches - job tries to push generated API changes back to the PR source branch, which conflicts with release bracnh policies.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
