### PR TITLE
Remove `ndjson`

### DIFF
--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -50,4 +50,4 @@ Data encodings:
 
 ### Parameters
 
-- `json_format`: Optional. Specifies the JSON format to parse. Valid values are `array`, `ndjson`, and `jsonl`. Defaults to `jsonl`
+- `json_format`: Optional. Specifies the JSON format to parse. Valid values are `array`, and `jsonl`. Defaults to `jsonl`


### PR DESCRIPTION
- `ndjson` is same as array, but isn't supported (tested on v1.10.1).
```shell
Invalid configuration for connector file. 'json_format' parameter must be one of: jsonl, array. Found ndjson.
```
