### PR TITLE
Update CLI commands with new --endpoint

### DIFF
--- a/website/docs/cli/reference/chat.md
+++ b/website/docs/cli/reference/chat.md
@@ -29,12 +29,14 @@ spice chat [flags] [<message>]
 
 ## Flags
 
-- `--cloud` Send requests to a Spice Cloud instance instead of the local instance. Default: `false`.
-- `--http-endpoint <string>` Runtime HTTP endpoint. Default: `http://localhost:8090`.
-- `--model <string>` Target model for the chat request. When omitted, the CLI uses the single ready model or prompts for a choice if several models are ready.
-- `--temperature <float32>` Model temperature used for chat request. Default: `1`.
-- `--user-agent <string>` Custom `User-Agent` header sent with every request.
+- `--cloud` Use a Spice Cloud instance for chat. Requires `--api-key`.
+- `--endpoint <endpoint>` Specifies the remote Spice instance endpoint. Supports `http://`, `https://`, `grpc://`, or `grpc+tls://` schemes. For example, `--endpoint http://my-remote-host:8090` (HTTP) or `--endpoint grpc://my-remote-host:50051` (Arrow Flight/gRPC).
+- `--http-endpoint <endpoint>` (Deprecated) Runtime HTTP endpoint. Default: `http://localhost:8090`.
+- `--model <string>` Target model for the chat request. When omitted, the CLI uses the single ready model or prompts for a choice if several models are ready.
+- `--temperature <float32>` Model temperature used for chat request. Default: `1.0`.
+- `--user-agent <string>` Custom `User-Agent` header sent with every request.
 - `--responses` Direct all chats to the `/v1/responses` endpoint, which exposes configured models that support [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses) and enables access to [OpenAI-hosted tools](https://platform.openai.com/docs/guides/tools). To learn more about Spice's support for OpenAI's Responses API, view the [OpenAI model provider documentation](/components/models/openai.md) or the [Azure OpenAI model provider documentation](/components/models/azure.md).
+
 ## Examples
 
 When exactly one model is **ready**, `spice chat` opens a REPL that uses that model automatically:
@@ -46,6 +48,19 @@ chat> hello
 Hello! How can I assist you today?
 
 Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s).
+```
+
+#### Remote and Cloud Examples
+
+```shell
+# Chat with Spice Cloud
+spice chat --cloud --api-key <your-api-key> --model <model>
+
+# Chat with a remote spiced instance over HTTP
+spice chat --endpoint http://my-remote-host:8090 --model <model>
+
+# Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
+spice chat --endpoint grpc://my-remote-host:50051 --model <model>
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/docs/cli/reference/search.md
+++ b/website/docs/cli/reference/search.md
@@ -1,6 +1,6 @@
 ---
-title: "search"
-sidebar_label: "search"
+title: 'search'
+sidebar_label: 'search'
 pagination_prev: null
 pagination_next: null
 ---
@@ -17,15 +17,26 @@ spice search [query] [flags]
 
 #### Flags
 
