### PR TITLE
Add Task History plan capture

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -198,14 +198,18 @@ runtime:
     captured_output: none
     retention_period: 8h
     retention_check_interval: 15m
+    min_sql_duration: 5s
 ```
 
-| Parameter name             | Optional | Description                                                                                    |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `enabled`                  | Yes      | Defaults to `true`.                                                                            |
-| `captured_output`          | Yes      | Specifies the level of output captured by the task history table. Defaults to `none`.          |
-| `retention_period`         | Yes      | Specifies how long records in the task history table are retained. Defaults to `8h` (8 hours). |
-| `retention_check_interval` | Yes      | Specifies how often old records are checked for removal. Defaults to `15m` (15 minutes).       |
+| Parameter name             | Optional | Description                                                                                                                                                  |
+| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                  | Yes      | Defaults to `true`.                                                                                                                                          |
+| `captured_output`          | Yes      | Specifies the level of output captured by the task history table. Defaults to `none`.                                                                        |
+| `captured_plan`            | Yes      | Controls SQL query plan capture. Options: `none` (default), `explain`, or `explain analyze`. Query plans are captured asynchronously after query completion. |
+| `min_sql_duration`         | Yes      | Minimum query execution duration before a plan is captured. Only queries exceeding this threshold are captured. Example: `5s`.                               |
+| `min_plan_duration`        | Yes      | Minimum plan execution duration before a plan is captured. This threshold applies to the execution time of the `EXPLAIN` operation itself. Example: `10s`.   |
+| `retention_period`         | Yes      | Specifies how long records in the task history table are retained. Defaults to `8h` (8 hours).                                                               |
+| `retention_check_interval` | Yes      | Specifies how often old records are checked for removal. Defaults to `15m` (15 minutes).                                                                     |
 
 ## `runtime.cors`
 
@@ -275,10 +279,11 @@ runtime:
 Allows to enable metrics that are disabled by default.
 
 Following metrics are disabled by default:
-* `dataset_acceleration_max_timestamp_before_refresh_ms`
-* `dataset_acceleration_max_timestamp_after_refresh_ms`
-* `dataset_acceleration_refresh_lag_ms`
-* `dataset_acceleration_ingestion_lag_ms`
+
+- `dataset_acceleration_max_timestamp_before_refresh_ms`
+- `dataset_acceleration_max_timestamp_after_refresh_ms`
+- `dataset_acceleration_refresh_lag_ms`
+- `dataset_acceleration_ingestion_lag_ms`
 
 For details about these metrics, see [Observability](/docs/features/observability/index.md).
 

--- a/website/docs/reference/task_history.md
+++ b/website/docs/reference/task_history.md
@@ -302,3 +302,64 @@ Example output:
 | sql_query | 2024-11-25T07:15:30.574257 | 40.908                | select  i_item_id  ,i_item_desc  ,s_store_id  ,s_store_name  ,min(ss_net_profit) as store_sales_prof |               | {protocol: FlightSQL, rows_produced: 0, accelerated: true, datasets: store_returns,date_dim,store,store_sales,item,catalog_sales, query_execution_duration_ms: 40.29496}          |
 +-----------+----------------------------+-----------------------+------------------------------------------------------------------------------------------------------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
+
+## SQL Query Plan Capture
+
+Spice supports automated SQL query plan capture through `EXPLAIN` or `EXPLAIN ANALYZE` statements. This feature stores query plans in the task history, providing detailed execution information for analysis and debugging. Query plans are captured asynchronously after query completion to avoid blocking query execution.
+
+### Configuration
+
+Configure SQL query plan capture using `runtime.task_history` parameters:
+
+```yaml
+runtime:
+  task_history:
+    captured_plan: explain analyze
+    min_sql_duration: 5s
+    min_plan_duration: 10s
+```
+
+#### Parameters
+
+- **`captured_plan`**: Determines which plan type is captured. Options:
+  - `none` (default): No plans are captured
+  - `explain`: Captures the logical query plan without executing it
+  - `explain analyze`: Captures the query plan with actual execution metrics
+- **`min_sql_duration`**: Minimum query execution duration before a plan is captured. Plans are captured only for queries that exceed this threshold.
+- **`min_plan_duration`**: Minimum plan execution duration before a plan is captured. This threshold applies to the execution time of the `EXPLAIN` or `EXPLAIN ANALYZE` operation itself.
+
+### Captured Output
+
+Query plans are stored in the `captured_output` column of the task history table. This column contains the result of the `EXPLAIN` or `EXPLAIN ANALYZE` statement generated for the original query.
+
+### Query Examples
+
+Retrieve query plans for slow queries:
+
+```sql
+SELECT
+    start_time,
+    execution_duration_ms,
+    SUBSTRING(input, 1, 80) AS query_preview,
+    captured_output
+FROM spice.runtime.task_history
+WHERE task = 'sql_query'
+  AND captured_output IS NOT NULL
+  AND execution_duration_ms > 5000
+ORDER BY start_time DESC
+LIMIT 5;
+```
+
+Find queries with specific execution patterns:
+
+```sql
+SELECT
+    start_time,
+    execution_duration_ms,
+    captured_output
+FROM spice.runtime.task_history
+WHERE task = 'sql_query'
+  AND captured_output LIKE '%TableScan%'
+  AND execution_duration_ms > 1000
+ORDER BY execution_duration_ms DESC;
+```

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -80,16 +80,16 @@ Time: 4.24s (first token 3.85s). Tokens: 826. Prompt: 793. Completion: 33 (85.50
 To inspect the last chat, run `spice trace ai_chat`, producing an AI chat trace output:
 
 ```console
