### PR TITLE
docs: Remove Perplexity model and websearch tool documentation

### DIFF
--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -20,6 +20,7 @@ Spice supports various model providers for traditional machine learning (ML) mod
 | [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
+| ~~`perplexity`~~           | ~~Perplexity~~ ([Removed][perplexity])       | Removed           | -            | -                               |
 
 [openai]: ./openai.md
 [bedrock]: ./bedrock.md
@@ -31,6 +32,7 @@ Spice supports various model providers for traditional machine learning (ML) mod
 [google]: ./google.md
 [xai]: ./xai.md
 [databricks]: ./databricks.md
+[perplexity]: ./perplexity.md
 
 Spice also tests and evaluates common models and grades their ability to integrate with Spice. See the [Models Grade Report](../reference/models).
 
@@ -63,7 +65,6 @@ The following provider prefixes are supported:
 | `xai`        | xAI                                   |
 | `anthropic`  | Anthropic                             |
 | `google`     | Google AI                             |
-| `perplexity` | Perplexity                            |
 | `hf`         | Hugging Face                          |
 | `file`       | Local filesystem                      |
 | `spiceai`    | Spice.ai Cloud Platform               |

--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -20,7 +20,7 @@ Spice supports various model providers for traditional machine learning (ML) mod
 | [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| ~~`perplexity`~~           | ~~Perplexity~~ ([Removed][perplexity])       | Removed           | -            | -                               |
+| ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])       | Deprecated           | -            | -                               |
 
 [openai]: ./openai.md
 [bedrock]: ./bedrock.md

--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -20,7 +20,7 @@ Spice supports various model providers for traditional machine learning (ML) mod
 | [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])       | Deprecated           | -            | -                               |
+| ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])    | Deprecated        | -            | -                               |
 
 [openai]: ./openai.md
 [bedrock]: ./bedrock.md

--- a/website/docs/components/models/perplexity.md
+++ b/website/docs/components/models/perplexity.md
@@ -6,5 +6,5 @@ sidebar_position: 4
 ---
 
 :::warning Removed
