### PR TITLE
Add `output_level` documentation

### DIFF
--- a/website/docs/cli/tracing.md
+++ b/website/docs/cli/tracing.md
@@ -9,8 +9,6 @@ tags:
   - logging
 ---
 
-Output trace verbosity is controlled by (in the order of presedence): 
-
 Trace output verbosity is determined by the following sources, listed in order of precedence:
 
 1. Verbosity flags (`-v`/`--verbose`, `-vv`/`--very-verbose`). If these flags are provided, they override all other settings.

--- a/website/docs/cli/tracing.md
+++ b/website/docs/cli/tracing.md
@@ -9,7 +9,13 @@ tags:
   - logging
 ---
 
-Output trace verbosity is controlled by the `SPICED_LOG` environment variable and verbosity flags (`-v`, `-vv`).
+Output trace verbosity is controlled by (in the order of presedence): 
+
+Trace output verbosity is determined by the following sources, listed in order of precedence:
+
+1. Verbosity flags (`-v`/`--verbose`, `-vv`/`--very-verbose`). If these flags are provided, they override all other settings.
+2. The `SPICED_LOG` environment variable. This is used only if verbosity flags are not set
+3. The `runtime.output_level` YAML configuration file. This is used only if neither verbosity flags nor the environment variable are set.
 
 ### Default
 
@@ -19,13 +25,25 @@ The default trace level is `INFO`, suitable for general information about the sy
 SPICED_LOG="task_history=INFO,spiced=INFO,runtime=INFO,secrets=INFO,data_components=INFO,cache=INFO,extensions=INFO,spice_cloud=INFO,llms=INFO,reqwest_retry::middleware=off,WARN"
 ```
 
+The equivalent `runtime.output_level` configuration is `info`:
+```yaml
+runtime:
+  output_level: info
+```
+
 ### Enabling Debug Mode
 
-Use the `-v` CLI flag to enable detailed logs, useful for debugging.
+Use the `-v`/`--verbose` CLI flags to enable detailed logs, useful for debugging.
 
 ```bash
 spice run -v
 spiced -v
+```
+
+Alternatively you can use `runtime` yaml configuration:
+```yaml
+runtime:
+  output_level: verbose
 ```
 
 This sets `SPICED_LOG` to `DEBUG` level:
@@ -36,11 +54,17 @@ SPICED_LOG="task_history=DEBUG,spiced=DEBUG,runtime=DEBUG,secrets=DEBUG,data_com
 
 ### Enabling Trace Mode
 
-Use the `-vv` CLI flag to enable the most detailed logs, typically for in-depth troubleshooting.
+Use the `-vv`/`--very-verbose` CLI flag to enable the most detailed logs, typically for in-depth troubleshooting.
 
 ```bash
 spice run -vv
 spiced -vv
+```
+
+Alternatively you can use `runtime` yaml configuration:
+```yaml
+runtime:
+  output_level: very_verbose
 ```
 
 This sets `SPICED_LOG` to `TRACE` level:

--- a/website/docs/cli/tracing.md
+++ b/website/docs/cli/tracing.md
@@ -38,7 +38,7 @@ spice run -v
 spiced -v
 ```
 
-Alternatively you can use `runtime` yaml configuration:
+Alternatively you can use `runtime.output_level` yaml configuration:
 ```yaml
 runtime:
   output_level: verbose
@@ -59,7 +59,7 @@ spice run -vv
 spiced -vv
 ```
 
-Alternatively you can use `runtime` yaml configuration:
+Alternatively you can use `runtime.output_level` yaml configuration:
 ```yaml
 runtime:
   output_level: very_verbose


### PR DESCRIPTION
## 🗣 Description

Includes documentation for the `runtime.output_level` configuration

## 🔨 Related Issues

https://github.com/spiceai/spiceai/issues/7106

## 🤔 Concerns

No concerns