### PR TITLE
Fix links in documentation for Federated SQL Query recipes and update

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -176,7 +176,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 - If a table fails to load during catalog refresh, it is skipped with a warning and does not fail the entire catalog.
 
 :::
-
-## Cookbook
-
-- A cookbook recipe to configure DuckLake as a catalog connector in Spice. [DuckLake Catalog Connector](https://github.com/spiceai/cookbook/tree/trunk/catalogs/ducklake#readme)

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -156,7 +156,3 @@ datasets:
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.
 
 :::
-
-## Cookbook
-
-- A cookbook recipe to configure DuckLake as a catalog and data connector in Spice. [DuckLake Catalog Connector](https://github.com/spiceai/cookbook/tree/trunk/catalogs/ducklake#readme)

--- a/website/docs/components/data-connectors/glue.md
+++ b/website/docs/components/data-connectors/glue.md
@@ -50,13 +50,13 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The following parameters are supported for configuring the connection to the Glue Data Catalog:
 
-| Parameter Name       | Definition                                                                                                                                                                  |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                                                                 |
-| `glue_catalog_id`    | The Glue catalog ID. For Amazon S3 Tables, use the format `<account_id>:s3tablescatalog/<table_bucket_name>`. If not provided, the default catalog for the account is used. |
-| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                           |
-| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                       |
-| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                    |
+| Parameter Name         | Definition                                                                                                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `glue_region`          | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                                                                                                  |
+| `glue_catalog_id`      | The Glue catalog ID. For Amazon S3 Tables, use the format `<account_id>:s3tablescatalog/<table_bucket_name>`. If not provided, the default catalog for the account is used.                                  |
+| `glue_key`             | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                                                            |
+| `glue_secret`          | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                                                        |
+| `glue_session_token`   | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                                                     |
 | `glue_iam_role_source` | Optional. IAM role credential source. `auto` (default) uses the default AWS credential chain, `metadata` uses only instance/container metadata (IMDS, ECS, EKS/IRSA), `env` uses only environment variables. |
 
 ## Examples

--- a/website/docs/components/data-connectors/glue.md
+++ b/website/docs/components/data-connectors/glue.md
@@ -241,4 +241,4 @@ Each query retrieves data from the S3 source, which might result in significant 
 
 ## Cookbook
 
-- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue/README)
+- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue#readme)

--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -70,20 +70,19 @@ Supported Data Connectors include:
 | `debezium`                         | Debezium CDC                          | Alpha             | Kafka + JSON                 |
 | `kafka`                            | Kafka                                 | Alpha             | Kafka + JSON                 |
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
-| `ducklake`                         | [DuckLake][ducklake]                  | Alpha             | Parquet                      |
+| `ducklake`                         | DuckLake                              | Alpha             | Parquet                      |
 | `scylladb`                         | ScyllaDB                              | Alpha             | CQL, Alternator (DynamoDB)   |
 | `adbc`                             | [ADBC][adbc]                          | Alpha             | Arrow (ADBC)                 |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme
 [dremio]: https://github.com/spiceai/cookbook/tree/trunk/dremio#readme
 [localpod]: https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md
 [iceberg]: https://github.com/spiceai/cookbook/tree/trunk/catalogs/iceberg#readme
-[glue]: https://github.com/spiceai/cookbook/tree/trunk/glue/README.md
-[ducklake]: https://github.com/spiceai/cookbook/tree/trunk/catalogs/ducklake#readme
+[glue]: https://github.com/spiceai/cookbook/tree/trunk/glue#readme
 [adbc]: https://arrow.apache.org/adbc/
 [ODPIC]: https://oracle.github.io/odpi/
 

--- a/website/docs/components/data-connectors/kafka.md
+++ b/website/docs/components/data-connectors/kafka.md
@@ -159,4 +159,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README).
+- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README.md).

