### PR TITLE
v1.7.1 Documentation Updates

### DIFF
--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -69,58 +69,62 @@ dataset_active_count{engine="duckdb"} 1
 
 ## Metrics
 
-| Metric                                                       | Description                                                                                                 |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `accelerated_ready_state_federated_fallback`<br/>_(count)_   | Number of times the federated table was queried due to the accelerated table loading the initial data.      |
-| `catalog_load_errors`<br/>_(count)_                          | Number of errors loading the catalog provider.                                                              |
-| `catalog_load_state`<br/>_(gauge)_                           | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown. |
-| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_    | Unix timestamp in seconds when the last refresh completed.                                                  |
-| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_ | Duration in milliseconds to load a full or appended refresh data.                                           |
-| `dataset_acceleration_refresh_errors`<br/>_(count)_          | Number of errors refreshing the dataset.                                                                    |
-| `dataset_active_count`<br/>_(gauge)_                         | Number of currently loaded datasets.                                                                        |
-| `dataset_load_state`<br/>_(gauge)_                           | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.          |
-| `dataset_unavailable_time_ms`<br/>_(gauge)_                  | Time dataset went offline in milliseconds.                                                                  |
-| `embeddings_active_count`<br/>_(gauge)_                      | Number of currently loaded embeddings.                                                                      |
-| `embeddings_load_errors`<br/>_(count)_                       | Number of errors loading the embedding.                                                                     |
-| `embeddings_load_state`<br/>_(gauge)_                        | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `flight_request_duration_ms`<br/>_(histogram)_               | Measures the duration of Flight requests in milliseconds.                                                   |
-| `flight_requests`<br/>_(count)_                              | Total number of Flight requests.                                                                            |
-| `http_requests_duration_ms`<br/>_(histogram)_                | Measures the duration of HTTP requests in milliseconds.                                                     |
-| `http_requests`<br/>_(count)_                                | Number of HTTP requests.                                                                                    |
-| `llm_load_state`<br/>_(gauge)_                               | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `model_active_count`<br/>_(gauge)_                           | Number of currently loaded models.                                                                          |
-| `model_load_duration_ms`<br/>_(histogram)_                   | Duration in milliseconds to load the model.                                                                 |
-| `model_load_errors`<br/>_(count)_                            | Number of errors loading the model.                                                                         |
-| `model_load_state`<br/>_(gauge)_                             | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.            |
-| `query_duration_ms`<br/>_(histogram)_                        | The total amount of time spent planning and executing queries in milliseconds.                              |
-| `query_execution_duration_ms`<br/>_(histogram)_              | The total amount of time spent only executing queries (0 for cached queries).                               |
-| `query_executions`<br/>_(count)_                             | Number of query executions.                                                                                 |
-| `query_failures`<br/>_(count)_                               | Number of query failures.                                                                                   |
-| `query_processed_bytes`<br/>_(count)_                        | Number of bytes processed by the runtime.                                                                   |
-| `query_returned_bytes`<br/>_(count)_                         | Number of bytes returned to query clients.                                                                  |
-| `embeddings_cache_max_size_bytes`<br/>_(gauge)_              | Maximum allowed size of the cache in bytes.                                                                 |
-| `embeddings_cache_requests`<br/>_(count)_                    | Number of requests to get a key from the cache.                                                             |
-| `embeddings_cache_hits`<br/>_(count)_                        | Cache hit count.                                                                                            |
-| `embeddings_cache_items_count`<br/>_(gauge)_                 | Number of items currently in the cache.                                                                     |
-| `embeddings_cache_size_bytes`<br/>_(gauge)_                  | Size of the cache in bytes.                                                                                 |
-| `results_cache_max_size_bytes`<br/>_(gauge)_                 | Maximum allowed size of the cache in bytes.                                                                 |
-| `results_cache_requests`<br/>_(count)_                       | Number of requests to get a key from the cache.                                                             |
-| `results_cache_hits`<br/>_(count)_                           | Cache hit count.                                                                                            |
-| `results_cache_items_count`<br/>_(gauge)_                    | Number of items currently in the cache.                                                                     |
-| `results_cache_size_bytes`<br/>_(gauge)_                     | Size of the cache in bytes.                                                                                 |
-| `search_results_cache_max_size_bytes`<br/>_(gauge)_          | Maximum allowed size of the search cache in bytes.                                                          |
-| `search_results_cache_requests`<br/>_(count)_                | Number of requests to get a key from the search cache.                                                      |
-| `search_results_cache_hits`<br/>_(count)_                    | Search cache hit count.                                                                                     |
-| `search_results_cache_items_count`<br/>_(gauge)_             | Number of items currently in the search cache.                                                              |
-| `search_results_cache_size_bytes`<br/>_(gauge)_              | Size of the search cache in bytes.                                                                          |
-| `runtime_flight_server_started`<br/>_(count)_                | Indicates the runtime Flight server has started.                                                            |
-| `runtime_http_server_started`<br/>_(count)_                  | Indicates the runtime HTTP server has started.                                                              |
-| `secrets_store_load_duration_ms`<br/>_(histogram)_           | Duration in milliseconds to load the secret stores.                                                         |
-| `tool_active_count`<br/>_(gauge)_                            | Number of currently loaded LLM tools.                                                                       |
-| `tool_load_errors`<br/>_(count)_                             | Number of errors loading the LLM tool.                                                                      |
-| `tool_load_state`<br/>_(gauge)_                              | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.        |
-| `view_load_errors`<br/>_(count)_                             | Number of errors loading the view.                                                                          |
-| `view_load_state`<br/>_(gauge)_                              | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.            |
+| Metric                                                               | Description                                                                                                             |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `accelerated_ready_state_federated_fallback`<br/>_(count)_           | Number of times the federated table was queried due to the accelerated table loading the initial data.                  |
+| `catalog_load_errors`<br/>_(count)_                                  | Number of errors loading the catalog provider.                                                                          |
+| `catalog_load_state`<br/>_(gauge)_                                   | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.             |
+| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_            | Unix timestamp in seconds when the last refresh completed.                                                              |
+| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_         | Duration in milliseconds to load a full or appended refresh data.                                                       |
+| `dataset_acceleration_max_timestamp_before_refresh_ms`<br/>_(gauge)_ | Maximum value of the dataset's time_column before the refresh operation, in milliseconds.                               |
+| `dataset_acceleration_max_timestamp_after_refresh_ms`<br/>_(gauge)_  | Maximum value of the dataset's time_column after the refresh operation, in milliseconds.                                |
+| `dataset_acceleration_refresh_lag_ms`<br/>_(gauge)_                  | Difference between the maximum time_column value after and before the refresh operation, in milliseconds.               |
+| `dataset_acceleration_ingestion_lag_ms`<br/>_(gauge)_                | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds. |
+| `dataset_acceleration_refresh_errors`<br/>_(count)_                  | Number of errors refreshing the dataset.                                                                                |
+| `dataset_active_count`<br/>_(gauge)_                                 | Number of currently loaded datasets.                                                                                    |
+| `dataset_load_state`<br/>_(gauge)_                                   | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                      |
+| `dataset_unavailable_time_ms`<br/>_(gauge)_                          | Time dataset went offline in milliseconds.                                                                              |
+| `embeddings_active_count`<br/>_(gauge)_                              | Number of currently loaded embeddings.                                                                                  |
+| `embeddings_load_errors`<br/>_(count)_                               | Number of errors loading the embedding.                                                                                 |
+| `embeddings_load_state`<br/>_(gauge)_                                | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `flight_request_duration_ms`<br/>_(histogram)_                       | Measures the duration of Flight requests in milliseconds.                                                               |
+| `flight_requests`<br/>_(count)_                                      | Total number of Flight requests.                                                                                        |
+| `http_requests_duration_ms`<br/>_(histogram)_                        | Measures the duration of HTTP requests in milliseconds.                                                                 |
+| `http_requests`<br/>_(count)_                                        | Number of HTTP requests.                                                                                                |
+| `llm_load_state`<br/>_(gauge)_                                       | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `model_active_count`<br/>_(gauge)_                                   | Number of currently loaded models.                                                                                      |
+| `model_load_duration_ms`<br/>_(histogram)_                           | Duration in milliseconds to load the model.                                                                             |
+| `model_load_errors`<br/>_(count)_                                    | Number of errors loading the model.                                                                                     |
+| `model_load_state`<br/>_(gauge)_                                     | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                        |
+| `query_duration_ms`<br/>_(histogram)_                                | The total amount of time spent planning and executing queries in milliseconds.                                          |
+| `query_execution_duration_ms`<br/>_(histogram)_                      | The total amount of time spent only executing queries (0 for cached queries).                                           |
+| `query_executions`<br/>_(count)_                                     | Number of query executions.                                                                                             |
+| `query_failures`<br/>_(count)_                                       | Number of query failures.                                                                                               |
+| `query_processed_bytes`<br/>_(count)_                                | Number of bytes processed by the runtime.                                                                               |
+| `query_returned_bytes`<br/>_(count)_                                 | Number of bytes returned to query clients.                                                                              |
+| `embeddings_cache_max_size_bytes`<br/>_(gauge)_                      | Maximum allowed size of the cache in bytes.                                                                             |
+| `embeddings_cache_requests`<br/>_(count)_                            | Number of requests to get a key from the cache.                                                                         |
+| `embeddings_cache_hits`<br/>_(count)_                                | Cache hit count.                                                                                                        |
+| `embeddings_cache_items_count`<br/>_(gauge)_                         | Number of items currently in the cache.                                                                                 |
+| `embeddings_cache_size_bytes`<br/>_(gauge)_                          | Size of the cache in bytes.                                                                                             |
+| `results_cache_max_size_bytes`<br/>_(gauge)_                         | Maximum allowed size of the cache in bytes.                                                                             |
+| `results_cache_requests`<br/>_(count)_                               | Number of requests to get a key from the cache.                                                                         |
+| `results_cache_hits`<br/>_(count)_                                   | Cache hit count.                                                                                                        |
+| `results_cache_items_count`<br/>_(gauge)_                            | Number of items currently in the cache.                                                                                 |
+| `results_cache_size_bytes`<br/>_(gauge)_                             | Size of the cache in bytes.                                                                                             |
+| `search_results_cache_max_size_bytes`<br/>_(gauge)_                  | Maximum allowed size of the search cache in bytes.                                                                      |
+| `search_results_cache_requests`<br/>_(count)_                        | Number of requests to get a key from the search cache.                                                                  |
+| `search_results_cache_hits`<br/>_(count)_                            | Search cache hit count.                                                                                                 |
+| `search_results_cache_items_count`<br/>_(gauge)_                     | Number of items currently in the search cache.                                                                          |
+| `search_results_cache_size_bytes`<br/>_(gauge)_                      | Size of the search cache in bytes.                                                                                      |
+| `runtime_flight_server_started`<br/>_(count)_                        | Indicates the runtime Flight server has started.                                                                        |
+| `runtime_http_server_started`<br/>_(count)_                          | Indicates the runtime HTTP server has started.                                                                          |
+| `secrets_store_load_duration_ms`<br/>_(histogram)_                   | Duration in milliseconds to load the secret stores.                                                                     |
+| `tool_active_count`<br/>_(gauge)_                                    | Number of currently loaded LLM tools.                                                                                   |
+| `tool_load_errors`<br/>_(count)_                                     | Number of errors loading the LLM tool.                                                                                  |
+| `tool_load_state`<br/>_(gauge)_                                      | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                    |
+| `view_load_errors`<br/>_(count)_                                     | Number of errors loading the view.                                                                                      |
+| `view_load_state`<br/>_(gauge)_                                      | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                        |
 
 :::note Component Metrics
 

