### PR TITLE
Add OTel exporter docs

### DIFF
--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -84,11 +84,12 @@ Spice can push metrics to an [OpenTelemetry](https://opentelemetry.io/) collecto
 
 Configure the OpenTelemetry exporter in `spicepod.yaml` under `runtime.telemetry.otel_exporter`:
 
-| Parameter       | Required | Default | Description                                                      |
-| --------------- | -------- | ------- | ---------------------------------------------------------------- |
-| `enabled`       | Yes      | -       | Enable the exporter                                              |
-| `endpoint`      | Yes      | -       | The OpenTelemetry collector endpoint.                            |
-| `push_interval` | No       | `60s`   | Default 30s. How frequently metrics are pushed to the collector. |
+| Parameter       | Required | Default | Description                                                           |
+| --------------- | -------- | ------- | --------------------------------------------------------------------- |
+| `enabled`       | No       | `true`  | Whether the OpenTelemetry exporter is enabled.                        |
+| `endpoint`      | Yes      | -       | The OpenTelemetry collector endpoint.                                 |
+| `push_interval` | No       | `60s`   | How frequently metrics are pushed to the collector.                   |
+| `metrics`       | No       | `[]`    | List of metric names to export. When empty, all metrics are exported. |
 
 ### Protocol Selection
 
@@ -122,6 +123,24 @@ runtime:
       endpoint: 'http://localhost:4318/v1/metrics'
       push_interval: '30s'
 ```
+
+### Metric Filtering
+
+To export only specific metrics, use the `metrics` parameter:
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      endpoint: 'localhost:4317'
+      metrics:
+        - query_duration_ms
+        - query_executions
+        - dataset_load_state
+```
+
+When `metrics` is empty or omitted, all available metrics are exported.
 
 For full configuration details, see the [runtime.telemetry reference](/docs/reference/spicepod/runtime#runtimetelemetry).
 

--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -1,49 +1,58 @@
 ---
 title: 'Observability & Monitoring'
 sidebar_label: 'Observability'
-description: 'Learn how to use Spice telemetry.'
+description: 'Monitor Spice with Prometheus metrics, OpenTelemetry, and distributed tracing.'
 sidebar_position: 12
 pagination_prev: null
 pagination_next: null
 ---
 
-Spice can be monitored using the [Spice Prometheus-compatible Metrics Endpoint](https://prometheus.io/docs/instrumenting/exposition_formats/#basic-info). Spice also supports distributed tracing by integrating with [Zipkin](https://zipkin.io/) and compatible tracing systems.
+Spice provides monitoring and observability through three mechanisms:
+
+- **Prometheus-compatible metrics endpoint**: Exposes metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#basic-info) for scraping by monitoring systems like [Datadog](https://www.datadoghq.com/), [New Relic](https://newrelic.com/), and [Chronosphere](https://chronosphere.io/).
+- **OpenTelemetry metrics export**: Pushes metrics to an [OpenTelemetry](https://opentelemetry.io/) collector using gRPC or HTTP.
+- **Distributed tracing**: Integrates with [Zipkin](https://zipkin.io/) and compatible tracing systems for request tracing.
 
 <img width="740" alt="observability" src="https://github.com/user-attachments/assets/2468e3e7-4fb4-4a74-8b26-45eeeee90310" />
 
-Monitoring clients configuration:
+### Monitoring Integrations
 
-- [Grafana](/docs/monitoring/grafana)
 - [Datadog](/docs/monitoring/datadog)
+- [Grafana & Prometheus](/docs/monitoring/grafana)
 - [Zipkin](/docs/monitoring/zipkin)
 
-## Spice Metrics Endpoint Configuration
+## Prometheus Metrics Endpoint
 
-The metrics endpoint uses port `9090` by default. The metrics endpoint configuration is logged at startup.
+Spice exposes a Prometheus-compatible metrics endpoint that monitoring systems can scrape. The endpoint serves metrics in the [Prometheus exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/), which is supported by most enterprise monitoring platforms including Datadog, New Relic, Chronosphere, Grafana Cloud, and others.
+
+### Default Configuration
+
+The metrics endpoint listens on port `9090` by default. The endpoint address is logged at startup:
 
 ```bash
 2024-11-28T19:48:10.942003Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 ```
 
-Pass the `--metrics` parameter to bind to a specific port. For example, to bind to port `9091`:
+### Custom Port Binding
+
+Use the `--metrics` flag to bind to a specific address and port:
 
 ```bash
- spiced --metrics 0.0.0.0:9091
+spiced --metrics 0.0.0.0:9091
 ```
 
-or when using Docker:
+For Docker deployments:
 
 ```Dockerfile
 FROM spiceai/spiceai:latest
 
-# Docker configuration ...
-
-# Configure the metrics endpoint on port 9090
 CMD ["--metrics", "0.0.0.0:9090"]
 EXPOSE 9090
 ```
 
-Configuration of the metrics endpoint can be verified using a HTTP GET request, for example:
+### Verifying the Endpoint
+
+Verify the metrics endpoint is working with a GET request:
 
 ```bash
 curl http://localhost:9090/metrics
@@ -67,107 +76,158 @@ dataset_active_count{engine="duckdb"} 1
 ...
 ```
 
-## Metrics
+## OpenTelemetry Metrics Exporter
 
-| Metric                                                                 | Description                                                                                                                                                                               |
-|------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `accelerated_ready_state_federated_fallback`<br/>_(count)_             | Number of times the federated table was queried due to the accelerated table loading the initial data.                                                                                    |
-| `accelerated_zero_results_federated_fallback`<br/>_(count)_            | Number of times the federated table was queried due to the accelerated table returning zero results.                                                                                      |
-| `ai_inferences_with_spice_count`<br/>_(count)_                         | AI Inferences with Spice count.                                                                                                                                                           |
-| `catalog_load_errors`<br/>_(count)_                                    | Number of errors loading the catalog provider.                                                                                                                                            |
-| `catalog_load_state`<br/>_(gauge)_                                     | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                               |
-| `component_metric_registered_count`<br/>_(gauge)_                      | Number of currently registered component metrics.                                                                                                                                         |
-| `dataset_acceleration_ingestion_lag_ms`<br/>_(gauge)_                  | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds.                                                                   |
-| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_              | Unix timestamp in milliseconds when the last refresh completed.                                                                                                                                |
-| `dataset_acceleration_max_timestamp_after_refresh_ms`<br/>_(gauge)_    | Maximum value of the dataset's time_column after the refresh operation, in milliseconds.                                                                                                  |
-| `dataset_acceleration_max_timestamp_before_refresh_ms`<br/>_(gauge)_   | Maximum value of the dataset's time_column before the refresh operation, in milliseconds.                                                                                                 |
-| `dataset_acceleration_refresh_data_fetches_skipped`<br/>_(count)_      | Number of refresh data fetches skipped due to unchanged file metadata.                                                                                                                    |
-| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_           | Duration in milliseconds to load a full or appended refresh data.                                                                                                                         |
-| `dataset_acceleration_refresh_errors`<br/>_(count)_                    | Number of errors refreshing the dataset.                                                                                                                                                  |
-| `dataset_acceleration_refresh_lag_ms`<br/>_(gauge)_                    | Difference between the maximum time_column value after and before the refresh operation, in milliseconds.                                                                                 |
-| `dataset_acceleration_refresh_worker_panics`<br/>_(count)_             | Number of times a refresh worker panicked while refreshing a dataset.                                                                                                                     |
-| `dataset_acceleration_snapshot_bootstrap_bytes`<br/>_(gauge)_          | Number of bytes downloaded when bootstrapping the acceleration from a snapshot.                                                                                                           |
-| `dataset_acceleration_snapshot_bootstrap_checksum`<br/>_(gauge)_       | Checksum of the snapshot downloaded during bootstrap (emitted with `checksum` attribute).                                                                                                 |
-| `dataset_acceleration_snapshot_bootstrap_duration_ms`<br/>_(count)_    | Time in milliseconds taken to download the snapshot used to bootstrap acceleration.                                                                                                       |
-| `dataset_acceleration_snapshot_failure_count`<br/>_(count)_            | Number of failures encountered while writing snapshots.                                                                                                                                   |
-| `dataset_acceleration_snapshot_write_bytes`<br/>_(gauge)_              | Number of bytes written for the most recent snapshot.                                                                                                                                     |
-| `dataset_acceleration_snapshot_write_checksum`<br/>_(gauge)_           | Checksum of the most recent snapshot write (emitted with `checksum` attribute).                                                                                                           |
-| `dataset_acceleration_snapshot_write_duration_ms`<br/>_(histogram)_    | Time in milliseconds taken to write the latest snapshot to object storage.                                                                                                                |
-| `dataset_acceleration_snapshot_write_timestamp`<br/>_(gauge)_          | Unix timestamp (seconds) when the most recent snapshot write completed.                                                                                                                   |
-| `dataset_active_count`<br/>_(gauge)_                                   | Number of currently loaded datasets.                                                                                                                                                      |
-| `dataset_load_errors`<br/>_(count)_                                    | Number of errors loading the dataset.                                                                                                                                                     |
-| `dataset_load_state`<br/>_(gauge)_                                     | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                        |
-| `dataset_unavailable_time_ms`<br/>_(gauge)_                            | Time dataset went offline in milliseconds.                                                                                                                                                |
-| `embeddings_active_count`<br/>_(gauge)_                                | Number of currently loaded embeddings.                                                                                                                                                    |
-| `embeddings_cache_evictions`<br/>_(count)_                             | Number of cache evictions.                                                                                                                                                                |
-| `embeddings_cache_hit_ratio`<br/>_(gauge)_                             | Cache hit ratio (hits / total requests).                                                                                                                                                  |
-| `embeddings_cache_hits`<br/>_(count)_                                  | Cache hit count.                                                                                                                                                                          |
-| `embeddings_cache_items_count`<br/>_(gauge)_                           | Number of items currently in the cache.                                                                                                                                                   |
-| `embeddings_cache_max_size_bytes`<br/>_(gauge)_                        | Maximum allowed size of the cache in bytes.                                                                                                                                               |
-| `embeddings_cache_misses`<br/>_(count)_                                | Cache miss count.                                                                                                                                                                         |
-| `embeddings_cache_requests`<br/>_(count)_                              | Number of requests to get a key from the cache.                                                                                                                                           |
-| `embeddings_cache_size_bytes`<br/>_(gauge)_                            | Size of the cache in bytes.                                                                                                                                                               |
-| `embeddings_cache_stale_swr_count`<br/>_(count)_                       | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
-| `embeddings_cache_swr_background_query_count`<br/>_(count)_            | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
-| `embeddings_failures`<br/>_(count)_                                    | Number of embedding failures.                                                                                                                                                             |
-| `embeddings_internal_request_duration_ms`<br/>_(histogram)_            | The duration of running an embedding(s) internally.                                                                                                                                       |
-| `embeddings_load_errors`<br/>_(count)_                                 | Number of errors loading the embedding.                                                                                                                                                   |
-| `embeddings_load_state`<br/>_(gauge)_                                  | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
-| `embeddings_requests`<br/>_(count)_                                    | Number of embedding requests.                                                                                                                                                             |
-| `flight_do_exchange_data_updates_sent`<br/>_(count)_                   | Number of data updates sent via DoExchange.                                                                                                                                               |
-| `flight_request_duration_ms`<br/>_(histogram)_                         | Measures the duration of Flight requests in milliseconds.                                                                                                                                 |
-| `flight_requests`<br/>_(count)_                                        | Total number of Flight requests.                                                                                                                                                          |
-| `http_requests`<br/>_(count)_                                          | Number of HTTP requests.                                                                                                                                                                  |
-| `http_requests_duration_ms`<br/>_(histogram)_                          | Measures the duration of HTTP requests in milliseconds.                                                                                                                                   |
-| `llm_failures`<br/>_(count)_                                           | Number of LLM failures.                                                                                                                                                                   |
-| `llm_internal_request_duration_ms`<br/>_(histogram)_                   | The duration of running an LLM request internally.                                                                                                                                        |
-| `llm_load_state`<br/>_(gauge)_                                         | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
-| `llm_requests`<br/>_(count)_                                           | Number of LLM requests.                                                                                                                                                                   |
-| `model_active_count`<br/>_(gauge)_                                     | Number of currently loaded models.                                                                                                                                                        |
-| `model_load_duration_ms`<br/>_(histogram)_                             | Duration in milliseconds to load the model.                                                                                                                                               |
-| `model_load_errors`<br/>_(count)_                                      | Number of errors loading the model.                                                                                                                                                       |
-| `model_load_state`<br/>_(gauge)_                                       | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                          |
-| `query_active_count`<br/>_(histogram)_                                 | Number of concurrent top-level queries actively being processed in the runtime. Includes the `protocol` dimension (`http`, `flight`, `flightsql`, `internal`) to indicate the query type. |
-| `query_duration_ms`<br/>_(histogram)_                                  | The total amount of time spent planning and executing queries in milliseconds.                                                                                                            |
-| `query_execution_duration_ms`<br/>_(histogram)_                        | The total amount of time spent only executing queries (0 for cached queries).                                                                                                             |
-| `query_executions`<br/>_(count)_                                       | Number of query executions.                                                                                                                                                               |
-| `query_failures`<br/>_(count)_                                         | Number of query failures.                                                                                                                                                                 |
-| `query_processed_bytes`<br/>_(count)_                                  | Number of bytes processed by the runtime.                                                                                                                                                 |
-| `query_produced_spills`<br/>_(count)_                                  | Number of spills produced by the query.                                                                                                                                                   |
-| `query_returned_bytes`<br/>_(count)_                                   | Number of bytes returned to query clients.                                                                                                                                                |
-| `query_returned_rows`<br/>_(histogram)_                                | Number of rows returned to query clients.                                                                                                                                                 |
-| `query_spilled_bytes`<br/>_(count)_                                    | Number of spilled bytes produced by the query.                                                                                                                                            |
-| `query_spilled_rows`<br/>_(count)_                                     | Number of spilled rows produced by the query.                                                                                                                                             |
-| `results_cache_evictions`<br/>_(count)_                                | Number of cache evictions.                                                                                                                                                                |
-| `results_cache_hit_ratio`<br/>_(gauge)_                                | Cache hit ratio (hits / total requests).                                                                                                                                                  |
-| `results_cache_hits`<br/>_(count)_                                     | Cache hit count.                                                                                                                                                                          |
-| `results_cache_items_count`<br/>_(gauge)_                              | Number of items currently in the cache.                                                                                                                                                   |
-| `results_cache_max_size_bytes`<br/>_(gauge)_                           | Maximum allowed size of the cache in bytes.                                                                                                                                               |
-| `results_cache_misses`<br/>_(count)_                                   | Cache miss count.                                                                                                                                                                         |
-| `results_cache_requests`<br/>_(count)_                                 | Number of requests to get a key from the cache.                                                                                                                                           |
-| `results_cache_size_bytes`<br/>_(gauge)_                               | Size of the cache in bytes.                                                                                                                                                               |
-| `results_cache_stale_swr_count`<br/>_(count)_                          | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
-| `results_cache_swr_background_query_count`<br/>_(count)_               | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
-| `runtime_flight_server_started`<br/>_(count)_                          | Indicates the runtime Flight server has started.                                                                                                                                          |
-| `runtime_http_server_started`<br/>_(count)_                            | Indicates the runtime HTTP server has started.                                                                                                                                            |
-| `search_results_cache_evictions`<br/>_(count)_                         | Number of cache evictions.                                                                                                                                                                |
-| `search_results_cache_hit_ratio`<br/>_(gauge)_                         | Cache hit ratio (hits / total requests).                                                                                                                                                  |
-| `search_results_cache_hits`<br/>_(count)_                              | Search cache hit count.                                                                                                                                                                   |
-| `search_results_cache_items_count`<br/>_(gauge)_                       | Number of items currently in the search cache.                                                                                                                                            |
-| `search_results_cache_max_size_bytes`<br/>_(gauge)_                    | Maximum allowed size of the search cache in bytes.                                                                                                                                        |
-| `search_results_cache_misses`<br/>_(count)_                            | Cache miss count.                                                                                                                                                                         |
-| `search_results_cache_requests`<br/>_(count)_                          | Number of requests to get a key from the search cache.                                                                                                                                    |
-| `search_results_cache_size_bytes`<br/>_(gauge)_                        | Size of the search cache in bytes.                                                                                                                                                        |
-| `search_results_cache_stale_swr_count`<br/>_(count)_                   | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
-| `search_results_cache_swr_background_query_count`<br/>_(count)_        | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
-| `secrets_store_load_duration_ms`<br/>_(histogram)_                     | Duration in milliseconds to load the secret stores.                                                                                                                                       |
-| `tool_active_count`<br/>_(gauge)_                                      | Number of currently loaded LLM tools.                                                                                                                                                     |
-| `tool_load_errors`<br/>_(count)_                                       | Number of errors loading the LLM tool.                                                                                                                                                    |
-| `tool_load_state`<br/>_(gauge)_                                        | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
-| `view_load_errors`<br/>_(count)_                                       | Number of errors loading the view.                                                                                                                                                        |
-| `view_load_state`<br/>_(gauge)_                                        | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                          |
-| `worker_active_count`<br/>_(gauge)_                                    | Number of currently loaded workers.                                                                                                                                                       |
-| `workers_load_duration_ms`<br/>_(histogram)_                           | Duration in milliseconds to load the worker.                                                                                                                                              |
+Spice can push metrics to an [OpenTelemetry](https://opentelemetry.io/) collector, enabling integration with platforms such as [Jaeger](https://www.jaegertracing.io/), [New Relic](https://newrelic.com/), [Honeycomb](https://www.honeycomb.io/), and other OpenTelemetry-compatible backends.
+
+### Configuration
+
+Configure the OpenTelemetry exporter in `spicepod.yaml` under `runtime.telemetry.otel_exporter`:
+
+| Parameter       | Required | Default | Description                                                      |
+| --------------- | -------- | ------- | ---------------------------------------------------------------- |
+| `enabled`       | Yes      | -       | Enable the exporter                                              |
+| `endpoint`      | Yes      | -       | The OpenTelemetry collector endpoint.                            |
+| `push_interval` | No       | `60s`   | Default 30s. How frequently metrics are pushed to the collector. |
+
+### Protocol Selection
+
+The protocol (gRPC or HTTP) is inferred from the endpoint format:
+
+| Format                                  | Protocol | Example                            |
+| --------------------------------------- | -------- | ---------------------------------- |
+| Host and port without scheme            | gRPC     | `localhost:4317`                   |
+| URL with `http://` or `https://` scheme | HTTP     | `http://localhost:4318/v1/metrics` |
+
+### Examples
+
+**gRPC (default port 4317):**
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      endpoint: 'localhost:4317'
+      push_interval: '30s'
+```
+
+**HTTP (default port 4318):**
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      endpoint: 'http://localhost:4318/v1/metrics'
+      push_interval: '30s'
+```
+
+For full configuration details, see the [runtime.telemetry reference](/docs/reference/spicepod/runtime#runtimetelemetry).
+
+## Available Metrics
+
+Spice exposes the following metrics. All metrics include relevant labels (dimensions) for filtering and aggregation.
+
+| Metric                                                               | Description                                                                                                                                                                               |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accelerated_ready_state_federated_fallback`<br/>_(count)_           | Number of times the federated table was queried due to the accelerated table loading the initial data.                                                                                    |
+| `accelerated_zero_results_federated_fallback`<br/>_(count)_          | Number of times the federated table was queried due to the accelerated table returning zero results.                                                                                      |
+| `ai_inferences_with_spice_count`<br/>_(count)_                       | AI Inferences with Spice count.                                                                                                                                                           |
+| `catalog_load_errors`<br/>_(count)_                                  | Number of errors loading the catalog provider.                                                                                                                                            |
+| `catalog_load_state`<br/>_(gauge)_                                   | Status of the catalog provider. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                               |
+| `component_metric_registered_count`<br/>_(gauge)_                    | Number of currently registered component metrics.                                                                                                                                         |
+| `dataset_acceleration_ingestion_lag_ms`<br/>_(gauge)_                | Lag between the current wall-clock time and the maximum time_column value after the refresh operation, in milliseconds.                                                                   |
+| `dataset_acceleration_last_refresh_time_ms`<br/>_(gauge)_            | Unix timestamp in milliseconds when the last refresh completed.                                                                                                                           |
+| `dataset_acceleration_max_timestamp_after_refresh_ms`<br/>_(gauge)_  | Maximum value of the dataset's time_column after the refresh operation, in milliseconds.                                                                                                  |
+| `dataset_acceleration_max_timestamp_before_refresh_ms`<br/>_(gauge)_ | Maximum value of the dataset's time_column before the refresh operation, in milliseconds.                                                                                                 |
+| `dataset_acceleration_refresh_data_fetches_skipped`<br/>_(count)_    | Number of refresh data fetches skipped due to unchanged file metadata.                                                                                                                    |
+| `dataset_acceleration_refresh_duration_ms`<br/>_(histogram)_         | Duration in milliseconds to load a full or appended refresh data.                                                                                                                         |
+| `dataset_acceleration_refresh_errors`<br/>_(count)_                  | Number of errors refreshing the dataset.                                                                                                                                                  |
+| `dataset_acceleration_refresh_lag_ms`<br/>_(gauge)_                  | Difference between the maximum time_column value after and before the refresh operation, in milliseconds.                                                                                 |
+| `dataset_acceleration_refresh_worker_panics`<br/>_(count)_           | Number of times a refresh worker panicked while refreshing a dataset.                                                                                                                     |
+| `dataset_acceleration_snapshot_bootstrap_bytes`<br/>_(gauge)_        | Number of bytes downloaded when bootstrapping the acceleration from a snapshot.                                                                                                           |
+| `dataset_acceleration_snapshot_bootstrap_checksum`<br/>_(gauge)_     | Checksum of the snapshot downloaded during bootstrap (emitted with `checksum` attribute).                                                                                                 |
+| `dataset_acceleration_snapshot_bootstrap_duration_ms`<br/>_(count)_  | Time in milliseconds taken to download the snapshot used to bootstrap acceleration.                                                                                                       |
+| `dataset_acceleration_snapshot_failure_count`<br/>_(count)_          | Number of failures encountered while writing snapshots.                                                                                                                                   |
+| `dataset_acceleration_snapshot_write_bytes`<br/>_(gauge)_            | Number of bytes written for the most recent snapshot.                                                                                                                                     |
+| `dataset_acceleration_snapshot_write_checksum`<br/>_(gauge)_         | Checksum of the most recent snapshot write (emitted with `checksum` attribute).                                                                                                           |
+| `dataset_acceleration_snapshot_write_duration_ms`<br/>_(histogram)_  | Time in milliseconds taken to write the latest snapshot to object storage.                                                                                                                |
+| `dataset_acceleration_snapshot_write_timestamp`<br/>_(gauge)_        | Unix timestamp (seconds) when the most recent snapshot write completed.                                                                                                                   |
+| `dataset_active_count`<br/>_(gauge)_                                 | Number of currently loaded datasets.                                                                                                                                                      |
+| `dataset_load_errors`<br/>_(count)_                                  | Number of errors loading the dataset.                                                                                                                                                     |
+| `dataset_load_state`<br/>_(gauge)_                                   | Status of the dataset. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                        |
+| `dataset_unavailable_time_ms`<br/>_(gauge)_                          | Time dataset went offline in milliseconds.                                                                                                                                                |
+| `embeddings_active_count`<br/>_(gauge)_                              | Number of currently loaded embeddings.                                                                                                                                                    |
+| `embeddings_cache_evictions`<br/>_(count)_                           | Number of cache evictions.                                                                                                                                                                |
+| `embeddings_cache_hit_ratio`<br/>_(gauge)_                           | Cache hit ratio (hits / total requests).                                                                                                                                                  |
+| `embeddings_cache_hits`<br/>_(count)_                                | Cache hit count.                                                                                                                                                                          |
+| `embeddings_cache_items_count`<br/>_(gauge)_                         | Number of items currently in the cache.                                                                                                                                                   |
+| `embeddings_cache_max_size_bytes`<br/>_(gauge)_                      | Maximum allowed size of the cache in bytes.                                                                                                                                               |
+| `embeddings_cache_misses`<br/>_(count)_                              | Cache miss count.                                                                                                                                                                         |
+| `embeddings_cache_requests`<br/>_(count)_                            | Number of requests to get a key from the cache.                                                                                                                                           |
+| `embeddings_cache_size_bytes`<br/>_(gauge)_                          | Size of the cache in bytes.                                                                                                                                                               |
+| `embeddings_cache_stale_swr_count`<br/>_(count)_                     | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
+| `embeddings_cache_swr_background_query_count`<br/>_(count)_          | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
+| `embeddings_failures`<br/>_(count)_                                  | Number of embedding failures.                                                                                                                                                             |
+| `embeddings_internal_request_duration_ms`<br/>_(histogram)_          | The duration of running an embedding(s) internally.                                                                                                                                       |
+| `embeddings_load_errors`<br/>_(count)_                               | Number of errors loading the embedding.                                                                                                                                                   |
+| `embeddings_load_state`<br/>_(gauge)_                                | Status of the embedding. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
+| `embeddings_requests`<br/>_(count)_                                  | Number of embedding requests.                                                                                                                                                             |
+| `flight_do_exchange_data_updates_sent`<br/>_(count)_                 | Number of data updates sent via DoExchange.                                                                                                                                               |
+| `flight_request_duration_ms`<br/>_(histogram)_                       | Measures the duration of Flight requests in milliseconds.                                                                                                                                 |
+| `flight_requests`<br/>_(count)_                                      | Total number of Flight requests.                                                                                                                                                          |
+| `http_requests`<br/>_(count)_                                        | Number of HTTP requests.                                                                                                                                                                  |
+| `http_requests_duration_ms`<br/>_(histogram)_                        | Measures the duration of HTTP requests in milliseconds.                                                                                                                                   |
+| `llm_failures`<br/>_(count)_                                         | Number of LLM failures.                                                                                                                                                                   |
+| `llm_internal_request_duration_ms`<br/>_(histogram)_                 | The duration of running an LLM request internally.                                                                                                                                        |
+| `llm_load_state`<br/>_(gauge)_                                       | Status of the LLM model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
+| `llm_requests`<br/>_(count)_                                         | Number of LLM requests.                                                                                                                                                                   |
+| `model_active_count`<br/>_(gauge)_                                   | Number of currently loaded models.                                                                                                                                                        |
+| `model_load_duration_ms`<br/>_(histogram)_                           | Duration in milliseconds to load the model.                                                                                                                                               |
+| `model_load_errors`<br/>_(count)_                                    | Number of errors loading the model.                                                                                                                                                       |
+| `model_load_state`<br/>_(gauge)_                                     | Status of the model. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                          |
+| `query_active_count`<br/>_(histogram)_                               | Number of concurrent top-level queries actively being processed in the runtime. Includes the `protocol` dimension (`http`, `flight`, `flightsql`, `internal`) to indicate the query type. |
+| `query_duration_ms`<br/>_(histogram)_                                | The total amount of time spent planning and executing queries in milliseconds.                                                                                                            |
+| `query_execution_duration_ms`<br/>_(histogram)_                      | The total amount of time spent only executing queries (0 for cached queries).                                                                                                             |
+| `query_executions`<br/>_(count)_                                     | Number of query executions.                                                                                                                                                               |
+| `query_failures`<br/>_(count)_                                       | Number of query failures.                                                                                                                                                                 |
+| `query_processed_bytes`<br/>_(count)_                                | Number of bytes processed by the runtime.                                                                                                                                                 |
+| `query_produced_spills`<br/>_(count)_                                | Number of spills produced by the query.                                                                                                                                                   |
+| `query_returned_bytes`<br/>_(count)_                                 | Number of bytes returned to query clients.                                                                                                                                                |
+| `query_returned_rows`<br/>_(histogram)_                              | Number of rows returned to query clients.                                                                                                                                                 |
+| `query_spilled_bytes`<br/>_(count)_                                  | Number of spilled bytes produced by the query.                                                                                                                                            |
+| `query_spilled_rows`<br/>_(count)_                                   | Number of spilled rows produced by the query.                                                                                                                                             |
+| `results_cache_evictions`<br/>_(count)_                              | Number of cache evictions.                                                                                                                                                                |
+| `results_cache_hit_ratio`<br/>_(gauge)_                              | Cache hit ratio (hits / total requests).                                                                                                                                                  |
+| `results_cache_hits`<br/>_(count)_                                   | Cache hit count.                                                                                                                                                                          |
+| `results_cache_items_count`<br/>_(gauge)_                            | Number of items currently in the cache.                                                                                                                                                   |
+| `results_cache_max_size_bytes`<br/>_(gauge)_                         | Maximum allowed size of the cache in bytes.                                                                                                                                               |
+| `results_cache_misses`<br/>_(count)_                                 | Cache miss count.                                                                                                                                                                         |
+| `results_cache_requests`<br/>_(count)_                               | Number of requests to get a key from the cache.                                                                                                                                           |
+| `results_cache_size_bytes`<br/>_(gauge)_                             | Size of the cache in bytes.                                                                                                                                                               |
+| `results_cache_stale_swr_count`<br/>_(count)_                        | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
+| `results_cache_swr_background_query_count`<br/>_(count)_             | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
+| `runtime_flight_server_started`<br/>_(count)_                        | Indicates the runtime Flight server has started.                                                                                                                                          |
+| `runtime_http_server_started`<br/>_(count)_                          | Indicates the runtime HTTP server has started.                                                                                                                                            |
+| `search_results_cache_evictions`<br/>_(count)_                       | Number of cache evictions.                                                                                                                                                                |
+| `search_results_cache_hit_ratio`<br/>_(gauge)_                       | Cache hit ratio (hits / total requests).                                                                                                                                                  |
+| `search_results_cache_hits`<br/>_(count)_                            | Search cache hit count.                                                                                                                                                                   |
+| `search_results_cache_items_count`<br/>_(gauge)_                     | Number of items currently in the search cache.                                                                                                                                            |
+| `search_results_cache_max_size_bytes`<br/>_(gauge)_                  | Maximum allowed size of the search cache in bytes.                                                                                                                                        |
+| `search_results_cache_misses`<br/>_(count)_                          | Cache miss count.                                                                                                                                                                         |
+| `search_results_cache_requests`<br/>_(count)_                        | Number of requests to get a key from the search cache.                                                                                                                                    |
+| `search_results_cache_size_bytes`<br/>_(gauge)_                      | Size of the search cache in bytes.                                                                                                                                                        |
+| `search_results_cache_stale_swr_count`<br/>_(count)_                 | Number of stale-while-revalidate background refreshes skipped due to existing in-flight revalidation.                                                                                     |
+| `search_results_cache_swr_background_query_count`<br/>_(count)_      | Number of background queries triggered for stale-while-revalidate cache refreshes.                                                                                                        |
+| `secrets_store_load_duration_ms`<br/>_(histogram)_                   | Duration in milliseconds to load the secret stores.                                                                                                                                       |
+| `tool_active_count`<br/>_(gauge)_                                    | Number of currently loaded LLM tools.                                                                                                                                                     |
+| `tool_load_errors`<br/>_(count)_                                     | Number of errors loading the LLM tool.                                                                                                                                                    |
+| `tool_load_state`<br/>_(gauge)_                                      | Status of the LLM tools. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                      |
+| `view_load_errors`<br/>_(count)_                                     | Number of errors loading the view.                                                                                                                                                        |
+| `view_load_state`<br/>_(gauge)_                                      | Status of the views. 0=Initializing, 1=Ready, 2=Disabled, 3=Error, 4=Refreshing, 5=ShuttingDown.                                                                                          |
+| `worker_active_count`<br/>_(gauge)_                                  | Number of currently loaded workers.                                                                                                                                                       |
+| `workers_load_duration_ms`<br/>_(histogram)_                         | Duration in milliseconds to load the worker.                                                                                                                                              |
 
 :::note Component Metrics
 

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -346,8 +346,10 @@ Configures an [OpenTelemetry](https://opentelemetry.io/) metrics exporter to pus
 
 | Parameter name  | Optional | Default | Description                                                                                                     |
 | --------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `enabled`       | Yes      | `true`  | Whether the OpenTelemetry exporter is enabled.                                                                  |
 | `endpoint`      | No       | -       | The OpenTelemetry collector endpoint. Protocol is inferred from the format (see examples below).                |
 | `push_interval` | Yes      | `60s`   | How frequently metrics are pushed to the collector. Specify as a [duration](/docs/reference/duration/index.md). |
+| `metrics`       | Yes      | `[]`    | List of metric names to export. When empty (default), all metrics are exported.                                 |
 
 **Protocol inference:**
 
@@ -379,6 +381,21 @@ runtime:
       # HTTP - include scheme and /v1/metrics path
       endpoint: 'http://localhost:4318/v1/metrics'
       push_interval: '30s'
+```
+
+With metric filtering (export only specific metrics):
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      endpoint: 'localhost:4317'
+      push_interval: '30s'
+      metrics:
+        - query_duration_ms
+        - query_executions
+        - dataset_load_state
 ```
 
 ## `runtime.metrics`

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -43,13 +43,13 @@ This setting specifies cache settings for supported Runtime components:
 
 Runtime caches support common configuration parameters:
 
-| Parameter name      | Optional | Default   | Description                                                                                                                                    |
-| ------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`           | Yes      | `true`    | Defaults to `true`.                                                                                                                            |
-| `max_size`          | Yes      | `128MiB`  | Maximum cache size. Defaults to `128MiB`.                                                                                                      |
-| `eviction_policy`   | Yes      | `lru`     | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`, which is currently the only supported value.                    |
-| `item_ttl`          | Yes      | `1s`      | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                          |
-| `hashing_algorithm` | Yes      | `xxh3`    | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `xxh3`. Supports `xxh3`, `ahash`, `siphash`, `blake3`, `xxh32`, `xxh64`, or `xxh128`.                                                                        |
+| Parameter name      | Optional | Default  | Description                                                                                                                                                                                |
+| ------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`           | Yes      | `true`   | Defaults to `true`.                                                                                                                                                                        |
+| `max_size`          | Yes      | `128MiB` | Maximum cache size. Defaults to `128MiB`.                                                                                                                                                  |
+| `eviction_policy`   | Yes      | `lru`    | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`, which is currently the only supported value.                                                                |
+| `item_ttl`          | Yes      | `1s`     | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                                                                      |
+| `hashing_algorithm` | Yes      | `xxh3`   | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `xxh3`. Supports `xxh3`, `ahash`, `siphash`, `blake3`, `xxh32`, `xxh64`, or `xxh128`. |
 
 ### `runtime.caching.search_results`
 
@@ -96,11 +96,11 @@ runtime:
 
 In addition to the common cache configuration parameters, `sql_results` also supports the following parameters:
 
-| Parameter name   | Optional | Default | Description                                                                                                                                   |
-| ---------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cache_key_type` | Yes      | `plan`  | Determines how cache keys are generated. Defaults to `plan`. `plan` uses the query's logical plan, while `sql` uses the raw SQL query string. |
-| `encoding`       | Yes      | `none`  | Compression algorithm for cached results. Defaults to `none`. Supports `none` or `zstd`.                                                      |
-| `stale_while_revalidate_ttl` | Yes      | `0s`      | Duration to serve stale cache entries while revalidating in the background. When set to a non-zero value, expired cache entries continue to be served while a background refresh occurs. Defaults to `0s` (disabled). |
+| Parameter name               | Optional | Default | Description                                                                                                                                                                                                           |
+| ---------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cache_key_type`             | Yes      | `plan`  | Determines how cache keys are generated. Defaults to `plan`. `plan` uses the query's logical plan, while `sql` uses the raw SQL query string.                                                                         |
+| `encoding`                   | Yes      | `none`  | Compression algorithm for cached results. Defaults to `none`. Supports `none` or `zstd`.                                                                                                                              |
+| `stale_while_revalidate_ttl` | Yes      | `0s`    | Duration to serve stale cache entries while revalidating in the background. When set to a non-zero value, expired cache entries continue to be served while a background refresh occurs. Defaults to `0s` (disabled). |
 
 :::info
 
@@ -322,9 +322,68 @@ runtime:
   output_level: info # or verbose, very_verbose
 ```
 
+## `runtime.telemetry`
+
+The telemetry section configures runtime telemetry collection and export. [Learn more](/docs/features/observability).
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      enabled: true
+      endpoint: 'localhost:4317'
+      push_interval: '5m'
+```
+
+### `runtime.telemetry.enabled`
+
+Enables or disables runtime telemetry collection. Defaults to `true`.
+
+### `runtime.telemetry.otel_exporter`
+
+Configures an [OpenTelemetry](https://opentelemetry.io/) metrics exporter to push metrics to an OpenTelemetry collector. The exporter automatically infers the protocol (gRPC or HTTP) based on the endpoint configuration.
+
+| Parameter name  | Optional | Default | Description                                                                                                     |
+| --------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `endpoint`      | No       | -       | The OpenTelemetry collector endpoint. Protocol is inferred from the format (see examples below).                |
+| `push_interval` | Yes      | `60s`   | How frequently metrics are pushed to the collector. Specify as a [duration](/docs/reference/duration/index.md). |
+
+**Protocol inference:**
+
+- **gRPC (default):** Use a bare host:port endpoint without a scheme (e.g., `localhost:4317`). gRPC uses port 4317 by default.
+- **HTTP:** Include the `http://` or `https://` scheme and the `/v1/metrics` path (e.g., `http://localhost:4318/v1/metrics`). HTTP uses port 4318 by default.
+
+**Examples:**
+
+gRPC configuration:
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      # gRPC - no scheme or path needed
+      endpoint: 'localhost:4317'
+      push_interval: '30s'
+```
+
+HTTP configuration:
+
+```yaml
+runtime:
+  telemetry:
+    enabled: true
+    otel_exporter:
+      enabled: true
+      # HTTP - include scheme and /v1/metrics path
+      endpoint: 'http://localhost:4318/v1/metrics'
+      push_interval: '30s'
+```
+
 ## `runtime.metrics`
 
-Allows to enable metrics that are disabled by default.
+Specifies metrics that are disabled by default.
 
 Following metrics are disabled by default:
 


### PR DESCRIPTION
This pull request updates the observability and monitoring documentation for Spice to clarify supported integrations, add configuration details for OpenTelemetry metrics export, and improve the reference documentation for telemetry settings. The changes make it easier for users to understand how to monitor Spice using Prometheus, OpenTelemetry, and distributed tracing, and provide clear examples for configuring telemetry exports.

**Observability & Monitoring Documentation Improvements**

* Expanded the overview in `website/docs/features/observability/index.md` to clarify that Spice supports Prometheus metrics, OpenTelemetry metrics export, and distributed tracing with Zipkin, including integrations with platforms like Datadog, New Relic, and Chronosphere.
* Added a new section detailing how to configure and use the OpenTelemetry metrics exporter, including protocol selection (gRPC vs HTTP), configuration examples, and supported platforms such as Jaeger and Honeycomb.

**Reference Documentation Enhancements**

* Added a new `runtime.telemetry` section to `website/docs/reference/spicepod/runtime.md`, documenting how to enable telemetry, configure the OpenTelemetry exporter, and how protocol inference works for endpoint configuration, with YAML examples for both gRPC and HTTP.
* Improved table formatting and descriptions for runtime cache settings and SQL results cache parameters for clarity and consistency. [[1]](diffhunk://#diff-50c8bfdf9f080389e3160bb96670192fb81385b41c1a9441c3770b9d876294cdL47-R47) [[2]](diffhunk://#diff-50c8bfdf9f080389e3160bb96670192fb81385b41c1a9441c3770b9d876294cdL100-R100)