-Perplexity model support was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). For documentation on Perplexity models in previous versions, see the [v1.11.x Perplexity documentation](/docs/1.11.x/components/models/perplexity).
+Perplexity model support was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). For documentation on Perplexity models in previous versions, see the [v1.11.x Perplexity documentation](https://docs.spiceai.org/docs/1.11.x/components/models/perplexity).
 :::

--- a/website/docs/components/models/perplexity.md
+++ b/website/docs/components/models/perplexity.md
@@ -1,10 +1,10 @@
 ---
-title: 'Perplexity Models (Removed)'
-description: 'Perplexity model support has been removed from Spice.'
-sidebar_label: 'Perplexity (Removed)'
+title: 'Perplexity Models (Deprecated)'
+description: 'Perplexity model support is no longer supported in Spice.'
+sidebar_label: 'Perplexity (Deprecated)'
 sidebar_position: 4
 ---
 
-:::warning Removed
-Perplexity model support was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). For documentation on Perplexity models in previous versions, see the [v1.11.x Perplexity documentation](https://docs.spiceai.org/docs/1.11.x/components/models/perplexity).
+:::warning Deprecated
+Perplexity model support is no longer supported and was deprecated in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). For documentation on Perplexity models in previous versions, see the [v1.11.x Perplexity documentation](https://docs.spiceai.org/docs/1.11.x/components/models/perplexity).
 :::

--- a/website/docs/components/models/perplexity.md
+++ b/website/docs/components/models/perplexity.md
@@ -1,41 +1,10 @@
 ---
-title: 'Perplexity Models'
-description: 'Instructions for using language models hosted on Perplexity with Spice.'
-sidebar_label: 'Perplexity'
+title: 'Perplexity Models (Removed)'
+description: 'Perplexity model support has been removed from Spice.'
+sidebar_label: 'Perplexity (Removed)'
 sidebar_position: 4
 ---
 
-To use a language model hosted on Perplexity, specify `perplexity` in the `from` field.
-
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `sonar`.
-
-```yaml
-models:
-  - name: webs
-    from: perplexity:sonar
-    params:
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
-```
-
-The following parameters are specific to Perplexity models:
-
-| Parameter               | Description                                                                                                                                                  | Default |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `perplexity_auth_token` | The Perplexity API authentication token.                                                                                                                     | -       |
-| `perplexity_*`          | Additional, perplexity specific parameters to use on all requests. See [Perplexity API Reference](https://docs.perplexity.ai/api-reference/chat-completions) | -       |
-
-**Note:** Like other models in Spice, Perplexity can set default overrides for OpenAI parameters. See [Parameter Overrides](../../features/large-language-models/parameter_overrides).
-
-### Example Configuration
-
-```yaml
-models:
-  - name: webs
-    from: perplexity:sonar
-    params:
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
-      perplexity_search_domain_filter:
-        - docs.spiceai.org
-        - huggingface.co
-      perplexity_temperature: 0.3141595
-```
+:::warning Removed
+Perplexity model support was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). For documentation on Perplexity models in previous versions, see the [v1.11.x Perplexity documentation](/docs/1.11.x/components/models/perplexity).
+:::

--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -8,18 +8,6 @@ A tool is a function or operation that can be called directly or by a [language 
 
 For details about providing LLMs tool access, see [Language Model Tools](../features/large-language-models/tools).
 
-**Example**
-
-```yaml
-tools:
-  - name: arpanet
-    from: websearch
-    description: 'Search the web for information.'
-    params:
-      engine: perplexity
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
-```
-
 For details on tool specifications, see the [Tools Spicepod Reference](../reference/spicepod/tools).
 
 ### Available Tools
@@ -35,7 +23,7 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
-| [`websearch`][websearch]  | Search the web for information.                                   | -             |
+| ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Removed)                  | -             |
 
 [websearch]: tools/websearch
 

--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -23,6 +23,7 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
+| ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Deprecated)               | -             |
 
 [websearch]: tools/websearch
 

--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -23,7 +23,6 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
-| ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Removed)                  | -             |
 
 [websearch]: tools/websearch
 

