### PR TITLE
Add High Availability documentation for distributed query clusters

### DIFF
--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -21,10 +21,10 @@ Spice integrates [Apache Ballista](https://github.com/apache/datafusion-ballista
 
 A distributed Spice cluster consists of two components:
 
-- **Scheduler** – Plans distributed queries and manages the work queue for the executor fleet. Single instance per cluster.
+- **Scheduler** – Plans distributed queries and manages the work queue for the executor fleet.
 - **Executors** – One or more nodes responsible for executing physical query plans.
 
-The scheduler holds the cluster-wide configuration for a Spicepod, while executors connect to the scheduler to receive work.
+The scheduler holds the cluster-wide configuration for a Spicepod, while executors connect to the scheduler to receive work. A cluster can run with a single scheduler for simplicity, or multiple schedulers for [high availability](#high-availability).
 
 ### Network Ports
 
@@ -140,4 +140,128 @@ EXPLAIN SELECT count(id) FROM my_dataset;
 - As a preview feature, clusters may encounter stability or performance issues.
 - Accelerator support is planned for future releases; follow release notes for updates.
 
+:::
+
+## High Availability
+
+For production deployments, Spice supports running multiple active schedulers in an active/active configuration. This eliminates the scheduler as a single point of failure and enables graceful handling of node failures.
+
+### HA Architecture
+
+In an HA cluster:
+
+- Multiple schedulers run simultaneously, each capable of accepting queries
+- Schedulers share state via an S3-compatible object store
+- Executors discover all schedulers automatically
+- A load balancer distributes client queries across schedulers
+
+```
+                    ┌─────────────────────┐
+                    │    Load Balancer    │
+                    └─────────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              ▼                ▼                ▼
+       ┌────────────┐   ┌────────────┐   ┌────────────┐
+       │ Scheduler  │   │ Scheduler  │   │ Scheduler  │◄──►  Object Store
+       │            │   │            │   │            │        (S3)
+       └────────────┘   └────────────┘   └────────────┘
+              ▲                ▲                ▲
+              │    (executor-initiated)         │
+       ┌────────────┐   ┌────────────┐   ┌────────────┐
+       │  Executor  │   │  Executor  │   │  Executor  │
+       └────────────┘   └────────────┘   └────────────┘
+```
+
+### Configuration
+
+Enable HA by configuring `runtime.scheduler.state_location` in the Spicepod to point to an S3-compatible object store:
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      region: us-east-1
+```
+
+The object store is used for scheduler registration and discovery. Job state persistence for query handoff between schedulers is planned for a future release.
+
+### S3 Configuration
+
+The `runtime.scheduler.params` section supports the following S3 parameters:
+
+| Parameter        | Description                                           | Default    |
+| ---------------- | ----------------------------------------------------- | ---------- |
+| `region`         | AWS region for the S3 bucket                          | -          |
+| `endpoint`       | Custom S3-compatible endpoint URL                     | -          |
+| `auth`           | Authentication method: `iam_role` or `key`            | `iam_role` |
+| `key`            | AWS access key ID (when `auth: key`)                  | -          |
+| `secret`         | AWS secret access key (when `auth: key`)              | -          |
+| `session_token`  | AWS session token for temporary credentials           | -          |
+| `client_timeout` | S3 client timeout                                     | -          |
+| `allow_http`     | Allow HTTP (non-TLS) connections to S3 endpoint       | `false`    |
+
+Example with explicit credentials:
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      region: us-east-1
+      auth: key
+      key: ${secrets:aws_access_key}
+      secret: ${secrets:aws_secret_key}
+```
+
+### Starting an HA Cluster
+
+1. **Configure shared state** in `spicepod.yaml`:
+
+   ```yaml
+   runtime:
+     scheduler:
+       state_location: s3://my-bucket/spice-cluster
+       params:
+         region: us-east-1
+   ```
+
+2. **Start multiple schedulers**, each with unique certificates:
+
+   ```bash
+   # Scheduler 1
+   spiced --role scheduler \
+     --flight 0.0.0.0:50051 \
+     --node-mtls-ca-certificate-file ~/.spice/pki/ca.crt \
+     --node-mtls-certificate-file ~/.spice/pki/scheduler1.crt \
+     --node-mtls-key-file ~/.spice/pki/scheduler1.key
+
+   # Scheduler 2 (on a different node)
+   spiced --role scheduler \
+     --flight 0.0.0.0:50051 \
+     --node-mtls-ca-certificate-file ~/.spice/pki/ca.crt \
+     --node-mtls-certificate-file ~/.spice/pki/scheduler2.crt \
+     --node-mtls-key-file ~/.spice/pki/scheduler2.key
+   ```
+
+3. **Start executors** (they discover all schedulers automatically):
+
+   ```bash
+   spiced --role executor \
+     --scheduler-address https://scheduler1:50052 \
+     --node-mtls-ca-certificate-file ~/.spice/pki/ca.crt \
+     --node-mtls-certificate-file ~/.spice/pki/executor1.crt \
+     --node-mtls-key-file ~/.spice/pki/executor1.key
+   ```
+
+4. **Configure a load balancer** to distribute queries across scheduler Flight SQL endpoints (port 50051).
+
+### HA Considerations
+
+- **Object store latency** – The object store is accessed during scheduler coordination. Use a low-latency object store (e.g., S3 Express One Zone) for best performance.
+- **Async queries recommended** – Synchronous queries cannot survive scheduler failure mid-execution. For maximum reliability, use the async query API.
+
+:::info Object Store Requirements
+The object store must support conditional writes (S3 ETags). Most S3-compatible stores support this, including AWS S3, MinIO, and Google Cloud Storage (with S3 compatibility mode).
 :::

--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -260,7 +260,6 @@ runtime:
 ### HA Considerations
 
 - **Object store latency** – The object store is accessed during scheduler coordination. Use a low-latency object store (e.g., S3 Express One Zone) for best performance.
-- **Async queries recommended** – Synchronous queries cannot survive scheduler failure mid-execution. For maximum reliability, use the async query API.
 
 :::info Object Store Requirements
 The object store must support conditional writes (S3 ETags). Most S3-compatible stores support this, including AWS S3, MinIO, and Google Cloud Storage (with S3 compatibility mode).

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -424,3 +424,77 @@ runtime:
       enabled: false
     - name: dataset_acceleration_ingestion_lag_ms
 ```
+
+## `runtime.scheduler`
+
+Configures shared state for [high availability distributed query](/docs/features/distributed-query/index.md#high-availability) clusters. When configured, multiple schedulers can coordinate via a shared object store.
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      region: us-east-1
+```
+
+### `runtime.scheduler.state_location`
+
+The S3 URI for shared cluster state. This is required to enable HA mode with multiple schedulers.
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+```
+
+### `runtime.scheduler.params`
+
+Optional parameters for S3 authentication and configuration.
+
+| Parameter        | Description                                           | Default    |
+| ---------------- | ----------------------------------------------------- | ---------- |
+| `region`         | AWS region for the S3 bucket                          | -          |
+| `endpoint`       | Custom S3-compatible endpoint URL                     | -          |
+| `auth`           | Authentication method: `iam_role` or `key`            | `iam_role` |
+| `key`            | AWS access key ID (when `auth: key`)                  | -          |
+| `secret`         | AWS secret access key (when `auth: key`)              | -          |
+| `session_token`  | AWS session token for temporary credentials           | -          |
+| `client_timeout` | S3 client timeout                                     | -          |
+| `allow_http`     | Allow HTTP (non-TLS) connections to S3 endpoint       | `false`    |
+
+Example with IAM role authentication (default):
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      region: us-east-1
+```
+
+Example with explicit credentials:
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      region: us-east-1
+      auth: key
+      key: ${secrets:aws_access_key}
+      secret: ${secrets:aws_secret_key}
+```
+
+Example with a custom S3-compatible endpoint (e.g., MinIO):
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-cluster
+    params:
+      endpoint: http://minio.local:9000
+      auth: key
+      key: ${secrets:minio_access_key}
+      secret: ${secrets:minio_secret_key}
+      allow_http: true
+```


### PR DESCRIPTION
Document how to configure and run multiple active schedulers using shared S3 state for fault tolerance. Includes runtime.scheduler configuration reference with S3 parameters.