--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -66,10 +66,12 @@ text_search(
   table STRING,              -- Dataset name (required)
   query STRING,              -- Keyword or phrase to search (required)
   col STRING,                -- Specific column to search (required if dataset has multiple indexed columns)
-  limit INTEGER,             -- Maximum results returned (optional, defaults to all results)
+  limit INTEGER,             -- Maximum results returned (optional, defaults to 1000)
   include_score BOOLEAN      -- Include relevance scores in results (optional, defaults to TRUE)
 )
 RETURNS TABLE                -- Original table columns plus an optional FLOAT column `score`
 ```
+
+By default, `text_search` retrieves up to 1000 results. To adjust this, specify the `limit` parameter in the function call.
 
 Use this function to integrate robust full-text search directly into your data workflows with minimal setup.

--- a/website/docs/features/search/index.md
+++ b/website/docs/features/search/index.md
@@ -91,7 +91,7 @@ SELECT id, title, content, fused_score
 FROM rrf(
     vector_search(documents, 'machine learning algorithms'),
     text_search(documents, 'neural networks deep learning', content),
-    id  -- join key for optimal performance
+    join_key => 'id'  -- join key for optimal performance
 )
 ORDER BY fused_score DESC
 LIMIT 5

--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -135,16 +135,24 @@ vector_search(
   table STRING,          -- Dataset name (required)
   query STRING,          -- Search text (required)
   col STRING,            -- Column name (optional if single embedding column)
-  limit INTEGER,         -- Results limit (default: all)
+  limit INTEGER,         -- Results limit (default: 1000)
   include_score BOOLEAN  -- Include relevance scores (default: TRUE)
 )
 RETURNS TABLE                -- The original table and:
                              --  - A FLOAT column `score` (if `include_score`).
 ```
 
