### PR TITLE
docs: add s3_url_style guidance for S3 connector

### DIFF
--- a/website/docs/components/data-connectors/s3.md
+++ b/website/docs/components/data-connectors/s3.md
@@ -84,7 +84,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data format. Required if it cannot be inferred from the object URI. Options: `parquet`, `csv`, `json`. Refer to [File Formats](./#file-formats) for details.                                                                                                                                     |
 | `s3_endpoint`               | S3 endpoint URL (e.g., for MinIO). Default is the region endpoint. E.g. `s3_endpoint: https://my.minio.server`                                                                                                                                                                                                 |
-| `s3_url_style`              | URL style used for S3 requests. Options: `vhost` (default) and `path`. Use `path` for S3-compatible systems that require path-style requests (e.g., MinIO and LocalStack). If `s3_endpoint` uses an IP address, `s3_url_style` must be `path`.                                                          |
+| `s3_url_style`              | URL style used for S3 requests. Options: `vhost` and `path`. When not set, auto-detected: IP endpoints use `path`; other custom endpoints are detected via DNS lookup on the virtual-hosted hostname; standard AWS endpoints use `vhost`. |
 | `s3_region`                 | S3 bucket region. Default: `us-east-1`.                                                                                                                                                                                                                                                                        |
 | `client_timeout`            | Timeout for S3 operations. Default: `30s`.                                                                                                                                                                                                                                                                     |
 | `hive_partitioning_enabled` | Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                                                                                                                                               |
@@ -102,12 +102,16 @@ For additional CSV, JSON, and Parquet specific parameters, see [File Formats](..
 
 The S3 connector supports two request URL styles:
 
-- `vhost` (default): `https://<bucket>.<endpoint>/<key>`
-- `path`: `https://<endpoint>/<bucket>/<key>`
+- `vhost`: `https://<bucket>.<endpoint>/<key>` (virtual-hosted)
+- `path`: `https://<endpoint>/<bucket>/<key>` (path-style)
 
-Use `path` style for S3-compatible systems that do not support bucket-prefixed hostnames (for example MinIO on local networks).
+When `s3_url_style` is not set, the connector auto-detects the correct style:
 
-If `s3_endpoint` is an IP address (for example `http://192.168.1.100:9000`), set `s3_url_style: path`.
+1. **IP address endpoints** (e.g. `http://192.168.1.100:9000`) → `path`
+2. **Custom hostname endpoints** → DNS lookup on `<bucket>.<host>`. If the name resolves, `vhost` is used; otherwise `path`.
+3. **No custom endpoint** (standard AWS S3) → `vhost`
+
+Set `s3_url_style` explicitly to skip auto-detection.
 
 ## Authentication
 

--- a/website/docs/components/data-connectors/s3.md
+++ b/website/docs/components/data-connectors/s3.md
@@ -84,7 +84,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data format. Required if it cannot be inferred from the object URI. Options: `parquet`, `csv`, `json`. Refer to [File Formats](./#file-formats) for details.                                                                                                                                     |
 | `s3_endpoint`               | S3 endpoint URL (e.g., for MinIO). Default is the region endpoint. E.g. `s3_endpoint: https://my.minio.server`                                                                                                                                                                                                 |
-| `s3_url_style`              | URL style used for S3 requests. Options: `virtual` (default) and `path`. Use `path` for S3-compatible systems that require path-style requests (e.g., MinIO and LocalStack). If `s3_endpoint` uses an IP address, `s3_url_style` must be `path`.                                                        |
+| `s3_url_style`              | URL style used for S3 requests. Options: `vhost` (default) and `path`. Use `path` for S3-compatible systems that require path-style requests (e.g., MinIO and LocalStack). If `s3_endpoint` uses an IP address, `s3_url_style` must be `path`.                                                          |
 | `s3_region`                 | S3 bucket region. Default: `us-east-1`.                                                                                                                                                                                                                                                                        |
 | `client_timeout`            | Timeout for S3 operations. Default: `30s`.                                                                                                                                                                                                                                                                     |
 | `hive_partitioning_enabled` | Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                                                                                                                                               |
@@ -102,7 +102,7 @@ For additional CSV, JSON, and Parquet specific parameters, see [File Formats](..
 
 The S3 connector supports two request URL styles:
 
-- `virtual` (default): `https://<bucket>.<endpoint>/<key>`
+- `vhost` (default): `https://<bucket>.<endpoint>/<key>`
 - `path`: `https://<endpoint>/<bucket>/<key>`
 
 Use `path` style for S3-compatible systems that do not support bucket-prefixed hostnames (for example MinIO on local networks).

--- a/website/docs/components/data-connectors/s3.md
+++ b/website/docs/components/data-connectors/s3.md
@@ -84,6 +84,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data format. Required if it cannot be inferred from the object URI. Options: `parquet`, `csv`, `json`. Refer to [File Formats](./#file-formats) for details.                                                                                                                                     |
 | `s3_endpoint`               | S3 endpoint URL (e.g., for MinIO). Default is the region endpoint. E.g. `s3_endpoint: https://my.minio.server`                                                                                                                                                                                                 |
+| `s3_url_style`              | URL style used for S3 requests. Options: `virtual` (default) and `path`. Use `path` for S3-compatible systems that require path-style requests (e.g., MinIO and LocalStack). If `s3_endpoint` uses an IP address, `s3_url_style` must be `path`.                                                        |
 | `s3_region`                 | S3 bucket region. Default: `us-east-1`.                                                                                                                                                                                                                                                                        |
 | `client_timeout`            | Timeout for S3 operations. Default: `30s`.                                                                                                                                                                                                                                                                     |
 | `hive_partitioning_enabled` | Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                                                                                                                                               |
@@ -96,6 +97,17 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
+
+### `s3_url_style`
+
+The S3 connector supports two request URL styles:
+
+- `virtual` (default): `https://<bucket>.<endpoint>/<key>`
+- `path`: `https://<endpoint>/<bucket>/<key>`
+
+Use `path` style for S3-compatible systems that do not support bucket-prefixed hostnames (for example MinIO on local networks).
+
+If `s3_endpoint` is an IP address (for example `http://192.168.1.100:9000`), set `s3_url_style: path`.
 
 ## Authentication
 
@@ -221,6 +233,7 @@ Create a dataset named `cool_dataset` from a Parquet file stored in MinIO.
   params:
     s3_endpoint: http://my.minio.server
     s3_region: 'us-east-1' # Best practice for MinIO
+    s3_url_style: path
     allow_http: true
 ```
 


### PR DESCRIPTION
## Summary
- Document the new `s3_url_style` parameter for the S3 data connector
- Explain supported values (`vhost`, `path`) and auto-detection behavior
- Describe auto-detection logic: IP → path, DNS lookup on `<bucket>.<host>` for custom endpoints, standard AWS → vhost
- Update the MinIO example to include `s3_url_style: path`

## Related
- Runtime change: https://github.com/spiceai/spiceai/pull/9642
- Issue: https://github.com/spiceai/spiceai/issues/9622
