### PR TITLE
Remove non existing `runtime.caching.search_results.stale_while_revalidate_ttl` from example

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -30,7 +30,6 @@ runtime:
       enabled: true
       max_size: 1GiB # Default 128 MiB
       item_ttl: 1m # Default 1s
-      stale_while_revalidate_ttl: 30s # Default 0s (disabled)
 ```
 
 ## `caching` Parameters


### PR DESCRIPTION
## 🗣 Description

Search results doesn't have this param. Warns from latest v1.11.0
```console
2026-02-07T03:11:50.521210Z  WARN spiced: Starting in pods watcher mode without a valid spicepod.yaml. The runtime will load components once a valid spicepod.yaml is provided.
Unable to load spicepod /Users/evgenii/Developer/my-spicepod: Failed to parse spicepod.yaml: runtime.caching.search_results: unknown field `stale_while_revalidate_ttl`, expected one of `enabled`, `max_size`, `item_ttl`, `caching_policy`, `eviction_policy`, `hashing_algorithm`, `engine` at line 15 column 7
```
