### PR TITLE
Add sitemap.xml

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -5,6 +5,7 @@ import type * as Preset from '@docusaurus/preset-classic'
 import type * as OpenApiPlugin from 'docusaurus-plugin-openapi-docs'
 import type { Options as BlogOptions } from '@docusaurus/plugin-content-blog'
 import type { Options as PageOptions } from '@docusaurus/plugin-content-pages'
+import type { Options as SitemapOptions } from '@docusaurus/plugin-sitemap'
 
 import tailwindPlugin from './plugins/tailwind-config.cjs'
 
@@ -92,8 +93,25 @@ const config: Config = {
         gtag: {
           trackingID: 'G-SST0X6NS37',
           anonymizeIP: true
-        }
-      } satisfies Preset.Options
+        },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: ({ type, permalink }) => {
+            if (type === 'docs') return 'weekly'
+            if (permalink.startsWith('/releases')) return 'monthly'
+            return 'weekly'
+          },
+          priority: ({ type, permalink }) => {
+            if (permalink === '/') return 1.0
+            if (type === 'docs') return 0.8
+            if (permalink.startsWith('/releases')) return 0.6
+            if (permalink.startsWith('/cookbook')) return 0.7
+            return 0.5
+          },
+          ignorePatterns: ['/tags/**'],
+          filename: 'sitemap.xml'
+        } as unknown as SitemapOptions
+      } satisfies Omit<Preset.Options, 'sitemap'> & { sitemap: SitemapOptions }
     ]
   ],
   themes: ['docusaurus-theme-openapi-docs'],
@@ -377,7 +395,7 @@ const config: Config = {
             from: '/blog/ai-needs-ai-ready-data',
             to: 'https://spice.ai/blog/ai-needs-ai-ready-data'
           },
-           {
+          {
             from: '/blog/2021/ai-needs-ai-ready-data',
             to: 'https://spice.ai/blog/ai-needs-ai-ready-data'
           },


### PR DESCRIPTION
This pull request updates the Docusaurus site configuration to add and customize sitemap generation. The main change is the introduction of a new `sitemap` configuration object, which controls how the sitemap is created and how its entries are prioritized and updated.

**Sitemap configuration additions and customization:**

* Added import for `SitemapOptions` type from `@docusaurus/plugin-sitemap` to support typed configuration for the sitemap plugin.
* Introduced a new `sitemap` configuration object within the Docusaurus preset options, specifying:
  * `lastmod` set to `'date'`.
  * Custom `changefreq` and `priority` logic based on page type and permalink.
  * `ignorePatterns` to exclude `/tags/**` from the sitemap.
  * Output filename set to `sitemap.xml`.
  * Ensured type safety by casting and updating the preset options type.