+By default, `vector_search` retrieves up to 1000 results. To adjust this limit, specify the `limit` parameter in the function call. When using a specific vector engine, such as `s3_vectors` the limit defaults to that of the vector engine.
+
+```sql
+SELECT id, title, score
+FROM vector_search('sales', 'cutting edge AI', 1500)
+ORDER BY score DESC;
+```
+
 :::warning[Limitations]
 
-- `vector_search` UDTF does not support chunked embedding columns.
+- `vector_search` UDTF does not yet support chunked embedding columns. Chunking support is on the roadmap.
 
 :::
 
@@ -225,12 +233,15 @@ sql> describe sales;
 ### Constraints
 
 1. **Underlying Column Presence:**
+
    - The underlying column must exist in the table, and be of `string` [Arrow data type](../../reference/datatypes/accelerators.md) .
 
 2. **Embeddings Column Naming Convention:**
+
    - For each underlying column, the corresponding embeddings column must be named as `<column_name>_embedding`. For example, a `customer_reviews` table with a `review` column must have a `review_embedding` column.
 
 3. **Embeddings Column Data Type:**
+
    - The embeddings column must have the following [Arrow data type](../../reference/datatypes/accelerators.md) when loaded into Spice:
      1. `FixedSizeList[Float32 or Float64, N]`, where `N` is the dimension (size) of the embedding vector. `FixedSizeList` is used for efficient storage and processing of fixed-size vectors.
      2. If the column is [**chunked**](/docs/components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -43,14 +43,16 @@ LIMIT 5;
 - `table`: Dataset name (required)
 - `query`: Search text (required)
 - `col`: Column name (optional if only one embedding column)
-- `limit`: Maximum results (optional)
+- `limit`: Maximum results (optional, default: 1000)
 - `include_score`: Include relevance scores (optional, default TRUE)
+
+By default, `vector_search` retrieves up to 1000 results. To change this, specify a limit parameter in the function call.
 
 #### Example
 
 ```sql
 SELECT review_id, rating, customer_id, body, score
-FROM vector_search(reviews, 'issues with same day shipping')
+FROM vector_search(reviews, 'issues with same day shipping', 1500)
 WHERE created_at >= to_unixtime(now() - INTERVAL '7 days')
 ORDER BY score DESC
 LIMIT 2;

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -79,9 +79,11 @@ LIMIT 5;
 - `table`: Dataset name (required)
 - `query`: Keyword or phrase (required)
 - `col`: Column to search (required if multiple indexed columns)
-- `limit`: Maximum results (optional)
+- `limit`: Maximum results (optional, default: 1000)
 - `include_score`: Include relevance scores (optional, default TRUE)
 - `rank_weight`: Result rank weight (optional, named argument, default `score * 1`, only when specified as an argument in [RRF](#reciprocal-rank-fusion-rrf))
+
+By default, `text_search` retrieves up to 1000 results. To change this, specify a limit parameter in the function call.
 
 #### Example
 
@@ -124,7 +126,6 @@ LIMIT 10;
 
 Note that `rank_weight` is specified as the last argument to either a `text_search` or `vector_search` UDTF call (as shown above). All other arguments can be specified in any order after the search calls (within an `rrf` invocation).
 
-
 | Parameter           | Type             | Required | Description                                                        |
 | ------------------- | ---------------- | -------- | ------------------------------------------------------------------ |
 | `query_1`           | Search UDTF call | Yes      | First search query (e.g., `vector_search`, `text_search`)          |
@@ -142,6 +143,7 @@ Note that `rank_weight` is specified as the last argument to either a `text_sear
 #### Examples
 
 **Basic Hybrid Search:**
+
 ```sql
 -- Combine vector and text search for enhanced relevance
 SELECT id, title, content, fused_score
@@ -156,6 +158,7 @@ LIMIT 5;
 ```
 
 **Weighted Ranking:**
+
 ```sql
 -- Boost semantic search over exact text matching
 SELECT fused_score, title, content
@@ -168,6 +171,7 @@ LIMIT 10;
 ```
 
 **Recency-Boosted Search:**
+
 ```sql
 -- Exponential decay favoring recent content
 SELECT fused_score, title, created_at
@@ -184,6 +188,7 @@ LIMIT 10;
 ```
 
 **Linear Decay:**
+
 ```sql
 -- Linear decay over 24 hours
 SELECT fused_score, content
@@ -247,4 +252,4 @@ SELECT * FROM my_table WHERE regexp_like(column, '^spice.*ai$');
 
 ---
 
-For more on hybrid and advanced search, see [Search Functionality](/docs/features/search) and [Vector-Based Search](/docs/features/search/vector-search).
+For more on hybrid and advanced search, see [Search Functionality](/docs/features/search) and [Vector-Based Search](/docs/features/search/vector-search)

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -18,12 +18,12 @@ This section documents search capabilities in Spice SQL, including vector search
     - [Example](#example-1)
 - [Reciprocal Rank Fusion (`rrf`)](#reciprocal-rank-fusion-rrf)
   - [Usage](#usage-2)
-    - [Example](#example-2)
+    - [Examples](#examples)
 - [Lexical Search: LIKE, =, and Regex](#lexical-search-like--and-regex)
   - [LIKE (Pattern Matching)](#like-pattern-matching)
   - [= (Keyword/Exact Match)](#-keywordexact-match)
   - [Regex Filtering](#regex-filtering)
-    - [Example](#example-3)
+    - [Example](#example-2)
 
 ---
 
@@ -45,6 +45,7 @@ LIMIT 5;
 - `col`: Column name (optional if only one embedding column)
 - `limit`: Maximum results (optional, default: 1000)
 - `include_score`: Include relevance scores (optional, default TRUE)
+- `rank_weight`: Result rank weight (optional, named argument, default `score * 1`, only when specified as an argument in [RRF](#reciprocal-rank-fusion-rrf))
 
 By default, `vector_search` retrieves up to 1000 results. To change this, specify a limit parameter in the function call.
 
@@ -80,6 +81,7 @@ LIMIT 5;
 - `col`: Column to search (required if multiple indexed columns)
 - `limit`: Maximum results (optional)
 - `include_score`: Include relevance scores (optional, default TRUE)
+- `rank_weight`: Result rank weight (optional, named argument, default `score * 1`, only when specified as an argument in [RRF](#reciprocal-rank-fusion-rrf))
 
 #### Example
 
@@ -96,19 +98,23 @@ See [Full-Text Search](/docs/features/search/full-text) for configuration and de
 
 ## Reciprocal Rank Fusion (`rrf`)
 
-Reciprocal Rank Fusion (RRF) combines results from multiple search queries to improve relevance by merging rankings from different search methods.
+Reciprocal Rank Fusion (RRF) combines results from multiple search queries to improve relevance by merging rankings from different search methods. Advanced features include per-query ranking weights, recency boosting, and flexible decay functions.
 
 ### Usage
 
-`rrf` is varadic and takes two or more search UDTF calls as arguments. An optional join key column and smoothing parameter can be provided. When no join key is specified, Spice will compute a JOIN key on-the-fly (by hashing rows) in order to fuse the results. Specifying an explicit JOIN key is recommended for optimal performance.
+`rrf` is variadic and takes two or more search UDTF calls as arguments. Named parameters provide advanced control over ranking, recency, and fusion behavior.
+
+:::info
+The `rrf` function automatically adds a `fused_score` column to the result set, which contains the combined relevance score from all input search queries. Results are sorted by `fused_score DESC` by default when no explicit `ORDER BY` clause is specified.
+:::
 
 ```sql
 SELECT id, content, fused_score
 FROM rrf(
-    vector_search(table, 'search query'),
+    vector_search(table, 'search query', rank_weight => 20),
     text_search(table, 'search terms', column),
-    id,    -- optional join key column
-    60.0   -- optional k parameter (smoothing factor)
+    join_key => 'id',    -- explicit join key for performance
+    k => 60.0            -- smoothing parameter
 )
 ORDER BY fused_score DESC
 LIMIT 10;
@@ -116,35 +122,95 @@ LIMIT 10;
 
 **Arguments:**
 
-| Parameter  | Type             | Required | Description                                               |
-| ---------- | ---------------- | -------- | --------------------------------------------------------- |
-| `query_1`  | Search UDTF call | Yes      | First search query (e.g., `vector_search`, `text_search`) |
-| `query_2`  | Search UDTF call | Yes      | Second search query                                       |
-| `...`      | Search UDTF call | No       | Additional search queries (variadic)                      |
-| `join_key` | Column           | No       | Column name to use for joining results across queries     |
-| `k`        | Float            | No       | Smoothing parameter for RRF scoring (default: 60)         |
+Note that `rank_weight` is specified as the last argument to either a `text_search` or `vector_search` UDTF call (as shown above). All other arguments can be specified in any order after the search calls (within an `rrf` invocation).
 
-#### Example
 
+| Parameter           | Type             | Required | Description                                                        |
+| ------------------- | ---------------- | -------- | ------------------------------------------------------------------ |
+| `query_1`           | Search UDTF call | Yes      | First search query (e.g., `vector_search`, `text_search`)          |
+| `query_2`           | Search UDTF call | Yes      | Second search query                                                |
+| `...`               | Search UDTF call | No       | Additional search queries (variadic)                               |
+| `join_key`          | String           | No       | Column name to use for joining results (default: auto-hash)        |
+| `k`                 | Float            | No       | Smoothing parameter for RRF scoring (default: 60.0)                |
+| `time_column`       | String           | No       | Column name containing timestamps for recency boosting             |
+| `recency_decay`     | String           | No       | Decay function: 'linear' or 'exponential' (default: 'exponential') |
+| `decay_constant`    | Float            | No       | Decay rate for exponential decay (default: 0.01)                   |
+| `decay_scale_secs`  | Float            | No       | Time scale in seconds for decay (default: 86400)                   |
+| `decay_window_secs` | Float            | No       | Window size for linear decay in seconds (default: 86400)           |
+| `rank_weight`       | Float            | No       | Per-query ranking weight (**specified within search functions**)   |
+
+#### Examples
+
+**Basic Hybrid Search:**
 ```sql
 -- Combine vector and text search for enhanced relevance
 SELECT id, title, content, fused_score
 FROM rrf(
     vector_search(documents, 'machine learning algorithms'),
     text_search(documents, 'neural networks deep learning', content),
-    id  -- use 'id' column as join key for better performance
+    join_key => 'id'  -- explicit join key for performance
 )
 WHERE fused_score > 0.01
 ORDER BY fused_score DESC
 LIMIT 5;
 ```
 
+**Weighted Ranking:**
+```sql
+-- Boost semantic search over exact text matching
+SELECT fused_score, title, content
+FROM rrf(
+    text_search(posts, 'artificial intelligence', rank_weight => 50.0),
+    vector_search(posts, 'AI machine learning', rank_weight => 200.0)
+)
+ORDER BY fused_score DESC
+LIMIT 10;
+```
+
+**Recency-Boosted Search:**
+```sql
+-- Exponential decay favoring recent content
+SELECT fused_score, title, created_at
+FROM rrf(
+    text_search(news, 'breaking news'),
+    vector_search(news, 'latest updates'),
+    time_column => 'created_at',
+    recency_decay => 'exponential',
+    decay_constant => 0.05,
+    decay_scale_secs => 3600  -- 1 hour scale
+)
+ORDER BY fused_score DESC
+LIMIT 10;
+```
+
+**Linear Decay:**
+```sql
+-- Linear decay over 24 hours
+SELECT fused_score, content
+FROM rrf(
+    text_search(posts, 'trending'),
+    vector_search(posts, 'viral popular'),
+    time_column => 'created_at',
+    recency_decay => 'linear',
+    decay_window_secs => 86400
+)
+ORDER BY fused_score DESC;
+```
+
 **How RRF works:**
 
 - Each input query is ranked independently by score
-- Rankings are combined using the formula: `RRF Score = Σ(1 / (k + rank))`
+- Rankings are combined using the formula: `RRF Score = Σ(rank_weight / (k + rank))`
 - Documents appearing in multiple result sets receive higher scores
 - The `k` parameter controls ranking sensitivity (lower = more sensitive to rank position)
+
+**Advanced query tuning**:
+
+- **Rank weighting**: Individual queries can be weighted using `rank_weight` parameter
+- **Recency boosting**: When `time_column` is specified, scores are multiplied by a decay factor
+  - **Exponential decay**: `e^(-decay_constant * age_in_units)` where age is in `decay_scale_secs`
+  - **Linear decay**: `max(0, 1 - (age_in_units / decay_window_secs))`
+- **Auto-join**: When no `join_key` is specified, rows are automatically hashed for joining
 
 ---
 

--- a/website/src/pages/cookbook/_ignored.tsx
+++ b/website/src/pages/cookbook/_ignored.tsx
@@ -91,6 +91,13 @@ const recipes: RecipeData[] = [
     videoUrl: 'https://youtu.be/5y26MveEJ8c'
   },
   {
+    title: 'Hybrid-Search with RRF',
+    description:
+      'Combine multiple search methods using Reciprocal Rank Fusion (RRF) for improved search results.',
+    path: '/search/README.md',
+    tags: ['ai', 'search', 'rrf']
+  },
+  {
     title: 'xAI Models',
     description: 'Use xAI models such as Grok.',
     path: '/models/xai/README.md',


### PR DESCRIPTION
This pull request updates the documentation for Spice SQL search and observability features, focusing on improvements to search function parameters, reciprocal rank fusion (RRF) capabilities, and metric definitions. The changes clarify default behaviors, add advanced search options, and expand metric coverage for dataset acceleration.

### Search Function Enhancements

* Updated `vector_search` documentation to clarify that the default result limit is now 1000, and added instructions for overriding the limit. Also explained that specific vector engines may have different default limits. [[1]](diffhunk://#diff-c08d667938c6707fb8fef678c92bb45e9ce58246da5f582c0e6fd6765584cf90L138-R155) [[2]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bL46-R56)
* Added the `rank_weight` parameter to both `vector_search` and `text_search`, allowing per-query ranking weights—especially useful when used within RRF for hybrid search relevance tuning. [[1]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bL46-R56) [[2]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bR84)
* Improved constraints documentation for vector search, specifying embedding column naming conventions and Arrow data type requirements, including details for chunked columns.

### Reciprocal Rank Fusion (RRF) Improvements

* Expanded RRF documentation to include advanced features such as per-query ranking weights, recency boosting, and flexible decay functions. Added new parameters (`time_column`, `recency_decay`, `decay_constant`, `decay_scale_secs`, `decay_window_secs`) for fine-tuned relevance and recency control.
* Provided multiple RRF usage examples: basic hybrid search, weighted ranking, recency-boosted search (exponential and linear decay), and explained the underlying scoring formulas and auto-join behavior. [[1]](diffhunk://#diff-1a42e537241b7ba2fb0215f345feb9c2c77a3884255e8351fd4dd5ca8f4daf5bL97-R214) [[2]](diffhunk://#diff-21ccf30be492f244d0efee0ef0470e6d565d30514f3dbd48a813fbca380b5738L94-R94)

### Observability Metrics Expansion

* Added new dataset acceleration metrics: maximum timestamp before/after refresh, refresh lag, and ingestion lag. These metrics help monitor data freshness and lag in accelerated tables.

### Minor Documentation Improvements

* Corrected and clarified section headings and example labels for better navigation and understanding in the SQL search documentation.

---

These updates make the documentation more comprehensive and actionable for users leveraging advanced search and observability features in Spice SQL.