--- a/website/docs/components/data-connectors/odbc.md
+++ b/website/docs/components/data-connectors/odbc.md
@@ -327,7 +327,7 @@ datasets:
       odbc_connection_string: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=spice_demo;Uid=postgres
 ```
 
-See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README) for more help on getting started with ODBC and Postgres.
+See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md) for more help on getting started with ODBC and Postgres.
 
 ## Secrets
 

--- a/website/docs/components/data-connectors/oracle.md
+++ b/website/docs/components/data-connectors/oracle.md
@@ -198,4 +198,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README)
+- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)

--- a/website/docs/components/models/huggingface.md
+++ b/website/docs/components/models/huggingface.md
@@ -114,4 +114,4 @@ For more details on authentication, see [access tokens](#access-tokens).
 
 ## Cookbook
 
-- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README)
+- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md)

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -44,7 +44,7 @@ Spice is primarily used for:
 
 - **Data Federation**: SQL query across any database, data warehouse, or data lake. [Learn More](https://spiceai.org/docs/features/query-federation).
 - **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai).
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README).
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md).
 - **AI Apps and Agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 :::info[Watch 🎥]
@@ -101,23 +101,23 @@ For detailed comparisons with other data query engines and AI frameworks, see [H
 
 ### Data-Grounded Agentic AI Applications
 
-- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README)
-- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
-- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
-- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README) | [Observability Documentation](https://spiceai.org/docs/features/observability)
+- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
+- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
+- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
+- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh
 
-- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README)
-- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README)
-- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README)
-- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
+- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md)
+- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)
+- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README.md)
+- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
 
 ### Retrieval-Augmented Generation (RAG)
 
-- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
+- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
 - **Semantic Knowledge Layer**: Define a semantic context model to enrich data for AI. [Semantic Model Documentation](./features/semantic-model/index.md)
-- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README)
+- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README.md)
 
 ## FAQ
 

--- a/website/docs/use-cases/ai/agentic-apps/index.md
+++ b/website/docs/use-cases/ai/agentic-apps/index.md
@@ -20,7 +20,7 @@ Unlike generic AI agent frameworks (e.g., AutoGen, CrewAI) that often lack direc
 
 ## Example
 
-A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
+A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
 
 ## Benefits
 
@@ -30,8 +30,8 @@ A SaaS customer success platform deploys a Spice.ai-powered agent to automate ti
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/ai/edge-ai/index.md
+++ b/website/docs/use-cases/ai/edge-ai/index.md
@@ -20,7 +20,7 @@ Unlike cloud-centric AI platforms (e.g., AWS SageMaker, Google Vertex AI) that r
 
 ## Example
 
-A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) demonstrates edge model deployment for such scenarios.
+A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) demonstrates edge model deployment for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A security IoT system processes real-time sensor data from edge devices to detec
 
 ### Learn More
 
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).

--- a/website/docs/use-cases/ai/federated-mcp-server/index.md
+++ b/website/docs/use-cases/ai/federated-mcp-server/index.md
@@ -20,7 +20,7 @@ Unlike centralized AI orchestration platforms (e.g., Apache Airflow for AI workf
 
 ## Example
 
-A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provides patterns adaptable to MCP federation workflows.
+A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provides patterns adaptable to MCP federation workflows.
 
 ## Benefits
 
@@ -30,5 +30,5 @@ A security operations center federates external MCP servers for threat intellige
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).

--- a/website/docs/use-cases/ai/object-store-ai-engine/index.md
+++ b/website/docs/use-cases/ai/object-store-ai-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) or separate search
 
 ## Example
 
-A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provide guidance for implementing search and query workflows on object stores.
+A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provide guidance for implementing search and query workflows on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to query object-store data (e.g., S
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Data Acceleration**: [Documentation](../../features/data-acceleration)

--- a/website/docs/use-cases/ai/real-time-decision-making/index.md
+++ b/website/docs/use-cases/ai/real-time-decision-making/index.md
@@ -30,9 +30,9 @@ A ride-sharing app optimizes driver assignments in milliseconds by combining rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) for an example.
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) for details.
-- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) for an example.
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) for details.
+- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/ai/tool-calling-ai/index.md
+++ b/website/docs/use-cases/ai/tool-calling-ai/index.md
@@ -31,5 +31,5 @@ A finserv platform uses Spice.ai as an MCP server to integrate a risk assessment
 ### Learn More
 
 - **MCP Documentation**: [Documentation](../../features/large-language-models/mcp).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/docs/use-cases/data/application-resilence-and-acceleration/index.md
+++ b/website/docs/use-cases/data/application-resilence-and-acceleration/index.md
@@ -30,6 +30,6 @@ A SaaS project management platform caches user task data and project states loca
 
 ### Learn More
 
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/data/data-mesh/index.md
+++ b/website/docs/use-cases/data/data-mesh/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, Redshift) that centralize da
 
 ## Example
 
-A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This gives teams the ability to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) demonstrates unified data access patterns for such scenarios.
+A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This gives teams the ability to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) demonstrates unified data access patterns for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A health-tech platform implements a data mesh to enable clinical teams to access
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/data/etl-free-workflows/index.md
+++ b/website/docs/use-cases/data/etl-free-workflows/index.md
@@ -30,6 +30,6 @@ A fintech firm migrates from an Oracle database to a cloud-native stack, queryin
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/data/object-store-data-engine/index.md
+++ b/website/docs/use-cases/data/object-store-data-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) that rely on costl
 
 ## Example
 
-A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provide practical guidance for implementing federated queries and data materialization.
+A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provide practical guidance for implementing federated queries and data materialization.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv platform queries transaction logs stored in S3, combines them with rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/data/reverse-etl/index.md
+++ b/website/docs/use-cases/data/reverse-etl/index.md
@@ -20,7 +20,7 @@ Unlike data-team-focused orchestration tools (e.g., Fivetran, Airbyte), Spice.ai
 
 ## Example
 
-A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, so teams can respond faster to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provides a practical guide to materializing datasets for such workflows.
+A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, so teams can respond faster to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provides a practical guide to materializing datasets for such workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesf
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/rag/reporting/index.md
+++ b/website/docs/use-cases/rag/reporting/index.md
@@ -30,7 +30,7 @@ A health-tech company generates real-time HIPAA compliance reports by combining 
 
 ### Learn More
 
-- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).

--- a/website/docs/use-cases/search/data-collection-and-search/index.md
+++ b/website/docs/use-cases/search/data-collection-and-search/index.md
@@ -20,7 +20,7 @@ Unlike complex streaming platforms (e.g., Apache Flink) that require extensive i
 
 ## Example
 
-A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, improving player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) demonstrates real-time data processing and search patterns adaptable to such use cases.
+A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, improving player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) demonstrates real-time data processing and search patterns adaptable to such use cases.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A gaming platform processes live player activity from Kafka streams to power in-
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/docs/use-cases/search/enterprise-search/index.md
+++ b/website/docs/use-cases/search/enterprise-search/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that lack bui
 
 ## Example
 
-A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
+A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv firm enables traders to search a knowledge base combining structured t
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/docs/use-cases/search/object-store-search-engine/index.md
+++ b/website/docs/use-cases/search/object-store-search-engine/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that require 
 
 ## Example
 
-A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) provide guidance for implementing hybrid search on object stores.
+A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) provide guidance for implementing hybrid search on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to search S3-stored network logs an
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/src/pages/cookbook/_ignored.tsx
+++ b/website/src/pages/cookbook/_ignored.tsx
@@ -86,7 +86,7 @@ const recipes: RecipeData[] = [
   {
     title: 'Nvidia NIM',
     description: 'Deploy Nvidia NIM infrastructure, on Kubernetes, with GPUs connected to Spice.',
-    path: '/nvidia-nim/README.md',
+    path: '/nvidia-nim/ec2/README.md',
     tags: ['ai', 'nvidia', 'nim']
   },
   {
@@ -158,7 +158,7 @@ const recipes: RecipeData[] = [
   {
     title: 'Hashed Partitioning with DuckDB',
     description: 'Use hashed partitioning for performance with DuckDB.',
-    path: '/duckdb/hashed-partitioning/README.md',
+    path: '/hashed_partitioning/README.md',
     tags: ['acceleration', 'duckdb', 'partitioning']
   },
   {
@@ -404,7 +404,7 @@ const recipes: RecipeData[] = [
   {
     title: 'Results Caching',
     description: 'Cache query results for improved performance.',
-    path: '/caching/README.md',
+    path: '/caching/accelerator/README.md',
     tags: ['performance', 'caching']
   },
   {
@@ -481,13 +481,13 @@ const recipes: RecipeData[] = [
   {
     title: 'Java JDBC Client',
     description: 'Query Spice.ai using the Java JDBC client.',
-    path: '/clients/jdbc/java/README.md',
+    path: '/clients/java/README.md',
     tags: ['client', 'java', 'jdbc']
   },
   {
     title: 'Scala JDBC Client',
     description: 'Query Spice.ai using the Scala JDBC client.',
-    path: '/clients/jdbc/scala/README.md',
+    path: '/clients/scala/README.md',
     tags: ['client', 'scala', 'jdbc']
   },
   // Security
@@ -514,7 +514,7 @@ const recipes: RecipeData[] = [
   {
     title: 'Cron Dataset Schedules',
     description: 'Schedule dataset refreshes using cron syntax.',
-    path: '/cron-schedules/README.md',
+    path: '/acceleration/cron/README.md',
     tags: ['configuration', 'scheduling', 'refresh']
   }
 ]

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/glue.md
@@ -210,4 +210,4 @@ Each query retrieves data from the S3 source, which might result in significant 
 
 ## Cookbook
 
-- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue/README)
+- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue#readme)

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/glue.md
@@ -50,13 +50,13 @@ The dataset name cannot be a [reserved keyword(../../reference/spicepod/keywords
 
 The following parameters are supported for configuring the connection to the Glue Data Catalog:
 
-| Parameter Name       | Definition                                                                  |
-| -------------------- | --------------------------------------------------------------------------- |
-| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                 |
+| Parameter Name       | Definition                                                                                                                                                                  |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                                                                 |
 | `glue_catalog_id`    | The Glue catalog ID. For Amazon S3 Tables, use the format `<account_id>:s3tablescatalog/<table_bucket_name>`. If not provided, the default catalog for the account is used. |
-| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                 |
-| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                             |
-| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials    |
+| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                           |
+| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                       |
+| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                    |
 
 ## Examples
 
@@ -180,15 +180,15 @@ The IAM role or user needs the following permissions to access Iceberg tables in
 
 ### Permission Details
 
-| Permission | Purpose |
-|------------|---------|
-| `s3:ListBucket` | Required. Allows scanning all objects from the bucket |
-| `s3:GetObject` | Required. Allows fetching objects |
-| `glue:GetCatalog` | Required. Retrieve metadata about the specified catalog. |
+| Permission          | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `s3:ListBucket`     | Required. Allows scanning all objects from the bucket          |
+| `s3:GetObject`      | Required. Allows fetching objects                              |
+| `glue:GetCatalog`   | Required. Retrieve metadata about the specified catalog.       |
 | `glue:GetDatabases` | Required. List the databases available in the current catalog. |
-| `glue:GetDatabase` | Required. Retrieve metadata about the specified database. |
-| `glue:GetTable` | Required. Retrieve metadata about the specified table. |
-| `glue:GetTables` | Required. List the tables available in the current database. |
+| `glue:GetDatabase`  | Required. Retrieve metadata about the specified database.      |
+| `glue:GetTable`     | Required. Retrieve metadata about the specified table.         |
+| `glue:GetTables`    | Required. List the tables available in the current database.   |
 
 ## Limitations
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/index.md
@@ -90,7 +90,7 @@ datasets:
 | Name                                          | Parameter              | Status  | Description                                   |
 | --------------------------------------------- | ---------------------- | ------- | --------------------------------------------- |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | Stable  | Columnar format optimized for analytics       |
-| [CSV](/docs/reference/file_format#csv)       | `file_format: csv`     | Stable  | Comma-separated values                        |
+| [CSV](/docs/reference/file_format#csv)        | `file_format: csv`     | Stable  | Comma-separated values                        |
 | JSON                                          | `file_format: json`    | Roadmap | JavaScript Object Notation                    |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap | Open table format for large analytic datasets |
 | Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                      |
@@ -157,7 +157,7 @@ Partition pruning improves query performance by reading only the relevant files.
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
 | [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
-| [CSV](/docs/reference/file_format#csv)       | `file_format: csv`     | ✅         | ❌                  |
+| [CSV](/docs/reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
 | JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
 | Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/kafka.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/kafka.md
@@ -143,4 +143,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README).
+- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README.md).

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/oracle.md
@@ -198,4 +198,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README)
+- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)

--- a/website/versioned_docs/version-1.10.x/index.mdx
+++ b/website/versioned_docs/version-1.10.x/index.mdx
@@ -27,7 +27,7 @@ Spice is primarily used for:
 
 - **Data Federation**: SQL query across any database, data warehouse, or data lake. [Learn More](https://spiceai.org/docs/features/query-federation).
 - **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai).
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README).
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md).
 - **AI Apps and Agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 :::info[Watch 🎥]
@@ -112,24 +112,24 @@ Limited = Partial or restricted support
 
 ### Data-Grounded Agentic AI Applications
 
-- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README)
-- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
-- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
-- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README) | [Observability Documentation](https://spiceai.org/docs/features/observability)
+- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
+- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
+- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
+- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh
 
-- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README)
-- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README)
-- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README)
-- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
+- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md)
+- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)
+- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README.md)
+- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
 
 ### Retrieval-Augmented Generation (RAG)
 
-- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
+- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
 - **Semantic Knowledge Layer**: Define a semantic context model to enrich data for AI. [Semantic Model Documentation](/docs/features/semantic-model)
-- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README)
-- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README)
+- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README.md)
+- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README.md)
 
 ## FAQ
 

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/agentic-apps/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/agentic-apps/index.md
@@ -20,7 +20,7 @@ Unlike generic AI agent frameworks (e.g., AutoGen, CrewAI) that often lack seaml
 
 ## Example
 
-A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [Vector-Based Search documentation](/docs/features/search) guide implementation of data access and search for agentic workflows.
+A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [Vector-Based Search documentation](/docs/features/search) guide implementation of data access and search for agentic workflows.
 
 ## Benefits
 
@@ -30,8 +30,8 @@ A SaaS customer success platform deploys a Spice.ai-powered agent to automate ti
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Semantic Model**: [Documentation](/docs/features/semantic-model).
 - **Observability**: [Documentation](/docs/features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/edge-ai/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/edge-ai/index.md
@@ -20,7 +20,7 @@ Unlike cloud-centric AI platforms (e.g., AWS SageMaker, Google Vertex AI) that r
 
 ## Example
 
-A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) demonstrates edge model deployment for such scenarios.
+A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) demonstrates edge model deployment for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A security IoT system processes real-time sensor data from edge devices to detec
 
 ### Learn More
 
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/federated-mcp-server/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/federated-mcp-server/index.md
@@ -20,7 +20,7 @@ Unlike centralized AI orchestration platforms (e.g., Apache Airflow for AI workf
 
 ## Example
 
-A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provides patterns adaptable to MCP federation workflows.
+A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provides patterns adaptable to MCP federation workflows.
 
 ## Benefits
 
@@ -30,5 +30,5 @@ A security operations center federates external MCP servers for threat intellige
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/object-store-ai-engine/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/object-store-ai-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) or separate search
 
 ## Example
 
-A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](/docs/features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provide guidance for implementing search and query workflows on object stores.
+A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](/docs/features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provide guidance for implementing search and query workflows on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to query object-store data (e.g., S
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Data Acceleration**: [Documentation](/docs/features/data-acceleration)

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/real-time-decision-making/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/real-time-decision-making/index.md
@@ -30,9 +30,9 @@ A ride-sharing app optimizes driver assignments in milliseconds by combining rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) for an example.
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) for details.
-- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) for an example.
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) for details.
+- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/ai/tool-calling-ai/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/ai/tool-calling-ai/index.md
@@ -31,5 +31,5 @@ A finserv platform uses Spice.ai as an MCP server to integrate a risk assessment
 ### Learn More
 
 - **MCP Documentation**: [Documentation](/docs/features/large-language-models/mcp).
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.10.x/use-cases/data/application-resilence-and-acceleration/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/data/application-resilence-and-acceleration/index.md
@@ -30,6 +30,6 @@ A SaaS project management platform caches user task data and project states loca
 
 ### Learn More
 
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/data/data-mesh/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/data/data-mesh/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, Redshift) that centralize da
 
 ## Example
 
-A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) demonstrates unified data access patterns for such scenarios.
+A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) demonstrates unified data access patterns for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A health-tech platform implements a data mesh to enable clinical teams to access
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/data/etl-free-workflows/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/data/etl-free-workflows/index.md
@@ -30,6 +30,6 @@ A fintech firm migrates from an Oracle database to a cloud-native stack, queryin
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/data/object-store-data-engine/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/data/object-store-data-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) that rely on costl
 
 ## Example
 
-A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provide practical guidance for implementing federated queries and data materialization.
+A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provide practical guidance for implementing federated queries and data materialization.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv platform queries transaction logs stored in S3, combines them with rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](/docs/features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](/docs/features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](/docs/features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/data/reverse-etl/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/data/reverse-etl/index.md
@@ -20,7 +20,7 @@ Unlike data-team-focused orchestration tools (e.g., Fivetran, Airbyte), Spice.ai
 
 ## Example
 
-A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provides a practical guide to materializing datasets for such workflows.
+A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provides a practical guide to materializing datasets for such workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesf
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/rag/reporting/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/rag/reporting/index.md
@@ -30,7 +30,7 @@ A health-tech company generates real-time HIPAA compliance reports by combining 
 
 ### Learn More
 
-- **Vector Similarity Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Vector Similarity Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Semantic Model**: [Documentation](/docs/features/semantic-model).

--- a/website/versioned_docs/version-1.10.x/use-cases/search/data-collection-and-search/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/search/data-collection-and-search/index.md
@@ -20,7 +20,7 @@ Unlike complex streaming platforms (e.g., Apache Flink) that require extensive i
 
 ## Example
 
-A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) demonstrates real-time data processing and search patterns adaptable to such use cases.
+A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) demonstrates real-time data processing and search patterns adaptable to such use cases.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A gaming platform processes live player activity from Kafka streams to power in-
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.10.x/use-cases/search/enterprise-search/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/search/enterprise-search/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that lack sea
 
 ## Example
 
-A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) and [Vector-Based Search documentation](/docs/features/search) provide implementation guidance for hybrid search workflows.
+A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) and [Vector-Based Search documentation](/docs/features/search) provide implementation guidance for hybrid search workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv firm enables traders to search a knowledge base combining structured t
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](/docs/features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.10.x/use-cases/search/object-store-search-engine/index.md
+++ b/website/versioned_docs/version-1.10.x/use-cases/search/object-store-search-engine/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that require 
 
 ## Example
 
-A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](/docs/features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) provide guidance for implementing hybrid search on object stores.
+A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](/docs/features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) provide guidance for implementing hybrid search on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to search S3-stored network logs an
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](/docs/features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Vector and Hybrid Search**: [Documentation](/docs/features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](/docs/features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](/docs/features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](/docs/features/observability).

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/glue.md
@@ -210,4 +210,4 @@ Each query retrieves data from the S3 source, which might result in significant 
 
 ## Cookbook
 
-- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue/README)
+- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue#readme)

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/index.md
@@ -73,7 +73,7 @@ Supported Data Connectors include:
 | `scylladb`                         | ScyllaDB                              | Alpha             | CQL, Alternator (DynamoDB)   |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/kafka.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/kafka.md
@@ -159,4 +159,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README).
+- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README.md).

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/odbc.md
@@ -327,7 +327,7 @@ datasets:
       odbc_connection_string: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=spice_demo;Uid=postgres
 ```
 
