### PR TITLE
Add Arrow Hash Index docs

### DIFF
--- a/website/docs/components/data-accelerators/arrow.md
+++ b/website/docs/components/data-accelerators/arrow.md
@@ -32,11 +32,32 @@ datasets:
       engine: arrow
 ```
 
+## Hash Index
+
+:::warning[Experimental]
+Hash index is an experimental feature available in Spice v1.11.0-rc.2 and later.
+:::
+
+The In-Memory Arrow Data Accelerator supports an optional [hash index](/docs/features/data-acceleration/hash-index) for O(1) point lookups on primary key columns. To enable, set `hash_index: enabled` in the dataset params:
+
+```yaml
+datasets:
+  - from: s3://bucket/orders.parquet
+    name: orders
+    acceleration:
+      engine: arrow
+      primary_key: order_id
+    params:
+      hash_index: enabled
+```
+
+See [Hash Index](/docs/features/data-acceleration/hash-index) for configuration details, supported data types, and performance characteristics.
+
 ## Limitations
 
 - The In-Memory Arrow Data Accelerator does not support persistent storage. Data is stored in-memory and will be lost when the Spice runtime is stopped.
 - The In-Memory Arrow Data Accelerator does not support `Decimal256` (76 digits), as it exceeds Arrow's maximum Decimal width of 38 digits.
-- The In-Memory Arrow Data Accelerator does not support [indexes](/docs/features/data-acceleration/indexes).
+- The In-Memory Arrow Data Accelerator does not support traditional [indexes](/docs/features/data-acceleration/indexes), but does support [hash indexes](/docs/features/data-acceleration/hash-index) (experimental) for point lookups.
 - The In-Memory Arrow Data Accelerator only supports primary-key [constraints](/docs/features/data-acceleration/constraints), not `unique` constraints.
 - With Arrow acceleration, mathematical operations like `value1 / value2` are treated as integer division if the values are integers. For example, `1 / 2` will result in 0 instead of the expected 0.5. Use casting to FLOAT to ensure conversion to a floating-point value: `CAST(1 AS FLOAT) / CAST(2 AS FLOAT)` (or `CAST(1 AS FLOAT) / 2`).
 

--- a/website/docs/features/data-acceleration/hash-index.md
+++ b/website/docs/features/data-acceleration/hash-index.md
@@ -1,0 +1,217 @@
+---
+title: 'Hash Index for Arrow Acceleration'
+sidebar_label: 'Hash Index'
+sidebar_position: 3
+description: 'Learn how to use hash indexes for O(1) point lookups on Arrow-accelerated datasets.'
+---
+
+:::warning[Experimental]
+Hash index is an experimental feature available in Spice v1.11.0-rc.2 and later.
+:::
+
+The hash index is an optional, high-performance indexing feature for Arrow-accelerated datasets. It provides O(1) point lookups on primary key columns, dramatically improving query performance for equality predicates.
+
+## Key Features
+
+- **O(1) Point Lookups**: Direct row access via primary key without full table scans
+- **256-Shard Design**: Minimizes lock contention for concurrent reads
+- **SIMD-Optimized Hashing**: Uses XXH3_64 for fast, high-quality hashing
+- **Built-in Bloom Filter**: Fast negative lookups to skip unnecessary hash table probes
+- **Auto-Threshold**: Index is only built when data size exceeds a minimum threshold
+
+## Configuration
+
+To use the hash index, explicitly enable it and specify a primary key:
+
+```yaml
+datasets:
+  - from: s3://bucket/orders.parquet
+    name: orders
+    acceleration:
+      engine: arrow
+      primary_key: order_id
+    params:
+      hash_index: enabled
+```
+
+### Configuration Options
+
+| Parameter     | Type                 | Required                    | Default    | Description          |
+| ------------- | -------------------- | --------------------------- | ---------- | -------------------- |
+| `hash_index`  | `enabled`/`disabled` | No                          | `disabled` | Enable hash indexing |
+| `primary_key` | string or list       | Yes (if hash_index enabled) | None       | Column(s) to index   |
+
+## Supported Data Types
+
+The hash index supports the following primary key column types:
+
+### Primitive Types
+
+- `Int8`, `Int16`, `Int32`, `Int64`
+- `UInt8`, `UInt16`, `UInt32`, `UInt64`
+
+### String Types
+
+- `Utf8`, `LargeUtf8`
+
+### Binary Types
+
+- `Binary`, `LargeBinary`
+
+## Query Optimization
+
+The hash index automatically accelerates queries with equality predicates on indexed columns.
+
+### Optimized Queries
+
+```sql
+-- Single key lookup (uses index)
+SELECT * FROM my_dataset WHERE id = 123;
+
+-- Multiple key lookups (uses index for each key)
+SELECT * FROM my_dataset WHERE id IN (1, 2, 3);
+```
+
+### Non-Optimized Queries
+
+```sql
+-- Range queries (full scan)
+SELECT * FROM my_dataset WHERE id > 100 AND id < 200;
+
+-- Pattern matching (full scan)
+SELECT * FROM my_dataset WHERE id LIKE 'A%';
+
+-- Composite key partial match (full scan)
+SELECT * FROM my_dataset WHERE region = 'US';
+-- (If composite key is (region, customer_id), both must be specified)
+```
+
+## Index Threshold
+
+The hash index is only built when the dataset exceeds a minimum size:
+
+```text
+threshold = 256 × CPU_cores
+```
+
+| CPU Cores | Minimum Rows for Index |
+| --------- | ---------------------- |
+| 1         | 256                    |
+| 4         | 1,024                  |
+| 8         | 2,048                  |
+| 16        | 4,096                  |
+| 32        | 8,192                  |
+
+For small tables below the threshold, a full scan is faster than index maintenance overhead.
+
+## Performance
+
+### Bloom Filter Performance
+
+The built-in bloom filter provides:
+
+- ~0.82% false positive rate (10 bits/item, 7 hash functions)
+- O(1) negative lookup confirmation
+- Reduced unnecessary hash table probes for non-existent keys
+
+## Memory Usage
+
+| Component    | Memory per Entry                         |
+| ------------ | ---------------------------------------- |
+| Hash slot    | 16 bytes (8-byte hash + 8-byte location) |
+| Bloom filter | ~1.25 bytes                              |
+| **Total**    | ~17.25 bytes per indexed row             |
+
+### Estimating Memory
+
+For a 10 million row dataset:
+
+```text
+Index memory ≈ 10M × 17.25 bytes ≈ 165 MB
+```
+
+## Architecture
+
+### Sharded Hash Table
+
+The index uses 256 independent shards to minimize lock contention:
+
+```text
+┌────────────────────────────────────────────────┐
+│                  HashIndex                     │
+├────────────────────────────────────────────────┤
+│  ┌─────────┐ ┌─────────┐      ┌─────────┐      │
+│  │ Shard 0 │ │ Shard 1 │ ...  │Shard 255│      │
+│  │ RwLock  │ │ RwLock  │      │ RwLock  │      │
+│  └────┬────┘ └────┬────┘      └────┬────┘      │
+│       │           │                │           │
+│       ▼           ▼                ▼           │
+│  ┌─────────┐ ┌─────────┐      ┌─────────┐      │
+│  │  Hash   │ │  Hash   │ ...  │  Hash   │      │
+│  │  Table  │ │  Table  │      │  Table  │      │
+│  └─────────┘ └─────────┘      └─────────┘      │
+├────────────────────────────────────────────────┤
+│  ┌─────────────────────────────────────────┐   │
+│  │        Optional Bloom Filter            │   │
+│  │        (Fast Negative Lookups)          │   │
+│  └─────────────────────────────────────────┘   │
+└────────────────────────────────────────────────┘
+```
+
+**Shard Selection**: Uses XOR-folded hash bits: `((hash >> 56) ^ (hash >> 48) ^ hash) & 0xFF`
+
+### Row Location
+
+Each indexed key maps to a `RowLocation`:
+
+```rust
+RowLocation {
+    partition: u32,  // Partition index
+    batch: u32,      // Batch index within partition
+    row: u32,        // Row index within batch
+}
+```
+
+### Hash Function
+
+Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
+
+- Deterministic hashing across instances
+- High-quality distribution (passes SMHasher)
+- SIMD acceleration on arm64/amd64
+
+## Limitations
+
+1. **Arrow Engine Only**: Hash index is only available for `engine: arrow` acceleration
+2. **Single Key Lookups**: Optimizes equality predicates, not ranges or patterns
+3. **Experimental**: API and behavior may change in future releases
+4. **No Persistence**: Index is rebuilt on restart (data persists, index is in-memory)
+5. **Duplicate Keys**: Primary key columns must have unique values
+
+## Troubleshooting
+
+### "No index available for point lookup"
+
+**Cause**: Dataset row count is below the index threshold.
+
+**Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
+
+### Warning: "Add 'hash_index: enabled' to use primary_key for fast lookups"
+
+**Cause**: `primary_key` is specified but `hash_index` is not enabled.
+
+**Solution**: Add `hash_index: enabled` to `params`:
+
+```yaml
+params:
+  hash_index: enabled
+```
+
+### High Memory Usage
+
+**Cause**: Index consumes ~17 bytes per row.
+
+**Solution**:
+
+- Disable hash_index for datasets where point lookups are rare
+- Consider using a different acceleration engine for very large datasets

--- a/website/docs/features/data-acceleration/indexes.md
+++ b/website/docs/features/data-acceleration/indexes.md
@@ -41,7 +41,9 @@ There are two types of indexes that can be specified in a Spicepod:
 
 :::warning[Limitations]
 
-Indexes are not supported for the in-memory Arrow or [Spice Cayenne](/docs/components/data-accelerators/cayenne.md) acceleration engines. Use [DuckDB](/docs/components/data-accelerators/duckdb.md), [SQLite](/docs/components/data-accelerators/sqlite.md), [Turso](/docs/components/data-accelerators/turso.md) (when MVCC is disabled), or [PostgreSQL](/docs/components/data-accelerators/postgres/index.md) as the acceleration engine to enable indexing.
+Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](/docs/components/data-accelerators/cayenne.md) acceleration engines. Use [DuckDB](/docs/components/data-accelerators/duckdb.md), [SQLite](/docs/components/data-accelerators/sqlite.md), [Turso](/docs/components/data-accelerators/turso.md) (when MVCC is disabled), or [PostgreSQL](/docs/components/data-accelerators/postgres/index.md) as the acceleration engine to enable indexing.
+
+For Arrow acceleration, see [Hash Index](./hash-index.md) (experimental, v1.11.0-rc.2+) for O(1) point lookups on primary key columns.
 
 :::
 

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -46,7 +46,7 @@ The default Arrow accelerator stores all data in memory uncompressed. Datasets m
 When using the optional [hash index](/docs/features/data-acceleration/hash-index), additional memory is required:
 
 | Component    | Memory per Row |
-|--------------|----------------|
+| ------------ | -------------- |
 | Hash slot    | 16 bytes       |
 | Bloom filter | ~1.25 bytes    |
 | **Total**    | ~17.25 bytes   |

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -41,6 +41,18 @@ The default Arrow accelerator stores all data in memory uncompressed. Datasets m
 - Best for smaller datasets requiring maximum query speed
 - Consider switching to file-based accelerators for datasets exceeding available memory
 
+**Hash Index Memory (Experimental, v1.11.0-rc.2+):**
+
+When using the optional [hash index](/docs/features/data-acceleration/hash-index), additional memory is required:
+
+| Component    | Memory per Row |
+|--------------|----------------|
+| Hash slot    | 16 bytes       |
+| Bloom filter | ~1.25 bytes    |
+| **Total**    | ~17.25 bytes   |
+
+For a 10 million row dataset with hash index enabled, expect ~165 MB additional memory overhead.
+
 ### Spice Cayenne
 
 [Spice Cayenne](/docs/components/data-accelerators/cayenne.md) stores data on disk using the [Vortex](https://github.com/vortex-data/vortex) columnar format, with configurable caches for metadata and frequently accessed data segments. The caches can be configured to reside either in memory or on disk, which impacts overall memory behavior.

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -27,6 +27,7 @@ Choose the appropriate [Data Accelerator](/docs/components/data-accelerators) ba
 | Large datasets (100 GB - 1+ TB)          | `cayenne`                  | Tune cache parameters                                                 |
 | Write-heavy workloads                    | `cayenne` with `zstd`      | Set `cayenne_compression_strategy: zstd`                              |
 | Point lookups, large datasets            | `cayenne`                  | Vortex provides [100x faster random access](https://bench.vortex.dev) |
+| Point lookups, small-medium datasets     | `arrow` with hash index    | Set `hash_index: enabled` (experimental, v1.11.0-rc.2+)               |
 | Point lookups with explicit indexes      | `duckdb` or `sqlite`       | Configure indexes                                                     |
 
 ## Spice Cayenne Performance Optimization


### PR DESCRIPTION
This pull request introduces documentation for a new experimental "hash index" feature for Arrow-accelerated datasets, available in Spice v1.11.0-rc.2 and later. The hash index enables O(1) point lookups on primary key columns, improving query performance for equality predicates. The documentation covers configuration, supported data types, performance characteristics, memory usage, and limitations. References to this new feature are added throughout relevant docs, and guidance is provided on when and how to use it.

**Hash Index Feature Documentation:**

- Added a comprehensive new page, `hash-index.md`, describing the experimental hash index for Arrow acceleration, including configuration, supported data types, performance, memory usage, architecture, and troubleshooting.
- Updated `arrow.md` to introduce the hash index, provide configuration examples, and clarify that while traditional indexes are not supported, hash indexes are now available for point lookups.

**Cross-References and Guidance:**

- Updated the general indexes documentation to clarify that traditional indexes are not supported for Arrow acceleration, but hash indexes are available as an experimental feature. Added cross-reference to the new documentation.
- Added a row to the performance tuning guide, recommending Arrow with hash index for point lookups on small to medium datasets, and provided configuration details.

**Memory Usage Documentation:**

- Updated the memory reference documentation to include details and a table on the additional memory overhead incurred by enabling the hash index, with concrete examples.