### PR TITLE
HTTP Connector Dynamic Query docs

### DIFF
--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -123,6 +123,27 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `retry_max_duration`     | Optional. Maximum total duration for all retries (e.g., `30s`, `5m`). If not set, retries continue up to `max_retries`.                                                                                     |
 | `retry_jitter`           | Optional. Randomization factor for retry delays (0.0 to 1.0). Default: `0.3` (30% randomization). Set to `0` for no jitter.                                                                                 |
 
+## HTTP Response Headers
+
+When querying HTTP(s) datasets, Spice respects standard HTTP caching headers in responses. The connector supports the following cache-related response headers:
+
+### `Cache-Control`
+
+The `Cache-Control` response header from the HTTP(s) endpoint controls how Spice caches the dataset. When the HTTP(s) server returns a `Cache-Control` header with the `stale-while-revalidate` directive, Spice serves stale data while refreshing the cache in the background.
+
+For example, if the HTTP(s) endpoint returns:
+
+```
+Cache-Control: max-age=10, stale-while-revalidate=10
+```
+
+Spice will:
+1. Serve fresh data for 10 seconds after fetching.
+2. Between 10-20 seconds, serve stale data while fetching fresh data in the background.
+3. After 20 seconds, fetch fresh data before serving the next request.
+
+This behavior mirrors the `stale_while_revalidate_ttl` configuration available in the [caching configuration](/docs/features/caching#stale-while-revalidate), but is controlled by the HTTP(s) server rather than the Spicepod configuration.
+
 ## Timeouts and Retries
 
 ### Timeouts

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -334,6 +334,78 @@ This example demonstrates:
 - Executing complex search queries against REST APIs
 - Fetching results based on structured query syntax
 
+### Processing JSON Responses
+
+APIs often return JSON data that requires parsing to extract specific fields. Spice provides [JSON functions](/docs/reference/sql/json) to process and transform JSON responses directly in SQL queries.
+
+#### Extracting Fields from JSON
+
+```yaml
+datasets:
+  - from: https://api.tvmaze.com
+    name: tvmaze
+    params:
+      file_format: json
+```
+
+Extract specific fields from JSON responses:
+
+```sql
+-- Extract the show name from a JSON response
+SELECT json_get_str(content, 'name') as name
+FROM tvmaze
+WHERE request_path = '/shows/169';
+```
+
+#### Working with Nested JSON
+
+APIs often return deeply nested JSON structures that require parsing to extract specific fields. Use chained JSON functions to navigate nested objects:
+
+```sql
+-- Extract nested fields from a show's network information
+SELECT
+  json_get_str(content, 'name') as show_name,
+  json_get_str(json_get(content, 'network'), 'name') as network_name,
+  json_get_str(json_get(json_get(content, 'network'), 'country'), 'name') as country,
+  json_get_str(json_get(json_get(content, 'network'), 'country'), 'code') as country_code
+FROM tvmaze
+WHERE request_path = '/shows/82';
+```
+
+This demonstrates extracting nested objects step by step:
+
+- `json_get(content, 'network')` extracts the network object
+- `json_get_str(json_get(content, 'network'), 'name')` gets the network name from the nested object
+- Multiple `json_get` calls can be chained to navigate deeper levels
+
+#### Extracting Multiple Fields
+
+```sql
+-- Parse multiple fields from a TV show API response
+SELECT
+  json_get_str(content, 'name') as show_name,
+  json_get_str(content, 'type') as show_type,
+  json_get_str(content, 'language') as language,
+  json_get_int(content, 'runtime') as runtime_minutes,
+  json_get_str(content, 'premiered') as premiere_date,
+  json_get_str(content, 'status') as status
+FROM tvmaze
+WHERE request_path = '/shows/169';
+```
+
+#### Processing JSON Arrays
+
+```sql
+-- Extract genres from a JSON array
+SELECT
+  json_get_str(content, 'name') as show_name,
+  json_get_array(content, 'genres') as genres_array
+FROM tvmaze
+WHERE request_path = '/shows/82';
+```
+
+For more details on available JSON functions including `json_get`, `json_get_str`, `json_get_int`, `json_get_bool`, and others, refer to the [JSON functions reference](/docs/reference/sql/json).
+
 ### Refresh SQL with Dynamic Filters
 
 The HTTP connector supports dynamic URL construction through `refresh_sql` with templated query parameters. This enables incremental data loading by appending filter conditions from the SQL query to the HTTP request URL.

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -129,7 +129,7 @@ When querying HTTP(s) datasets, Spice respects standard HTTP caching headers in 
 
 ### `Cache-Control`
 
-The `Cache-Control` response header from the HTTP(s) endpoint controls how Spice caches the dataset. When the HTTP(s) server returns a `Cache-Control` header with the `stale-while-revalidate` directive, Spice serves stale data while refreshing the cache in the background.
+The `Cache-Control` response header from the HTTP(s) endpoint is passed through to clients querying Spice. When the HTTP(s) server returns a `Cache-Control` header with the `stale-while-revalidate` directive, clients can use this value to determine appropriate caching behavior.
 
 For example, if the HTTP(s) endpoint returns:
 
@@ -137,12 +137,12 @@ For example, if the HTTP(s) endpoint returns:
 Cache-Control: max-age=10, stale-while-revalidate=10
 ```
 
-Spice will:
+Clients querying Spice will receive this header and can:
 1. Serve fresh data for 10 seconds after fetching.
 2. Between 10-20 seconds, serve stale data while fetching fresh data in the background.
 3. After 20 seconds, fetch fresh data before serving the next request.
 
-This behavior mirrors the `stale_while_revalidate_ttl` configuration available in the [caching configuration](/docs/features/caching#stale-while-revalidate), but is controlled by the HTTP(s) server rather than the Spicepod configuration.
+The stale-while-revalidate behavior in Spice is controlled by the `stale_while_revalidate_ttl` parameter in the [caching configuration](/docs/features/caching#stale-while-revalidate). When `stale_while_revalidate_ttl` is set to `0` (default), stale data will not be served. When set to a non-zero value, Spice serves stale cache entries while revalidating in the background.
 
 ## Timeouts and Retries
 

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -5,7 +5,7 @@ description: 'HTTP(s) Data Connector Documentation'
 pagination_prev: null
 ---
 
-The HTTP(s) Data Connector enables federated SQL query across [supported file formats](/docs/components/data-connectors/index.md#object-store-file-formats) stored at an HTTP(s) endpoint.
+The HTTP(s) Data Connector enables federated SQL query across [supported file formats](/docs/components/data-connectors/index.md#object-store-file-formats) stored at an HTTP(s) endpoint. The connector supports dynamic query and data refresh through SQL-based filtering.
 
 ```yaml
 datasets:
@@ -15,11 +15,67 @@ datasets:
       http_password: ${env:MY_HTTP_PASS}
 ```
 
+## Examples
+
+### Basic Example
+
+```yaml
+datasets:
+  - from: https://github.com/LAION-AI/audio-dataset/raw/7fd6ae3cfd7cde619f6bed817da7aa2202a5bc28/metadata/freesound/parquet/freesound_parquet.parquet
+    name: laion_freesound
+```
+
+### Using Basic Authentication
+
+```yaml
+datasets:
+  - from: http://static_username@localhost:3001/report.csv
+    name: local_report
+    params:
+      http_password: ${env:MY_HTTP_PASS}
+```
+
+### Using Custom Headers
+
+Custom HTTP headers can be specified for authentication, API keys, or other requirements. Headers are treated as sensitive data and will not be logged.
+
+```yaml
+datasets:
+  - from: https://api.example.com/data.csv
+    name: api_data
+    params:
+      http_headers: 'Authorization:Bearer ${secrets:api_token},Accept:application/json'
+```
+
+Headers can also be separated by semicolons:
+
+```yaml
+datasets:
+  - from: https://api.example.com/data.csv
+    name: api_data
+    params:
+      http_headers: 'Authorization: Bearer ${secrets:api_token}; X-API-Key: ${secrets:api_key}'
+```
+
 ## Configuration
 
 ### `from`
 
-The `from` field must contain a valid URI to the location of a [supported file](/docs/components/data-connectors/index.md#object-store-file-formats). For example, `http://static_username@localhost:3001/report.csv`.
+The `from` field specifies the HTTP(s) endpoint and can be configured in two ways:
+
+1. **Direct URL to a file**: A complete URL pointing to a specific [supported file](/docs/components/data-connectors/index.md#object-store-file-formats).
+
+   ```yaml
+   from: https://example.com/data/report.csv
+   ```
+
+2. **Base domain/path**: A base URL that will be combined with special metadata fields to construct the complete request.
+
+   ```yaml
+   from: https://api.example.com/v1
+   ```
+
+The connector supports templated URLs with query parameters that can be dynamically populated using `refresh_sql` filters and special metadata fields.
 
 ### `name`
 
@@ -50,34 +106,278 @@ The dataset name cannot be a [reserved keyword](/docs/reference/spicepod/keyword
 
 ### `params`
 
-The connector supports Basic HTTP authentication via `param` values.
+The connector supports authentication, timeout, connection pooling, and retry configuration via `params`.
 
-| Parameter Name   | Description                                                                                                                                                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `http_port`      | Optional. Port to create HTTP(s) connection over. Default: 80 and 443 for HTTP and HTTPS respectively.                                                                                                                          |
-| `http_username`  | Optional. Username to provide connection for HTTP basic authentication. Default: None.                                                                                                                                          |
-| `http_password`  | Optional. Password to provide connection for HTTP basic authentication. Default: None. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_http_pass}`. |
-| `client_timeout` | Optional. Specifies timeout for HTTP operations. Default value is `30s` E.g. `client_timeout: 60s`                                                                                                                              |
+| Parameter Name           | Description                                                                                                                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http_port`              | Optional. Port to create HTTP(s) connection over. Default: 80 and 443 for HTTP and HTTPS respectively.                                                                                                      |
+| `http_username`          | Optional. Username for HTTP basic authentication. Default: None.                                                                                                                                            |
+| `http_password`          | Optional. Password for HTTP basic authentication. Default: None. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_http_pass}`.   |
+| `http_headers`           | Optional. Custom HTTP headers as a comma-separated list of `key:value` pairs. Example: `Content-Type:application/json,Accept:application/json`. Default: None.                                              |
+| `client_timeout`         | Optional. Maximum time to wait for a response from the HTTP server (in seconds). Default: `30`. Supports duration formats like `30s`, `1m`, `500ms`, `2m30s`. Applied to the entire request-response cycle. |
+| `connect_timeout`        | Optional. Timeout for establishing HTTP(s) connections (in seconds). Default: `10`.                                                                                                                         |
+| `pool_max_idle_per_host` | Optional. Maximum number of idle connections to keep alive per host. Default: `10`.                                                                                                                         |
+| `pool_idle_timeout`      | Optional. Timeout for idle connections in the pool (in seconds). Default: `90`.                                                                                                                             |
+| `max_retries`            | Optional. Maximum number of retries for failed HTTP requests. Default: `3`.                                                                                                                                 |
+| `retry_backoff_method`   | Optional. Retry backoff strategy: `fibonacci` (default), `linear`, or `exponential`.                                                                                                                        |
+| `retry_max_duration`     | Optional. Maximum total duration for all retries (e.g., `30s`, `5m`). If not set, retries continue up to `max_retries`.                                                                                     |
+| `retry_jitter`           | Optional. Randomization factor for retry delays (0.0 to 1.0). Default: `0.3` (30% randomization). Set to `0` for no jitter.                                                                                 |
 
-## Examples
+## Timeouts and Retries
 
-### Basic example
+### Timeouts
+
+The connector provides granular control over HTTP timeouts:
+
+- **`client_timeout`**: Maximum time to wait for a complete HTTP response (default: 30 seconds)
+- **`connect_timeout`**: Maximum time to establish a connection (default: 10 seconds)
+
+Example configuration:
 
 ```yaml
 datasets:
-  - from: https://github.com/LAION-AI/audio-dataset/raw/7fd6ae3cfd7cde619f6bed817da7aa2202a5bc28/metadata/freesound/parquet/freesound_parquet.parquet
-    name: laion_freesound
-```
-
-### Using Basic Authentication
-
-```yaml
-datasets:
-  - from: http://static_username@localhost:3001/report.csv
-    name: local_report
+  - from: https://example.com/data.csv
+    name: my_data
     params:
-      http_password: ${env:MY_HTTP_PASS}
+      client_timeout: 60s
+      connect_timeout: 15s
 ```
+
+### Connection Pooling
+
+The connector maintains a connection pool for improved performance:
+
+- **`pool_max_idle_per_host`**: Maximum idle connections per host (default: 10)
+- **`pool_idle_timeout`**: How long idle connections are kept (default: 90 seconds)
+
+Example configuration:
+
+```yaml
+datasets:
+  - from: https://api.example.com/data
+    name: api_data
+    params:
+      pool_max_idle_per_host: 20
+      pool_idle_timeout: 120
+```
+
+### Retries
+
+The HTTP connector automatically retries failed requests with configurable retry behavior:
+
+- **Automatic retries**: Transient failures (network errors, 5xx server errors) trigger automatic retries
+- **Default strategy**: Fibonacci backoff with 3 maximum attempts
+- **Configurable options**:
+  - `max_retries`: Number of retry attempts (default: 3)
+  - `retry_backoff_method`: Strategy for retry delays - `fibonacci` (default), `linear`, or `exponential`
+  - `retry_max_duration`: Total time limit for all retries (e.g., `30s`, `5m`)
+  - `retry_jitter`: Randomization to prevent thundering herd (default: 0.3 for 30% randomization)
+
+Example with custom retry configuration:
+
+```yaml
+datasets:
+  - from: https://api.example.com/data.csv
+    name: my_data
+    params:
+      max_retries: 5
+      retry_backoff_method: exponential
+      retry_max_duration: 2m
+      retry_jitter: 0.5
+```
+
+### Special Metadata Fields
+
+The HTTP connector supports special metadata fields that provide fine-grained control over HTTP requests. These fields can be included in your dataset schema to dynamically construct request URLs and payloads:
+
+| Field Name      | Type   | Description                                                                                                                                                                                                                                                                                                    |
+| --------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request_path`  | String | Specifies the URL path to append to the base URL from the `from` field. When using a base domain/path in `from`, `request_path` constructs the complete endpoint. Example: If `from: https://api.example.com` and `request_path: /users/123`, the request will be made to `https://api.example.com/users/123`. |
+| `request_query` | String | Defines query parameters to append to the request URL. Formatted as a query string (e.g., `key1=value1&key2=value2`). These parameters are appended to the URL after any path specified in `request_path`.                                                                                                     |
+| `request_body`  | String | Contains the request body for POST/PUT requests. Typically used with REST APIs that require a JSON or form-encoded payload. The content type should be specified using `http_headers`.                                                                                                                         |
+
+These metadata fields work in combination:
+
+- If `from` specifies a complete file URL, these fields are ignored
+- If `from` specifies a base URL, these fields construct the full request dynamically
+- `request_path` is appended to the base URL
+- `request_query` is appended as query parameters
+- `request_body` is sent as the request payload (requires appropriate HTTP method configuration)
+
+## Advanced Usage
+
+### Using Special Metadata Fields with Base URL
+
+When using a base URL with special metadata fields, you can dynamically construct different API endpoints:
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_requests
+    params:
+      http_headers: 'Content-Type:application/json'
+```
+
+With the above configuration, you can query different endpoints by providing values for the special metadata fields:
+
+```sql
+-- Query a specific user endpoint
+SELECT * FROM api_requests
+WHERE request_path = '/users/123' AND request_query = 'include=profile,settings';
+
+-- Make a POST request with a body
+SELECT * FROM api_requests
+WHERE request_path = '/data/upload' AND request_body = '{"name":"example","value":42}';
+```
+
+The connector will construct requests like:
+
+- `https://api.example.com/v1/users/123?include=profile,settings`
+- `https://api.example.com/v1/data/upload` with the JSON body
+
+### Dynamic Filters with Metadata Fields
+
+The special metadata fields can be combined with dynamic filters to create sophisticated data refresh patterns.
+
+#### Dynamic API Queries with SQL
+
+```yaml
+datasets:
+  - from: https://api.tvmaze.com
+    name: tv_shows
+    params:
+      http_headers: 'Accept:application/json'
+```
+
+Query specific API endpoints dynamically:
+
+```sql
+-- Search for shows by name
+SELECT * FROM tv_shows
+WHERE request_path = '/search/shows' AND request_query = 'q=game+of+thrones';
+
+-- Get a specific show by ID
+SELECT * FROM tv_shows
+WHERE request_path = '/shows/82';
+
+-- Get episodes for a show with filters
+SELECT * FROM tv_shows
+WHERE request_path = '/shows/82/episodes' AND request_query = 'season=1';
+```
+
+#### Incremental Loading with Metadata Fields
+
+```yaml
+datasets:
+  - from: https://api.example.com
+    name: events
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_sql: |
+        SELECT * FROM events
+        WHERE request_path = '/events'
+          AND request_query = CONCAT('since=', (SELECT MAX(created_at) FROM events))
+```
+
+This configuration:
+
+- Uses `request_path` to specify the `/events` endpoint
+- Dynamically constructs the `request_query` parameter using the latest timestamp from existing data
+- On each refresh, only fetches events created after the last refresh
+
+#### Paginated Data Loading
+
+```yaml
+datasets:
+  - from: https://api.example.com/v2
+    name: paginated_data
+    params:
+      http_headers: 'Content-Type:application/json'
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_sql: |
+        SELECT * FROM paginated_data
+        WHERE request_path = '/data'
+          AND request_query = CONCAT('page=', 
+                              COALESCE((SELECT MAX(page_number) FROM paginated_data) + 1, 1),
+                              '&limit=100')
+```
+
+This incrementally loads pages of data by:
+
+- Tracking the last loaded page number
+- Constructing the next page query parameter
+- Fetching 100 records per page
+
+#### POST Request with Dynamic Body
+
+```yaml
+datasets:
+  - from: https://api.example.com
+    name: search_results
+    params:
+      http_headers: 'Content-Type:application/json'
+    acceleration:
+      enabled: true
+      refresh_mode: full
+      refresh_sql: |
+        SELECT * FROM search_results
+        WHERE request_path = '/search'
+          AND _body = '{"query": {"match": {"status": "active"}}, "from": 0, "size": 1000}'
+```
+
+This example demonstrates:
+
+- Using `_body` to send a JSON payload for a POST request
+- Executing complex search queries against REST APIs
+- Fetching results based on structured query syntax
+
+### Refresh SQL with Dynamic Filters
+
+The HTTP connector supports dynamic URL construction through `refresh_sql` with templated query parameters. This enables incremental data loading by appending filter conditions from the SQL query to the HTTP request URL.
+
+#### How It Works
+
+When `refresh_sql` is specified with filters, the connector extracts filter conditions and appends them as query parameters to the URL. This is particularly useful for APIs that support filtering via query parameters.
+
+#### Time-Based Incremental Loading
+
+```yaml
+datasets:
+  - from: https://api.example.com/data.csv?start_time={start_time}&end_time={end_time}
+    name: incremental_data
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_sql: |
+        SELECT * FROM incremental_data 
+        WHERE timestamp > (SELECT MAX(timestamp) FROM incremental_data)
+```
+
+In this example:
+
+- The `{start_time}` and `{end_time}` placeholders in the URL are replaced with values extracted from the `WHERE` clause in `refresh_sql`
+- Each refresh appends only new data since the last refresh
+- The connector automatically maps SQL filter conditions to URL query parameters
+
+#### Supported Filter Operations
+
+The dynamic filter feature supports the following SQL operations:
+
+- Equality comparisons (`=`)
+- Greater than (`>`)
+- Less than (`<`)
+- Greater than or equal (`>=`)
+- Less than or equal (`<=`)
+- Range queries with `BETWEEN`
+
+#### Notes
+
+- URL parameters must match filter column names in the `refresh_sql`
+- Only filters that can be pushed down to the HTTP source will be applied to the URL
+- Complex filters may not be supported for URL templating
 
 ## Secrets
 

--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -25,10 +25,12 @@ runtime:
       enabled: true
       max_size: 1GiB # Default 128 MiB
       item_ttl: 1m # Default 1s
+      stale_while_revalidate_ttl: 30s # Default 0s (disabled)
     search_results:
       enabled: true
       max_size: 1GiB # Default 128 MiB
       item_ttl: 1m # Default 1s
+      stale_while_revalidate_ttl: 30s # Default 0s (disabled)
 ```
 
 ## `caching` Parameters
@@ -43,13 +45,14 @@ runtime:
 
 Every cache type (`sql_results`, `search_results`, `embeddings`) supports the following parameters:
 
-| Parameter name      | Optional | Default   | Description                                                                                                                                    |
-| ------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`           | Yes      | `true`    | Defaults to `true`.                                                                                                                            |
-| `max_size`          | Yes      | `128MiB`  | Maximum cache size. Defaults to `128MiB`.                                                                                                      |
-| `eviction_policy`   | Yes      | `lru`     | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`, which is currently the only supported value.                    |
-| `item_ttl`          | Yes      | `1s`      | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                          |
-| `hashing_algorithm` | Yes      | `siphash` | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `siphash`. Supports `siphash` or `ahash`. |
+| Parameter name               | Optional | Default   | Description                                                                                                                                    |
+| ---------------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                    | Yes      | `true`    | Defaults to `true`.                                                                                                                            |
+| `max_size`                   | Yes      | `128MiB`  | Maximum cache size. Defaults to `128MiB`.                                                                                                      |
+| `eviction_policy`            | Yes      | `lru`     | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`, which is currently the only supported value.                    |
+| `item_ttl`                   | Yes      | `1s`      | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                          |
+| `stale_while_revalidate_ttl` | Yes      | `0s`      | Duration to serve stale cache entries while revalidating in the background. When set to a non-zero value, expired cache entries continue to be served while a background refresh occurs. Defaults to `0s` (disabled). |
+| `hashing_algorithm`          | Yes      | `siphash` | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `siphash`. Supports `siphash` or `ahash`. |
 
 ## Choosing a `hashing_algorithm`
 
@@ -91,6 +94,7 @@ The value of the header indicates the status of the cache:
 | `HIT`                | The query result was served from the cache.                                                        |
 | `MISS`               | The cache was checked, but the result was not found.                                               |
 | `BYPASS`             | The cache was bypassed for this query (e.g., when `cache-control: no-cache` is specified).         |
+| `STALE`              | A stale cache entry was served while the cache is being revalidated in the background (when `stale_while_revalidate_ttl` is configured). |
 | _header not present_ | The cache did not apply to this query (e.g., when caching is disabled or querying a system table). |
 
 ### Examples
@@ -131,9 +135,51 @@ content-length: 416
 date: Thu, 13 Feb 2025 03:14:00 GMT
 ```
 
+#### Stale Cache Response (Stale-While-Revalidate)
+
+```bash
+$ curl -XPOST -i http://localhost:8090/v1/sql -d 'select * from taxi_trips limit 1;'
+HTTP/1.1 200 OK
+content-type: text/plain; charset=utf-8
+results-cache-status: STALE
+vary: origin, access-control-request-method, access-control-request-headers
+content-length: 416
+date: Thu, 13 Feb 2025 03:15:30 GMT
+```
+
 ## Cache Control
 
 You can control caching behavior for specific requests using HTTP headers. The `Cache-Control` header helps skip the cache for a request while caching the results for subsequent requests.
+
+### Stale-While-Revalidate
+
+The `stale_while_revalidate_ttl` parameter configures a grace period during which stale cache entries continue to be served while a background refresh occurs. This technique reduces latency for end users by serving cached data immediately, even after `item_ttl` expires, while the system fetches fresh data asynchronously.
+
+When `stale_while_revalidate_ttl` is set to a non-zero value:
+
+1. Cache entries are served normally until `item_ttl` expires.
+2. After `item_ttl` expires but before `item_ttl + stale_while_revalidate_ttl` expires, the stale entry is served immediately with a `STALE` cache status.
+3. Simultaneously, a background task refreshes the cache entry.
+4. Once the background refresh completes, subsequent requests receive the fresh data with a `HIT` cache status.
+5. After `item_ttl + stale_while_revalidate_ttl` expires, the entry is evicted and the next request results in a `MISS`.
+
+#### Example Configuration
+
+```yaml
+runtime:
+  caching:
+    sql_results:
+      enabled: true
+      item_ttl: 10s
+      stale_while_revalidate_ttl: 10s
+```
+
+With this configuration:
+- Fresh cache entries are served for 10 seconds after creation.
+- Between 10-20 seconds after creation, stale entries are served while being refreshed in the background.
+- After 20 seconds, the entry is evicted if not refreshed.
+
+This approach is particularly useful for queries that take significant time to execute, providing a better user experience by reducing perceived latency while keeping data reasonably fresh.
 
 ### HTTP/Flight API
 
@@ -142,9 +188,15 @@ The following endpoints support the standard HTTP [`Cache-Control` header](https
 - SQL query (HTTP and Arrow Flight)
 - Search (HTTP)
 
-The [`no-cache` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-cache) skips the cache for the current request but caches the results for future requests.
+The following `Cache-Control` directives are supported:
 
-Other `Cache-Control` directives are not supported.
+| Directive | Description |
+| --------- | ----------- |
+| [`no-cache`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-cache) | Skips the cache for the current request but caches the results for future requests. |
+| [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh) | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds. |
+| [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale) | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds. |
+| [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data. |
+| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -154,6 +206,18 @@ curl -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 
 # Skip cache for this query, but cache the results for future queries
 curl -H "cache-control: no-cache" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
+
+# Only use cached response if it will be fresh for at least 30 more seconds
+curl -H "cache-control: min-fresh=30" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
+
+# Accept cached responses that are stale for up to 60 seconds
+curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
+
+# Only return cached responses, fail if cache miss
+curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
+
+# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
+curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -186,7 +250,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that follows the same behavior as the HTTP `Cache-Control` header:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
 
 ```bash
 # Default behavior (use cache if available)
@@ -195,6 +259,14 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
+# Only use cached response if fresh for at least 30 more seconds
+spice sql --cache-control min-fresh=30
+# Accept cached responses stale for up to 60 seconds
+spice sql --cache-control max-stale=60
+# Only return cached responses, fail if cache miss
+spice sql --cache-control only-if-cached
+# Serve stale cache (up to 300 seconds) if fetching fails
+spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -202,6 +274,8 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
+# Accept stale search results up to 60 seconds old
+spice search --cache-control max-stale=60
 ```
 
 ## Custom Cache Keys


### PR DESCRIPTION
This pull request updates the caching documentation to introduce support for stale-while-revalidate caching and expands the supported cache-control directives for both HTTP and CLI usage. The changes clarify configuration options, document new cache behaviors, and provide usage examples for the new directives.

**New caching features and configuration:**

* Added documentation for the `stale_while_revalidate_ttl` parameter in the `runtime.caching` configuration, allowing stale cache entries to be served while a background refresh occurs. [[1]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1R28-R33) [[2]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1L47-R54)
* Explained the behavior and benefits of stale-while-revalidate, including a step-by-step description and example configuration.

**Cache status and API changes:**

* Documented the new `STALE` cache status in API responses, indicating when a stale entry is served during background revalidation.
* Expanded the list of supported HTTP `Cache-Control` directives, now including `min-fresh`, `max-stale`, `only-if-cached`, and `stale-if-error`, with descriptions and examples for each. [[1]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1R138-R199) [[2]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1R209-R220)

**CLI enhancements:**

* Updated CLI documentation to show support for all cache-control directives via the `--cache-control` flag in `spice sql` and `spice search`, with example usage for each directive. [[1]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1L189-R253) [[2]](diffhunk://#diff-852e7f7327ec7d3196872edd8235e4e4600ddca8928887957606d70caa24fdf1R262-R278)