-See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README) for more help on getting started with ODBC and Postgres.
+See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md) for more help on getting started with ODBC and Postgres.
 
 ## Secrets
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/oracle.md
@@ -198,4 +198,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README)
+- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)

--- a/website/versioned_docs/version-1.11.x/components/models/huggingface.md
+++ b/website/versioned_docs/version-1.11.x/components/models/huggingface.md
@@ -114,4 +114,4 @@ For more details on authentication, see [access tokens](#access-tokens).
 
 ## Cookbook
 
-- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README)
+- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md)

--- a/website/versioned_docs/version-1.11.x/index.mdx
+++ b/website/versioned_docs/version-1.11.x/index.mdx
@@ -44,7 +44,7 @@ Spice is primarily used for:
 
 - **Data Federation**: SQL query across any database, data warehouse, or data lake. [Learn More](https://spiceai.org/docs/features/query-federation).
 - **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai).
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README).
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md).
 - **AI Apps and Agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 :::info[Watch 🎥]
@@ -134,24 +134,24 @@ Limited = Partial or restricted support
 
 ### Data-Grounded Agentic AI Applications
 
-- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README)
-- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
-- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
-- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README) | [Observability Documentation](https://spiceai.org/docs/features/observability)
+- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
+- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
+- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
+- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh
 
-- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README)
-- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README)
-- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README)
-- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
+- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md)
+- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)
+- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README.md)
+- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
 
 ### Retrieval-Augmented Generation (RAG)
 
-- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
+- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
 - **Semantic Knowledge Layer**: Define a semantic context model to enrich data for AI. [Semantic Model Documentation](./features/semantic-model/index.md)
-- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README)
-- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README)
+- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README.md)
+- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README.md)
 
 ## FAQ
 

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/agentic-apps/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/agentic-apps/index.md
@@ -20,7 +20,7 @@ Unlike generic AI agent frameworks (e.g., AutoGen, CrewAI) that often lack direc
 
 ## Example
 
-A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
+A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
 
 ## Benefits
 
@@ -30,8 +30,8 @@ A SaaS customer success platform deploys a Spice.ai-powered agent to automate ti
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/edge-ai/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/edge-ai/index.md
@@ -20,7 +20,7 @@ Unlike cloud-centric AI platforms (e.g., AWS SageMaker, Google Vertex AI) that r
 
 ## Example
 
-A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) demonstrates edge model deployment for such scenarios.
+A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) demonstrates edge model deployment for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A security IoT system processes real-time sensor data from edge devices to detec
 
 ### Learn More
 
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/federated-mcp-server/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/federated-mcp-server/index.md
@@ -20,7 +20,7 @@ Unlike centralized AI orchestration platforms (e.g., Apache Airflow for AI workf
 
 ## Example
 
-A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provides patterns adaptable to MCP federation workflows.
+A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provides patterns adaptable to MCP federation workflows.
 
 ## Benefits
 
@@ -30,5 +30,5 @@ A security operations center federates external MCP servers for threat intellige
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/object-store-ai-engine/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/object-store-ai-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) or separate search
 
 ## Example
 
-A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provide guidance for implementing search and query workflows on object stores.
+A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provide guidance for implementing search and query workflows on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to query object-store data (e.g., S
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Data Acceleration**: [Documentation](../../features/data-acceleration)

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/real-time-decision-making/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/real-time-decision-making/index.md
@@ -30,9 +30,9 @@ A ride-sharing app optimizes driver assignments in milliseconds by combining rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) for an example.
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) for details.
-- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) for an example.
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) for details.
+- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/ai/tool-calling-ai/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/ai/tool-calling-ai/index.md
@@ -31,5 +31,5 @@ A finserv platform uses Spice.ai as an MCP server to integrate a risk assessment
 ### Learn More
 
 - **MCP Documentation**: [Documentation](../../features/large-language-models/mcp).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.11.x/use-cases/data/application-resilence-and-acceleration/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/data/application-resilence-and-acceleration/index.md
@@ -30,6 +30,6 @@ A SaaS project management platform caches user task data and project states loca
 
 ### Learn More
 
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/data/data-mesh/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/data/data-mesh/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, Redshift) that centralize da
 
 ## Example
 
-A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This gives teams the ability to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) demonstrates unified data access patterns for such scenarios.
+A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This gives teams the ability to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) demonstrates unified data access patterns for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A health-tech platform implements a data mesh to enable clinical teams to access
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/data/etl-free-workflows/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/data/etl-free-workflows/index.md
@@ -30,6 +30,6 @@ A fintech firm migrates from an Oracle database to a cloud-native stack, queryin
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/data/object-store-data-engine/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/data/object-store-data-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) that rely on costl
 
 ## Example
 
-A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provide practical guidance for implementing federated queries and data materialization.
+A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provide practical guidance for implementing federated queries and data materialization.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv platform queries transaction logs stored in S3, combines them with rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/data/reverse-etl/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/data/reverse-etl/index.md
@@ -20,7 +20,7 @@ Unlike data-team-focused orchestration tools (e.g., Fivetran, Airbyte), Spice.ai
 
 ## Example
 
-A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, so teams can respond faster to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provides a practical guide to materializing datasets for such workflows.
+A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, so teams can respond faster to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provides a practical guide to materializing datasets for such workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesf
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/rag/reporting/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/rag/reporting/index.md
@@ -30,7 +30,7 @@ A health-tech company generates real-time HIPAA compliance reports by combining 
 
 ### Learn More
 
-- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).

--- a/website/versioned_docs/version-1.11.x/use-cases/search/data-collection-and-search/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/search/data-collection-and-search/index.md
@@ -20,7 +20,7 @@ Unlike complex streaming platforms (e.g., Apache Flink) that require extensive i
 
 ## Example
 
-A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, improving player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) demonstrates real-time data processing and search patterns adaptable to such use cases.
+A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, improving player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) demonstrates real-time data processing and search patterns adaptable to such use cases.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A gaming platform processes live player activity from Kafka streams to power in-
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.11.x/use-cases/search/enterprise-search/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/search/enterprise-search/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that lack bui
 
 ## Example
 
-A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
+A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv firm enables traders to search a knowledge base combining structured t
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.11.x/use-cases/search/object-store-search-engine/index.md
+++ b/website/versioned_docs/version-1.11.x/use-cases/search/object-store-search-engine/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that require 
 
 ## Example
 
