### PR TITLE
Fix rust `params`

### DIFF
--- a/website/docs/sdks/rust/index.md
+++ b/website/docs/sdks/rust/index.md
@@ -85,7 +85,7 @@ async fn main() {
 
     let data = client.query_with_params(
         "SELECT * FROM products WHERE price > $1 AND category = $2",
-        params
+        Some(params)
     ).await;
 }
 ```


### PR DESCRIPTION
## 🗣 Description

Properly wrap `params` with `Some`