### PR TITLE
docs: Bring v1.11.1 content changes to trunk

### DIFF
--- a/website/docs/components/data-accelerators/cayenne.md
+++ b/website/docs/components/data-accelerators/cayenne.md
@@ -506,7 +506,6 @@ Consider the following limitations when using Spice Cayenne acceleration:
 
 - **Beta Status**: Spice Cayenne is in active development. Configuration options may change between releases.
 - **File Mode Only**: Spice Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
-- **No Snapshot Support**: Spice Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots) for bootstrapping from object storage.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
 - **Unsupported Data Types**: `Interval`, `Duration`, `Map`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.

--- a/website/docs/components/data-connectors/dynamodb.md
+++ b/website/docs/components/data-connectors/dynamodb.md
@@ -613,9 +613,11 @@ datasets:
 
 #### Dataset Parameters
 
-- **`ready_lag`** - Defines the maximum lag threshold before the dataset is reported as "Ready". Once the stream lag falls below this value, queries can be executed against the dataset. Default behavior reports ready immediately after bootstrap completes.
+- **`ready_lag`** - Defines the maximum lag threshold before the dataset is reported as "Ready". Once the stream lag falls below this value, queries can be executed against the dataset. Default is `2s`
 
 - **`scan_interval`** - Controls the polling frequency for checking new records in the DynamoDB stream. Lower values provide more real-time updates but increase API calls. Higher values reduce API usage but may introduce additional latency.