--- a/website/docs/components/tools/websearch.md
+++ b/website/docs/components/tools/websearch.md
@@ -9,5 +9,5 @@ The `websearch` tool was removed in [spiceai/spiceai#9910](https://github.com/sp
 
 For web search functionality, use [OpenAI's hosted web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) via the [OpenAI Responses API](/docs/features/web-search#web-search-through-openai-hosted-tools).
 
-For documentation on the websearch tool in previous versions, see the [v1.11.x websearch documentation](/docs/1.11.x/components/tools/websearch).
+For documentation on the websearch tool in previous versions, see the [v1.11.x websearch documentation](https://docs.spiceai.org/docs/1.11.x/components/tools/websearch).
 :::

--- a/website/docs/components/tools/websearch.md
+++ b/website/docs/components/tools/websearch.md
@@ -1,66 +1,13 @@
 ---
-title: 'Web Search Tool'
-sidebar_label: 'Websearch'
-description: 'Configure web search tools for LLMs to search the internet using Perplexity and other search engines.'
+title: 'Web Search Tool (Removed)'
+sidebar_label: 'Websearch (Removed)'
+description: 'The websearch tool has been removed from Spice.'
 ---
 
-The Web Search Tool enables Spice models to search the web for information. The tool is available through the `websearch` tool, and backed by different search engines.
+:::warning Removed
+The `websearch` tool was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). The tool was backed by Perplexity, which is no longer supported.
 
-## Usage
+For web search functionality, use [OpenAI's hosted web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) via the [OpenAI Responses API](/docs/features/web-search#web-search-through-openai-hosted-tools).
 
-```yaml
-tools:
-  - name: the_internet
-    from: websearch
-    description: "Search the web for information."
-    params:
-      engine: perplexity
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
-```
-
-## Configuration
-
-### `from`
-
-The `from` field specifies the tool to use. For the Web Search Tool, use `websearch`.
-
-### `name`
-
-The `name` field specifies the name of the tool. This name is used:
-
-- To reference the tool in the model's `params.tools` field
-- To make HTTP requests to the tool via the [API](../../api/HTTP/post), i.e. `v1/tools/{name}`
-- Provided to any language model that uses the tool
-
-### `description`
-
-The `description` field provides a description of the tool. This description is provided to any language model that uses the tool.
-
-### `params`
-
-The `params` field specifies configuration options for the tool. The following parameters are supported:
-
-- `engine`: The search engine to use. Possible values:
-  - `perplexity`: Use the Perplexity search engine.
-- `engine_*`: Each search engine has its own set of parameters. See the documentation for the specific search engine for more information.
-
-## Search Engines
-
-- [Perplexity](https://perplexity.com): Powered by Perplexity [Sonar](https://docs.perplexity.ai/).
-
-### Perplexity
-
-To define a Perplexity search engine, use the following parameters:
-
-- `perplexity_auth_token` (required): The authentication token for the Perplexity API. Use the [secret replacement syntax](../secret-stores/) to reference a secret, e.g. `${secrets:my_perplexity_auth_token}`. To get an authentication token, see Perplexity's [Getting Started](https://docs.perplexity.ai/guides/getting-started).
-- `perplexity_return_images` (default: false): Determines whether a request should return images.
-- `perplexity_return_related_questions` (default: false): Determines whether a request should return related questions.
-- `perplexity_search_domain_filter`: Given a list of domains, limit the citations used by the online model to URLs from the specified domains. Currently limited to only 3 domains for whitelisting and blacklisting. For blacklisting add a `-` to the beginning of the domain string. Example:
-
-  ```yaml
-  perplexity_search_domain_filter:
-    - spice.ai
-    - docs.perplexity.ai
-  ```
-
-- `perplexity_search_recency_filter`: Returns search results within the specified time interval (does not apply to images). One of: `month`, `week`, `day`, `hour`.
+For documentation on the websearch tool in previous versions, see the [v1.11.x websearch documentation](/docs/1.11.x/components/tools/websearch).
+:::

--- a/website/docs/components/tools/websearch.md
+++ b/website/docs/components/tools/websearch.md
@@ -1,11 +1,11 @@
 ---
-title: 'Web Search Tool (Removed)'
-sidebar_label: 'Websearch (Removed)'
-description: 'The websearch tool has been removed from Spice.'
+title: 'Web Search Tool (Deprecated)'
+sidebar_label: 'Websearch (Deprecated)'
+description: 'The websearch tool is no longer supported in Spice.'
 ---
 
-:::warning Removed
-The `websearch` tool was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). The tool was backed by Perplexity, which is no longer supported.
+:::warning Deprecated
+The `websearch` tool is no longer supported and was deprecated in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). The tool was backed by Perplexity, which is no longer supported.
 
 For web search functionality, use [OpenAI's hosted web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) via the [OpenAI Responses API](/docs/features/web-search#web-search-through-openai-hosted-tools).
 

--- a/website/docs/features/web-search/index.md
+++ b/website/docs/features/web-search/index.md
@@ -11,7 +11,7 @@ tags:
 Spice provides web search functionality through OpenAI's hosted tools, enabling access to recent information and relevant context.
 
 :::note
-The `websearch` tool (backed by Perplexity) was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). Use OpenAI's hosted web search tool as described below.
+The `websearch` tool (backed by Perplexity) is no longer supported and was deprecated in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). Use OpenAI's hosted web search tool as described below.
 :::
 
 ## Web Search Through OpenAI Hosted Tools

--- a/website/docs/features/web-search/index.md
+++ b/website/docs/features/web-search/index.md
@@ -8,50 +8,15 @@ tags:
   - models
 ---
 
-Spice provides web search functionality through LLMs and tools, enabling access to recent information and relevant context. Spice supports two ways of using web search in the runtime, namely through tools and through specific model providers.
+Spice provides web search functionality through OpenAI's hosted tools, enabling access to recent information and relevant context.
 
-## Web Search Through LLM Tools
-
-One way of using web search with Spice is through the dedicated web search tool configured to use Perplexity as the engine. Sample Spicepod configuration:
-
-```yaml
-tools:
-  - name: the_internet
-    from: websearch
-    description: 'Search the web for information.'
-    params:
-      engine: perplexity
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
-```
-
-This tool can then be provided to any configured models like so:
-
-```yaml
-models:
-  - from: openai:gpt-4.1
-    name: my-model
-    params:
-      openai_api_key: ${secrets:OPENAI_API_KEY}
-      tools: websearch # configure the model to use the websearch tool.
-
-  - from: anthropic:claude-3-5-sonnet-latest
-    name: claude_3_5_sonnet
-    params:
-      anthropic_api_key: ${ secrets:SPICE_ANTHROPIC_API_KEY }
-      tools: websearch # configure the model to use the websearch tool.
-
-  - from: xai:grok4
-    name: xai
-    params:
-      xai_api_key: ${secrets:SPICE_GROK_API_KEY}
-      tools: websearch # configure the model to use the websearch tool.
-```
-
-These models can then be invoked via an interactive REPL through [`spice chat`](../../cli/reference/chat) or via the OpenAI-compatible `/v1/chat/completions` HTTP endpoint. To learn more about the `websearch` tool, refer to [the reference](../../components/tools/websearch).
+:::note
+The `websearch` tool (backed by Perplexity) was removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910). Use OpenAI's hosted web search tool as described below.
+:::
 
 ## Web Search Through OpenAI Hosted Tools
 
