### PR TITLE
Integrate async queries API into distributed query docs

### DIFF
--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -35,7 +35,7 @@ spice [command] [--help]
 | [models](reference/models)         | Lists models loaded by the Spice runtime                               |
 | nsql                               | Text-to-SQL REPL - translate natural language to SQL                   |
 | [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                            |
-| query                              | Submit an async query or start an interactive async query REPL         |
+| [query](reference/query)           | Submit an async query or start an interactive async query REPL         |
 | [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                          |
 | [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary          |
 | [search](reference/search)         | Search datasets with embeddings                                        |

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -15,36 +15,36 @@ spice [command] [--help]
 
 ### Full Command Reference
 
-| Command                                | Description                                                            |
-| -------------------------------------- | ---------------------------------------------------------------------- |
-| [acceleration](reference/acceleration) | Manage dataset acceleration features                                   |
-| [add](reference/add)                   | Add Spicepod - adds a Spicepod to the project                          |
-| [catalogs](reference/catalogs)         | List [catalogs](../../components/catalogs) loaded by the Spice runtime |
-| [chat](reference/chat)                 | Chat with an LLM                                                       |
-| [cloud](reference/cloud)               | Manage Spice Cloud resources                                           |
-| [cluster](reference/cluster)           | Cluster operations for the Spice runtime                               |
-| [completion](reference/completion)     | Generate the autocompletion script for the specified shell             |
-| [connect](reference/connect)           | Connect to a Spice.ai Cloud Platform app                               |
-| [dataset](reference/dataset)           | Dataset operations (configure datasets)                                |
-| [datasets](reference/datasets)         | Lists datasets loaded by the Spice runtime                             |
-| [eval](reference/eval)                 | Run model evaluation                                                   |
-| help                                   | Help about any command                                                 |
-| [init](reference/init)                 | Initialize Spice app - creates a new spicepod.yaml                     |
-| [install](reference/install)           | Install or reinstall the Spice.ai runtime                              |
-| [login](reference/login)               | Login to Spice.ai or configure credentials for data sources            |
-| [models](reference/models)             | Lists models loaded by the Spice runtime                               |
-| [nsql](reference/nsql)                 | Text-to-SQL REPL - translate natural language to SQL                   |
-| [pods](reference/pods)                 | Lists Spicepods loaded by the Spice runtime                            |
-| [query](reference/query)               | Submit an async query or start an interactive async query REPL         |
-| [refresh](reference/refresh)           | Refresh a dataset loaded by the Spice runtime                          |
-| [run](reference/run)                   | Run Spice - starts the Spice runtime, installing if necessary          |
-| [search](reference/search)             | Search datasets with embeddings                                        |
-| [sql](reference/sql)                   | Start an interactive SQL query session against the Spice runtime       |
-| [status](reference/status)             | Spice runtime status                                                   |
-| [trace](reference/trace)               | Return traces for operations that occurred in Spice                    |
-| [upgrade](reference/upgrade)           | Upgrades the Spice CLI and runtime to the latest release               |
-| [version](reference/version)           | Spice CLI version                                                      |
-| [workers](reference/workers)           | Lists workers loaded by the Spice runtime                              |
+| Command                            | Description                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| acceleration                       | Manage dataset acceleration features                                   |
+| [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                          |
+| [catalogs](reference/catalogs)     | List [catalogs](../../components/catalogs) loaded by the Spice runtime |
+| [chat](reference/chat)             | Chat with an LLM                                                       |
+| cloud                              | Manage Spice Cloud resources                                           |
+| cluster                            | Cluster operations for the Spice runtime                               |
+| [completion](reference/completion) | Generate the autocompletion script for the specified shell             |
+| [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
+| [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
+| [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
+| eval                               | Run model evaluation                                                   |
+| help                               | Help about any command                                                 |
+| [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                     |
+| [install](reference/install)       | Install or reinstall the Spice.ai runtime                              |
+| [login](reference/login)           | Login to Spice.ai or configure credentials for data sources            |
+| [models](reference/models)         | Lists models loaded by the Spice runtime                               |
+| nsql                               | Text-to-SQL REPL - translate natural language to SQL                   |
+| [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                            |
+| query                              | Submit an async query or start an interactive async query REPL         |
+| [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                          |
+| [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary          |
+| [search](reference/search)         | Search datasets with embeddings                                        |
+| [sql](reference/sql)               | Start an interactive SQL query session against the Spice runtime       |
+| [status](reference/status)         | Spice runtime status                                                   |
+| [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
+| [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest release               |
+| [version](reference/version)       | Spice CLI version                                                      |
+| workers                            | Lists workers loaded by the Spice runtime                              |
 
 ### Command Flags
 

--- a/website/docs/cli/reference/query.md
+++ b/website/docs/cli/reference/query.md
@@ -1,0 +1,88 @@
+---
+title: 'query'
+sidebar_label: 'query'
+pagination_prev: null
+pagination_next: null
+---
+
+Submit an async query or start an interactive async query REPL against the Spice runtime's distributed query engine.
+
+### Usage
+
+```shell
+spice query [flags] [SQL]
+```
+
+When invoked with a SQL statement, submits it as an async query and waits for the result. When invoked without arguments, starts an interactive REPL.
+
+#### Flags
+
+- `--no-wait` Submit the query and return immediately without waiting for results.
+- `--timeout <DURATION>` Maximum client-side wait time (e.g., `30s`, `5m`). The query continues running on timeout.
+- `-o`, `--output <FORMAT>` Output format: `table` (default) or `json`.
+- `-h`, `--help` Print this help message.
+
+#### Subcommands
+
+| Subcommand                                  | Description                        |
+| ------------------------------------------- | ---------------------------------- |
+| `spice query list [--status X] [--limit N]` | List queries                       |
+| `spice query status <query_id>`             | Check query status                 |
+| `spice query results <query_id>`            | Fetch results of a completed query |
+| `spice query cancel <query_id>`             | Cancel a running query             |
+
+### Examples
+
+#### Submit and Wait
+
+```shell
+$ spice query "SELECT * FROM orders WHERE total > 100 LIMIT 50;"
+```
+
+The CLI auto-polls with a spinner and displays results when ready. Press `Ctrl+C` to stop waiting — the query continues running in the background.
+
+#### Submit Without Waiting
+
+```shell
+$ spice query "SELECT * FROM large_table;" --no-wait
+```
+
+#### Interactive REPL
+
+```shell
+$ spice query
+query> SELECT COUNT(*)
+     > FROM large_table
+     > WHERE status = 'active';
+Submitted query: 01ABC-DEF-456-7890AB (PENDING)
+Press Ctrl+C to stop waiting (query continues in background)
+⠹ RUNNING (2.3s)...
+✓ SUCCEEDED (5.1s)
++----------+
+| count(*) |
++----------+
+| 42000    |
++----------+
+
+Time: 5.10000000 seconds. 1 rows.
+```
+
+**REPL Commands**:
+
+| Command                | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `.list`                | List all queries tracked in this REPL session  |
+| `.status <id>`         | Show detailed status of a query                |
+| `.results <id>`        | Fetch and display results of a completed query |
+| `.wait <id>`           | Resume waiting for a query to complete         |
+| `.cancel <id>`         | Cancel a running query                         |
+| `.clear`               | Clear the local tracked queries list           |
+| `.clear history`       | Clear command history                          |
+| `.help`                | Show available commands                        |
+| `.exit`, `.quit`, `.q` | Exit the REPL                                  |
+
+Query IDs can be abbreviated if they uniquely identify a query within the tracked session.
+
+:::note
+The `spice query` command requires the runtime to be running in [cluster mode](/docs/features/distributed-query) with `--role scheduler` and `scheduler.state_location` configured.
+:::

--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'Distributed Query'
 sidebar_label: 'Distributed Query'
-description: 'Learn how to run Spice in distributed mode for larger scale queries.'
+description: 'Learn how to run Spice in distributed mode for larger scale queries, including the async queries API.'
 sidebar_position: 4
 pagination_prev: null
 pagination_next: null
@@ -21,130 +21,10 @@ Spice integrates [Apache Ballista](https://github.com/apache/datafusion-ballista
 
 A distributed Spice cluster consists of two components:
 
-- **Scheduler** – Plans distributed queries and manages the work queue for the executor fleet.
+- **Scheduler** – Plans distributed queries and manages the work queue for the executor fleet. Also manages async query jobs when `scheduler.state_location` is configured.
 - **Executors** – One or more nodes responsible for executing physical query plans.
 
 The scheduler holds the cluster-wide configuration for a Spicepod, while executors connect to the scheduler to receive work. A cluster can run with a single scheduler for simplicity, or multiple schedulers for [high availability](#high-availability).
-
-### Network Ports
-
-Spice separates public and internal cluster traffic across different ports:
-
-| Port | Service | Description |
-|------|---------|-------------|
-| 50051 | Flight SQL | Public query endpoint |
-| 8090 | HTTP API | Public REST API |
-| 9090 | Prometheus | Metrics endpoint |
-| 50052 | Cluster Service | Internal scheduler/executor communication (mTLS enforced, by default) |
-
-Internal cluster services are isolated on port 50052 with mTLS enforced by default.
-
-## Secure Cluster Communication (mTLS)
-
-Distributed query cluster mode uses mutual TLS (mTLS) for secure communication between schedulers and executors. Internal cluster communication includes highly privileged RPC calls like fetching Spicepod configuration and expanding secrets. mTLS ensures only authenticated nodes can join the cluster and access sensitive data.
-
-### Certificate Requirements
-
-Each node in the cluster requires:
-
-- A CA certificate (`ca.crt`) trusted by all nodes
-- A node certificate with the node's advertise address in the Subject Alternative Names (SANs)
-- A private key for the node certificate
-
-Production deployments should use the organization's PKI infrastructure to generate certificates with proper SANs for each node.
-
-### Development Certificates
-
-For local development and testing, the Spice CLI provides commands to generate self-signed certificates:
-
-```bash
-# Initialize CA and generate CA certificate
-spice cluster tls init
-
-# Generate certificate for the scheduler node
-spice cluster tls add scheduler1
-
-# Generate certificate for an executor node
-spice cluster tls add executor1
-```
-
-Certificates are stored in `~/.spice/pki/` by default.
-
-:::warning
-CLI-generated certificates are not intended for production use. Production deployments should use certificates issued by the organization's PKI or a trusted certificate authority.
-:::
-
-### Insecure Mode
-
-For local development and testing, mTLS can be disabled using the `--allow-insecure-connections` flag:
-
-```bash
-spiced --role scheduler --allow-insecure-connections
-```
-
-:::warning
-Do not use `--allow-insecure-connections` in production environments. This flag disables authentication and encryption for internal cluster communication.
-:::
-
-### Network Ports
-
-Spice separates public and internal cluster traffic across different ports:
-
-| Port | Service | Description |
-|------|---------|-------------|
-| 50051 | Flight SQL | Public query endpoint |
-| 8090 | HTTP API | Public REST API |
-| 9090 | Prometheus | Metrics endpoint |
-| 50052 | Cluster Service | Internal scheduler/executor communication (mTLS enforced, by default) |
-
-Internal cluster services are isolated on port 50052 with mTLS enforced by default.
-
-## Secure Cluster Communication (mTLS)
-
-Distributed query cluster mode uses mutual TLS (mTLS) for secure communication between schedulers and executors. Internal cluster communication includes highly privileged RPC calls like fetching Spicepod configuration and expanding secrets. mTLS ensures only authenticated nodes can join the cluster and access sensitive data.
-
-### Certificate Requirements
-
-Each node in the cluster requires:
-
-- A CA certificate (`ca.crt`) trusted by all nodes
-- A node certificate with the node's advertise address in the Subject Alternative Names (SANs)
-- A private key for the node certificate
-
-Production deployments should use the organization's PKI infrastructure to generate certificates with proper SANs for each node.
-
-### Development Certificates
-
-For local development and testing, the Spice CLI provides commands to generate self-signed certificates:
-
-```bash
-# Initialize CA and generate CA certificate
-spice cluster tls init
-
-# Generate certificate for the scheduler node
-spice cluster tls add scheduler1
-
-# Generate certificate for an executor node
-spice cluster tls add executor1
-```
-
-Certificates are stored in `~/.spice/pki/` by default.
-
-:::warning
-CLI-generated certificates are not intended for production use. Production deployments should use certificates issued by the organization's PKI or a trusted certificate authority.
-:::
-
-### Insecure Mode
-
-For local development and testing, mTLS can be disabled using the `--allow-insecure-connections` flag:
-
-```bash
-spiced --role scheduler --allow-insecure-connections
-```
-
-:::warning
-Do not use `--allow-insecure-connections` in production environments. This flag disables authentication and encryption for internal cluster communication.
-:::
 
 ### Network Ports
 
@@ -261,6 +141,489 @@ EXPLAIN SELECT count(id) FROM my_dataset;
 - Accelerator support is planned for future releases; follow release notes for updates.
 
 :::
+
+## Async Queries API
+
+For long-running queries, the async queries API enables submitting queries for background execution, polling for status, and retrieving paginated results when ready.
+
+:::warning
+The async queries API is experimental and requires `scheduler.state_location` to be configured.
+:::
+
+### Prerequisites
+
+- Spice runtime running in cluster mode with `--role scheduler`
+- `scheduler.state_location` configured in the Spicepod (see [High Availability > Configuration](#configuration))
+- At least one executor node connected to the scheduler
+
+### Enabling Async Queries
+
+Configure `runtime.scheduler.state_location` in your `spicepod.yaml` to enable the async queries API:
+
+```yaml
+runtime:
+  scheduler:
+    state_location: s3://my-bucket/spice-state
+    params:
+      region: us-east-1
+```
+
+The state location is a shared object store (S3, GCS, Azure Blob, or local filesystem via `file://`) used to persist async query job state and result chunks.
+
+For local development:
+
+```yaml
+runtime:
+  scheduler:
+    state_location: "file://.data/scheduler-state"
+```
+
+### HTTP REST API
+
+Base path: `/v1/queries`
+
+#### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/queries` | Submit a query for async execution |
+| `GET` | `/v1/queries` | List all queries |
+| `GET` | `/v1/queries/{query_id}` | Get query status and first result chunk |
+| `GET` | `/v1/queries/{query_id}/status` | Get query status only |
+| `GET` | `/v1/queries/{query_id}/results` | Get results (with pagination) |
+| `GET` | `/v1/queries/{query_id}/results/chunks/{chunk_index}` | Get a specific result chunk |
+| `POST` | `/v1/queries/{query_id}/cancel` | Cancel a running query |
+
+#### Submit Query
+
+`POST /v1/queries`
+
+Submits a SQL query for asynchronous execution and returns immediately with a job ID.
+
+**Request Body** (`application/json`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sql` | string | Yes | SQL statement to execute |
+| `parameters` | array | No | Bind variables for parameterized queries (`$1`, `$2`, ...) |
+| `timeout_seconds` | integer | No | Maximum execution time in seconds. The query is cancelled and failed on timeout. |
+| `maximum_size` | integer | No | Maximum result size in bytes. The query is failed if results exceed this limit. |
+
+**Request Example**:
+
+```json
+{
+  "sql": "SELECT * FROM large_table WHERE status = $1 AND created_at > $2",
+  "parameters": ["active", "2025-01-01"],
+  "timeout_seconds": 300,
+  "maximum_size": 104857600
+}
+```
+
+**Response** (HTTP 202 Accepted):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "status": "PENDING",
+  "error": null,
+  "status_url": "/v1/queries/01ABC-DEF-456-7890AB/status",
+  "results_url": "/v1/queries/01ABC-DEF-456-7890AB/results"
+}
+```
+
+#### Get Query
+
+`GET /v1/queries/{query_id}`
+
+Returns the full query status, result manifest, and the first result chunk (if completed successfully).
+
+**Response** (HTTP 200):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "status": "SUCCEEDED",
+  "error": null,
+  "manifest": {
+    "format": "ARROW_IPC",
+    "schema": {
+      "column_count": 3,
+      "columns": [
+        { "name": "id", "type_name": "Int64", "nullable": false, "position": 0 },
+        { "name": "status", "type_name": "Utf8", "nullable": true, "position": 1 },
+        { "name": "created_at", "type_name": "Timestamp(Microsecond, Some(\"UTC\"))", "nullable": true, "position": 2 }
+      ]
+    },
+    "total_row_count": 25000,
+    "total_chunk_count": 3
+  },
+  "result": {
+    "chunk_index": 0,
+    "row_offset": 0,
+    "row_count": 10000,
+    "next_chunk_index": 1,
+    "next_chunk_url": "/v1/queries/01ABC-DEF-456-7890AB/results/chunks/1",
+    "data_array": [
+      { "id": 1, "status": "active", "created_at": "2025-06-15T10:30:00Z" }
+    ]
+  },
+  "created_at": "2026-03-02T12:00:00+00:00",
+  "started_at": "2026-03-02T12:00:00.050+00:00",
+  "completed_at": "2026-03-02T12:00:05.200+00:00",
+  "expires_at": "2026-03-03T00:00:05.200+00:00"
+}
+```
+
+#### Get Status
+
+`GET /v1/queries/{query_id}/status`
+
+Returns the current status of a query without result data. Use this for lightweight polling.
+
+**Response** (HTTP 200):
+
+```json
+{
+  "status": "RUNNING",
+  "error": null
+}
+```
+
+When the query has failed:
+
+```json
+{
+  "status": "FAILED",
+  "error": {
+    "error_code": "EXECUTION_FAILED",
+    "message": "Table 'missing_table' not found",
+    "sql_state": null
+  }
+}
+```
+
+#### Get Results
+
+`GET /v1/queries/{query_id}/results`
+
+Returns result data for a completed query. Use the `partition` query parameter to paginate through chunks.
+
+**Query Parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `partition` | integer | `0` | Chunk index to retrieve (0-based) |
+
+**Response** (HTTP 200):
+
+```json
+{
+  "chunk_index": 0,
+  "row_offset": 0,
+  "row_count": 10000,
+  "next_chunk_index": 1,
+  "next_chunk_url": "/v1/queries/01ABC-DEF-456-7890AB/results/chunks/1",
+  "data_array": [
+    { "id": 1, "status": "active" }
+  ]
+}
+```
+
+When the last chunk is reached, `next_chunk_index` and `next_chunk_url` are `null`.
+
+#### Get Chunk
+
+`GET /v1/queries/{query_id}/results/chunks/{chunk_index}`
+
+Returns a specific result chunk by index. Same response format as **Get Results**.
+
+#### Cancel Query
+
+`POST /v1/queries/{query_id}/cancel`
+
+Cancels a running query. Also cancels the underlying distributed query on the Ballista scheduler.
+
+**Response** (HTTP 200):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "status": "CANCELLED",
+  "error": null,
+  "manifest": null,
+  "result": null,
+  "created_at": "2026-03-02T12:00:00+00:00",
+  "started_at": "2026-03-02T12:00:00.050+00:00",
+  "completed_at": "2026-03-02T12:00:02.100+00:00",
+  "expires_at": null
+}
+```
+
+#### List Queries
+
+`GET /v1/queries`
+
+Lists all queries, optionally filtered by status.
+
+**Query Parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `status` | string | *all* | Filter by status: `queued`/`pending`, `running`, `completed`/`succeeded`, `failed`, `cancelled`, `closed` |
+| `limit` | integer | `100` | Maximum number of results |
+
+**Response** (HTTP 200):
+
+```json
+{
+  "queries": [
+    {
+      "query_id": "01ABC-DEF-456-7890AB",
+      "status": "RUNNING",
+      "sql_preview": "SELECT * FROM large_table WHERE status = ...",
+      "created_at": "2026-03-02T12:00:00+00:00"
+    }
+  ],
+  "total_count": 1
+}
+```
+
+The `sql_preview` field contains the first 100 characters of the SQL statement.
+
+#### HTTP Error Responses
+
+| HTTP Status | Condition |
+|-------------|-----------|
+| 202 Accepted | Query successfully submitted |
+| 200 OK | Status/results retrieved successfully |
+| 404 Not Found | Query ID, chunk, or result not found |
+| 409 Conflict | Query not yet complete (when fetching results by chunk) |
+| 410 Gone | Query results have expired |
+| 425 Too Early | Query still running (results endpoint) |
+| 500 Internal Server Error | Execution or serialization failure |
+| 503 Service Unavailable | Not running in scheduler cluster mode, or executor not yet initialized |
+
+### Arrow Flight API
+
+The async query API is also available via Apache Arrow Flight `DoAction` requests. This is more efficient for programmatic access since results are returned in Arrow IPC binary format instead of JSON.
+
+| Action Type | Request Body (JSON) | Response |
+|-------------|---------------------|----------|
+| `SubmitAsyncQuery` | `{"sql": "...", "parameters": [...]}` | JSON: `{"query_id": "...", "status": "PENDING"}` |
+| `GetAsyncQueryStatus` | `{"query_id": "..."}` | JSON: query status with error/result metadata |
+| `GetAsyncQueryResult` | `{"query_id": "...", "chunk_index": 0}` | Binary: Arrow IPC stream |
+| `CancelAsyncQuery` | `{"query_id": "..."}` | JSON: `{"query_id": "...", "cancelled": true, "status": "CANCELLED"}` |
+
+#### SubmitAsyncQuery
+
+**Request**:
+
+```json
+{
+  "sql": "SELECT * FROM large_table",
+  "parameters": []
+}
+```
+
+**Response** (JSON):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "status": "PENDING"
+}
+```
+
+#### GetAsyncQueryStatus
+
+**Request**:
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB"
+}
+```
+
+**Response** (JSON):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "status": "SUCCEEDED",
+  "error": null,
+  "result": {
+    "total_row_count": 25000,
+    "total_chunk_count": 3
+  }
+}
+```
+
+#### GetAsyncQueryResult
+
+**Request**:
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "chunk_index": 0
+}
+```
+
+**Response**: Arrow IPC binary stream containing the `RecordBatch` data for the requested chunk.
+
+#### CancelAsyncQuery
+
+**Request**:
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB"
+}
+```
+
+**Response** (JSON):
+
+```json
+{
+  "query_id": "01ABC-DEF-456-7890AB",
+  "cancelled": true,
+  "status": "CANCELLED"
+}
+```
+
+### CLI
+
+The `spice query` command provides a CLI and interactive REPL for the async queries API.
+
+#### Submit and Wait
+
+```bash
+spice query "SELECT * FROM orders WHERE total > 100 LIMIT 50;"
+```
+
+The CLI auto-polls with a spinner and displays results when ready. Press `Ctrl+C` to stop waiting — the query continues running in the background.
+
+#### Submit Without Waiting
+
+```bash
+spice query "SELECT * FROM large_table;" --no-wait
+```
+
+#### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--no-wait` | `false` | Submit the query and return immediately without waiting for results |
+| `--timeout <DURATION>` | *none* | Maximum client-side wait time (e.g., `30s`, `5m`). The query itself continues running on timeout. |
+| `-o, --output <FORMAT>` | `table` | Output format: `table` or `json` |
+
+#### Subcommands
+
+```bash
+spice query list [--status X] [--limit N]    # List queries
+spice query status <query_id>                # Check query status
+spice query results <query_id>               # Fetch results of completed query
+spice query cancel <query_id>                # Cancel a running query
+```
+
+#### Interactive REPL
+
+When invoked without arguments, `spice query` starts an interactive REPL:
+
+```
+query> SELECT COUNT(*)
+     > FROM large_table
+     > WHERE status = 'active';
+Submitted query: 01ABC-DEF-456-7890AB (PENDING)
+Press Ctrl+C to stop waiting (query continues in background)
+⠹ RUNNING (2.3s)...
+✓ SUCCEEDED (5.1s)
++----------+
+| count(*) |
++----------+
+| 42000    |
++----------+
+
+Time: 5.10000000 seconds. 1 rows.
+```
+
+**REPL Commands**:
+
+| Command | Description |
+|---------|-------------|
+| `.list` | List all queries tracked in this REPL session |
+| `.status <id>` | Show detailed status of a query |
+| `.results <id>` | Fetch and display results of a completed query |
+| `.wait <id>` | Resume waiting for a query to complete |
+| `.cancel <id>` | Cancel a running query |
+| `.clear` | Clear the local tracked queries list |
+| `.clear history` | Clear command history |
+| `.help` | Show available commands |
+| `.exit`, `.quit`, `.q` | Exit the REPL |
+
+Query IDs can be abbreviated if they uniquely identify a query within the tracked session.
+
+### Job Lifecycle
+
+```
+PENDING → RUNNING → SUCCEEDED → CLOSED (after 12h TTL)
+                   → FAILED
+                   → CANCELLED
+```
+
+| Status | Description |
+|--------|-------------|
+| `PENDING` | Job is queued but not yet executing |
+| `RUNNING` | Job is actively executing on the distributed cluster |
+| `SUCCEEDED` | Job completed successfully, results are available |
+| `FAILED` | Job execution failed (see `error` field for details) |
+| `CANCELLED` | Job was cancelled by the user |
+| `CLOSED` | Job results have expired and been cleaned up |
+
+### Error Codes
+
+When a query fails, the `error` object contains an `error_code` field:
+
+| Error Code | Description |
+|------------|-------------|
+| `SCHEDULER_UNAVAILABLE` | The Ballista scheduler is not reachable |
+| `SUBMISSION_FAILED` | Failed to submit the query to the distributed scheduler |
+| `EXECUTION_FAILED` | The query failed during execution |
+| `FETCHING_RESULTS_FAILED` | Failed to retrieve results from executor nodes |
+| `CANCELLED` | The query was explicitly cancelled |
+| `PARAMETER_BINDING_FAILED` | Failed to bind the provided query parameters |
+| `NOT_FOUND` | The referenced query or job was not found |
+| `INTERNAL` | An unexpected internal error occurred |
+| `TIMEOUT` | The query exceeded the configured `timeout_seconds` |
+
+### Storage Layout
+
+Job state and result chunks are stored in the shared object store configured via `scheduler.state_location`:
+
+```
+{base_prefix}/
+├── jobs/
+│   ├── {job_id}.json          # Job state (JSON)
+│   └── {job_id}/
+│       ├── chunk_0.arrow      # Result chunk 0 (Arrow IPC)
+│       ├── chunk_1.arrow      # Result chunk 1
+│       └── ...
+```
+
+### Defaults and Limitations
+
+| Setting | Default |
+|---------|---------|
+| Chunk size | 10,000 rows |
+| Result TTL | 12 hours |
+| List limit | 100 queries |
+
+- Only available in cluster mode with `--role scheduler`
+- Requires `scheduler.state_location` to be configured
+- The `format` query parameter on the results endpoint is declared but not yet implemented (results are always JSON over HTTP, Arrow IPC over Flight)
+- Result TTL is not yet configurable per-query (fixed at 12 hours)
+- Chunk size is not yet configurable per-query (fixed at 10,000 rows)
 
 ## High Availability
 

--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -30,11 +30,11 @@ The scheduler holds the cluster-wide configuration for a Spicepod, while executo
 
 Spice separates public and internal cluster traffic across different ports:
 
-| Port | Service | Description |
-|------|---------|-------------|
-| 50051 | Flight SQL | Public query endpoint |
-| 8090 | HTTP API | Public REST API |
-| 9090 | Prometheus | Metrics endpoint |
+| Port  | Service         | Description                                                           |
+| ----- | --------------- | --------------------------------------------------------------------- |
+| 50051 | Flight SQL      | Public query endpoint                                                 |
+| 8090  | HTTP API        | Public REST API                                                       |
+| 9090  | Prometheus      | Metrics endpoint                                                      |
 | 50052 | Cluster Service | Internal scheduler/executor communication (mTLS enforced, by default) |
 
 Internal cluster services are isolated on port 50052 with mTLS enforced by default.
@@ -184,15 +184,15 @@ Base path: `/v1/queries`
 
 #### Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/v1/queries` | Submit a query for async execution |
-| `GET` | `/v1/queries` | List all queries |
-| `GET` | `/v1/queries/{query_id}` | Get query status and first result chunk |
-| `GET` | `/v1/queries/{query_id}/status` | Get query status only |
-| `GET` | `/v1/queries/{query_id}/results` | Get results (with pagination) |
-| `GET` | `/v1/queries/{query_id}/results/chunks/{chunk_index}` | Get a specific result chunk |
-| `POST` | `/v1/queries/{query_id}/cancel` | Cancel a running query |
+| Method | Path                                                  | Description                             |
+| ------ | ----------------------------------------------------- | --------------------------------------- |
+| `POST` | `/v1/queries`                                         | Submit a query for async execution      |
+| `GET`  | `/v1/queries`                                         | List all queries                        |
+| `GET`  | `/v1/queries/{query_id}`                              | Get query status and first result chunk |
+| `GET`  | `/v1/queries/{query_id}/status`                       | Get query status only                   |
+| `GET`  | `/v1/queries/{query_id}/results`                      | Get results (with pagination)           |
+| `GET`  | `/v1/queries/{query_id}/results/chunks/{chunk_index}` | Get a specific result chunk             |
+| `POST` | `/v1/queries/{query_id}/cancel`                       | Cancel a running query                  |
 
 #### Submit Query
 
@@ -202,12 +202,12 @@ Submits a SQL query for asynchronous execution and returns immediately with a jo
 
 **Request Body** (`application/json`):
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `sql` | string | Yes | SQL statement to execute |
-| `parameters` | array | No | Bind variables for parameterized queries (`$1`, `$2`, ...) |
-| `timeout_seconds` | integer | No | Maximum execution time in seconds. The query is cancelled and failed on timeout. |
-| `maximum_size` | integer | No | Maximum result size in bytes. The query is failed if results exceed this limit. |
+| Field             | Type    | Required | Description                                                                      |
+| ----------------- | ------- | -------- | -------------------------------------------------------------------------------- |
+| `sql`             | string  | Yes      | SQL statement to execute                                                         |
+| `parameters`      | array   | No       | Bind variables for parameterized queries (`$1`, `$2`, ...)                       |
+| `timeout_seconds` | integer | No       | Maximum execution time in seconds. The query is cancelled and failed on timeout. |
+| `maximum_size`    | integer | No       | Maximum result size in bytes. The query is failed if results exceed this limit.  |
 
 **Request Example**:
 
@@ -311,9 +311,9 @@ Returns result data for a completed query. Use the `partition` query parameter t
 
 **Query Parameters**:
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `partition` | integer | `0` | Chunk index to retrieve (0-based) |
+| Parameter   | Type    | Default | Description                       |
+| ----------- | ------- | ------- | --------------------------------- |
+| `partition` | integer | `0`     | Chunk index to retrieve (0-based) |
 
 **Response** (HTTP 200):
 
@@ -368,10 +368,10 @@ Lists all queries, optionally filtered by status.
 
 **Query Parameters**:
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `status` | string | *all* | Filter by status: `queued`/`pending`, `running`, `completed`/`succeeded`, `failed`, `cancelled`, `closed` |
-| `limit` | integer | `100` | Maximum number of results |
+| Parameter | Type    | Default | Description                                                                                               |
+| --------- | ------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `status`  | string  | *all*   | Filter by status: `queued`/`pending`, `running`, `completed`/`succeeded`, `failed`, `cancelled`, `closed` |
+| `limit`   | integer | `100`   | Maximum number of results                                                                                 |
 
 **Response** (HTTP 200):
 
@@ -393,27 +393,27 @@ The `sql_preview` field contains the first 100 characters of the SQL statement.
 
 #### HTTP Error Responses
 
-| HTTP Status | Condition |
-|-------------|-----------|
-| 202 Accepted | Query successfully submitted |
-| 200 OK | Status/results retrieved successfully |
-| 404 Not Found | Query ID, chunk, or result not found |
-| 409 Conflict | Query not yet complete (when fetching results by chunk) |
-| 410 Gone | Query results have expired |
-| 425 Too Early | Query still running (results endpoint) |
-| 500 Internal Server Error | Execution or serialization failure |
-| 503 Service Unavailable | Not running in scheduler cluster mode, or executor not yet initialized |
+| HTTP Status               | Condition                                                              |
+| ------------------------- | ---------------------------------------------------------------------- |
+| 202 Accepted              | Query successfully submitted                                           |
+| 200 OK                    | Status/results retrieved successfully                                  |
+| 404 Not Found             | Query ID, chunk, or result not found                                   |
+| 409 Conflict              | Query not yet complete (when fetching results by chunk)                |
+| 410 Gone                  | Query results have expired                                             |
+| 425 Too Early             | Query still running (results endpoint)                                 |
+| 500 Internal Server Error | Execution or serialization failure                                     |
+| 503 Service Unavailable   | Not running in scheduler cluster mode, or executor not yet initialized |
 
 ### Arrow Flight API
 
 The async query API is also available via Apache Arrow Flight `DoAction` requests. This is more efficient for programmatic access since results are returned in Arrow IPC binary format instead of JSON.
 
-| Action Type | Request Body (JSON) | Response |
-|-------------|---------------------|----------|
-| `SubmitAsyncQuery` | `{"sql": "...", "parameters": [...]}` | JSON: `{"query_id": "...", "status": "PENDING"}` |
-| `GetAsyncQueryStatus` | `{"query_id": "..."}` | JSON: query status with error/result metadata |
-| `GetAsyncQueryResult` | `{"query_id": "...", "chunk_index": 0}` | Binary: Arrow IPC stream |
-| `CancelAsyncQuery` | `{"query_id": "..."}` | JSON: `{"query_id": "...", "cancelled": true, "status": "CANCELLED"}` |
+| Action Type           | Request Body (JSON)                     | Response                                                              |
+| --------------------- | --------------------------------------- | --------------------------------------------------------------------- |
+| `SubmitAsyncQuery`    | `{"sql": "...", "parameters": [...]}`   | JSON: `{"query_id": "...", "status": "PENDING"}`                      |
+| `GetAsyncQueryStatus` | `{"query_id": "..."}`                   | JSON: query status with error/result metadata                         |
+| `GetAsyncQueryResult` | `{"query_id": "...", "chunk_index": 0}` | Binary: Arrow IPC stream                                              |
+| `CancelAsyncQuery`    | `{"query_id": "..."}`                   | JSON: `{"query_id": "...", "cancelled": true, "status": "CANCELLED"}` |
 
 #### SubmitAsyncQuery
 
@@ -512,11 +512,11 @@ spice query "SELECT * FROM large_table;" --no-wait
 
 #### Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--no-wait` | `false` | Submit the query and return immediately without waiting for results |
-| `--timeout <DURATION>` | *none* | Maximum client-side wait time (e.g., `30s`, `5m`). The query itself continues running on timeout. |
-| `-o, --output <FORMAT>` | `table` | Output format: `table` or `json` |
+| Option                  | Default | Description                                                                                       |
+| ----------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `--no-wait`             | `false` | Submit the query and return immediately without waiting for results                               |
+| `--timeout <DURATION>`  | *none*  | Maximum client-side wait time (e.g., `30s`, `5m`). The query itself continues running on timeout. |
+| `-o, --output <FORMAT>` | `table` | Output format: `table` or `json`                                                                  |
 
 #### Subcommands
 
@@ -550,17 +550,17 @@ Time: 5.10000000 seconds. 1 rows.
 
 **REPL Commands**:
 
-| Command | Description |
-|---------|-------------|
-| `.list` | List all queries tracked in this REPL session |
-| `.status <id>` | Show detailed status of a query |
-| `.results <id>` | Fetch and display results of a completed query |
-| `.wait <id>` | Resume waiting for a query to complete |
-| `.cancel <id>` | Cancel a running query |
-| `.clear` | Clear the local tracked queries list |
-| `.clear history` | Clear command history |
-| `.help` | Show available commands |
-| `.exit`, `.quit`, `.q` | Exit the REPL |
+| Command                | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `.list`                | List all queries tracked in this REPL session  |
+| `.status <id>`         | Show detailed status of a query                |
+| `.results <id>`        | Fetch and display results of a completed query |
+| `.wait <id>`           | Resume waiting for a query to complete         |
+| `.cancel <id>`         | Cancel a running query                         |
+| `.clear`               | Clear the local tracked queries list           |
+| `.clear history`       | Clear command history                          |
+| `.help`                | Show available commands                        |
+| `.exit`, `.quit`, `.q` | Exit the REPL                                  |
 
 Query IDs can be abbreviated if they uniquely identify a query within the tracked session.
 
@@ -572,30 +572,30 @@ PENDING → RUNNING → SUCCEEDED → CLOSED (after 12h TTL)
                    → CANCELLED
 ```
 
-| Status | Description |
-|--------|-------------|
-| `PENDING` | Job is queued but not yet executing |
-| `RUNNING` | Job is actively executing on the distributed cluster |
-| `SUCCEEDED` | Job completed successfully, results are available |
-| `FAILED` | Job execution failed (see `error` field for details) |
-| `CANCELLED` | Job was cancelled by the user |
-| `CLOSED` | Job results have expired and been cleaned up |
+| Status      | Description                                          |
+| ----------- | ---------------------------------------------------- |
+| `PENDING`   | Job is queued but not yet executing                  |
+| `RUNNING`   | Job is actively executing on the distributed cluster |
+| `SUCCEEDED` | Job completed successfully, results are available    |
+| `FAILED`    | Job execution failed (see `error` field for details) |
+| `CANCELLED` | Job was cancelled by the user                        |
+| `CLOSED`    | Job results have expired and been cleaned up         |
 
 ### Error Codes
 
 When a query fails, the `error` object contains an `error_code` field:
 
-| Error Code | Description |
-|------------|-------------|
-| `SCHEDULER_UNAVAILABLE` | The Ballista scheduler is not reachable |
-| `SUBMISSION_FAILED` | Failed to submit the query to the distributed scheduler |
-| `EXECUTION_FAILED` | The query failed during execution |
-| `FETCHING_RESULTS_FAILED` | Failed to retrieve results from executor nodes |
-| `CANCELLED` | The query was explicitly cancelled |
-| `PARAMETER_BINDING_FAILED` | Failed to bind the provided query parameters |
-| `NOT_FOUND` | The referenced query or job was not found |
-| `INTERNAL` | An unexpected internal error occurred |
-| `TIMEOUT` | The query exceeded the configured `timeout_seconds` |
+| Error Code                 | Description                                             |
+| -------------------------- | ------------------------------------------------------- |
+| `SCHEDULER_UNAVAILABLE`    | The Ballista scheduler is not reachable                 |
+| `SUBMISSION_FAILED`        | Failed to submit the query to the distributed scheduler |
+| `EXECUTION_FAILED`         | The query failed during execution                       |
+| `FETCHING_RESULTS_FAILED`  | Failed to retrieve results from executor nodes          |
+| `CANCELLED`                | The query was explicitly cancelled                      |
+| `PARAMETER_BINDING_FAILED` | Failed to bind the provided query parameters            |
+| `NOT_FOUND`                | The referenced query or job was not found               |
+| `INTERNAL`                 | An unexpected internal error occurred                   |
+| `TIMEOUT`                  | The query exceeded the configured `timeout_seconds`     |
 
 ### Storage Layout
 
@@ -613,10 +613,10 @@ Job state and result chunks are stored in the shared object store configured via
 
 ### Defaults and Limitations
 
-| Setting | Default |
-|---------|---------|
+| Setting    | Default     |
+| ---------- | ----------- |
 | Chunk size | 10,000 rows |
-| Result TTL | 12 hours |
+| Result TTL | 12 hours    |
 | List limit | 100 queries |
 
 - Only available in cluster mode with `--role scheduler`
@@ -674,16 +674,16 @@ The object store is used for scheduler registration and discovery. Job state per
 
 The `runtime.scheduler.params` section supports the following S3 parameters:
 
-| Parameter        | Description                                           | Default    |
-| ---------------- | ----------------------------------------------------- | ---------- |
-| `region`         | AWS region for the S3 bucket                          | -          |
-| `endpoint`       | Custom S3-compatible endpoint URL                     | -          |
-| `auth`           | Authentication method: `iam_role` or `key`            | `iam_role` |
-| `key`            | AWS access key ID (when `auth: key`)                  | -          |
-| `secret`         | AWS secret access key (when `auth: key`)              | -          |
-| `session_token`  | AWS session token for temporary credentials           | -          |
-| `client_timeout` | S3 client timeout                                     | -          |
-| `allow_http`     | Allow HTTP (non-TLS) connections to S3 endpoint       | `false`    |
+| Parameter        | Description                                     | Default    |
+| ---------------- | ----------------------------------------------- | ---------- |
+| `region`         | AWS region for the S3 bucket                    | -          |
+| `endpoint`       | Custom S3-compatible endpoint URL               | -          |
+| `auth`           | Authentication method: `iam_role` or `key`      | `iam_role` |
+| `key`            | AWS access key ID (when `auth: key`)            | -          |
+| `secret`         | AWS secret access key (when `auth: key`)        | -          |
+| `session_token`  | AWS session token for temporary credentials     | -          |
+| `client_timeout` | S3 client timeout                               | -          |
+| `allow_http`     | Allow HTTP (non-TLS) connections to S3 endpoint | `false`    |
 
 Example with explicit credentials:
 

--- a/website/versioned_docs/version-1.11.x/cli/reference/index.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/index.md
@@ -35,7 +35,7 @@ spice [command] [--help]
 | [models](reference/models)         | Lists models loaded by the Spice runtime                            |
 | nsql                               | Text-to-SQL REPL - translate natural language to SQL                |
 | [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                         |
-| query                              | Submit an async query or start an interactive async query REPL      |
+| [query](reference/query)           | Submit an async query or start an interactive async query REPL      |
 | [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                       |
 | [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary       |
 | [search](reference/search)         | Search datasets with embeddings                                     |

--- a/website/versioned_docs/version-1.11.x/cli/reference/index.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/index.md
@@ -15,36 +15,36 @@ spice [command] [--help]
 
 ### Full Command Reference
 
-| Command                                | Description                                                         |
-| -------------------------------------- | ------------------------------------------------------------------- |
-| [acceleration](reference/acceleration) | Manage dataset acceleration features                                |
-| [add](reference/add)                   | Add Spicepod - adds a Spicepod to the project                       |
-| [catalogs](reference/catalogs)         | List [catalogs](../components/catalogs) loaded by the Spice runtime |
-| [chat](reference/chat)                 | Chat with an LLM                                                    |
-| [cloud](reference/cloud)               | Manage Spice Cloud resources                                        |
-| [cluster](reference/cluster)           | Cluster operations for the Spice runtime                            |
-| [completion](reference/completion)     | Generate the autocompletion script for the specified shell          |
-| [connect](reference/connect)           | Connect to a Spice.ai Cloud Platform app                            |
-| [dataset](reference/dataset)           | Dataset operations (configure datasets)                             |
-| [datasets](reference/datasets)         | Lists datasets loaded by the Spice runtime                          |
-| [eval](reference/eval)                 | Run model evaluation                                                |
-| help                                   | Help about any command                                              |
-| [init](reference/init)                 | Initialize Spice app - creates a new spicepod.yaml                  |
-| [install](reference/install)           | Install or reinstall the Spice.ai runtime                           |
-| [login](reference/login)               | Login to Spice.ai or configure credentials for data sources         |
-| [models](reference/models)             | Lists models loaded by the Spice runtime                            |
-| [nsql](reference/nsql)                 | Text-to-SQL REPL - translate natural language to SQL                |
-| [pods](reference/pods)                 | Lists Spicepods loaded by the Spice runtime                         |
-| [query](reference/query)               | Submit an async query or start an interactive async query REPL      |
-| [refresh](reference/refresh)           | Refresh a dataset loaded by the Spice runtime                       |
-| [run](reference/run)                   | Run Spice - starts the Spice runtime, installing if necessary       |
-| [search](reference/search)             | Search datasets with embeddings                                     |
-| [sql](reference/sql)                   | Start an interactive SQL query session against the Spice runtime    |
-| [status](reference/status)             | Spice runtime status                                                |
-| [trace](reference/trace)               | Return traces for operations that occurred in Spice                 |
-| [upgrade](reference/upgrade)           | Upgrades the Spice CLI and runtime to the latest release            |
-| [version](reference/version)           | Spice CLI version                                                   |
-| [workers](reference/workers)           | Lists workers loaded by the Spice runtime                           |
+| Command                            | Description                                                         |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| acceleration                       | Manage dataset acceleration features                                |
+| [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                       |
+| [catalogs](reference/catalogs)     | List [catalogs](../components/catalogs) loaded by the Spice runtime |
+| [chat](reference/chat)             | Chat with an LLM                                                    |
+| cloud                              | Manage Spice Cloud resources                                        |
+| cluster                            | Cluster operations for the Spice runtime                            |
+| [completion](reference/completion) | Generate the autocompletion script for the specified shell          |
+| [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                            |
+| [dataset](reference/dataset)       | Dataset operations (configure datasets)                             |
+| [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                          |
+| eval                               | Run model evaluation                                                |
+| help                               | Help about any command                                              |
+| [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                  |
+| [install](reference/install)       | Install or reinstall the Spice.ai runtime                           |
+| [login](reference/login)           | Login to Spice.ai or configure credentials for data sources         |
+| [models](reference/models)         | Lists models loaded by the Spice runtime                            |
+| nsql                               | Text-to-SQL REPL - translate natural language to SQL                |
+| [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                         |
+| query                              | Submit an async query or start an interactive async query REPL      |
+| [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                       |
+| [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary       |
+| [search](reference/search)         | Search datasets with embeddings                                     |
+| [sql](reference/sql)               | Start an interactive SQL query session against the Spice runtime    |
+| [status](reference/status)         | Spice runtime status                                                |
+| [trace](reference/trace)           | Return traces for operations that occurred in Spice                 |
+| [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest release            |
+| [version](reference/version)       | Spice CLI version                                                   |
+| workers                            | Lists workers loaded by the Spice runtime                           |
 
 ### Command Flags
 

--- a/website/versioned_docs/version-1.11.x/cli/reference/query.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/query.md
@@ -1,0 +1,88 @@
+---
+title: 'query'
+sidebar_label: 'query'
+pagination_prev: null
+pagination_next: null
+---
+
+Submit an async query or start an interactive async query REPL against the Spice runtime's distributed query engine.
+
+### Usage
+
+```shell
+spice query [flags] [SQL]
+```
+
+When invoked with a SQL statement, submits it as an async query and waits for the result. When invoked without arguments, starts an interactive REPL.
+
+#### Flags
+
+- `--no-wait` Submit the query and return immediately without waiting for results.
+- `--timeout <DURATION>` Maximum client-side wait time (e.g., `30s`, `5m`). The query continues running on timeout.
+- `-o`, `--output <FORMAT>` Output format: `table` (default) or `json`.
+- `-h`, `--help` Print this help message.
+
+#### Subcommands
+
+| Subcommand                                  | Description                        |
+| ------------------------------------------- | ---------------------------------- |
+| `spice query list [--status X] [--limit N]` | List queries                       |
+| `spice query status <query_id>`             | Check query status                 |
+| `spice query results <query_id>`            | Fetch results of a completed query |
+| `spice query cancel <query_id>`             | Cancel a running query             |
+
+### Examples
+
+#### Submit and Wait
+
+```shell
+$ spice query "SELECT * FROM orders WHERE total > 100 LIMIT 50;"
+```
+
+The CLI auto-polls with a spinner and displays results when ready. Press `Ctrl+C` to stop waiting — the query continues running in the background.
+
+#### Submit Without Waiting
+
+```shell
+$ spice query "SELECT * FROM large_table;" --no-wait
+```
+
+#### Interactive REPL
+
+```shell
+$ spice query
+query> SELECT COUNT(*)
+     > FROM large_table
+     > WHERE status = 'active';
+Submitted query: 01ABC-DEF-456-7890AB (PENDING)
+Press Ctrl+C to stop waiting (query continues in background)
+⠹ RUNNING (2.3s)...
+✓ SUCCEEDED (5.1s)
++----------+
+| count(*) |
++----------+
+| 42000    |
++----------+
+
+Time: 5.10000000 seconds. 1 rows.
+```
+
+**REPL Commands**:
+
+| Command                | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `.list`                | List all queries tracked in this REPL session  |
+| `.status <id>`         | Show detailed status of a query                |
+| `.results <id>`        | Fetch and display results of a completed query |
+| `.wait <id>`           | Resume waiting for a query to complete         |
+| `.cancel <id>`         | Cancel a running query                         |
+| `.clear`               | Clear the local tracked queries list           |
+| `.clear history`       | Clear command history                          |
+| `.help`                | Show available commands                        |
+| `.exit`, `.quit`, `.q` | Exit the REPL                                  |
+
+Query IDs can be abbreviated if they uniquely identify a query within the tracked session.
+
+:::note
+The `spice query` command requires the runtime to be running in [cluster mode](/docs/features/distributed-query) with `--role scheduler` and `scheduler.state_location` configured.
+:::

--- a/website/versioned_docs/version-1.11.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/run.md
@@ -38,7 +38,7 @@ Flags that are passed to the `spiced` runtime directly using `--`.
 - `--repl` Start a SQL REPL against the runtime's Flight endpoint
 - `-v`, `--verbose` Enable verbose logging (use `-vv` for more detail)
 - `--very-verbose` Enable very verbose logging
-- `--set-runtime` Override [runtime configuration](../reference/spicepod/#runtime) with a name/value pair specified as `name=value`. Multiple overrides can be specified by using the flag multiple times.
+- `--set-runtime` Override [runtime configuration](../../reference/spicepod/#runtime) with a name/value pair specified as `name=value`. Multiple overrides can be specified by using the flag multiple times.
 - `[PATH]` Positional argument specifying the path to a Spicepod directory or file. Supports local paths and `s3://` remote URLs.
 
 ### Examples

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/runtime.md
@@ -457,7 +457,7 @@ runtime:
 
 ## `runtime.scheduler`
 
-Configures the cluster scheduler when running Spice in [cluster mode](../deployment/architectures/cluster). This section is relevant only when using `--role scheduler`.
+Configures the cluster scheduler when running Spice in [cluster mode](../../deployment/architectures/cluster). This section is relevant only when using `--role scheduler`.
 
 ```yaml
 runtime:


### PR DESCRIPTION
Integrates the full async queries API reference (HTTP REST, Arrow Flight, CLI, REPL) into the distributed query feature doc. Also fixes duplicated Network Ports and mTLS sections (3x -> 1x). Related cookbook PR: https://github.com/spiceai/cookbook/pull/357