+
+- **`lag_exceeds_shard_retention_behavior`** - Controls how the connector handles lag expiration, which occurs when the stream lag exceeds the DynamoDB Streams shard retention period. Default: `error`. See [Lag Expiration Behavior](#lag-expiration-behavior) for details.
 
 #### Acceleration Parameters
 
@@ -627,6 +629,28 @@ datasets:
 
 See [Acceleration snapshots](../../features/data-acceleration/snapshots) for more details.
 
+### Lag Expiration Behavior
+
+When using DynamoDB Streams, the connector maintains an offset to track its position in the stream. If the connector falls behind beyond the DynamoDB Streams shard retention period, the offset expires and is no longer valid. The `lag_exceeds_shard_retention_behavior` parameter controls how the connector handles this scenario.
+
+```yaml
+datasets:
+  - from: dynamodb:my_table
+    name: my_table
+    params:
+      lag_exceeds_shard_retention_behavior: error  # error | ready_before_load | ready_after_load
+    acceleration:
+      enabled: true
+      engine: duckdb
+      refresh_mode: changes
+```
+
+| Value                | Description                                                                                                                                                                                            |
+| -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `error` (default)    | Returns an error and the table never becomes Ready. Use this when data consistency is critical and manual intervention is preferred over automatic recovery.                                           |
+| `ready_before_load`  | The table becomes Ready immediately before re-initiliazation begins. Queries are served from the existing (stale) data while the table goes through the process of re-initialization in the background. |
+| `ready_after_load`   | Performs a full table re-initiliazation. The table becomes Ready after re-initiliazation process is complete.                                                                                          |
+
 ### Metrics
 
 The following [Component Metrics](../../features/observability/component_metrics) are provided for monitoring streaming performance and health:
@@ -637,6 +661,7 @@ The following [Component Metrics](../../features/observability/component_metrics
 | `records_consumed_total` | Counter | Total number of records consumed from the stream                           |
 | `lag_ms`                 | Gauge   | Current lag in milliseconds between stream watermark and the current time  |
 | `errors_transient_total` | Counter | Total number of transient errors encountered while polling from the stream |
+| `reinitializations_on_lag_exceeds_shard_retention_total` | Counter | Total number of re-initializations triggered when stream lag exceeds shard retention. See [Lag Expiration Behavior](#lag-expiration-behavior). |
 
 These metrics are not enabled by default, enable them by setting the metrics parameter:
 ```yaml
@@ -651,6 +676,7 @@ datasets:
    - name: records_consumed_total
    - name: lag_ms
    - name: errors_transient_total
+   - name: reinitializations_on_lag_exceeds_shard_retention_total
 ```
 
 You can find an example dashboard for DynamoDB Streams in [monitoring/grafana-dashboard.json](https://github.com/spiceai/spiceai/blob/trunk/monitoring/grafana-dashboard.json).
@@ -678,6 +704,7 @@ datasets:
      - name: records_consumed_total
      - name: lag_ms
      - name: errors_transient_total
+     - name: reinitializations_on_lag_exceeds_shard_retention_total
 ```
 
 :::warning[Limitations]

--- a/website/docs/components/data-connectors/flightsql.md
+++ b/website/docs/components/data-connectors/flightsql.md
@@ -36,6 +36,10 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `flightsql_username` | Optional. The username to use in the underlying Apache flight Handshake Request to authenticate to the server (see [reference](https://arrow.apache.org/docs/format/Flight.html#authentication)).                                                   |
 | `flightsql_password` | Optional. The password to use in the underlying Apache flight Handshake Request to authenticate to the server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_flightsql_pass}`. |
 
+## Cookie Middleware
+
+The Flight SQL connector includes built-in cookie middleware that automatically handles `Set-Cookie` headers from the server and attaches `Cookie` headers on subsequent requests. This enables transparent session affinity when connecting through load balancers (e.g. AWS ALB) that rely on sticky cookies for routing. No additional configuration is required.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -129,6 +129,39 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `max_request_body_bytes`   | Optional. Maximum size in bytes for `request_body` filter values. Default: `16384` (16 KiB). Maximum: `65536` (64 KiB).                                                                                                                                                              |
 | `health_probe`             | Optional. Custom health probe path for endpoint validation during initialization (e.g., `/health`, `/api/status`). The endpoint must return a 2xx status code to pass validation. If not set, a random path is used and any status (including 404) is accepted. Must start with `/`. |
 
+## Response Schema
+
+Each row returned by the HTTP connector includes the following columns:
+
+| Column Name      | Type                          | Nullable | Description                                                                                           |
+| ---------------- | ----------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `request_path`   | `Utf8`                        | Yes      | The URL path used for the request. See [Special Metadata Fields](#special-metadata-fields).           |
+| `request_query`  | `Utf8`                        | Yes      | The query parameters used for the request. See [Special Metadata Fields](#special-metadata-fields).   |
+| `request_body`   | `Utf8`                        | Yes      | The request body used for the request. See [Special Metadata Fields](#special-metadata-fields).       |
+| `content`        | `Utf8`                        | No       | The response body content.                                                                            |
+| `response_status`| `UInt16`                      | No       | The HTTP status code of the response (e.g. `200`, `404`, `500`).                                      |
+| `fetched_at`     | `Timestamp(Nanosecond)`       | Yes      | The timestamp when the response was fetched.                                                          |
+
+### HTTP Status Code Handling
+
+The connector treats all HTTP responses as queryable data, not just successful ones:
+
+- **2xx/3xx responses**: Returned as data and cached normally.
+- **4xx responses** (e.g. `404 Not Found`): Returned as data and cached normally. This allows querying for error responses from APIs.
+- **5xx responses** (e.g. `500 Internal Server Error`): Retried with backoff (up to `max_retries`), then returned as data. **5xx responses are excluded from the cache** to prevent transient server errors from polluting cached results.
+
+Use the `response_status` column to filter or inspect the status of responses:
+
+```sql
+-- Get only successful responses
+SELECT content FROM my_api WHERE request_path = '/users' AND response_status = 200;
+
+-- Check for error responses
+SELECT request_path, response_status, content
+FROM my_api
+WHERE response_status >= 400;
+```
+
 ## HTTP Response Headers
 
 When querying HTTP(s) datasets, Spice respects standard HTTP caching headers in responses. The connector supports the following cache-related response headers:
@@ -637,7 +670,7 @@ datasets:
 
 - **Connection Pooling**: The connector maintains up to 10 idle connections per host by default
 - **Retry Overhead**: With the default 3 retries and Fibonacci backoff, failed requests may take several seconds before returning an error
-- **Cache Behavior**: HTTP responses are cached based on the combination of path, query, and body parameters
+- **Cache Behavior**: HTTP responses are cached based on the combination of path, query, and body parameters. 5xx responses are excluded from cache to prevent transient errors from polluting cached results
 
 ## Secrets
 

--- a/website/docs/features/data-acceleration/snapshots.md
+++ b/website/docs/features/data-acceleration/snapshots.md
@@ -30,10 +30,6 @@ datasets:
 
 Acceleration snapshots let Spice reuse a pre-built acceleration file on startup instead of waiting for a full refresh. When a dataset uses a file-mode acceleration engine (DuckDB or SQLite) and the local file is missing (for example on first boot or when using ephemeral NVMe storage), Spice downloads the most recent snapshot from object storage and moves the dataset straight to a ready state.
 
-:::info Preview
-Acceleration snapshots are available in preview.
-:::
-
 ## How it works
 
 - On startup, Spice checks whether the file supplied in `acceleration.params` (for example `duckdb_file`) exists.

--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -69,9 +69,9 @@ The `text_search()` function has the following signature:
 
 ```sql
 text_search(
-  table STRING,              -- Dataset name (required)
+  table IDENTIFIER,          -- Dataset name (required, unquoted)
   query STRING,              -- Keyword or phrase to search (required)
-  col STRING,                -- Specific column to search (required if dataset has multiple indexed columns)
+  col IDENTIFIER,            -- Column name to search (required if dataset has multiple indexed columns, unquoted)
   limit INTEGER,             -- Maximum results returned (optional, defaults to 1000)
   include_score BOOLEAN      -- Include relevance scores in results (optional, defaults to TRUE)
 )

--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -137,9 +137,9 @@ LIMIT 5;
 
 ```sql
 vector_search(
-  table STRING,          -- Dataset name (required)
+  table IDENTIFIER,      -- Dataset name (required, unquoted)
   query STRING,          -- Search text (required)
-  col STRING,            -- Column name (optional if single embedding column)
+  col IDENTIFIER,        -- Column name (optional if single embedding column, unquoted)
   limit INTEGER,         -- Results limit (default: 1000)
   include_score BOOLEAN  -- Include relevance scores (default: TRUE)
 )


### PR DESCRIPTION
Cherry-pick release-specific documentation updates from `release/1.11` that were not yet on `trunk`:

## Changes

- **DynamoDB**: Update `ready_lag` default to `2s`, add `lag_exceeds_shard_retention_behavior` parameter and Lag Expiration Behavior section, add `reinitializations_on_lag_exceeds_shard_retention_total` metric
- **FlightSQL**: Add Cookie Middleware section for load balancer session affinity
- **HTTP(s)**: Add Response Schema section with column definitions, HTTP status code handling, and 5xx cache exclusion note
- **Cayenne**: Remove outdated 'No Snapshot Support' limitation
- **Snapshots**: Remove 'Preview' admonition (snapshots are no longer in preview)
- **Search**: Update `text_search` and `vector_search` function signatures to use `IDENTIFIER` type for `table` and `col` parameters

These are the content-only changes from `release/1.11` PRs #1358 and #1362 that were not carried over to trunk during the v1.11.1 release.