-Spice also supports web search using [OpenAI's hosted web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) when using [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses). Sample Spicepod configuration:
+Spice supports web search using [OpenAI's hosted web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) when using [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses). Sample Spicepod configuration:
 
 ```yaml
 models:
@@ -72,40 +37,9 @@ Start Spice with `spice run`. Then, execute the following command, which makes a
 curl -s -H "Content-Type: application/json" -X POST "http://localhost:8090/v1/responses" -d '{"model": "openai_model", "input": "what is the latest news today? use the web search tool"}' | jq -r '.output[] | select(.type=="message") | .content[] | select(.type=="output_text") | .text'
 ```
 
-Output:
-
-```
-Here are some of the latest news updates as of August 30, 2025:
-
-**International Affairs**
-
-- **Thailand's Prime Minister Removed from Office**: The Constitutional Court of Thailand has dismissed Prime Minister Paetongtarn Shinawatra from office due to ethical misconduct related to leaked phone calls with former Cambodian Prime Minister Hun Sen. ([en.wikipedia.org](https://en.wikipedia.org/wiki/2025?utm_source=openai))
-
-- **Armenia and Azerbaijan Sign Peace Deal**: On August 8, Armenia and Azerbaijan signed a peace agreement mediated by the United States, ending 37 years of hostilities over the Nagorno-Karabakh region. ([en.wikipedia.org](https://en.wikipedia.org/wiki/2025?utm_source=openai))
-
-**Science and Technology**
-
-- **OpenAI Releases GPT-5**: OpenAI has unveiled GPT-5, an upgraded version of its language model, featuring "PhD-level intelligence." ([en.wikipedia.org](https://en.wikipedia.org/wiki/2025_in_science?utm_source=openai))
-
-- **NASA-ISRO Synthetic Aperture Radar (NISAR) Satellite Launched**: A joint project between NASA and the Indian Space Research Organisation (ISRO), the NISAR satellite was launched on July 30, 2025. It is the first dual-band radar imaging satellite, designed for remote sensing of Earth's surface. ([en.wikipedia.org](https://en.wikipedia.org/wiki/2025_in_spaceflight?utm_source=openai))
-
-**United States**
-
-- **Federal Reserve Governor Lisa Cook Dismissed**: President Donald Trump has removed Federal Reserve Governor Lisa Cook from her position, citing "false statements" on "one or more mortgage agreements." This decision has led to a weakening of the U.S. dollar. ([cnbc.com](https://www.cnbc.com/2025/08/25/stock-market-today-live-updates.html?utm_source=openai))
-
-- **Stock Market Performance**: On August 26, 2025, major U.S. stock indices closed with gains. The Nasdaq Composite advanced 0.44%, the S&P 500 gained 0.41%, and the Dow Jones Industrial Average climbed 0.30%. ([cnbc.com](https://www.cnbc.com/2025/08/25/stock-market-today-live-updates.html?utm_source=openai))
-
-**Space Exploration**
-
-- **SpaceX's Seventh Starship Test Flight**: On January 16, 2025, SpaceX launched its seventh test flight of the Starship launch vehicle from its Starbase site in Boca Chica, Texas. The first stage was successfully recovered, but the second stage broke up shortly before engine shutdown. ([en.wikipedia.org](https://en.wikipedia.org/wiki/2025_in_Texas?utm_source=openai))
-
-Please note that news developments are ongoing, and it's advisable to consult multiple sources for the most current information.
-```
-
 To invoke this model, use [`spice chat --responses`](../../cli/reference/chat) for an interactive REPL or the OpenAI-compatible `/v1/responses` HTTP endpoint in the runtime. To learn more about configuring models provided by OpenAI, view [the reference](../../components/models/openai).
 
 ## References
 
-- [Perplexity Search Documentation](https://docs.perplexity.ai/getting-started/overview)
 - [OpenAI Web Search Tool Documentation](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses)
 - [OpenAI Responses API Documentation](https://platform.openai.com/docs/api-reference/responses)

--- a/website/docs/reference/spicepod/tools.md
+++ b/website/docs/reference/spicepod/tools.md
@@ -14,12 +14,11 @@ Example:
 
 ```yaml
 tools:
-  - name: arpanet
-    from: websearch
-    description: 'Search the web for information.'
+  - name: my_mcp_tool
+    from: mcp
+    description: 'An MCP tool.'
     params:
-      engine: perplexity
-      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
+      mcp_endpoint: http://localhost:3000/sse
 ```
 
 ### `name`


### PR DESCRIPTION
## Summary

- **Remove Perplexity model and websearch tool**: Updated docs to reflect that Perplexity model provider and the `websearch` tool were removed in [spiceai/spiceai#9910](https://github.com/spiceai/spiceai/pull/9910)
- Pages are kept (to avoid broken links) but marked as removed, with links to the [v1.11.x versioned docs](/docs/1.11.x/) for historical reference
- Removed Perplexity from the model provider prefix table
- Updated the web search feature page to only document OpenAI hosted web search

## Files Changed

- `website/docs/components/models/perplexity.md` - Marked as removed with link to v1.11.x docs
- `website/docs/components/models/index.md` - Removed from provider prefix table, marked as removed in model list
- `website/docs/components/tools/websearch.md` - Marked as removed with link to v1.11.x docs
- `website/docs/components/tools/index.md` - Removed Perplexity example, marked websearch as removed
- `website/docs/features/web-search/index.md` - Removed Perplexity section, kept OpenAI hosted tools section
- `website/docs/reference/spicepod/tools.md` - Replaced Perplexity example with MCP example

## Test plan

- [ ] Verify pages load correctly and deprecation notices are visible
- [ ] Verify versioned doc links work correctly
- [ ] Verify no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)