### PR TITLE
Add limit information for vector_search

### DIFF
--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -142,7 +142,7 @@ RETURNS TABLE                -- The original table and:
                              --  - A FLOAT column `score` (if `include_score`).
 ```
 
-By default, `vector_search` retrieves up to 1000 results. To adjust this limit, specify the `limit` parameter in the function call.
+By default, `vector_search` retrieves up to 1000 results. To adjust this limit, specify the `limit` parameter in the function call. When using a specific vector engine, such as `s3_vectors` the limit defaults to that of the vector engine.
 
 ```sql
 SELECT id, title, score

--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -135,16 +135,24 @@ vector_search(
   table STRING,          -- Dataset name (required)
   query STRING,          -- Search text (required)
   col STRING,            -- Column name (optional if single embedding column)
-  limit INTEGER,         -- Results limit (default: all)
+  limit INTEGER,         -- Results limit (default: 1000)
   include_score BOOLEAN  -- Include relevance scores (default: TRUE)
 )
 RETURNS TABLE                -- The original table and:
                              --  - A FLOAT column `score` (if `include_score`).
 ```
 
+By default, `vector_search` retrieves up to 1000 results. To adjust this limit, specify the `limit` parameter in the function call.
+
+```sql
+SELECT id, title, score
+FROM vector_search('sales', 'cutting edge AI', 1500)
+ORDER BY score DESC;
+```
+
 :::warning[Limitations]
 
-- `vector_search` UDTF does not support chunked embedding columns.
+- `vector_search` UDTF does not yet support chunked embedding columns. Chunking support is on the roadmap.
 
 :::
 
@@ -225,12 +233,15 @@ sql> describe sales;
 ### Constraints
 
 1. **Underlying Column Presence:**
+
    - The underlying column must exist in the table, and be of `string` [Arrow data type](../../reference/datatypes/accelerators.md) .
 
 2. **Embeddings Column Naming Convention:**
+
    - For each underlying column, the corresponding embeddings column must be named as `<column_name>_embedding`. For example, a `customer_reviews` table with a `review` column must have a `review_embedding` column.
 
 3. **Embeddings Column Data Type:**
+
    - The embeddings column must have the following [Arrow data type](../../reference/datatypes/accelerators.md) when loaded into Spice:
      1. `FixedSizeList[Float32 or Float64, N]`, where `N` is the dimension (size) of the embedding vector. `FixedSizeList` is used for efficient storage and processing of fixed-size vectors.
      2. If the column is [**chunked**](/docs/components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -43,14 +43,16 @@ LIMIT 5;
 - `table`: Dataset name (required)
 - `query`: Search text (required)
 - `col`: Column name (optional if only one embedding column)
-- `limit`: Maximum results (optional)
+- `limit`: Maximum results (optional, default: 1000)
 - `include_score`: Include relevance scores (optional, default TRUE)
+
+By default, `vector_search` retrieves up to 1000 results. To change this, specify a limit parameter in the function call.
 
 #### Example
 
 ```sql
 SELECT review_id, rating, customer_id, body, score
-FROM vector_search(reviews, 'issues with same day shipping')
+FROM vector_search(reviews, 'issues with same day shipping', 1500)
 WHERE created_at >= to_unixtime(now() - INTERVAL '7 days')
 ORDER BY score DESC
 LIMIT 2;


### PR DESCRIPTION
This pull request updates the documentation for the `vector_search` function to clarify and standardize its default behavior and usage, particularly around the result limit. The changes improve the accuracy and clarity of the docs for both feature and reference pages.

**Documentation improvements for `vector_search` usage:**

* Updated the default value for the `limit` parameter to 1000 in function signatures and descriptions in both `website/docs/features/search/vector-search.md` and `website/docs/reference/sql/search.md`, ensuring consistency across documentation. [[1]](diffhunk://#diff-c08d667938c6707fb8fef678c92bb45e9ce58246da5f582c0e6fd6765584cf90L138-R155) [[2]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bL46-R55)
* Added explicit examples showing how to override the default result limit by specifying the `limit` parameter in SQL queries. [[1]](diffhunk://#diff-c08d667938c6707fb8fef678c92bb45e9ce58246da5f582c0e6fd6765584cf90L138-R155) [[2]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bL46-R55)

**Clarifications and constraints:**

* Improved the limitations section to clarify that chunked embedding column support is planned for the future, making roadmap expectations clear.
* Enhanced the constraints section by adding bullet points for required column presence, naming conventions, and embedding column data types, improving readability and guidance for users.