### PR TITLE
Improve ADBC documentation with examples and driver options

### DIFF
--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -2,23 +2,35 @@
 title: 'ADBC Data Connector'
 sidebar_label: 'ADBC Data Connector'
 description: 'ADBC Data Connector Documentation'
+pagination_prev: null
 ---
 
-[ADBC](https://arrow.apache.org/adbc/) (Arrow Database Connectivity) is a columnar, minimal-overhead alternative to JDBC/ODBC for analytical data access. It uses [Apache Arrow](https://arrow.apache.org/) for data transfer, avoiding serialization overhead between the database driver and Spice.
+[ADBC](https://arrow.apache.org/adbc/) (Arrow Database Connectivity) is a columnar, minimal-overhead alternative to JDBC/ODBC for analytical data access. It transfers data using [Apache Arrow](https://arrow.apache.org/), avoiding serialization overhead between the database driver and Spice.
 
-The ADBC data connector dynamically loads ADBC-compatible drivers (e.g., DuckDB, SQLite, PostgreSQL) and provides federated SQL query access through connection pooling.
+The ADBC data connector dynamically loads any ADBC-compatible driver at runtime and provides federated SQL query access through a managed connection pool. It currently supports read-only operations, and pushes filters, projections, and limits down to the source database.
 
 ```yaml
 datasets:
-  - from: adbc:table_name
+  - from: adbc:MY_TABLE
     name: my_table
     params:
-      adbc_driver: duckdb # or sqlite, postgres, etc.
-      adbc_uri: path/to/database.db
-      # Optional connection pool settings
-      connection_pool_size: 5
-      connection_pool_min_idle: 1
+      adbc_driver: snowflake
+      adbc_uri: ${secrets:SNOWFLAKE_URI}
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_driver_options: >-
+        snowflake.sql.warehouse=MY_WH;
+        snowflake.sql.role=MY_ROLE;
+        snowflake.sql.auth_type=auth_snowflake
 ```
+
+## Prerequisites
+
+An ADBC-compatible driver must be installed on the system where Spice runs. Spice loads the driver shared library by name (e.g., `snowflake`, `bigquery`) or by an explicit file path.
+
+E.g. For Snowflake, install the [Snowflake ADBC driver](https://arrow.apache.org/adbc/current/driver/snowflake.html). The driver shared library (e.g., `libadbc_driver_snowflake.so` on Linux, `libadbc_driver_snowflake.dylib` on macOS) must be on the system library path or referenced with `adbc_driver_path`.
+
+For BigQuery, install the [BigQuery ADBC driver](https://arrow.apache.org/adbc/current/driver/bigquery.html). Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL.
 
 ## Configuration
 
@@ -26,23 +38,25 @@ datasets:
 
 The `from` field takes the form `adbc:table_name`, where `table_name` is the name of the table to read from the connected database.
 
+For Snowflake, table names are case-sensitive and should match the casing used in Snowflake (typically uppercase). Fully qualified names that include database and schema can be specified when `adbc_catalog` and `adbc_schema` are not set.
+
 ### `name`
 
-The dataset name. This is used as the table name within Spice.
-
-Example:
+The dataset name, used as the table name within Spice.
 
 ```yaml
 datasets:
-  - from: adbc:table_name
-    name: cool_dataset
+  - from: adbc:LINEITEM
+    name: lineitem
     params:
-      adbc_driver: duckdb
-      adbc_uri: path/to/database.db
+      adbc_driver: snowflake
+      adbc_uri: ${secrets:SNOWFLAKE_URI}
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
 ```
 
 ```sql
-SELECT COUNT(*) FROM cool_dataset;
+SELECT COUNT(*) FROM lineitem;
 ```
 
 ```shell
@@ -57,47 +71,211 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 ### `params`
 
-| Parameter Name             | Description                                                                                                                              |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `adbc_driver`              | Required. The ADBC driver name (e.g., `duckdb`, `sqlite`, `postgres`).                                                                   |
-| `adbc_uri`                 | Required. Database URI or connection string for the ADBC driver. In-memory URIs (e.g., `:memory:`) are not supported.                    |
-| `adbc_driver_path`         | Optional. Path to the ADBC driver shared library. When omitted, the driver is loaded by name.                                            |
-| `adbc_driver_options`      | Optional. Semicolon-separated key-value pairs of driver-specific options passed to the ADBC driver on connection.                        |
-| `connection_pool_size`     | Optional. Maximum number of connections in the connection pool. Default value is `5`.                                                    |
-| `connection_pool_min_idle` | Optional. Minimum number of idle connections to keep open in the pool. Default value is `1`.                                             |
+| Parameter Name             | Description                                                                                                                          |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `adbc_driver`              | Required. The ADBC driver name (e.g., `snowflake`, `bigquery`).                                                                      |
+| `adbc_uri`                 | Required. Database URI or connection string for the ADBC driver. In-memory URIs (e.g., `:memory:`) are not supported.                |
+| `adbc_driver_path`         | Optional. Absolute path to the ADBC driver shared library. When omitted, the driver is loaded by name from the system library path.  |
+| `adbc_username`            | Optional. Username for database authentication. Supports [Secrets Stores](../secret-stores/).                                        |
+| `adbc_password`            | Optional. Password for database authentication. Supports [Secrets Stores](../secret-stores/).                                        |
+| `adbc_driver_options`      | Optional. Semicolon-delimited key-value pairs of driver-specific options. See [Driver Options](#driver-options-adbc_driver_options). |
+| `adbc_catalog`             | Optional. Sets the default catalog for the connection.                                                                               |
+| `adbc_schema`              | Optional. Sets the default schema for the connection.                                                                                |
+| `connection_pool_size`     | Optional. Maximum number of connections in the connection pool. Default: `5`.                                                        |
+| `connection_pool_min_idle` | Optional. Minimum number of idle connections in the pool. Default: `1`.                                                              |
 
 :::warning[In-memory databases]
-In-memory database URIs (e.g., `:memory:` or URIs containing `mode=memory`) are not supported. Each pooled connection would create an isolated in-memory database, leading to data inconsistency.
+In-memory database URIs (e.g., `:memory:` or URIs containing `mode=memory`) are not supported.
 :::
 
-## Examples
+### Driver Options (`adbc_driver_options`)
 
-### PostgreSQL
+The `adbc_driver_options` parameter passes driver-specific configuration as semicolon-delimited `key=value` pairs. Each key is automatically prefixed with `adbc.` if it does not already start with that prefix.
+
+For example, the following two configurations are equivalent:
 
 ```yaml
-datasets:
-  - from: adbc:my_table
-    name: my_table
-    params:
-      adbc_driver: postgres
-      adbc_uri: postgresql://user:password@localhost:5432/mydb
+# Without adbc. prefix (added automatically)
+adbc_driver_options: snowflake.sql.warehouse=MY_WH;snowflake.sql.role=MY_ROLE
+
+# With explicit adbc. prefix
+adbc_driver_options: adbc.snowflake.sql.warehouse=MY_WH;adbc.snowflake.sql.role=MY_ROLE
 ```
 
-### Driver Options (Snowflake)
+Trailing semicolons are permitted. Entries without an `=` sign or with an empty key are ignored.
 
-Use `adbc_driver_options` to pass driver-specific options as semicolon-separated key-value pairs:
+For multi-line readability, use YAML's `>-` folded block scalar:
+
+```yaml
+adbc_driver_options: >-
+  snowflake.sql.warehouse=MY_WH;
+  snowflake.sql.role=MY_ROLE;
+  snowflake.sql.auth_type=auth_snowflake
+```
+
+#### Snowflake Driver Options
+
+The [Snowflake ADBC driver](https://arrow.apache.org/adbc/current/driver/snowflake.html) accepts the following options through `adbc_driver_options`. See the [Snowflake ADBC client options](https://arrow.apache.org/adbc/current/driver/snowflake.html#client-options) for the complete reference.
+
+| Option Key                               | Description                                                                             |
+| ---------------------------------------- | --------------------------------------------------------------------------------------- |
+| `snowflake.sql.warehouse`                | The Snowflake warehouse to use for queries.                                             |
+| `snowflake.sql.role`                     | The Snowflake role to assume.                                                           |
+| `snowflake.sql.auth_type`                | Authentication type. Common values: `auth_snowflake` (password), `auth_jwt` (key-pair). |
+| `snowflake.sql.db`                       | The Snowflake database to use.                                                          |
+| `snowflake.sql.schema`                   | The Snowflake schema to use.                                                            |
+| `snowflake.sql.region`                   | The Snowflake region for the account.                                                   |
+| `snowflake.sql.account`                  | The Snowflake account identifier.                                                       |
+| `snowflake.sql.client_option.keep_alive` | Enable session keep-alive. Default: `true`.                                             |
+| `snowflake.sql.client_option.app_name`   | Application name reported to Snowflake.                                                 |
+
+### Catalog and Schema
+
+The `adbc_catalog` and `adbc_schema` parameters set connection-level defaults that apply to all queries on the connection. These map to the ADBC standard connection options `adbc.connection.catalog` and `adbc.connection.db_schema`.
+
+For Snowflake, `adbc_catalog` corresponds to the Snowflake database and `adbc_schema` corresponds to the Snowflake schema:
 
 ```yaml
 datasets:
-  - from: adbc:my_table
+  - from: adbc:LINEITEM
+    name: lineitem
+    params:
+      adbc_driver: snowflake
+      adbc_uri: ${secrets:SNOWFLAKE_URI}
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_catalog: SNOWFLAKE_SAMPLE_DATA  # Snowflake database
+      adbc_schema: TPCH_SF1               # Snowflake schema
+      adbc_driver_options: >-
+        snowflake.sql.warehouse=MY_WH;
+        snowflake.sql.role=MY_ROLE
+```
+
+### Connection Pooling
+
+The ADBC connector maintains a pool of database connections for concurrent query execution. The pool is configured with:
+
+- `connection_pool_size`: The maximum number of connections. Increase for workloads with many concurrent queries.
+- `connection_pool_min_idle`: The minimum number of idle connections kept open to reduce connection setup latency.
+
+Both values must be positive integers. A `connection_pool_min_idle` greater than `connection_pool_size` is coerced to `connection_pool_size`.
+
+### Query Pushdown
+
+The ADBC connector pushes SQL operations down to the source database when possible, reducing the amount of data transferred:
+
+- **Filter pushdown**: `WHERE` clauses are pushed to the source.
+- **Projection pushdown**: Only the columns referenced in the query are fetched.
+- **Limit pushdown**: `LIMIT` clauses are applied at the source.
+
+No special configuration is required. Pushdown happens automatically when the source database supports the operation.
+
+## Auth
+
+Authentication credentials (`adbc_username`, `adbc_password`) can be provided directly or through [Secrets Stores](../secret-stores/).
+
+```bash
+SPICE_SECRET_ADBC_USERNAME=myuser \
+SPICE_SECRET_ADBC_PASSWORD=mypassword \
+spice run
+```
+
+```yaml
+datasets:
+  - from: adbc:MY_TABLE
     name: my_table
     params:
       adbc_driver: snowflake
-      adbc_uri: user:password@account.snowflakecomputing.com/mydb/myschema
+      adbc_uri: myaccount.snowflakecomputing.com
+      adbc_username: ${secrets:ADBC_USERNAME}
+      adbc_password: ${secrets:ADBC_PASSWORD}
+      adbc_driver_options: >-
+        snowflake.sql.warehouse=MY_WH;
+        snowflake.sql.auth_type=auth_snowflake
+```
+
+## Examples
+
+### Snowflake
+
+Connect to a Snowflake table with warehouse, role, and authentication options:
+
+```yaml
+datasets:
+  - from: adbc:LINEITEM
+    name: lineitem
+    params:
+      adbc_driver: snowflake
+      adbc_uri: ${secrets:SNOWFLAKE_URI}
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_catalog: SNOWFLAKE_SAMPLE_DATA
+      adbc_schema: TPCH_SF1
+      adbc_driver_options: >-
+        snowflake.sql.warehouse=COMPUTE_WH;
+        snowflake.sql.role=ACCOUNTADMIN;
+        snowflake.sql.auth_type=auth_snowflake
+      connection_pool_size: 10
+      connection_pool_min_idle: 2
+```
+
+```sql
+SELECT l_returnflag, l_linestatus, SUM(l_quantity) AS sum_qty
+FROM lineitem
+GROUP BY l_returnflag, l_linestatus
+ORDER BY l_returnflag, l_linestatus;
+```
+
+#### Snowflake with Key-Pair Authentication
+
+Use JWT-based key-pair authentication by setting `snowflake.sql.auth_type` to `auth_jwt`:
+
+```yaml
+datasets:
+  - from: adbc:MY_TABLE
+    name: my_table
+    params:
+      adbc_driver: snowflake
+      adbc_uri: myaccount.snowflakecomputing.com
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PRIVATE_KEY}
       adbc_driver_options: >-
         snowflake.sql.warehouse=MY_WH;
         snowflake.sql.role=MY_ROLE;
-        snowflake.sql.auth_type=auth_snowflake
+        snowflake.sql.auth_type=auth_jwt
+```
+
+### BigQuery
+
+Connect to a BigQuery table. Spice translates federated queries into BigQuery-compatible SQL automatically.
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: bigquery
+      adbc_uri: "grpc://bigquery.googleapis.com"
+      adbc_catalog: my-gcp-project
+      adbc_schema: my_dataset
+      adbc_driver_options: >-
+        adbc.bigquery.sql.auth_type=auth_google_default
+```
+
+To authenticate with a service account JSON key:
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: bigquery
+      adbc_uri: "grpc://bigquery.googleapis.com"
+      adbc_catalog: my-gcp-project
+      adbc_schema: my_dataset
+      adbc_driver_options: >-
+        adbc.bigquery.sql.auth_type=auth_json_credential_file;
+        adbc.bigquery.sql.auth_credentials=/path/to/service-account.json
 ```
 
 ### Custom Driver Path
@@ -106,10 +284,15 @@ When the ADBC driver shared library is not on the system library path, specify i
 
 ```yaml
 datasets:
-  - from: adbc:my_table
+  - from: adbc:MY_TABLE
     name: my_table
     params:
-      adbc_driver: duckdb
-      adbc_driver_path: /opt/drivers/libadbc_driver_duckdb.so
-      adbc_uri: /path/to/database.duckdb
+      adbc_driver: snowflake
+      adbc_driver_path: /opt/drivers/libadbc_driver_snowflake.so
+      adbc_uri: ${secrets:SNOWFLAKE_URI}
+      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
+      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_driver_options: >-
+        snowflake.sql.warehouse=MY_WH;
+        snowflake.sql.role=MY_ROLE
 ```

--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -7,30 +7,40 @@ pagination_prev: null
 
 [ADBC](https://arrow.apache.org/adbc/) (Arrow Database Connectivity) is a columnar, minimal-overhead alternative to JDBC/ODBC for analytical data access. It transfers data using [Apache Arrow](https://arrow.apache.org/), avoiding serialization overhead between the database driver and Spice.
 
-The ADBC data connector dynamically loads any ADBC-compatible driver at runtime and provides federated SQL query access through a managed connection pool. It currently supports read-only operations, and pushes filters, projections, and limits down to the source database.
+The ADBC data connector dynamically loads any ADBC-compatible driver at runtime and provides federated SQL query access through a managed connection pool. It supports both read and write operations, and pushes filters, projections, and limits down to the source database.
+
+Drivers are available for [BigQuery](https://docs.adbc-drivers.org/drivers/bigquery/index.html), [Trino](https://docs.adbc-drivers.org/drivers/trino/index.html), [Snowflake](https://docs.adbc-drivers.org/drivers/snowflake/index.html), [Amazon Redshift](https://docs.adbc-drivers.org/drivers/redshift/index.html), [Databricks](https://docs.adbc-drivers.org/drivers/databricks/index.html), and more. See [ADBC Driver Foundry](https://docs.adbc-drivers.org/) for the full list.
 
 ```yaml
 datasets:
-  - from: adbc:MY_TABLE
+  - from: adbc:my_table
     name: my_table
     params:
-      adbc_driver: snowflake
-      adbc_uri: ${secrets:SNOWFLAKE_URI}
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_driver: bigquery
+      adbc_uri: "bigquery:///my-gcp-project"
       adbc_driver_options: >-
-        snowflake.sql.warehouse=MY_WH;
-        snowflake.sql.role=MY_ROLE;
-        snowflake.sql.auth_type=auth_snowflake
+        adbc.bigquery.sql.dataset_id=my_dataset
 ```
 
 ## Prerequisites
 
-An ADBC-compatible driver must be installed on the system where Spice runs. Spice loads the driver shared library by name (e.g., `snowflake`, `bigquery`) or by an explicit file path.
+An ADBC-compatible driver must be installed on the system where Spice runs. Spice loads the driver shared library by name (e.g., `bigquery`, `trino`, `snowflake`, `redshift`) or by an explicit file path.
 
-E.g. For Snowflake, install the [Snowflake ADBC driver](https://arrow.apache.org/adbc/current/driver/snowflake.html). The driver shared library (e.g., `libadbc_driver_snowflake.so` on Linux, `libadbc_driver_snowflake.dylib` on macOS) must be on the system library path or referenced with `adbc_driver_path`.
+The recommended way to install drivers is with [`dbc`](https://docs.columnar.tech/dbc/), the command-line tool for installing and managing ADBC drivers:
 
-For BigQuery, install the [BigQuery ADBC driver](https://arrow.apache.org/adbc/current/driver/bigquery.html). Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL.
+```shell
+# Install dbc
+curl -LsSf https://dbc.columnar.tech/install.sh | sh
+
+# Install drivers
+dbc install bigquery
+dbc install trino
+dbc install redshift
+```
+
+See the [`dbc` documentation](https://docs.columnar.tech/dbc/) for other installation methods (pip, Homebrew, Windows MSI) and platform support.
+
+Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL automatically.
 
 ## Configuration
 
@@ -38,7 +48,7 @@ For BigQuery, install the [BigQuery ADBC driver](https://arrow.apache.org/adbc/c
 
 The `from` field takes the form `adbc:table_name`, where `table_name` is the name of the table to read from the connected database.
 
-For Snowflake, table names are case-sensitive and should match the casing used in Snowflake (typically uppercase). Fully qualified names that include database and schema can be specified when `adbc_catalog` and `adbc_schema` are not set.
+Table name casing depends on the source database. For example, Snowflake uses uppercase table names by default, while BigQuery and Trino use lowercase. When `adbc_catalog` and `adbc_schema` are not set, fully qualified names can be specified in the `from` field.
 
 ### `name`
 
@@ -46,17 +56,17 @@ The dataset name, used as the table name within Spice.
 
 ```yaml
 datasets:
-  - from: adbc:LINEITEM
-    name: lineitem
+  - from: adbc:my_table
+    name: my_table
     params:
-      adbc_driver: snowflake
-      adbc_uri: ${secrets:SNOWFLAKE_URI}
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
+      adbc_driver: bigquery
+      adbc_uri: "bigquery:///my-gcp-project"
+      adbc_driver_options: >-
+        adbc.bigquery.sql.dataset_id=my_dataset
 ```
 
 ```sql
-SELECT COUNT(*) FROM lineitem;
+SELECT COUNT(*) FROM my_table;
 ```
 
 ```shell
@@ -73,7 +83,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 | Parameter Name             | Description                                                                                                                          |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `adbc_driver`              | Required. The ADBC driver name (e.g., `snowflake`, `bigquery`).                                                                      |
+| `adbc_driver`              | Required. The ADBC driver name (e.g., `bigquery`, `trino`, `snowflake`, `redshift`).                                                 |
 | `adbc_uri`                 | Required. Database URI or connection string for the ADBC driver. In-memory URIs (e.g., `:memory:`) are not supported.                |
 | `adbc_driver_path`         | Optional. Absolute path to the ADBC driver shared library. When omitted, the driver is loaded by name from the system library path.  |
 | `adbc_username`            | Optional. Username for database authentication. Supports [Secrets Stores](../secret-stores/).                                        |
@@ -95,11 +105,11 @@ The `adbc_driver_options` parameter passes driver-specific configuration as semi
 For example, the following two configurations are equivalent:
 
 ```yaml
-# Without adbc. prefix (added automatically)
-adbc_driver_options: snowflake.sql.warehouse=MY_WH;snowflake.sql.role=MY_ROLE
+# Without adbc. prefix (prefix is added automatically)
+adbc_driver_options: bigquery.sql.project_id=my-project;bigquery.sql.dataset_id=my_dataset
 
 # With explicit adbc. prefix
-adbc_driver_options: adbc.snowflake.sql.warehouse=MY_WH;adbc.snowflake.sql.role=MY_ROLE
+adbc_driver_options: adbc.bigquery.sql.project_id=my-project;adbc.bigquery.sql.dataset_id=my_dataset
 ```
 
 Trailing semicolons are permitted. Entries without an `=` sign or with an empty key are ignored.
@@ -108,47 +118,75 @@ For multi-line readability, use YAML's `>-` folded block scalar:
 
 ```yaml
 adbc_driver_options: >-
-  snowflake.sql.warehouse=MY_WH;
-  snowflake.sql.role=MY_ROLE;
-  snowflake.sql.auth_type=auth_snowflake
+  adbc.bigquery.sql.project_id=my-project;
+  adbc.bigquery.sql.dataset_id=my_dataset
 ```
 
-#### Snowflake Driver Options
+Driver-specific options are documented at [ADBC Driver Foundry](https://docs.adbc-drivers.org/).
 
-The [Snowflake ADBC driver](https://arrow.apache.org/adbc/current/driver/snowflake.html) accepts the following options through `adbc_driver_options`. See the [Snowflake ADBC client options](https://arrow.apache.org/adbc/current/driver/snowflake.html#client-options) for the complete reference.
+#### BigQuery Driver Options
 
-| Option Key                               | Description                                                                             |
-| ---------------------------------------- | --------------------------------------------------------------------------------------- |
-| `snowflake.sql.warehouse`                | The Snowflake warehouse to use for queries.                                             |
-| `snowflake.sql.role`                     | The Snowflake role to assume.                                                           |
-| `snowflake.sql.auth_type`                | Authentication type. Common values: `auth_snowflake` (password), `auth_jwt` (key-pair). |
-| `snowflake.sql.db`                       | The Snowflake database to use.                                                          |
-| `snowflake.sql.schema`                   | The Snowflake schema to use.                                                            |
-| `snowflake.sql.region`                   | The Snowflake region for the account.                                                   |
-| `snowflake.sql.account`                  | The Snowflake account identifier.                                                       |
-| `snowflake.sql.client_option.keep_alive` | Enable session keep-alive. Default: `true`.                                             |
-| `snowflake.sql.client_option.app_name`   | Application name reported to Snowflake.                                                 |
+The [BigQuery ADBC driver](https://docs.adbc-drivers.org/drivers/bigquery/index.html) accepts the following commonly-used options through `adbc_driver_options`.
+
+| Option Key                         | Description                                                                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `adbc.bigquery.sql.project_id`     | The Google Cloud project ID.                                                                                     |
+| `adbc.bigquery.sql.dataset_id`     | The BigQuery dataset ID.                                                                                         |
+| `adbc.bigquery.sql.auth_type`      | Authentication type. `0` = Application Default Credentials (default), `1` = service account JSON file, `2` = service account JSON string. |
+| `adbc.bigquery.sql.auth_credentials` | Path to the service account JSON file (when `auth_type=1`) or the JSON string (when `auth_type=2`).             |
+
+BigQuery also supports connection string URIs as the `adbc_uri` value:
+
+```
+bigquery:///my-project-123
+bigquery:///my-project-123?OAuthType=1&AuthCredentials=/path/to/key.json
+bigquery:///my-project-123?DatasetId=analytics&Location=US
+```
+
+See the [BigQuery ADBC driver documentation](https://docs.adbc-drivers.org/drivers/bigquery/index.html) for the full reference.
+
+#### Trino Driver Options
+
+The [Trino ADBC driver](https://docs.adbc-drivers.org/drivers/trino/index.html) uses a connection string URI as the `adbc_uri` value:
+
+```
+trino://[user[:password]@]host[:port][/catalog[/schema]][?param=value&...]
+```
+
+Examples:
+
+```
+trino://trino.example.com:8080/hive/default
+trino://user:pass@trino.example.com:8443/postgresql/public?SSL=true
+trino://user@localhost:8443/memory/default?SSLVerification=NONE
+```
+
+By default, connections use HTTPS. Add `SSL=false` to use HTTP. For self-signed certificates, add `SSLVerification=NONE`.
+
+See the [Trino ADBC driver documentation](https://docs.adbc-drivers.org/drivers/trino/index.html) for the full reference.
 
 ### Catalog and Schema
 
 The `adbc_catalog` and `adbc_schema` parameters set connection-level defaults that apply to all queries on the connection. These map to the ADBC standard connection options `adbc.connection.catalog` and `adbc.connection.db_schema`.
 
-For Snowflake, `adbc_catalog` corresponds to the Snowflake database and `adbc_schema` corresponds to the Snowflake schema:
+How these map to source database concepts varies by driver:
+
+| Driver    | `adbc_catalog`        | `adbc_schema`          |
+| --------- | --------------------- | ---------------------- |
+| BigQuery  | GCP project ID        | BigQuery dataset       |
+| Trino     | Trino catalog         | Schema within catalog  |
+| Redshift  | Redshift database     | Redshift schema        |
+| Snowflake | Snowflake database    | Snowflake schema       |
 
 ```yaml
 datasets:
-  - from: adbc:LINEITEM
-    name: lineitem
+  - from: adbc:my_table
+    name: my_table
     params:
-      adbc_driver: snowflake
-      adbc_uri: ${secrets:SNOWFLAKE_URI}
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
-      adbc_catalog: SNOWFLAKE_SAMPLE_DATA  # Snowflake database
-      adbc_schema: TPCH_SF1               # Snowflake schema
-      adbc_driver_options: >-
-        snowflake.sql.warehouse=MY_WH;
-        snowflake.sql.role=MY_ROLE
+      adbc_driver: bigquery
+      adbc_uri: "bigquery:///my-gcp-project"
+      adbc_catalog: my-gcp-project
+      adbc_schema: my_dataset
 ```
 
 ### Connection Pooling
@@ -172,7 +210,13 @@ No special configuration is required. Pushdown happens automatically when the so
 
 ## Auth
 
-Authentication credentials (`adbc_username`, `adbc_password`) can be provided directly or through [Secrets Stores](../secret-stores/).
+Authentication varies by driver. Credentials can be provided through `adbc_username`, `adbc_password`, `adbc_driver_options`, the connection URI, or through [Secrets Stores](../secret-stores/).
+
+For BigQuery, authentication typically uses Google Cloud Application Default Credentials or a service account JSON file passed through `adbc_driver_options`.
+
+For Trino, credentials are embedded in the connection URI (`trino://user:pass@host/catalog`).
+
+For drivers that accept `adbc_username` and `adbc_password` (e.g., Redshift, Snowflake), these can be set through environment variables:
 
 ```bash
 SPICE_SECRET_ADBC_USERNAME=myuser \
@@ -182,87 +226,41 @@ spice run
 
 ```yaml
 datasets:
-  - from: adbc:MY_TABLE
+  - from: adbc:my_table
     name: my_table
     params:
-      adbc_driver: snowflake
-      adbc_uri: myaccount.snowflakecomputing.com
+      adbc_driver: redshift
+      adbc_uri: "redshift://my-cluster.region.redshift.amazonaws.com:5439/dev"
       adbc_username: ${secrets:ADBC_USERNAME}
       adbc_password: ${secrets:ADBC_PASSWORD}
-      adbc_driver_options: >-
-        snowflake.sql.warehouse=MY_WH;
-        snowflake.sql.auth_type=auth_snowflake
 ```
 
 ## Examples
 
-### Snowflake
-
-Connect to a Snowflake table with warehouse, role, and authentication options:
-
-```yaml
-datasets:
-  - from: adbc:LINEITEM
-    name: lineitem
-    params:
-      adbc_driver: snowflake
-      adbc_uri: ${secrets:SNOWFLAKE_URI}
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
-      adbc_catalog: SNOWFLAKE_SAMPLE_DATA
-      adbc_schema: TPCH_SF1
-      adbc_driver_options: >-
-        snowflake.sql.warehouse=COMPUTE_WH;
-        snowflake.sql.role=ACCOUNTADMIN;
-        snowflake.sql.auth_type=auth_snowflake
-      connection_pool_size: 10
-      connection_pool_min_idle: 2
-```
-
-```sql
-SELECT l_returnflag, l_linestatus, SUM(l_quantity) AS sum_qty
-FROM lineitem
-GROUP BY l_returnflag, l_linestatus
-ORDER BY l_returnflag, l_linestatus;
-```
-
-#### Snowflake with Key-Pair Authentication
-
-Use JWT-based key-pair authentication by setting `snowflake.sql.auth_type` to `auth_jwt`:
-
-```yaml
-datasets:
-  - from: adbc:MY_TABLE
-    name: my_table
-    params:
-      adbc_driver: snowflake
-      adbc_uri: myaccount.snowflakecomputing.com
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PRIVATE_KEY}
-      adbc_driver_options: >-
-        snowflake.sql.warehouse=MY_WH;
-        snowflake.sql.role=MY_ROLE;
-        snowflake.sql.auth_type=auth_jwt
-```
-
 ### BigQuery
 
-Connect to a BigQuery table. Spice translates federated queries into BigQuery-compatible SQL automatically.
+Connect to a BigQuery table using Application Default Credentials. Spice translates federated queries into BigQuery-compatible SQL automatically.
 
-```yaml
-datasets:
-  - from: adbc:my_table
-    name: my_table
-    params:
-      adbc_driver: bigquery
-      adbc_uri: "grpc://bigquery.googleapis.com"
-      adbc_catalog: my-gcp-project
-      adbc_schema: my_dataset
-      adbc_driver_options: >-
-        adbc.bigquery.sql.auth_type=auth_google_default
+```shell
+# Install the driver
+dbc install bigquery
+
+# Authenticate with Google Cloud
+gcloud auth application-default login
 ```
 
-To authenticate with a service account JSON key:
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: bigquery
+      adbc_uri: "bigquery:///my-gcp-project?DatasetId=my_dataset"
+```
+
+#### BigQuery with Service Account
+
+Authenticate with a service account JSON key file:
 
 ```yaml
 datasets:
@@ -270,29 +268,107 @@ datasets:
     name: my_table
     params:
       adbc_driver: bigquery
-      adbc_uri: "grpc://bigquery.googleapis.com"
+      adbc_uri: "bigquery:///my-gcp-project?OAuthType=1&AuthCredentials=/path/to/service-account.json"
+      adbc_catalog: my-gcp-project
+      adbc_schema: my_dataset
+```
+
+Or equivalently, using `adbc_driver_options`:
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: bigquery
+      adbc_uri: "bigquery:///my-gcp-project"
       adbc_catalog: my-gcp-project
       adbc_schema: my_dataset
       adbc_driver_options: >-
-        adbc.bigquery.sql.auth_type=auth_json_credential_file;
+        adbc.bigquery.sql.auth_type=1;
         adbc.bigquery.sql.auth_credentials=/path/to/service-account.json
+```
+
+### Trino
+
+Connect to a Trino cluster:
+
+```shell
+dbc install trino
+```
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: trino
+      adbc_uri: "trino://trino.example.com:8080/hive/default?SSL=false"
+```
+
+#### Trino with Authentication
+
+Connect over HTTPS with HTTP Basic authentication:
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: trino
+      adbc_uri: "trino://user:${secrets:TRINO_PASSWORD}@trino.example.com:8443/hive/default"
+      connection_pool_size: 10
+```
+
+For self-signed certificates, add `SSLVerification=NONE`:
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: trino
+      adbc_uri: "trino://user@trino.internal:8443/hive/default?SSLVerification=NONE"
+```
+
+### Amazon Redshift
+
+Connect to a Redshift Provisioned cluster:
+
+```shell
+dbc install redshift
+```
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: redshift
+      adbc_uri: "redshift://admin:${secrets:REDSHIFT_PASSWORD}@my-cluster.region.redshift.amazonaws.com:5439/dev"
+```
+
+#### Redshift Serverless with IAM
+
+```yaml
+datasets:
+  - from: adbc:my_table
+    name: my_table
+    params:
+      adbc_driver: redshift
+      adbc_uri: "redshift:///dev?cluster_type=redshift-serverless&workgroup_name=my-workgroup"
 ```
 
 ### Custom Driver Path
 
-When the ADBC driver shared library is not on the system library path, specify its location with `adbc_driver_path`:
+When the ADBC driver shared library is not on the system library path (e.g., not installed via `dbc`), specify its location with `adbc_driver_path`:
 
 ```yaml
 datasets:
-  - from: adbc:MY_TABLE
+  - from: adbc:my_table
     name: my_table
     params:
-      adbc_driver: snowflake
-      adbc_driver_path: /opt/drivers/libadbc_driver_snowflake.so
-      adbc_uri: ${secrets:SNOWFLAKE_URI}
-      adbc_username: ${secrets:SNOWFLAKE_USERNAME}
-      adbc_password: ${secrets:SNOWFLAKE_PASSWORD}
-      adbc_driver_options: >-
-        snowflake.sql.warehouse=MY_WH;
-        snowflake.sql.role=MY_ROLE
+      adbc_driver: bigquery
+      adbc_driver_path: /opt/drivers/libadbc_driver_bigquery.so
+      adbc_uri: "bigquery:///my-gcp-project?DatasetId=my_dataset"
 ```

--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -128,12 +128,12 @@ Driver-specific options are documented at [ADBC Driver Foundry](https://docs.adb
 
 The [BigQuery ADBC driver](https://docs.adbc-drivers.org/drivers/bigquery/index.html) accepts the following commonly-used options through `adbc_driver_options`.
 
-| Option Key                         | Description                                                                                                      |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `adbc.bigquery.sql.project_id`     | The Google Cloud project ID.                                                                                     |
-| `adbc.bigquery.sql.dataset_id`     | The BigQuery dataset ID.                                                                                         |
-| `adbc.bigquery.sql.auth_type`      | Authentication type. `0` = Application Default Credentials (default), `1` = service account JSON file, `2` = service account JSON string. |
-| `adbc.bigquery.sql.auth_credentials` | Path to the service account JSON file (when `auth_type=1`) or the JSON string (when `auth_type=2`).             |
+| Option Key                           | Description                                                                                                                               |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `adbc.bigquery.sql.project_id`       | The Google Cloud project ID.                                                                                                              |
+| `adbc.bigquery.sql.dataset_id`       | The BigQuery dataset ID.                                                                                                                  |
+| `adbc.bigquery.sql.auth_type`        | Authentication type. `0` = Application Default Credentials (default), `1` = service account JSON file, `2` = service account JSON string. |
+| `adbc.bigquery.sql.auth_credentials` | Path to the service account JSON file (when `auth_type=1`) or the JSON string (when `auth_type=2`).                                       |
 
 BigQuery also supports connection string URIs as the `adbc_uri` value:
 
@@ -171,12 +171,12 @@ The `adbc_catalog` and `adbc_schema` parameters set connection-level defaults th
 
 How these map to source database concepts varies by driver:
 
-| Driver    | `adbc_catalog`        | `adbc_schema`          |
-| --------- | --------------------- | ---------------------- |
-| BigQuery  | GCP project ID        | BigQuery dataset       |
-| Trino     | Trino catalog         | Schema within catalog  |
-| Redshift  | Redshift database     | Redshift schema        |
-| Snowflake | Snowflake database    | Snowflake schema       |
+| Driver    | `adbc_catalog`     | `adbc_schema`         |
+| --------- | ------------------ | --------------------- |
+| BigQuery  | GCP project ID     | BigQuery dataset      |
+| Trino     | Trino catalog      | Schema within catalog |
+| Redshift  | Redshift database  | Redshift schema       |
+| Snowflake | Snowflake database | Snowflake schema      |
 
 ```yaml
 datasets:

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -86,6 +86,7 @@ See [Large Language Models](../../features/large-language-models) for additional
 
 - [Tools](../../features/large-language-models/tools)
 - [Memory](../../features/large-language-models/memory)
+- [Evals](../../features/large-language-models/evals)
 - [Parameter overrides](../../features/large-language-models/parameter_overrides)
 
 ## Supported OpenAI Compatible Providers

--- a/website/docs/components/models/openai.md
+++ b/website/docs/components/models/openai.md
@@ -86,7 +86,6 @@ See [Large Language Models](../../features/large-language-models) for additional
 
 - [Tools](../../features/large-language-models/tools)
 - [Memory](../../features/large-language-models/memory)
-- [Evals](../../features/large-language-models/evals)
 - [Parameter overrides](../../features/large-language-models/parameter_overrides)
 
 ## Supported OpenAI Compatible Providers


### PR DESCRIPTION
This pull request significantly expands and clarifies the documentation for the ADBC Data Connector, providing more comprehensive guidance on supported drivers, configuration, authentication, and advanced features. It also adds a small update to the OpenAI models documentation. The most important changes are grouped below:

**ADBC Data Connector Documentation Enhancements:**

* Expanded documentation to cover a wider range of ADBC-compatible drivers (BigQuery, Trino, Snowflake, Redshift, Databricks, etc.), including links to official driver resources and installation instructions using `dbc`.
* Added detailed sections on configuration parameters, including new options for authentication (`adbc_username`, `adbc_password`), catalog/schema selection (`adbc_catalog`, `adbc_schema`), and driver-specific options (`adbc_driver_options`). Provided clear explanations and tables mapping these options to various supported drivers.
* Introduced advanced features documentation, such as query pushdown (filters, projections, limits), connection pooling, and SQL dialect translation for BigQuery. [[1]](diffhunk://#diff-4e5dbc79f2b13d4ae5eecf67037ebd12091fda6e677846ff2579791b8d685c0fR5-R69) [[2]](diffhunk://#diff-4e5dbc79f2b13d4ae5eecf67037ebd12091fda6e677846ff2579791b8d685c0fL61-R373)
* Added example configurations for BigQuery, Trino, Redshift, and custom driver paths, including authentication methods and use of secrets stores.
* Improved clarity and accuracy throughout, including updated YAML and SQL examples, and guidance on table naming conventions across different databases.

**OpenAI Models Documentation Update:**

* Added a link to the "Evals" feature in the OpenAI models documentation sidebar for easier navigation.