### PR TITLE
Improve JSON format documentation

### DIFF
--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -29,7 +29,7 @@ The `file_format` parameter accepts these values:
 | `parquet` | Apache Parquet      | `.parquet`        |                                             |
 | `csv`     | CSV                 | `.csv`            | Uses `csv_*` parameters.                    |
 | `tsv`     | TSV (tab-delimited) | `.tsv`            | Uses `tsv_*` parameters. Delimiter is tab.  |
-| `json`    | JSON                | `.json`           | Uses `json_format` to control parsing mode. |
+| `json`    | JSON                | `.json`           | Auto-detects format. Uses `json_format` to control parsing mode. |
 | `jsonl`   | JSON Lines          | `.jsonl`          | Line-delimited JSON.                        |
 
 When `file_format` is omitted, Spice infers the format from the dataset path extension. If the extension does not match one of the values above, a configuration error is returned.
@@ -89,11 +89,52 @@ TSV (tab-separated values) is a first-class format. Set `file_format: tsv` or us
 
 Set `file_format: json` for JSON files. Use the `json_format` parameter to select the parsing mode.
 
+### Parsing Modes {#json-parsing-modes}
+
+The `json_format` parameter controls how JSON content is interpreted.
+
+| Value                          | Description                                                                                                                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auto`                         | Default. Auto-detects the format by inspecting content. Detects SODA responses, JSON arrays, single objects, and line-delimited JSON.                                             |
+| `json`                         | Auto-detects array vs line-delimited JSON by peeking at the first byte, but does not perform SODA auto-detection. Used implicitly when `file_format: json` is set explicitly. |
+| `jsonl`, `ndjson`, `ldjson`    | Line-delimited JSON. Each line contains one JSON value.                                                                                                                           |
+| `array`                        | The file contains a single top-level JSON array. Each element becomes a row.                                                                                                      |
+| `object`                       | The file contains a single JSON object, producing one row.                                                                                                                        |
+| `soda`, `socrata`              | [Socrata Open Data API (SODA)](https://dev.socrata.com/docs/endpoints.html) format. Schema is derived from `meta.view.columns` in the response. Cannot be combined with `json_pointer`.    |
+
+When `file_format` is omitted and the file extension is `.json`, the default parsing mode is `auto`, which includes SODA auto-detection. When `file_format: json` is set explicitly, the default mode is `json`, which skips SODA auto-detection.
+
 ### Parameters
 
-| Parameter      | Type    | Default | Description                                                                                                       |
-| -------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
-| `json_format`  | String  | `jsonl` | Parsing mode. `jsonl`, `ndjson`, and `ldjson` produce line-delimited JSON. `array` parses a top-level JSON array. |
-| `flatten_json` | Boolean | `false` | When `true`, nested JSON objects are flattened with `.` as a separator (e.g., `address.city`).                    |
+| Parameter       | Type    | Default    | Description                                                                                                                                      |
+| --------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `json_format`   | String  | `auto`     | Parsing mode. See [Parsing Modes](#json-parsing-modes).                                                                                          |
+| `json_pointer`  | String  | _none_     | Extracts a sub-value from the document before parsing. Alias: `json_path`. Cannot be used with `soda` format. |
+| `flatten_json`  | Boolean | `false`    | When `true`, nested JSON objects are flattened with `.` as a separator (e.g., `address.city`).                                                   |
+| `soda_metadata` | String  | `disabled` | When `enabled`, includes Socrata metadata columns (`:sid`, `:id`, `:position`, `:created_at`, `:created_meta`, `:updated_at`, `:updated_meta`, `:meta`) in the output. Only applies when parsing SODA format data. |
 
-Setting `file_format: jsonl` uses the DataFusion JSON Lines reader directly, without `json_format` or `flatten_json` support.
+Setting `file_format: jsonl` uses the DataFusion JSON Lines reader directly, without `json_format`, `flatten_json`, or `json_pointer` support.
+
+### Examples
+
+Extract a nested value from a JSON document using `json_pointer`:
+
+```yaml
+datasets:
+  - from: s3://my-bucket/data/
+    name: events
+    params:
+      file_format: json
+      json_pointer: /results/events
+```
+
+Read a SODA response with metadata columns included:
+
+```yaml
+datasets:
+  - from: https://data.ct.gov/api/views/kf98-j89e/rows.json?accessType=DOWNLOAD
+    name: house_price_index
+    params:
+      json_format: soda
+      soda_metadata: enabled
+```

--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -130,11 +130,32 @@ datasets:
 
 Read a SODA response with metadata columns included:
 
+```bash
+curl -sL "https://data.ct.gov/api/views/kf98-j89e/rows.json?accessType=DOWNLOAD" -o house_price_index.json
+```
+
 ```yaml
 datasets:
-  - from: https://data.ct.gov/api/views/kf98-j89e/rows.json?accessType=DOWNLOAD
+  - from: file:house_price_index.json
     name: house_price_index
     params:
       json_format: soda
       soda_metadata: enabled
+```
+
+```sql
+sql> select * from house_price_index limit 5;
+
++--------------------+--------------------------------------+-----------+-------------+---------------+-------------+---------------+-------+---------------------+---------+
+|        :sid        |                  :id                 | :position | :created_at | :created_meta | :updated_at | :updated_meta | :meta |   observation_date  | ctsthpi |
+|       varchar      |                varchar               |   int64   |    int64    |    varchar    |    int64    |    varchar    |varchar|     timestamp[s]    | float64 |
++--------------------+--------------------------------------+-----------+-------------+---------------+-------------+---------------+-------+---------------------+---------+
+| row-r4ag~gfrd~dqcz | 00000000-0000-0000-6A52-5730E0309BF7 | 0         | 1768216213  |               | 1768216213  |               | { }   | 1975-01-01T00:00:00 | 62.9    |
+| row-65s5_stm6-jbjc | 00000000-0000-0000-3B25-D45DF23837A7 | 0         | 1768216213  |               | 1768216213  |               | { }   | 1975-04-01T00:00:00 | 62.94   |
+| row-buhc_mzb7.95pa | 00000000-0000-0000-A414-989C0238E96F | 0         | 1768216213  |               | 1768216213  |               | { }   | 1975-07-01T00:00:00 | 61.93   |
+| row-3fp4~bx38-mwgi | 00000000-0000-0000-58CE-D4AF76C589B0 | 0         | 1768216213  |               | 1768216213  |               | { }   | 1975-10-01T00:00:00 | 61.85   |
+| row-khut~7dd3-vi9e | 00000000-0000-0000-A274-646F4876CC81 | 0         | 1768216213  |               | 1768216213  |               | { }   | 1976-01-01T00:00:00 | 64.83   |
++--------------------+--------------------------------------+-----------+-------------+---------------+-------------+---------------+-------+---------------------+---------+
+
+Time: 0.0028895 seconds. 5 rows.
 ```


### PR DESCRIPTION
Document JSON support improvements from [spiceai/spiceai#9743](https://github.com/spiceai/spiceai/pull/9743) and [spiceai/spiceai#9795](https://github.com/spiceai/spiceai/pull/9795), including `json_format` parsing modes, `json_pointer` extraction, SODA/Socrata support, and `flatten_json`.
