### PR TITLE
Add acceleration refresh metrics docs

### DIFF
--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -69,58 +69,62 @@ dataset_active_count{engine="duckdb"} 1
 
 ## Metrics
 
-| Metric                                                       | Description                                                                                                 |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `accelerated_ready_state_federated_fallback`<br/>_(count)_   | Number of times the federated table was queried due to the accelerated table loading the initial data.      |
-| `catalog_load_errors`<br/>_(count)_                          | Number of errors loading the catalog provider.                                                              |
-| `catalog_load_state`<br/>_(gauge)_                           | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
-| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_    | Unix timestamp in seconds when the last refresh completed.                                                  |
-| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_ | Duration in milliseconds to load a full or appended refresh data.                                           |
-| `dataset_acceleration_refresh_errors`<br/>_(count)_          | Number of errors refreshing the dataset.                                                                    |
-| `dataset_active_count`<br/>_(gauge)_                         | Number of currently loaded datasets.                                                                        |
-| `dataset_load_state`<br/>_(gauge)_                           | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.          |
-| `dataset_unavailable_time_ms`<br/>_(gauge)_                  | Time dataset went offline in milliseconds.                                                                  |
-| `embeddings_active_count`<br/>_(gauge)_                      | Number of currently loaded embeddings.                                                                      |
-| `embeddings_load_errors`<br/>_(count)_                       | Number of errors loading the embedding.                                                                     |
-| `embeddings_load_state`<br/>_(gauge)_                        | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `flight_request_duration_ms`<br/>_(histogram)_               | Measures the duration of Flight requests in milliseconds.                                                   |
-| `flight_requests`<br/>_(count)_                              | Total number of Flight requests.                                                                            |
-| `http_requests_duration_ms`<br/>_(histogram)_                | Measures the duration of HTTP requests in milliseconds.                                                     |
-| `http_requests`<br/>_(count)_                                | Number of HTTP requests.                                                                                    |
-| `llm_load_state`<br/>_(gauge)_                               | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `model_active_count`<br/>_(gauge)_                           | Number of currently loaded models.                                                                          |
-| `model_load_duration_ms`<br/>_(histogram)_                   | Duration in milliseconds to load the model.                                                                 |
-| `model_load_errors`<br/>_(count)_                            | Number of errors loading the model.                                                                         |
-| `model_load_state`<br/>_(gauge)_                             | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.            |
-| `query_duration_ms`<br/>_(histogram)_                        | The total amount of time spent planning and executing queries in milliseconds.                              |
-| `query_execution_duration_ms`<br/>_(histogram)_              | The total amount of time spent only executing queries (0 for cached queries).                               |
-| `query_executions`<br/>_(count)_                             | Number of query executions.                                                                                 |
-| `query_failures`<br/>_(count)_                               | Number of query failures.                                                                                   |
-| `query_processed_bytes`<br/>_(count)_                        | Number of bytes processed by the runtime.                                                                   |
-| `query_returned_bytes`<br/>_(count)_                         | Number of bytes returned to query clients.                                                                  |
-| `embeddings_cache_max_size_bytes`<br/>_(gauge)_              | Maximum allowed size of the cache in bytes.                                                                 |
-| `embeddings_cache_requests`<br/>_(count)_                    | Number of requests to get a key from the cache.                                                             |
-| `embeddings_cache_hits`<br/>_(count)_                        | Cache hit count.                                                                                            |
-| `embeddings_cache_items_count`<br/>_(gauge)_                 | Number of items currently in the cache.                                                                     |
-| `embeddings_cache_size_bytes`<br/>_(gauge)_                  | Size of the cache in bytes.                                                                                 |
-| `results_cache_max_size_bytes`<br/>_(gauge)_                 | Maximum allowed size of the cache in bytes.                                                                 |
-| `results_cache_requests`<br/>_(count)_                       | Number of requests to get a key from the cache.                                                             |
-| `results_cache_hits`<br/>_(count)_                           | Cache hit count.                                                                                            |
-| `results_cache_items_count`<br/>_(gauge)_                    | Number of items currently in the cache.                                                                     |
-| `results_cache_size_bytes`<br/>_(gauge)_                     | Size of the cache in bytes.                                                                                 |
-| `search_results_cache_max_size_bytes`<br/>_(gauge)_          | Maximum allowed size of the search cache in bytes.                                                          |
-| `search_results_cache_requests`<br/>_(count)_                | Number of requests to get a key from the search cache.                                                      |
-| `search_results_cache_hits`<br/>_(count)_                    | Search cache hit count.                                                                                     |
-| `search_results_cache_items_count`<br/>_(gauge)_             | Number of items currently in the search cache.                                                              |
-| `search_results_cache_size_bytes`<br/>_(gauge)_              | Size of the search cache in bytes.                                                                          |
-| `runtime_flight_server_started`<br/>_(count)_                | Indicates the runtime Flight server has started.                                                            |
-| `runtime_http_server_started`<br/>_(count)_                  | Indicates the runtime HTTP server has started.                                                              |
-| `secrets_store_load_duration_ms`<br/>_(histogram)_           | Duration in milliseconds to load the secret stores.                                                         |
-| `tool_active_count`<br/>_(gauge)_                            | Number of currently loaded LLM tools.                                                                       |
-| `tool_load_errors`<br/>_(count)_                             | Number of errors loading the LLM tool.                                                                      |
-| `tool_load_state`<br/>_(gauge)_                              | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `view_load_errors`<br/>_(count)_                             | Number of errors loading the view.                                                                          |
-| `view_load_state`<br/>_(gauge)_                              | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.            |
+| Metric                                                               | Description                                                                                                             |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `accelerated_ready_state_federated_fallback`<br/>_(count)_           | Number of times the federated table was queried due to the accelerated table loading the initial data.                  |
+| `catalog_load_errors`<br/>_(count)_                                  | Number of errors loading the catalog provider.                                                                          |
+| `catalog_load_state`<br/>_(gauge)_                                   | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.             |
+| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_            | Unix timestamp in seconds when the last refresh completed.                                                              |
+| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_         | Duration in milliseconds to load a full or appended refresh data.                                                       |
+| `dataset_acceleration_max_timestamp_before_refresh_ms`<br/>_(gauge)_ | Maximum value of the dataset's time_column before the refresh operation, in milliseconds.                               |
+| `dataset_acceleration_max_timestamp_after_refresh_ms`<br/>_(gauge)_  | Maximum value of the dataset's time_column after the refresh operation, in milliseconds.                                |
+| `dataset_acceleration_refresh_lag_ms`<br/>_(gauge)_                  | Difference between the maximum time_column value after and before the refresh operation, in milliseconds.               |
+| `dataset_acceleration_ingestion_lag_ms`<br/>_(gauge)_                | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds. |
+| `dataset_acceleration_refresh_errors`<br/>_(count)_                  | Number of errors refreshing the dataset.                                                                                |
+| `dataset_active_count`<br/>_(gauge)_                                 | Number of currently loaded datasets.                                                                                    |
+| `dataset_load_state`<br/>_(gauge)_                                   | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                      |
+| `dataset_unavailable_time_ms`<br/>_(gauge)_                          | Time dataset went offline in milliseconds.                                                                              |
+| `embeddings_active_count`<br/>_(gauge)_                              | Number of currently loaded embeddings.                                                                                  |
+| `embeddings_load_errors`<br/>_(count)_                               | Number of errors loading the embedding.                                                                                 |
+| `embeddings_load_state`<br/>_(gauge)_                                | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `flight_request_duration_ms`<br/>_(histogram)_                       | Measures the duration of Flight requests in milliseconds.                                                               |
+| `flight_requests`<br/>_(count)_                                      | Total number of Flight requests.                                                                                        |
+| `http_requests_duration_ms`<br/>_(histogram)_                        | Measures the duration of HTTP requests in milliseconds.                                                                 |
+| `http_requests`<br/>_(count)_                                        | Number of HTTP requests.                                                                                                |
+| `llm_load_state`<br/>_(gauge)_                                       | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `model_active_count`<br/>_(gauge)_                                   | Number of currently loaded models.                                                                                      |
+| `model_load_duration_ms`<br/>_(histogram)_                           | Duration in milliseconds to load the model.                                                                             |
+| `model_load_errors`<br/>_(count)_                                    | Number of errors loading the model.                                                                                     |
+| `model_load_state`<br/>_(gauge)_                                     | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                        |
+| `query_duration_ms`<br/>_(histogram)_                                | The total amount of time spent planning and executing queries in milliseconds.                                          |
+| `query_execution_duration_ms`<br/>_(histogram)_                      | The total amount of time spent only executing queries (0 for cached queries).                                           |
+| `query_executions`<br/>_(count)_                                     | Number of query executions.                                                                                             |
+| `query_failures`<br/>_(count)_                                       | Number of query failures.                                                                                               |
+| `query_processed_bytes`<br/>_(count)_                                | Number of bytes processed by the runtime.                                                                               |
+| `query_returned_bytes`<br/>_(count)_                                 | Number of bytes returned to query clients.                                                                              |
+| `embeddings_cache_max_size_bytes`<br/>_(gauge)_                      | Maximum allowed size of the cache in bytes.                                                                             |
+| `embeddings_cache_requests`<br/>_(count)_                            | Number of requests to get a key from the cache.                                                                         |
+| `embeddings_cache_hits`<br/>_(count)_                                | Cache hit count.                                                                                                        |
+| `embeddings_cache_items_count`<br/>_(gauge)_                         | Number of items currently in the cache.                                                                                 |
+| `embeddings_cache_size_bytes`<br/>_(gauge)_                          | Size of the cache in bytes.                                                                                             |
+| `results_cache_max_size_bytes`<br/>_(gauge)_                         | Maximum allowed size of the cache in bytes.                                                                             |
+| `results_cache_requests`<br/>_(count)_                               | Number of requests to get a key from the cache.                                                                         |
+| `results_cache_hits`<br/>_(count)_                                   | Cache hit count.                                                                                                        |
+| `results_cache_items_count`<br/>_(gauge)_                            | Number of items currently in the cache.                                                                                 |
+| `results_cache_size_bytes`<br/>_(gauge)_                             | Size of the cache in bytes.                                                                                             |
+| `search_results_cache_max_size_bytes`<br/>_(gauge)_                  | Maximum allowed size of the search cache in bytes.                                                                      |
+| `search_results_cache_requests`<br/>_(count)_                        | Number of requests to get a key from the search cache.                                                                  |
+| `search_results_cache_hits`<br/>_(count)_                            | Search cache hit count.                                                                                                 |
+| `search_results_cache_items_count`<br/>_(gauge)_                     | Number of items currently in the search cache.                                                                          |
+| `search_results_cache_size_bytes`<br/>_(gauge)_                      | Size of the search cache in bytes.                                                                                      |
+| `runtime_flight_server_started`<br/>_(count)_                        | Indicates the runtime Flight server has started.                                                                        |
+| `runtime_http_server_started`<br/>_(count)_                          | Indicates the runtime HTTP server has started.                                                                          |
+| `secrets_store_load_duration_ms`<br/>_(histogram)_                   | Duration in milliseconds to load the secret stores.                                                                     |
+| `tool_active_count`<br/>_(gauge)_                                    | Number of currently loaded LLM tools.                                                                                   |
+| `tool_load_errors`<br/>_(count)_                                     | Number of errors loading the LLM tool.                                                                                  |
+| `tool_load_state`<br/>_(gauge)_                                      | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `view_load_errors`<br/>_(count)_                                     | Number of errors loading the view.                                                                                      |
+| `view_load_state`<br/>_(gauge)_                                      | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                        |
 
 :::note Component Metrics
 


### PR DESCRIPTION
## 🗣 Description
Add 4 acceleration refresh metrics to observalibility docs:
* `dataset_acceleration_max_timestamp_before_refresh_ms`
* `dataset_acceleration_max_timestamp_after_refresh_ms`
* `dataset_acceleration_refresh_lag_ms`
* `dataset_acceleration_ingestion_lag_ms`

## 🔨 Related Issues
https://github.com/spiceai/spiceai/issues/7184

## 🤔 Concerns
N/A