-- `--cloud`  Whether to use cloud instance for search (default: false)
-- `--limit`  Limit number of search results
-- `--model`  Model to use for search
-- `--http-endpoint`  HTTP endpoint for search (default: http://localhost:8090).
+- `--cloud` Use a Spice Cloud instance for search. Requires `--api-key`.
+- `--endpoint <endpoint>` Specifies the remote Spice instance HTTP endpoint (e.g., `http://localhost:8090`).
+- `--limit` Limit number of search results.
+- `--model` Model to use for search.
+- `--http-endpoint <endpoint>` (Deprecated) HTTP endpoint for search (default: `http://localhost:8090`).
 
 ### Examples
 
 ```shell
 >>> spice search --limit 2
+```
+
+#### Remote and Cloud Examples
+
+```shell
+# Search with Spice Cloud
+spice search --cloud --api-key <your-api-key>
+
+# Search with a remote spiced instance
+spice search --endpoint http://my-remote-host:8090
 ```
 
 ```shell

--- a/website/docs/cli/reference/sql.md
+++ b/website/docs/cli/reference/sql.md
@@ -1,6 +1,6 @@
 ---
-title: "sql"
-sidebar_label: "sql"
+title: 'sql'
+sidebar_label: 'sql'
 pagination_prev: null
 pagination_next: null
 ---
@@ -9,20 +9,22 @@ Start an interactive SQL query session against the Spice runtime
 
 ### Usage
 
-```shell 
+```shell
 spice sql [flags]
 ```
 
 #### Flags
 
-- `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
-- `-h`, `--help`   Print this help message
-- `--flight-endpoint` Configure runtime Flight endpoint. Defaults to http://127.0.0.1:50051
-- `--http-endpoint`  Configure runtime HTTP endpoint. Defaults to http://127.0.0.1:8090
+- `--cloud` Use a Spice Cloud instance as the SQL backend. Requires `--api-key`.
+- `--endpoint <endpoint>` Specifies the remote Spice instance endpoint. Supports `http://`, `https://`, `grpc://`, or `grpc+tls://` schemes. If not provided, uses the local spiced runtime.
+- `--flight-endpoint <endpoint>` (Deprecated) Specifies the remote Spice instance Flight endpoint (treated as gRPC endpoint). If not provided, uses the local spiced runtime.
+- `--http-endpoint <endpoint>` (Deprecated) HTTP endpoint of Spice (default: `http://127.0.0.1:8090`).
+- `--tls-root-certificate-file <file>` The path to the root certificate file used to verify the Spice.ai runtime server certificate.
+- `-h`, `--help` Print this help message.
 
 ### Examples
 
-```shell 
+```shell
 $ spice sql
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.
 
@@ -44,6 +46,19 @@ sql> show tables
 ```shell
 $ spice sql --tls-root-certificate-file /path/to/cert.pem
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+```
+
+#### Remote and Cloud Examples
+
+```shell
+# Connect to Spice Cloud
+spice sql --cloud --api-key <your-api-key>
+
+# Connect to a remote spiced instance over HTTP
+spice sql --endpoint http://my-remote-host:8090
+
+# Connect to a remote spiced instance over Arrow Flight SQL (gRPC)
+spice sql --endpoint grpc://my-remote-host:50051
 
 show tables;  -- list available tables
 sql> show tables


### PR DESCRIPTION
This pull request updates the CLI documentation for the `chat`, `search`, and `sql` commands to clarify and standardize remote and cloud connection options. The main improvements include clearer flag descriptions, deprecation notices for older flags, and new example usage blocks for connecting to Spice Cloud and remote instances.

**CLI Documentation Improvements:**

* Standardized and clarified the `--cloud`, `--endpoint`, and deprecated `--http-endpoint`/`--flight-endpoint` flags across `chat`, `search`, and `sql` command docs to better explain remote and cloud usage, including supported schemes and requirements for cloud connections. [[1]](diffhunk://#diff-872d6927c806071816b73df66740518542f3bb9b9ea401e18bfc8d83dc36f02cL32-R39) [[2]](diffhunk://#diff-0b7b1cc34fd91190bc88ee4ed07ccc478ae54b4b0d8550e704a6b3e51133ac3fL20-R41) [[3]](diffhunk://#diff-6f59712a6d4f155d91debc19f23f17dd6094c27a7ba4b33a73aa4d46f7ce8b99L18-R23)
* Added dedicated "Remote and Cloud Examples" sections to each command reference, demonstrating how to connect to Spice Cloud and remote instances using the new flags and various protocols (HTTP, gRPC/Arrow Flight). [[1]](diffhunk://#diff-872d6927c806071816b73df66740518542f3bb9b9ea401e18bfc8d83dc36f02cR53-R65) [[2]](diffhunk://#diff-0b7b1cc34fd91190bc88ee4ed07ccc478ae54b4b0d8550e704a6b3e51133ac3fL20-R41) [[3]](diffhunk://#diff-6f59712a6d4f155d91debc19f23f17dd6094c27a7ba4b33a73aa4d46f7ce8b99R49-R61)

**Formatting and Consistency:**

* Updated frontmatter in `search.md` and `sql.md` for consistent use of single quotes in YAML metadata. [[1]](diffhunk://#diff-0b7b1cc34fd91190bc88ee4ed07ccc478ae54b4b0d8550e704a6b3e51133ac3fL2-R3) [[2]](diffhunk://#diff-6f59712a6d4f155d91debc19f23f17dd6094c27a7ba4b33a73aa4d46f7ce8b99L2-R3)