-[8153c6563c7f9d88] ( 4234.38ms) ai_chat 
-  ├── [8656eaacb6c7a57d] (    0.13ms) tool_use::list_datasets 
-  ├── [3873d8257d8ea30c] ( 4233.47ms) ai_completion 
-  ├── [02f2def1712f1473] (    1.11ms) tool_use::sql 
-  │ └── [1e4e5f4e79e74e5e] (    0.91ms) sql_query 
-  ├── [8d1db4d4db80c021] ( 3185.46ms) ai_completion 
-  ├── [0c7b421812ca8180] (    0.17ms) tool_use::table_schema 
-  ├── [a49553aca9f19384] ( 2166.24ms) ai_completion 
-  ├── [ec69ce81b3d71b1a] (    3.38ms) tool_use::sql 
-  │ └── [24769e9b068656ed] (    3.33ms) sql_query 
+[8153c6563c7f9d88] ( 4234.38ms) ai_chat
+  ├── [8656eaacb6c7a57d] (    0.13ms) tool_use::list_datasets
+  ├── [3873d8257d8ea30c] ( 4233.47ms) ai_completion
+  ├── [02f2def1712f1473] (    1.11ms) tool_use::sql
+  │ └── [1e4e5f4e79e74e5e] (    0.91ms) sql_query
+  ├── [8d1db4d4db80c021] ( 3185.46ms) ai_completion
+  ├── [0c7b421812ca8180] (    0.17ms) tool_use::table_schema
+  ├── [a49553aca9f19384] ( 2166.24ms) ai_completion
+  ├── [ec69ce81b3d71b1a] (    3.38ms) tool_use::sql
+  │ └── [24769e9b068656ed] (    3.33ms) sql_query
   └── [6ff16c04ecf6f6ff] (  961.39ms) ai_completion
 ```
 
@@ -123,7 +123,7 @@ For more information, view the [task history documentation](../reference/task_hi
 
 ## Logging Additional Captured Output
 
-Set `runtime.task_history.captured_output` to `truncated` to store summarized SQL query information in the `captured_output` `task_history` column. Enable captured output by running `spiced` with  `--set-runtime task_history.captured_output=truncated` or adjusting the Spicepod parameter `runtime.task_history.captured_output`.
+Set `runtime.task_history.captured_output` to `truncated` to store summarized SQL query information in the `captured_output` `task_history` column. Enable captured output by running `spiced` with `--set-runtime task_history.captured_output=truncated` or adjusting the Spicepod parameter `runtime.task_history.captured_output`.
 
 Example Spicepod excerpt:
 
@@ -146,6 +146,48 @@ Example captured output:
 | 2025-02-07T00:17:54.717312222 | 2025-02-07T00:17:54.728507220 | sql_query           | [{"subject":"Hello, world!"}] |               |
 +-------------------------------+-------------------------------+---------------------+-------------------------------+---------------+
 ```
