### PR TITLE
docs: Update file formats and data connectors documentation

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -114,7 +114,7 @@ datasets:
 | Name                                          | Parameter              | Status  | Description                                                                                                    |
 | --------------------------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics                                                                        |
-| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
+| [CSV](../reference/file_format#csv)           | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Stable  | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
@@ -134,7 +134,7 @@ File formats support additional parameters for fine-grained control. Common exam
 | `csv_delimiter`  | CSV        | Field delimiter character (default: `,`)         |
 | `csv_quote`      | CSV        | Quote character for fields containing delimiters |
 
-For complete format options, see [File Formats Reference](../../reference/file_format).
+For complete format options, see [File Formats Reference](../reference/file_format).
 
 ### Applicable Connectors {#object-store-file-formats}
 
@@ -276,7 +276,7 @@ Schema inference happens once, when the dataset is first registered. Some connec
 | [Kafka](data-connectors/kafka)           | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
 | [DynamoDB](data-connectors/dynamodb)     | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
 | [MongoDB](data-connectors/mongodb)       | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
-| [CSV files](../../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
+| [CSV files](../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
 
 For connectors that read self-describing formats (Parquet, Arrow, Avro), the schema is read directly from file metadata and does not require sampling.
 
@@ -302,7 +302,7 @@ Runtime schema evolution controls are planned for a future release. When availab
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
-| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
+| [CSV](../reference/file_format#csv)           | `file_format: csv`     | ✅         | ❌                  |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |

--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -55,7 +55,7 @@ Supported Data Connectors include:
 | `odbc`                             | ODBC                                  | Beta              | ODBC                         |
 | `snowflake`                        | Snowflake                             | Beta              | Arrow                        |
 | `spark`                            | Spark                                 | Beta              | [Spark Connect][spark]       |
-| `iceberg`                          | [Apache Iceberg][iceberg]             | Beta              | Parquet                      |
+| `iceberg`                          | [Apache Iceberg][iceberg]             | Stable            | Parquet                      |
 | `abfs`                             | Azure BlobFS                          | Alpha             | Parquet, CSV, JSON           |
 | `ftp`, `sftp`                      | FTP/SFTP                              | Alpha             | Parquet, CSV, JSON           |
 | `smb`                              | SMB                                   | Alpha             | Parquet, CSV, JSON           |
@@ -114,14 +114,14 @@ datasets:
 | Name                                          | Parameter              | Status  | Description                                                                                                    |
 | --------------------------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics                                                                        |
-| [CSV](../reference/file_format#csv)           | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
+| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Beta    | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Stable  | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
 | Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                                                                                       |
 | Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)                                                                   |
 | Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)                                                                             |
-| PDF                                           | `file_format: pdf`     | Alpha   | Portable Document Format (document format)                                                                     |
+| PDF                                           | `file_format: pdf`     | Beta    | Portable Document Format (document format)                                                                     |
 | Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)                                                                         |
 
 ### Format-Specific Parameters
@@ -134,7 +134,7 @@ File formats support additional parameters for fine-grained control. Common exam
 | `csv_delimiter`  | CSV        | Field delimiter character (default: `,`)         |
 | `csv_quote`      | CSV        | Quote character for fields containing delimiters |
 
-For complete format options, see [File Formats Reference](../reference/file_format).
+For complete format options, see [File Formats Reference](../../reference/file_format).
 
 ### Applicable Connectors {#object-store-file-formats}
 
@@ -186,11 +186,11 @@ File-based connectors can expose per-file object store metadata as virtual colum
 
 #### Available Columns
 
-| Column           | Type                   | Description                        |
-| ---------------- | ---------------------- | ---------------------------------- |
-| `_location`      | `Utf8`                 | Full URI of the source file        |
-| `_last_modified` | `Timestamp(µs, "UTC")` | When the file was last modified    |
-| `_size`          | `UInt64`               | File size in bytes                 |
+| Column           | Type                   | Description                     |
+| ---------------- | ---------------------- | ------------------------------- |
+| `_location`      | `Utf8`                 | Full URI of the source file     |
+| `_last_modified` | `Timestamp(µs, "UTC")` | When the file was last modified |
+| `_size`          | `UInt64`               | File size in bytes              |
 
 #### Enabling Metadata Columns
 
@@ -259,11 +259,11 @@ ORDER BY _location;
 
 Metadata columns are supported by all file-based connectors:
 
-| Connector Type               | Connectors                             |
-| ---------------------------- | -------------------------------------- |
-| **Object Stores**            | S3, Azure Blob (ABFS), HTTP/HTTPS      |
-| **Network-Attached Storage** | FTP, SFTP, SMB, NFS                    |
-| **Local Storage**            | File                                   |
+| Connector Type               | Connectors                        |
+| ---------------------------- | --------------------------------- |
+| **Object Stores**            | S3, Azure Blob (ABFS), HTTP/HTTPS |
+| **Network-Attached Storage** | FTP, SFTP, SMB, NFS               |
+| **Local Storage**            | File                              |
 
 ## Schema Inference
 
@@ -271,12 +271,12 @@ Spice infers the schema for each dataset from its data source at startup. The in
 
 Schema inference happens once, when the dataset is first registered. Some connectors support tuning the inference behavior with connector-specific parameters:
 
-| Connector                             | Parameter                          | Default | Description                                         |
-| ------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
-| [Kafka](data-connectors/kafka)        | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
-| [DynamoDB](data-connectors/dynamodb)  | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
-| [MongoDB](data-connectors/mongodb)    | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
-| [CSV files](../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
+| Connector                                | Parameter                          | Default | Description                                         |
+| ---------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
+| [Kafka](data-connectors/kafka)           | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
+| [DynamoDB](data-connectors/dynamodb)     | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
+| [MongoDB](data-connectors/mongodb)       | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
+| [CSV files](../../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
 
 For connectors that read self-describing formats (Parquet, Arrow, Avro), the schema is read directly from file metadata and does not require sampling.
 
@@ -302,14 +302,14 @@ Runtime schema evolution controls are planned for a future release. When availab
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
-| [CSV](../reference/file_format#csv)           | `file_format: csv`     | ✅         | ❌                  |
+| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Beta      | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |
 | Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
 | Markdown                                      | `file_format: md`      | ✅         | ✅                  |
 | Text                                          | `file_format: txt`     | ✅         | ✅                  |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| PDF                                           | `file_format: pdf`     | Beta      | ✅                  |
 | Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 ### Document Formats {#document-formats}
@@ -320,7 +320,7 @@ Runtime schema evolution controls are planned for a future release. When availab
 Document formats (Markdown, Text, PDF, Word) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
 
 :::warning[Note]
-Document formats in Alpha (PDF, DOCX) may not parse all structure or text from the underlying documents correctly.
+Document formats in Alpha (DOCX) may not parse all structure or text from the underlying documents correctly.
 :::
 
 #### Document Table Schema

--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -271,11 +271,11 @@ Spice infers the schema for each dataset from its data source at startup. The in
 
 Schema inference happens once, when the dataset is first registered. Some connectors support tuning the inference behavior with connector-specific parameters:
 
-| Connector                                | Parameter                          | Default | Description                                         |
-| ---------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
-| [Kafka](data-connectors/kafka)           | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
-| [DynamoDB](data-connectors/dynamodb)     | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
-| [MongoDB](data-connectors/mongodb)       | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
+| Connector                             | Parameter                          | Default | Description                                         |
+| ------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
+| [Kafka](data-connectors/kafka)        | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
+| [DynamoDB](data-connectors/dynamodb)  | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
+| [MongoDB](data-connectors/mongodb)    | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
 | [CSV files](../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
 
 For connectors that read self-describing formats (Parquet, Arrow, Avro), the schema is read directly from file metadata and does not require sampling.

--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -6,7 +6,7 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/sftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
+File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/ftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
 
 ## Common Parameters
 

--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -6,15 +6,39 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Spice supports CSV, JSON, Parquet, Delta Lake, and Iceberg data file-formats for data connectors that can read files from a file system or cloud object storage (i.e. [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), etc.). Delta Lake and Iceberg are supported for object store connectors. Iceberg requires a catalog to be configured.
+File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/sftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
 
-The parameters supported for specific file-formats are detailed on this page.
+## Common Parameters
+
+These parameters apply across multiple file formats.
+
+| Parameter                   | Type    | Default        | Description                                                                                                                   |
+| --------------------------- | ------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | String  | Inferred       | Selects the file reader. If omitted, format is inferred from the file extension. See [Supported Formats](#supported-formats). |
+| `file_extension`            | String  | Derived        | Overrides the file extension filter used when listing files. Defaults to the extension matching the resolved format.          |
+| `schema_infer_max_records`  | Integer | `1000`         | Maximum number of records scanned to infer the schema.                                                                        |
+| `file_compression_type`     | String  | `UNCOMPRESSED` | File-level compression for CSV, TSV, and JSON files. Valid values: `GZIP`, `BZIP2`, `XZ`, `ZSTD`, `UNCOMPRESSED`.             |
+| `hive_partitioning_enabled` | Boolean | `false`        | Enables Hive-style partition discovery from directory structure.                                                              |
+
+## Supported Formats {#supported-formats}
+
+The `file_format` parameter accepts these values:
+
+| Value     | Reader              | Default Extension | Notes                                       |
+| --------- | ------------------- | ----------------- | ------------------------------------------- |
+| `parquet` | Apache Parquet      | `.parquet`        |                                             |
+| `csv`     | CSV                 | `.csv`            | Uses `csv_*` parameters.                    |
+| `tsv`     | TSV (tab-delimited) | `.tsv`            | Uses `tsv_*` parameters. Delimiter is tab.  |
+| `json`    | JSON                | `.json`           | Uses `json_format` to control parsing mode. |
+| `jsonl`   | JSON Lines          | `.jsonl`          | Line-delimited JSON.                        |
+
+When `file_format` is omitted, Spice infers the format from the dataset path extension. If the extension does not match one of the values above, a configuration error is returned.
 
 ## Parquet
 
-Spice automatically supports reading any Parquet file, regardless of the compression codec or data encoding used.
+Spice reads any Parquet file regardless of the compression codec or data encoding.
 
-Compression codecs:
+Supported compression codecs:
 
 - [`UNCOMPRESSED`](https://parquet.apache.org/docs/file-format/data-pages/compression/#uncompressed)
 - [`SNAPPY`](https://parquet.apache.org/docs/file-format/data-pages/compression/#snappy)
@@ -25,7 +49,7 @@ Compression codecs:
 - [`LZ4_RAW`](https://parquet.apache.org/docs/file-format/data-pages/compression/#lz4_raw)
 - [`ZSTD`](https://parquet.apache.org/docs/file-format/data-pages/compression/#zstd)
 
-Data encodings:
+Supported data encodings:
 
 - [`PLAIN`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#plain-plain--0)
 - [`PLAIN_DICTIONARY` / `RLE_DICTIONARY`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#dictionary-encoding-plain_dictionary--2-and-rle_dictionary--8)
@@ -38,16 +62,38 @@ Data encodings:
 
 ## CSV
 
+### Parameters {#csv}
+
+| Parameter                      | Type    | Default | Description                                                                                           |
+| ------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `csv_has_header`               | Boolean | `true`  | Whether the first row contains column headers.                                                        |
+| `csv_quote`                    | Char    | `"`     | Character used to quote fields containing special characters.                                         |
+| `csv_escape`                   | Char    | _none_  | Character used to escape special characters within a field.                                           |
+| `csv_delimiter`                | Char    | `,`     | Character used to separate fields.                                                                    |
+| `csv_schema_infer_max_records` | Integer | `1000`  | **Deprecated.** Use `schema_infer_max_records` instead. Maximum records scanned for schema inference. |
+
+## TSV
+
+TSV (tab-separated values) is a first-class format. Set `file_format: tsv` or use a `.tsv` file extension. The delimiter is always tab and cannot be changed.
+
 ### Parameters
 
-- `csv_has_header`: Optional. Indicate if the CSV file has header row. Defaults to `true`
-- `csv_quote`: Optional. A one-character string used to quote fields containing special characters. Defaults to `"`
-- `csv_escape`: Optional. A one-character string used to represent special characters or to include characters that would normally be interpreted as delimiters or new line characters within a field value. Defaults to `null`
-- `csv_schema_infer_max_records`: Optional. A number used to set the limit in terms of records to scan to infer the schema. Defaults to `1000`
-- `csv_delimiter`: Optional. A one-character string used to separate individual fields. Defaults to `,`
+| Parameter                      | Type    | Default | Description                                                                                           |
+| ------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `tsv_has_header`               | Boolean | `true`  | Whether the first row contains column headers.                                                        |
+| `tsv_quote`                    | Char    | `"`     | Character used to quote fields containing special characters.                                         |
+| `tsv_escape`                   | Char    | _none_  | Character used to escape special characters within a field.                                           |
+| `tsv_schema_infer_max_records` | Integer | `1000`  | **Deprecated.** Use `schema_infer_max_records` instead. Maximum records scanned for schema inference. |
 
 ## JSON
 
+Set `file_format: json` for JSON files. Use the `json_format` parameter to select the parsing mode.
+
 ### Parameters
 
-- `json_format`: Optional. Specifies the JSON format to parse. Valid values are `array`, `ndjson`, and `jsonl`. Defaults to `jsonl`
+| Parameter      | Type    | Default | Description                                                                                                       |
+| -------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `json_format`  | String  | `jsonl` | Parsing mode. `jsonl`, `ndjson`, and `ldjson` produce line-delimited JSON. `array` parses a top-level JSON array. |
+| `flatten_json` | Boolean | `false` | When `true`, nested JSON objects are flattened with `.` as a separator (e.g., `address.city`).                    |
+
+Setting `file_format: jsonl` uses the DataFusion JSON Lines reader directly, without `json_format` or `flatten_json` support.

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
@@ -109,17 +109,18 @@ datasets:
 
 ### Supported Formats
 
-| Name                                          | Parameter              | Status  | Description                                   |
-| --------------------------------------------- | ---------------------- | ------- | --------------------------------------------- |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics       |
-| [CSV](../reference/file_format#csv)           | `file_format: csv`     | Stable  | Comma-separated values                        |
-| JSON                                          | `file_format: json`    | Roadmap | JavaScript Object Notation                    |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap | Open table format for large analytic datasets |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                      |
-| Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)  |
-| Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)            |
-| PDF                                           | `file_format: pdf`     | Alpha   | Portable Document Format (document format)    |
-| Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)        |
+| Name                                          | Parameter              | Status  | Description                                                                                                    |
+| --------------------------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics                                                                        |
+| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
+| JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
+| [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Beta    | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
+| Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                                                                                       |
+| Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)                                                                   |
+| Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)                                                                             |
+| PDF                                           | `file_format: pdf`     | Beta    | Portable Document Format (document format)                                                                     |
+| Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)                                                                         |
 
 ### Format-Specific Parameters
 
@@ -131,7 +132,7 @@ File formats support additional parameters for fine-grained control. Common exam
 | `csv_delimiter`  | CSV        | Field delimiter character (default: `,`)         |
 | `csv_quote`      | CSV        | Quote character for fields containing delimiters |
 
-For complete format options, see [File Formats Reference](../reference/file_format).
+For complete format options, see [File Formats Reference](../../reference/file_format).
 
 ### Applicable Connectors {#object-store-file-formats}
 
@@ -268,12 +269,12 @@ Spice infers the schema for each dataset from its data source at startup. The in
 
 Schema inference happens once, when the dataset is first registered. Some connectors support tuning the inference behavior with connector-specific parameters:
 
-| Connector                             | Parameter                          | Default | Description                                         |
-| ------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
-| [Kafka](data-connectors/kafka)        | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
-| [DynamoDB](data-connectors/dynamodb)  | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
-| [MongoDB](data-connectors/mongodb)    | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
-| [CSV files](../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
+| Connector                                | Parameter                          | Default | Description                                         |
+| ---------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
+| [Kafka](data-connectors/kafka)           | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
+| [DynamoDB](data-connectors/dynamodb)     | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
+| [MongoDB](data-connectors/mongodb)       | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
+| [CSV files](../../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
 
 For connectors that read self-describing formats (Parquet, Arrow, Avro), the schema is read directly from file metadata and does not require sampling.
 
@@ -299,13 +300,14 @@ Runtime schema evolution controls are planned for a future release. When availab
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
-| [CSV](../reference/file_format#csv)           | `file_format: csv`     | ✅         | ❌                  |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
-| JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
+| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
+| [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
+| JSON                                          | `file_format: json`    | ✅         | ❌                  |
 | Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
 | Markdown                                      | `file_format: md`      | ✅         | ✅                  |
 | Text                                          | `file_format: txt`     | ✅         | ✅                  |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| PDF                                           | `file_format: pdf`     | Beta      | ✅                  |
 | Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 ### Document Formats {#document-formats}

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
@@ -112,7 +112,7 @@ datasets:
 | Name                                          | Parameter              | Status  | Description                                                                                                    |
 | --------------------------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics                                                                        |
-| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
+| [CSV](../reference/file_format#csv)           | `file_format: csv`     | Stable  | Comma-separated values                                                                                         |
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Beta    | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
@@ -132,7 +132,7 @@ File formats support additional parameters for fine-grained control. Common exam
 | `csv_delimiter`  | CSV        | Field delimiter character (default: `,`)         |
 | `csv_quote`      | CSV        | Quote character for fields containing delimiters |
 
-For complete format options, see [File Formats Reference](../../reference/file_format).
+For complete format options, see [File Formats Reference](../reference/file_format).
 
 ### Applicable Connectors {#object-store-file-formats}
 
@@ -269,12 +269,12 @@ Spice infers the schema for each dataset from its data source at startup. The in
 
 Schema inference happens once, when the dataset is first registered. Some connectors support tuning the inference behavior with connector-specific parameters:
 
-| Connector                                | Parameter                          | Default | Description                                         |
-| ---------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
-| [Kafka](data-connectors/kafka)           | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
-| [DynamoDB](data-connectors/dynamodb)     | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
-| [MongoDB](data-connectors/mongodb)       | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
-| [CSV files](../../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
+| Connector                             | Parameter                          | Default | Description                                         |
+| ------------------------------------- | ---------------------------------- | ------- | --------------------------------------------------- |
+| [Kafka](data-connectors/kafka)        | `schema_infer_max_records`         | 10      | Number of messages sampled to infer the JSON schema |
+| [DynamoDB](data-connectors/dynamodb)  | `schema_infer_max_records`         | 10      | Number of items sampled to infer the schema         |
+| [MongoDB](data-connectors/mongodb)    | `mongodb_num_docs_to_infer_schema` | 400     | Number of documents sampled to infer the schema     |
+| [CSV files](../reference/file_format) | `csv_schema_infer_max_records`     | 1000    | Number of rows sampled to infer the CSV schema      |
 
 For connectors that read self-describing formats (Parquet, Arrow, Avro), the schema is read directly from file metadata and does not require sampling.
 
@@ -300,7 +300,7 @@ Runtime schema evolution controls are planned for a future release. When availab
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
-| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
+| [CSV](../reference/file_format#csv)           | `file_format: csv`     | ✅         | ❌                  |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |

--- a/website/versioned_docs/version-1.11.x/reference/file_format.md
+++ b/website/versioned_docs/version-1.11.x/reference/file_format.md
@@ -6,7 +6,7 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/sftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
+File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/ftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
 
 ## Common Parameters
 

--- a/website/versioned_docs/version-1.11.x/reference/file_format.md
+++ b/website/versioned_docs/version-1.11.x/reference/file_format.md
@@ -6,15 +6,39 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Spice currently supports CSV, JSON, and Parquet data file-formats for data connectors that can read files from a file system or cloud object storage (i.e. [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), etc.). Support for Iceberg and other file-formats are on the roadmap.
+File-based [data connectors](../components/data-connectors/index.md) — including [`s3://`](../components/data-connectors/s3), [`abfs://`](../components/data-connectors/abfs), [`file://`](../components/data-connectors/file), [`ftp://`](../components/data-connectors/ftp), [`sftp://`](../components/data-connectors/sftp), and others — support multiple structured and document file formats. This page details the format-specific parameters available for each.
 
-The parameters supported for specific file-formats are detailed on this page.
+## Common Parameters
+
+These parameters apply across multiple file formats.
+
+| Parameter                   | Type    | Default        | Description                                                                                                                   |
+| --------------------------- | ------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | String  | Inferred       | Selects the file reader. If omitted, format is inferred from the file extension. See [Supported Formats](#supported-formats). |
+| `file_extension`            | String  | Derived        | Overrides the file extension filter used when listing files. Defaults to the extension matching the resolved format.          |
+| `schema_infer_max_records`  | Integer | `1000`         | Maximum number of records scanned to infer the schema.                                                                        |
+| `file_compression_type`     | String  | `UNCOMPRESSED` | File-level compression for CSV, TSV, and JSON files. Valid values: `GZIP`, `BZIP2`, `XZ`, `ZSTD`, `UNCOMPRESSED`.             |
+| `hive_partitioning_enabled` | Boolean | `false`        | Enables Hive-style partition discovery from directory structure.                                                              |
+
+## Supported Formats {#supported-formats}
+
+The `file_format` parameter accepts these values:
+
+| Value     | Reader              | Default Extension | Notes                                       |
+| --------- | ------------------- | ----------------- | ------------------------------------------- |
+| `parquet` | Apache Parquet      | `.parquet`        |                                             |
+| `csv`     | CSV                 | `.csv`            | Uses `csv_*` parameters.                    |
+| `tsv`     | TSV (tab-delimited) | `.tsv`            | Uses `tsv_*` parameters. Delimiter is tab.  |
+| `json`    | JSON                | `.json`           | Uses `json_format` to control parsing mode. |
+| `jsonl`   | JSON Lines          | `.jsonl`          | Line-delimited JSON.                        |
+
+When `file_format` is omitted, Spice infers the format from the dataset path extension. If the extension does not match one of the values above, a configuration error is returned.
 
 ## Parquet
 
-Spice automatically supports reading any Parquet file, regardless of the compression codec or data encoding used.
+Spice reads any Parquet file regardless of the compression codec or data encoding.
 
-Compression codecs:
+Supported compression codecs:
 
 - [`UNCOMPRESSED`](https://parquet.apache.org/docs/file-format/data-pages/compression/#uncompressed)
 - [`SNAPPY`](https://parquet.apache.org/docs/file-format/data-pages/compression/#snappy)
@@ -25,7 +49,7 @@ Compression codecs:
 - [`LZ4_RAW`](https://parquet.apache.org/docs/file-format/data-pages/compression/#lz4_raw)
 - [`ZSTD`](https://parquet.apache.org/docs/file-format/data-pages/compression/#zstd)
 
-Data encodings:
+Supported data encodings:
 
 - [`PLAIN`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#plain-plain--0)
 - [`PLAIN_DICTIONARY` / `RLE_DICTIONARY`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#dictionary-encoding-plain_dictionary--2-and-rle_dictionary--8)
@@ -38,16 +62,38 @@ Data encodings:
 
 ## CSV
 
+### Parameters {#csv}
+
+| Parameter                      | Type    | Default | Description                                                                                           |
+| ------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `csv_has_header`               | Boolean | `true`  | Whether the first row contains column headers.                                                        |
+| `csv_quote`                    | Char    | `"`     | Character used to quote fields containing special characters.                                         |
+| `csv_escape`                   | Char    | _none_  | Character used to escape special characters within a field.                                           |
+| `csv_delimiter`                | Char    | `,`     | Character used to separate fields.                                                                    |
+| `csv_schema_infer_max_records` | Integer | `1000`  | **Deprecated.** Use `schema_infer_max_records` instead. Maximum records scanned for schema inference. |
+
+## TSV
+
+TSV (tab-separated values) is a first-class format. Set `file_format: tsv` or use a `.tsv` file extension. The delimiter is always tab and cannot be changed.
+
 ### Parameters
 
-- `csv_has_header`: Optional. Indicate if the CSV file has header row. Defaults to `true`
-- `csv_quote`: Optional. A one-character string used to quote fields containing special characters. Defaults to `"`
-- `csv_escape`: Optional. A one-character string used to represent special characters or to include characters that would normally be interpreted as delimiters or new line characters within a field value. Defaults to `null`
-- `csv_schema_infer_max_records`: Optional. A number used to set the limit in terms of records to scan to infer the schema. Defaults to `1000`
-- `csv_delimiter`: Optional. A one-character string used to separate individual fields. Defaults to `,`
+| Parameter                      | Type    | Default | Description                                                                                           |
+| ------------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `tsv_has_header`               | Boolean | `true`  | Whether the first row contains column headers.                                                        |
+| `tsv_quote`                    | Char    | `"`     | Character used to quote fields containing special characters.                                         |
+| `tsv_escape`                   | Char    | _none_  | Character used to escape special characters within a field.                                           |
+| `tsv_schema_infer_max_records` | Integer | `1000`  | **Deprecated.** Use `schema_infer_max_records` instead. Maximum records scanned for schema inference. |
 
 ## JSON
 
+Set `file_format: json` for JSON files. Use the `json_format` parameter to select the parsing mode.
+
 ### Parameters
 
-- `json_format`: Optional. Specifies the JSON format to parse. Valid values are `array`, `ndjson`, and `jsonl`. Defaults to `jsonl`
+| Parameter      | Type    | Default | Description                                                                                                       |
+| -------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `json_format`  | String  | `jsonl` | Parsing mode. `jsonl`, `ndjson`, and `ldjson` produce line-delimited JSON. `array` parses a top-level JSON array. |
+| `flatten_json` | Boolean | `false` | When `true`, nested JSON objects are flattened with `.` as a separator (e.g., `address.city`).                    |
+
+Setting `file_format: jsonl` uses the DataFusion JSON Lines reader directly, without `json_format` or `flatten_json` support.


### PR DESCRIPTION
Updates file format reference and data connector index pages for accuracy based on the actual implementation.

### Changes

**File Formats Reference** (`docs/reference/file_format.md` + v1.11.x):
- Added Common Parameters section (file_format, file_extension, schema_infer_max_records, file_compression_type, hive_partitioning_enabled)
- Added Supported Formats table listing all recognized file_format values
- Added TSV section with full parameter documentation
- Added deprecation notes for csv_schema_infer_max_records and tsv_schema_infer_max_records
- Added flatten_json and ldjson to JSON parameters
- Noted behavioral difference between file_format: json vs file_format: jsonl

**Data Connectors Index** (`docs/components/data-connectors/index.md` + v1.11.x):
- Fixed broken links: `../reference/file_format` to `../../reference/file_format`
- Updated Iceberg connector and file format status to Stable
- Updated PDF file format status to Beta
- Added missing Delta Lake and JSON entries to v1.11.x file format tables
- Added missing ducklake connector to v1.11.x
- Updated warning text to reflect PDF promotion from Alpha to Beta
