### PR TITLE
Enhance documentation on PostgreSQL identifier handling in datasets and SELECT syntax

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -130,6 +130,28 @@ datasets:
 
 The name of the dataset. Used to reference the dataset in the pod manifest, as well as in external data sources. The name cannot be a [reserved keyword](./keywords).
 
+Spice follows PostgreSQL SQL syntax conventions, which normalize unquoted identifiers to lowercase. A dataset named `LINEITEM` is accessible in queries as `lineitem`.
+
+To preserve uppercase or mixed-case names, wrap the name in double quotes. In YAML, this requires an extra layer of quoting:
+
+```yaml
+datasets:
+  - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM
+    name: '"LINEITEM"'
+    params:
+      snowflake_account: JYFGIWYEFBW
+      snowflake_warehouse: snowflake_wh
+      snowflake_password: ${secrets:SNOWFLAKE_PASSWORD}
+      snowflake_username: ${secrets:SNOWFLAKE_USERNAME}
+```
+
+```sql
+-- Query using the preserved uppercase name
+SELECT * FROM "LINEITEM";
+```
+
+Without the double quotes, the same dataset would be queryable only as `lineitem`.
+
 ## `description`
 
 The description of the dataset. Used as part of the [Semantic Data Model](../../features/semantic-model).

--- a/website/docs/reference/sql/select.md
+++ b/website/docs/reference/sql/select.md
@@ -13,7 +13,19 @@ Spice is built on [Apache DataFusion](https://datafusion.apache.org/) and uses t
 ## SELECT syntax
 
 The queries in Spice scan data from tables and return 0 or more rows.
-Please be aware that column names in queries are made lower-case, but not on the inferred schema. Accordingly, if you want to query against a capitalized field, make sure to use double quotes.
+
+Spice follows PostgreSQL conventions for identifier handling: unquoted identifiers (table and column names) are normalized to lowercase. To reference a table or column with uppercase or mixed-case characters, wrap the identifier in double quotes.
+
+```sql
+-- These are equivalent (both reference the lowercase table name)
+SELECT * FROM lineitem;
+SELECT * FROM LINEITEM;
+
+-- Double quotes preserve the exact casing
+SELECT * FROM "LINEITEM";
+```
+
+See [dataset `name` configuration](../spicepod/datasets#name) for how to set a case-sensitive dataset name in the Spicepod manifest.
 
 Spice supports the following syntax for queries:
 

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -130,6 +130,28 @@ datasets:
 
 The name of the dataset. Used to reference the dataset in the pod manifest, as well as in external data sources. The name cannot be a [reserved keyword](./keywords).
 
+Spice follows PostgreSQL SQL syntax conventions, which normalize unquoted identifiers to lowercase. A dataset named `LINEITEM` is accessible in queries as `lineitem`.
+
+To preserve uppercase or mixed-case names, wrap the name in double quotes. In YAML, this requires an extra layer of quoting:
+
+```yaml
+datasets:
+  - from: snowflake:SNOWFLAKE_SAMPLE_DATA.TPCH_SF100.LINEITEM
+    name: '"LINEITEM"'
+    params:
+      snowflake_account: JYFGIWYEFBW
+      snowflake_warehouse: snowflake_wh
+      snowflake_password: ${secrets:SNOWFLAKE_PASSWORD}
+      snowflake_username: ${secrets:SNOWFLAKE_USERNAME}
+```
+
+```sql
+-- Query using the preserved uppercase name
+SELECT * FROM "LINEITEM";
+```
+
+Without the double quotes, the same dataset would be queryable only as `lineitem`.
+
 ## `description`
 
 The description of the dataset. Used as part of the [Semantic Data Model](../../features/semantic-model).

--- a/website/versioned_docs/version-1.11.x/reference/sql/select.md
+++ b/website/versioned_docs/version-1.11.x/reference/sql/select.md
@@ -13,7 +13,19 @@ Spice is built on [Apache DataFusion](https://datafusion.apache.org/) and uses t
 ## SELECT syntax
 
 The queries in Spice scan data from tables and return 0 or more rows.
-Please be aware that column names in queries are made lower-case, but not on the inferred schema. Accordingly, if you want to query against a capitalized field, make sure to use double quotes.
+
+Spice follows PostgreSQL conventions for identifier handling: unquoted identifiers (table and column names) are normalized to lowercase. To reference a table or column with uppercase or mixed-case characters, wrap the identifier in double quotes.
+
+```sql
+-- These are equivalent (both reference the lowercase table name)
+SELECT * FROM lineitem;
+SELECT * FROM LINEITEM;
+
+-- Double quotes preserve the exact casing
+SELECT * FROM "LINEITEM";
+```
+
+See [dataset `name` configuration](../spicepod/datasets#name) for how to set a case-sensitive dataset name in the Spicepod manifest.
 
 Spice supports the following syntax for queries:
 


### PR DESCRIPTION
This pull request updates the Spice documentation to clarify how identifier casing works for datasets, tables, and columns, following PostgreSQL conventions. The changes explain how unquoted identifiers are normalized to lowercase, how to preserve uppercase or mixed-case names using double quotes, and provide configuration examples for both YAML and SQL. These updates are made in both the main and versioned (1.11.x) documentation.

**Identifier casing and query syntax documentation:**

* Added a section in `datasets.md` describing how dataset names are normalized to lowercase unless wrapped in double quotes, with YAML and SQL examples for preserving uppercase or mixed-case names.
* Updated the `SELECT` query documentation to clarify that unquoted table and column names are normalized to lowercase, and that double quotes preserve the original casing, including code examples and a cross-reference to dataset name configuration.

**Versioned documentation consistency:**

* Mirrored the above changes in the versioned 1.11.x documentation to ensure consistency across documentation versions. [[1]](diffhunk://#diff-ad7af4df0f494bef3fcbc8813594d9740831fa9691e1d37f3460877ab9e3ef93R133-R154) [[2]](diffhunk://#diff-d18b5a28cff02cb463f876fcf51b2fe1e32706131dca1acb5d84af00f8e18af7L16-R28)