+
+## Capturing SQL Query Plans in Task History
+
+Configure Spice to automatically capture SQL query plans (`EXPLAIN` or `EXPLAIN ANALYZE`) in the task history. This feature captures query execution information asynchronously, storing results in the `captured_output` column for later analysis without impacting query performance.
+
+Configure plan capture using the `runtime.task_history` settings:
+
+```yaml
+runtime:
+  task_history:
+    captured_plan: explain analyze
+    min_sql_duration: 5s
+    min_plan_duration: 10s
+```
+
+### Configuration Parameters
+
+- **`captured_plan`**: Determines the type of plan captured:
+  - `none` (default): No plans are captured
+  - `explain`: Captures logical and physical query plans
+  - `explain analyze`: Captures plans with actual execution metrics
+- **`min_sql_duration`**: Minimum query duration before plan capture. Only queries exceeding this threshold generate a plan.
+- **`min_plan_duration`**: Minimum plan execution duration before storage. Plans that execute faster than this threshold are discarded.
+
+### Query Examples
+
+Review captured plans for slow queries:
+
+```sql
+SELECT
+    start_time,
+    execution_duration_ms,
+    SUBSTRING(input, 1, 80) AS query_preview,
+    captured_output
+FROM spice.runtime.task_history
+WHERE task = 'sql_query'
+  AND captured_output IS NOT NULL
+ORDER BY execution_duration_ms DESC
+LIMIT 5;
+```
+
+Plans are captured asynchronously after query completion, ensuring query execution proceeds without blocking. For more details, view the [task history documentation](../reference/task_history.md#sql-query-plan-capture).
 
 ## SQL Explain Plans
 
@@ -232,6 +274,6 @@ docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spicea
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh
 
-# At this point, a shell with standard Linux tools is available via the busybox binary. 
+# At this point, a shell with standard Linux tools is available via the busybox binary.
 # However, commands must be prefixed with `/busy/busybox`, for example: `/busy/busybox ls -l /app`.
 ```


### PR DESCRIPTION
This pull request updates the documentation to introduce and explain automated SQL query plan capture in Spice, including configuration options and usage examples. The changes clarify how to enable query plan capture, describe new configuration parameters, and provide practical SQL examples for analyzing captured plans. These improvements help users understand and leverage query plan capture for debugging and performance analysis.

**SQL Query Plan Capture Documentation:**

* Added detailed documentation for automated SQL query plan capture using `EXPLAIN` or `EXPLAIN ANALYZE`, including an overview, configuration options, and usage examples in `website/docs/reference/task_history.md` and `website/docs/troubleshooting/index.md`. [[1]](diffhunk://#diff-1232ebf2bc5364ef68ac1a400c38093a4e3b48edaad3b17bf2abec84bcb90ef3R305-R365) [[2]](diffhunk://#diff-59f5453d614e381bdfa7faa931e3d2c7e2c4c27e1d7c7171b5c7edcf4f1758b7R150-R191)
* Described new configuration parameters for enabling and controlling plan capture: `captured_plan`, `min_sql_duration`, and `min_plan_duration` in the `runtime.task_history` section of `website/docs/reference/spicepod/runtime.md`, including their effects and example values.

**Documentation Consistency and Formatting:**

* Updated parameter tables and lists to include the new options and ensure consistent formatting across the documentation. [[1]](diffhunk://#diff-50c8bfdf9f080389e3160bb96670192fb81385b41c1a9441c3770b9d876294cdR201-R210) [[2]](diffhunk://#diff-50c8bfdf9f080389e3160bb96670192fb81385b41c1a9441c3770b9d876294cdL278-R286)

**Practical Usage Examples:**

* Provided SQL query examples to help users retrieve and analyze captured query plans from the `task_history` table, focusing on slow queries and specific execution patterns. [[1]](diffhunk://#diff-1232ebf2bc5364ef68ac1a400c38093a4e3b48edaad3b17bf2abec84bcb90ef3R305-R365) [[2]](diffhunk://#diff-59f5453d614e381bdfa7faa931e3d2c7e2c4c27e1d7c7171b5c7edcf4f1758b7R150-R191)