-A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) provide guidance for implementing hybrid search on object stores.
+A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) provide guidance for implementing hybrid search on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to search S3-stored network logs an
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook.md)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/index.md
@@ -71,15 +71,15 @@ File formats currently supported are:
 
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅        | ❌                 |
-| [CSV](../../reference/file_format.md#csv)     | `file_format: csv`     | ✅        | ❌                 |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                 |
-| JSON                                          | `file_format: json`    | Roadmap   | ❌                 |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                 |
-| Markdown                                      | `file_format: md`      | ✅        | ✅                 |
-| Text                                          | `file_format: txt`     | ✅        | ✅                 |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                 |
-| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                 |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
+| [CSV](../../reference/file_format.md#csv)     | `file_format: csv`     | ✅         | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
+| JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Markdown                                      | `file_format: md`      | ✅         | ✅                  |
+| Text                                          | `file_format: txt`     | ✅         | ✅                  |
+| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](../../reference/file_format)
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 | `mongodb`                          | MongoDB                               | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/glue.md
@@ -46,12 +46,12 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The following parameters are supported for configuring the connection to the Glue Data Catalog:
 
-| Parameter Name       | Definition                                                                  |
-| -------------------- | --------------------------------------------------------------------------- |
-| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                 |
-| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                 |
-| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                             |
-| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials    |
+| Parameter Name       | Definition                                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                           |
+| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.     |
+| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles. |
+| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                              |
 
 ## Authentication
 
@@ -146,15 +146,15 @@ The IAM role or user needs the following permissions to access Iceberg tables in
 
 ### Permission Details
 
-| Permission | Purpose |
-|------------|---------|
-| `s3:ListBucket` | Required. Allows scanning all objects from the bucket |
-| `s3:GetObject` | Required. Allows fetching objects |
-| `glue:GetCatalog` | Required. Retrieve metadata about the specified catalog. |
+| Permission          | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `s3:ListBucket`     | Required. Allows scanning all objects from the bucket          |
+| `s3:GetObject`      | Required. Allows fetching objects                              |
+| `glue:GetCatalog`   | Required. Retrieve metadata about the specified catalog.       |
 | `glue:GetDatabases` | Required. List the databases available in the current catalog. |
-| `glue:GetDatabase` | Required. Retrieve metadata about the specified database. |
-| `glue:GetTable` | Required. Retrieve metadata about the specified table. |
-| `glue:GetTables` | Required. List the tables available in the current database. |
+| `glue:GetDatabase`  | Required. Retrieve metadata about the specified database.      |
+| `glue:GetTable`     | Required. Retrieve metadata about the specified table.         |
+| `glue:GetTables`    | Required. List the tables available in the current database.   |
 
 ## Limitations
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/glue.md
@@ -176,4 +176,4 @@ Each query retrieves data from the S3 source, which might result in significant 
 
 ## Cookbook
 
-- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue/README)
+- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue#readme)

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 | `mongodb`                          | MongoDB                               | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/kafka.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/kafka.md
@@ -112,4 +112,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README).
+- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README.md).

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/odbc.md
@@ -327,7 +327,7 @@ datasets:
       odbc_connection_string: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=spice_demo;Uid=postgres
 ```
 
-See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README) for more help on getting started with ODBC and Postgres.
+See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md) for more help on getting started with ODBC and Postgres.
 
 ## Secrets
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/oracle.md
@@ -198,4 +198,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README)
+- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)

--- a/website/versioned_docs/version-1.6.x/components/models/huggingface.md
+++ b/website/versioned_docs/version-1.6.x/components/models/huggingface.md
@@ -114,4 +114,4 @@ For more details on authentication, see [access tokens](#access-tokens).
 
 ## Cookbook
 
-- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README)
+- Use the Llama family of models locally from HuggingFace using Spice. [Running Llama3 Locally](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md)

--- a/website/versioned_docs/version-1.6.x/index.mdx
+++ b/website/versioned_docs/version-1.6.x/index.mdx
@@ -27,7 +27,7 @@ Spice is primarily used for:
 
 - **Data Federation**: SQL query across any database, data warehouse, or data lake. [Learn More](https://spiceai.org/docs/features/query-federation).
 - **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai).
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README).
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md).
 - **AI Apps and Agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 :::info[Watch 🎥]
@@ -112,24 +112,24 @@ Limited = Partial or restricted support
 
 ### Data-Grounded Agentic AI Applications
 
-- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README)
-- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
-- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
-- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README) | [Observability Documentation](https://spiceai.org/docs/features/observability)
+- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
+- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
+- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
+- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh
 
-- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README)
-- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README)
-- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README)
-- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
+- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md)
+- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)
+- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README.md)
+- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
 
 ### Retrieval-Augmented Generation (RAG)
 
-- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
+- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
 - **Semantic Knowledge Layer**: Define a semantic context model to enrich data for AI. [Semantic Model Documentation](features/semantic-model/index.md)
-- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README)
-- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README)
+- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README.md)
+- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README.md)
 
 ## FAQ
 

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/agentic-apps/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/agentic-apps/index.md
@@ -20,7 +20,7 @@ Unlike generic AI agent frameworks (e.g., AutoGen, CrewAI) that often lack seaml
 
 ## Example
 
-A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
+A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
 
 ## Benefits
 
@@ -30,8 +30,8 @@ A SaaS customer success platform deploys a Spice.ai-powered agent to automate ti
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/edge-ai/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/edge-ai/index.md
@@ -20,7 +20,7 @@ Unlike cloud-centric AI platforms (e.g., AWS SageMaker, Google Vertex AI) that r
 
 ## Example
 
-A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) demonstrates edge model deployment for such scenarios.
+A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) demonstrates edge model deployment for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A security IoT system processes real-time sensor data from edge devices to detec
 
 ### Learn More
 
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/federated-mcp-server/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/federated-mcp-server/index.md
@@ -20,7 +20,7 @@ Unlike centralized AI orchestration platforms (e.g., Apache Airflow for AI workf
 
 ## Example
 
-A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provides patterns adaptable to MCP federation workflows.
+A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provides patterns adaptable to MCP federation workflows.
 
 ## Benefits
 
@@ -30,5 +30,5 @@ A security operations center federates external MCP servers for threat intellige
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/object-store-ai-engine/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/object-store-ai-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) or separate search
 
 ## Example
 
-A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provide guidance for implementing search and query workflows on object stores.
+A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provide guidance for implementing search and query workflows on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to query object-store data (e.g., S
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Data Acceleration**: [Documentation](../../features/data-acceleration)

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/real-time-decision-making/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/real-time-decision-making/index.md
@@ -30,9 +30,9 @@ A ride-sharing app optimizes driver assignments in milliseconds by combining rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) for an example.
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) for details.
-- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) for an example.
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) for details.
+- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/ai/tool-calling-ai/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/ai/tool-calling-ai/index.md
@@ -31,5 +31,5 @@ A finserv platform uses Spice.ai as an MCP server to integrate a risk assessment
 ### Learn More
 
 - **MCP Documentation**: [Documentation](../../features/large-language-models/mcp).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.6.x/use-cases/data/application-resilence-and-acceleration/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/data/application-resilence-and-acceleration/index.md
@@ -30,6 +30,6 @@ A SaaS project management platform caches user task data and project states loca
 
 ### Learn More
 
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/data/data-mesh/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/data/data-mesh/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, Redshift) that centralize da
 
 ## Example
 
-A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) demonstrates unified data access patterns for such scenarios.
+A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) demonstrates unified data access patterns for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A health-tech platform implements a data mesh to enable clinical teams to access
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/data/etl-free-workflows/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/data/etl-free-workflows/index.md
@@ -30,6 +30,6 @@ A fintech firm migrates from an Oracle database to a cloud-native stack, queryin
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/data/object-store-data-engine/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/data/object-store-data-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) that rely on costl
 
 ## Example
 
-A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provide practical guidance for implementing federated queries and data materialization.
+A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provide practical guidance for implementing federated queries and data materialization.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv platform queries transaction logs stored in S3, combines them with rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/data/reverse-etl/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/data/reverse-etl/index.md
@@ -20,7 +20,7 @@ Unlike data-team-focused orchestration tools (e.g., Fivetran, Airbyte), Spice.ai
 
 ## Example
 
-A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provides a practical guide to materializing datasets for such workflows.
+A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provides a practical guide to materializing datasets for such workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesf
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/rag/reporting/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/rag/reporting/index.md
@@ -30,7 +30,7 @@ A health-tech company generates real-time HIPAA compliance reports by combining 
 
 ### Learn More
 
-- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).

--- a/website/versioned_docs/version-1.6.x/use-cases/search/data-collection-and-search/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/search/data-collection-and-search/index.md
@@ -20,7 +20,7 @@ Unlike complex streaming platforms (e.g., Apache Flink) that require extensive i
 
 ## Example
 
-A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) demonstrates real-time data processing and search patterns adaptable to such use cases.
+A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) demonstrates real-time data processing and search patterns adaptable to such use cases.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A gaming platform processes live player activity from Kafka streams to power in-
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.6.x/use-cases/search/enterprise-search/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/search/enterprise-search/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that lack sea
 
 ## Example
 
-A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
+A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv firm enables traders to search a knowledge base combining structured t
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.6.x/use-cases/search/object-store-search-engine/index.md
+++ b/website/versioned_docs/version-1.6.x/use-cases/search/object-store-search-engine/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that require 
 
 ## Example
 
-A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) provide guidance for implementing hybrid search on object stores.
+A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) provide guidance for implementing hybrid search on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to search S3-stored network logs an
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/glue.md
@@ -46,12 +46,12 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The following parameters are supported for configuring the connection to the Glue Data Catalog:
 
-| Parameter Name       | Definition                                                                  |
-| -------------------- | --------------------------------------------------------------------------- |
-| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                 |
-| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                 |
-| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                             |
-| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials    |
+| Parameter Name       | Definition                                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                           |
+| `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.     |
+| `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles. |
+| `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                              |
 
 ## Authentication
 
@@ -146,15 +146,15 @@ The IAM role or user needs the following permissions to access Iceberg tables in
 
 ### Permission Details
 
-| Permission | Purpose |
-|------------|---------|
-| `s3:ListBucket` | Required. Allows scanning all objects from the bucket |
-| `s3:GetObject` | Required. Allows fetching objects |
-| `glue:GetCatalog` | Required. Retrieve metadata about the specified catalog. |
+| Permission          | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `s3:ListBucket`     | Required. Allows scanning all objects from the bucket          |
+| `s3:GetObject`      | Required. Allows fetching objects                              |
+| `glue:GetCatalog`   | Required. Retrieve metadata about the specified catalog.       |
 | `glue:GetDatabases` | Required. List the databases available in the current catalog. |
-| `glue:GetDatabase` | Required. Retrieve metadata about the specified database. |
-| `glue:GetTable` | Required. Retrieve metadata about the specified table. |
-| `glue:GetTables` | Required. List the tables available in the current database. |
+| `glue:GetDatabase`  | Required. Retrieve metadata about the specified database.      |
+| `glue:GetTable`     | Required. Retrieve metadata about the specified table.         |
+| `glue:GetTables`    | Required. List the tables available in the current database.   |
 
 ## Limitations
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/glue.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/glue.md
@@ -176,4 +176,4 @@ Each query retrieves data from the S3 source, which might result in significant 
 
 ## Cookbook
 
-- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue/README)
+- A cookbook recipe to configure Glue as a data connector in Spice. [Glue Data Connector](https://github.com/spiceai/cookbook/tree/trunk/glue#readme)

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/index.md
@@ -71,15 +71,15 @@ File formats currently supported are:
 
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅        | ❌                 |
-| [CSV](../../reference/file_format#csv)     | `file_format: csv`     | ✅        | ❌                 |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                 |
-| JSON                                          | `file_format: json`    | Roadmap   | ❌                 |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                 |
-| Markdown                                      | `file_format: md`      | ✅        | ✅                 |
-| Text                                          | `file_format: txt`     | ✅        | ✅                 |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                 |
-| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                 |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
+| [CSV](../../reference/file_format#csv)        | `file_format: csv`     | ✅         | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
+| JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Markdown                                      | `file_format: md`      | ✅         | ✅                  |
+| Text                                          | `file_format: txt`     | ✅         | ✅                  |
+| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](../../reference/file_format)
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/kafka.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/kafka.md
@@ -143,4 +143,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README).
+- See how to query Kafka real-time data with other datasets using federated queries in [Live Orders Analytics example](https://github.com/spiceai/cookbook/blob/trunk/kafka/README.md).

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/odbc.md
@@ -327,7 +327,7 @@ datasets:
       odbc_connection_string: Driver={PostgreSQL Unicode};Server=localhost;Port=5432;Database=spice_demo;Uid=postgres
 ```
 
-See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README) for more help on getting started with ODBC and Postgres.
+See the [ODBC Cookbook](https://github.com/spiceai/cookbook/blob/trunk/odbc/README.md) for more help on getting started with ODBC and Postgres.
 
 ## Secrets
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/oracle.md
@@ -198,4 +198,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 ## Cookbook
 
-- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README)
+- A cookbook recipe to connect to and accelerate data from an Oracle database in Spice. [Oracle Data Connector](https://github.com/spiceai/cookbook/blob/trunk/oracle/README.md)

--- a/website/versioned_docs/version-1.7.x/index.mdx
+++ b/website/versioned_docs/version-1.7.x/index.mdx
@@ -27,7 +27,7 @@ Spice is primarily used for:
 
 - **Data Federation**: SQL query across any database, data warehouse, or data lake. [Learn More](https://spiceai.org/docs/features/query-federation).
 - **Data Materialization and Acceleration**: Materialize, accelerate, and cache database queries. [Read the MaterializedView interview - Building a CDN for Databases](https://materializedview.io/p/building-a-cdn-for-databases-spice-ai).
-- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README).
+- **Enterprise Search**: Keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search for structured and unstructured data. [Learn More](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md).
 - **AI Apps and Agents**: An AI-database powering retrieval-augmented generation (RAG) and intelligent agents. [Learn More](https://spiceai.org/docs/use-cases/rag).
 
 :::info[Watch 🎥]
@@ -112,24 +112,24 @@ Limited = Partial or restricted support
 
 ### Data-Grounded Agentic AI Applications
 
-- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README)
-- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
-- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
-- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README) | [Observability Documentation](https://spiceai.org/docs/features/observability)
+- **OpenAI-Compatible API**: Connect to hosted models (OpenAI, Anthropic, xAI) or deploy locally (Llama, NVIDIA NIM). [AI Gateway Recipe](https://github.com/spiceai/cookbook/blob/trunk/openai_sdk/README.md)
+- **Federated Data Access**: Query using SQL and NSQL (text-to-SQL) across databases, data warehouses, and data lakes with advanced query push-down. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
+- **Search and RAG**: Perform keyword, vector, and full-text search with Tantivy-powered BM25 and vector similarity search (VSS) integrated into SQL queries using `vector_search` and `text_search`. Supports multi-column vector search with reciprocal rank fusion. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
+- **LLM Memory and Observability**: Store and retrieve history and context for AI agents with visibility into data flows, model performance, and traces. [LLM Memory Recipe](https://github.com/spiceai/cookbook/blob/trunk/llm-memory/README.md) | [Observability Documentation](https://spiceai.org/docs/features/observability)
 
 ### Database CDN and Query Mesh
 
-- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README)
-- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README)
-- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README)
-- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README)
+- **Data Acceleration**: Co-locate materialized datasets in Arrow, SQLite, or DuckDB for sub-second queries. [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md)
+- **Resiliency and Local Dataset Replication**: Maintain availability with local replicas of critical datasets. [Local Dataset Replication Recipe](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)
+- **Responsive Dashboards**: Enable fast, real-time analytics for frontends and BI tools. [Sales BI Dashboard Demo](https://github.com/spiceai/cookbook/blob/trunk/sales-bi/README.md)
+- **Simplified Legacy Migration**: Unify legacy systems with modern infrastructure via federated SQL querying. [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md)
 
 ### Retrieval-Augmented Generation (RAG)
 
-- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README)
+- **Unified Search with Vector Similarity**: Perform efficient vector similarity search across structured and unstructured data, with native support for Amazon S3 Vectors for petabyte-scale storage and querying. Supports distance metrics like cosine similarity, Euclidean distance, or dot product. [Amazon S3 Vectors Recipe](https://github.com/spiceai/cookbook/blob/trunk/vectors/s3/README.md)
 - **Semantic Knowledge Layer**: Define a semantic context model to enrich data for AI. [Semantic Model Documentation](features/semantic-model/index.md)
-- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README)
-- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README)
+- **Text-to-SQL**: Convert natural language queries into SQL using built-in NSQL and sampling tools. [Text-to-SQL Recipe](https://github.com/spiceai/cookbook/blob/trunk/text-to-sql/README.md)
+- **Model and Data Evaluations**: Assess model performance and data quality with integrated evaluation tools. [Language Model Evaluations Recipe](https://github.com/spiceai/cookbook/blob/trunk/evals/README.md)
 
 ## FAQ
 

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/agentic-apps/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/agentic-apps/index.md
@@ -20,7 +20,7 @@ Unlike generic AI agent frameworks (e.g., AutoGen, CrewAI) that often lack seaml
 
 ## Example
 
-A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
+A SaaS customer success platform deploys a Spice.ai-powered agent to automate ticket resolution by querying real-time user data from PostgreSQL, historical support interactions from Databricks, and unstructured knowledge base articles via hybrid search. The agent uses LLM inference to generate personalized responses and escalate critical issues, reducing resolution time compared to manual processes or generic AI agents lacking deep data integration. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [Vector-Based Search documentation](../../features/search) guide implementation of data access and search for agentic workflows.
 
 ## Benefits
 
@@ -30,8 +30,8 @@ A SaaS customer success platform deploys a Spice.ai-powered agent to automate ti
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/edge-ai/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/edge-ai/index.md
@@ -20,7 +20,7 @@ Unlike cloud-centric AI platforms (e.g., AWS SageMaker, Google Vertex AI) that r
 
 ## Example
 
-A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) demonstrates edge model deployment for such scenarios.
+A security IoT system processes real-time sensor data from edge devices to detect unauthorized access attempts in a corporate facility, using local AI models to prioritize alerts without cloud dependency. This ensures instant threat detection and response, even during network outages, outperforming cloud-dependent systems that suffer from latency and connectivity issues. The [Running Llama3 Locally recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) demonstrates edge model deployment for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A security IoT system processes real-time sensor data from edge devices to detec
 
 ### Learn More
 
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/federated-mcp-server/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/federated-mcp-server/index.md
@@ -20,7 +20,7 @@ Unlike centralized AI orchestration platforms (e.g., Apache Airflow for AI workf
 
 ## Example
 
-A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provides patterns adaptable to MCP federation workflows.
+A security operations center federates external MCP servers for threat intelligence, behavioral analysis, and log parsing, delivering AI-driven threat reports enriched with real-time network data from Databricks. This streamlines incident response by unifying disparate tools, reducing response times compared to fragmented integrations, and enhances threat detection accuracy. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provides patterns adaptable to MCP federation workflows.
 
 ## Benefits
 
@@ -30,5 +30,5 @@ A security operations center federates external MCP servers for threat intellige
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/object-store-ai-engine/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/object-store-ai-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) or separate search
 
 ## Example
 
-A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) provide guidance for implementing search and query workflows on object stores.
+A security operations platform uses Spice.ai to query object-store data (e.g., S3-stored network logs), perform hybrid search to identify threat patterns (semantic via VSS, precise via BM25), and run LLM inference to generate real-time threat intelligence reports. This unified workflow detects anomalies in minutes without moving data to a centralized warehouse, outperforming traditional platforms requiring complex ETL pipelines and separate AI tools. The [Vector-Based Search documentation](../../features/search) and [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) provide guidance for implementing search and query workflows on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to query object-store data (e.g., S
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
 - **Data Acceleration**: [Documentation](../../features/data-acceleration)

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/real-time-decision-making/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/real-time-decision-making/index.md
@@ -30,9 +30,9 @@ A ride-sharing app optimizes driver assignments in milliseconds by combining rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) for an example.
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README) for details.
-- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) for an example.
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md) for details.
+- **Vector Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/ai/tool-calling-ai/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/ai/tool-calling-ai/index.md
@@ -31,5 +31,5 @@ A finserv platform uses Spice.ai as an MCP server to integrate a risk assessment
 ### Learn More
 
 - **MCP Documentation**: [Documentation](../../features/large-language-models/mcp).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.7.x/use-cases/data/application-resilence-and-acceleration/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/data/application-resilence-and-acceleration/index.md
@@ -30,6 +30,6 @@ A SaaS project management platform caches user task data and project states loca
 
 ### Learn More
 
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/data/data-mesh/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/data/data-mesh/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, Redshift) that centralize da
 
 ## Example
 
-A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) demonstrates unified data access patterns for such scenarios.
+A health-tech platform implements a data mesh to enable clinical teams to access real-time patient data from PostgreSQL, research datasets from Databricks, and regulatory guidelines from cloud storage, all through a unified SQL interface. This empowers teams to develop patient-centric applications, such as real-time treatment recommendation systems, without relying on centralized data teams, improving agility and compliance compared to monolithic data warehouses. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) demonstrates unified data access patterns for such scenarios.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A health-tech platform implements a data mesh to enable clinical teams to access
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/data/etl-free-workflows/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/data/etl-free-workflows/index.md
@@ -30,6 +30,6 @@ A fintech firm migrates from an Oracle database to a cloud-native stack, queryin
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/data/object-store-data-engine/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/data/object-store-data-engine/index.md
@@ -20,7 +20,7 @@ Unlike traditional data platforms (e.g., Snowflake, BigQuery) that rely on costl
 
 ## Example
 
-A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provide practical guidance for implementing federated queries and data materialization.
+A finserv platform queries transaction logs stored in S3, combines them with real-time market data from PostgreSQL, and materializes high-frequency trading datasets for low-latency portfolio analysis. This approach avoids moving data to a centralized warehouse, reducing costs and ensuring compliance with regulatory requirements, unlike ETL-heavy platforms that introduce delays and complexity. The [Federated SQL Query recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md) and [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provide practical guidance for implementing federated queries and data materialization.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv platform queries transaction logs stored in S3, combines them with rea
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/data/reverse-etl/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/data/reverse-etl/index.md
@@ -20,7 +20,7 @@ Unlike data-team-focused orchestration tools (e.g., Fivetran, Airbyte), Spice.ai
 
 ## Example
 
-A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README) provides a practical guide to materializing datasets for such workflows.
+A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesforce CRM, enabling real-time account health scoring for sales teams. This reduces integration time from weeks to days compared to traditional ETL tools, allowing faster response to customer needs. The [DuckDB Data Accelerator recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md) provides a practical guide to materializing datasets for such workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A SaaS company syncs customer usage data from a Databricks lakehouse to a Salesf
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/rag/reporting/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/rag/reporting/index.md
@@ -30,7 +30,7 @@ A health-tech company generates real-time HIPAA compliance reports by combining 
 
 ### Learn More
 
-- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
+- **Vector Similarity Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
 - **Semantic Model**: [Documentation](../../features/semantic-model).

--- a/website/versioned_docs/version-1.7.x/use-cases/search/data-collection-and-search/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/search/data-collection-and-search/index.md
@@ -20,7 +20,7 @@ Unlike complex streaming platforms (e.g., Apache Flink) that require extensive i
 
 ## Example
 
-A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) demonstrates real-time data processing and search patterns adaptable to such use cases.
+A gaming platform processes live player activity from Kafka streams to power in-game leaderboards and personalized challenges, while using hybrid search to enable players to research game strategies by querying unstructured content (e.g., guides, forums) and structured metadata. This unified approach bypasses the infrastructure overhead of separate streaming pipelines and search engines, enhancing player engagement and feature delivery. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) demonstrates real-time data processing and search patterns adaptable to such use cases.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A gaming platform processes live player activity from Kafka streams to power in-
 
 ### Learn More
 
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.7.x/use-cases/search/enterprise-search/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/search/enterprise-search/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that lack sea
 
 ## Example
 
-A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
+A finserv firm enables traders to search a knowledge base combining structured transaction data from Databricks with unstructured compliance documents from cloud storage. Hybrid search retrieves relevant regulations semantically (via vector search) and precise contract terms (via BM25), streamlining compliance checks and reducing research time compared to siloed search tools. This improves operational efficiency and regulatory adherence. The [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) and [Vector-Based Search documentation](../../features/search) provide implementation guidance for hybrid search workflows.
 
 ## Benefits
 
@@ -30,6 +30,6 @@ A finserv firm enables traders to search a knowledge base combining structured t
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **AI Gateway**: [Documentation](../../features/large-language-models) and [Running Llama3 Locally Recipe](https://github.com/spiceai/cookbook/blob/trunk/llama/README.md).

--- a/website/versioned_docs/version-1.7.x/use-cases/search/object-store-search-engine/index.md
+++ b/website/versioned_docs/version-1.7.x/use-cases/search/object-store-search-engine/index.md
@@ -20,7 +20,7 @@ Unlike standalone search engines (e.g., Elasticsearch, OpenSearch) that require 
 
 ## Example
 
-A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README) provide guidance for implementing hybrid search on object stores.
+A security operations platform uses Spice.ai to search S3-stored network logs and threat intelligence data, combining semantic VSS for identifying emerging threat patterns with BM25 for precise log entry retrieval. This enables rapid incident analysis without moving data to a centralized index, reducing costs and ensuring compliance compared to ETL-dependent search engines. The [Vector-Based Search documentation](../../features/search) and [Searching GitHub Files recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md) provide guidance for implementing hybrid search on object stores.
 
 ## Benefits
 
@@ -30,7 +30,7 @@ A security operations platform uses Spice.ai to search S3-stored network logs an
 
 ### Learn More
 
-- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README).
-- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README).
-- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README).
+- **Vector and Hybrid Search**: [Documentation](../../features/search) and [Searching GitHub Files Recipe](https://github.com/spiceai/cookbook/blob/trunk/search_github_files/README.md).
+- **Federated SQL Queries**: [Documentation](../../features/query-federation) and [Federated SQL Query Recipe](https://github.com/spiceai/cookbook/blob/trunk/federation/README.md).
+- **Data Acceleration**: [Documentation](../../features/data-acceleration) and [DuckDB Data Accelerator Recipe](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md).
 - **Observability**: [Documentation](../../features/observability).

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook.md)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/index.md
@@ -71,15 +71,15 @@ File formats currently supported are:
 
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅        | ❌                 |
-| [CSV](../reference/file_format#csv)     | `file_format: csv`     | ✅        | ❌                 |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                 |
-| JSON                                          | `file_format: json`    | Roadmap   | ❌                 |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                 |
-| Markdown                                      | `file_format: md`      | ✅        | ✅                 |
-| Text                                          | `file_format: txt`     | ✅        | ✅                 |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                 |
-| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                 |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
+| [CSV](../reference/file_format#csv)           | `file_format: csv`     | ✅         | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
+| JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Markdown                                      | `file_format: md`      | ✅         | ✅                  |
+| Text                                          | `file_format: txt`     | ✅         | ✅                  |
+| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](../reference/file_format)
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -124,4 +124,4 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap/outlook.md)
+- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -17,18 +17,18 @@ datasets:
 
 ## Schema
 
-| Field Name   | Data Type    | Nullable | Description                                                                      |
-| ------------ | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`       | `Date64`     | No       | The date and time when the email was sent.                                       |
-| `subject`    | `Utf8`       | Yes      | The subject line of the email.                                                   |
-| `from`       | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
-| `to`         | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
-| `cc`         | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
-| `bcc`        | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
-| `reply_to`   | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
-| `message_id` | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
-| `in_reply_to`| `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
-| `content`    | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
+| Field Name    | Data Type    | Nullable | Description                                                                      |
+| ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
+| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
+| `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
+| `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |
+| `cc`          | `List<Utf8>` | Yes      | The carbon copy recipient(s) of the email.                                       |
+| `bcc`         | `List<Utf8>` | Yes      | The blind carbon copy recipient(s) of the email.                                 |
+| `reply_to`    | `List<Utf8>` | Yes      | The email address(es) to which replies should be sent.                           |
+| `message_id`  | `Utf8`       | Yes      | A unique identifier for the email message.                                       |
+| `in_reply_to` | `Utf8`       | Yes      | The `message_id` of the email this message is replying to, if applicable.        |
+| `content`     | `Utf8`       | Yes      | The raw email body of this message. Not retrieved when acceleration is disabled. |
 
 If a MIME-encoded value is retrieved for a field, it is not decoded and the MIME-encoded value is returned in SQL queries.
 
@@ -95,14 +95,14 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 The IMAP connector supports the following connection and authentication parameters:
 
-| Parameter Name      | Description                                                                                            |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `imap_username`     | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field. |
-| `imap_password`     | Optional. The password to use for the IMAP connection, in plaintext authentication mode. |
-| `imap_host`         | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`         | Optional. The port of the IMAP server to connect to. |
-| `imap_mailbox`      | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox. |
-| `imap_ssl_mode`     | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`. |
+| Parameter Name  | Description                                                                                                                  |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
+| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
+| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/index.md
@@ -71,15 +71,15 @@ File formats currently supported are:
 
 | Name                                          | Parameter              | Supported | Is Document Format |
 | --------------------------------------------- | ---------------------- | --------- | ------------------ |
-| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅        | ❌                 |
-| [CSV](../../reference/file_format.md#csv)     | `file_format: csv`     | ✅        | ❌                 |
-| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                 |
-| JSON                                          | `file_format: json`    | Roadmap   | ❌                 |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                 |
-| Markdown                                      | `file_format: md`      | ✅        | ✅                 |
-| Text                                          | `file_format: txt`     | ✅        | ✅                 |
-| PDF                                           | `file_format: pdf`     | Alpha     | ✅                 |
-| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                 |
+| [Apache Parquet](https://parquet.apache.org/) | `file_format: parquet` | ✅         | ❌                  |
+| [CSV](../../reference/file_format.md#csv)     | `file_format: csv`     | ✅         | ❌                  |
+| [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Roadmap   | ❌                  |
+| JSON                                          | `file_format: json`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Markdown                                      | `file_format: md`      | ✅         | ✅                  |
+| Text                                          | `file_format: txt`     | ✅         | ✅                  |
+| PDF                                           | `file_format: pdf`     | Alpha     | ✅                  |
+| Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
 
 File formats support additional parameters in the `params` (like `csv_has_header`) described in [File Formats](../reference/file_format)
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/index.md
@@ -51,7 +51,7 @@ Supported Data Connectors include:
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
 | `elasticsearch`                    | ElasticSearch                         | Roadmap           |                              |
 
-[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks/delta_lake
+[databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
 [s3]: https://github.com/spiceai/cookbook/tree/trunk/s3#readme
 [spiceai]: https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme


### PR DESCRIPTION
This pull request focuses on improving documentation consistency by standardizing and correcting links to cookbook recipes and references across multiple documentation files. The changes ensure that all links point to the correct locations (typically ending with `.md` or `#readme`), remove outdated or redundant sections, and improve formatting for better readability.

The most important changes include:

**Cookbook Link Standardization and Corrections:**
- Updated all links to cookbook recipes throughout the documentation to consistently use the correct `.md` or `#readme` suffix, ensuring users are directed to the intended resources. This affects references for connectors like Glue, Oracle, IMAP, Kafka, ODBC, DuckLake, Llama, OpenAI, Federation, Vectors, and more. [[1]](diffhunk://#diff-09c79f6b6a71d659d93974765c0dd125ed37f56bfad53091945655a07c53d8dfL244-R244) [[2]](diffhunk://#diff-bf78f16b95c4218b2ba9d8bf660e76675919c294bea658835e88a4f5472ffe81L127-R127) [[3]](diffhunk://#diff-3ca13cfdf635e5e301d13fbc6c44fb35649851ca6e65e056afe243f5d910b0faL162-R162) [[4]](diffhunk://#diff-61761b4c68332c5120b16c4d6acf9ab76a72ac6b5d91db2b95984f69ccb3b080L330-R330) [[5]](diffhunk://#diff-5c5f02d0c68e1de3f2f6c2a1698980b8e456abc989f52beee7336bb7ce0b7eabL201-R201) [[6]](diffhunk://#diff-629c0f39dc0bfd565f5bfcf953c404392c9344b30df9e6dbeeb121053fe70a9eL117-R117) [[7]](diffhunk://#diff-2ea5bb8dadf2837f0192b452a8b95ccf532ae207d2d9886028aafe3ef7a6f476L47-R47) [[8]](diffhunk://#diff-2ea5bb8dadf2837f0192b452a8b95ccf532ae207d2d9886028aafe3ef7a6f476L104-R120) [[9]](diffhunk://#diff-2293a5cf42413592f01510faa5a61c69d320434c2de416aeb84f731cdf401bc3L23-R23) [[10]](diffhunk://#diff-2293a5cf42413592f01510faa5a61c69d320434c2de416aeb84f731cdf401bc3L33-R35) [[11]](diffhunk://#diff-443d104e46b3b0aa3645ae251fdb655bba08e0a3d3222d4c1fb06a8e9babc229L23-R23) [[12]](diffhunk://#diff-443d104e46b3b0aa3645ae251fdb655bba08e0a3d3222d4c1fb06a8e9babc229L33-R35) [[13]](diffhunk://#diff-786e6a1abedbdc55f682c26e8e21ff8f4971dacb9ed09477e5099010312dd760L23-R23)

**Removal of Redundant Cookbook Sections:**
- Removed outdated "Cookbook" sections and redundant recipe references from the DuckLake catalog and data connector documentation to avoid duplication and keep the docs concise. [[1]](diffhunk://#diff-506622257d15e500ff2884519b45bde98d6ae53dc8b38952d9ba94f59fea90a2L179-L182) [[2]](diffhunk://#diff-0556acc6a3d2df76b3bdb38ff4fb6373ae4112904a970ca1ff574d9fbbebbef3L159-L162)

**Reference and Formatting Improvements:**
- Fixed formatting in parameter tables (e.g., in the Glue connector docs) for better readability and consistency.
- Updated reference links at the bottom of connector index files to point to the correct README locations, ensuring all footnotes are accurate.

These changes collectively enhance user experience by making documentation more reliable, easier to navigate, and up-to-date with the latest resource locations.