### PR TITLE
docs: Document system_prompt support for v1/responses endpoint

### DIFF
--- a/website/docs/features/large-language-models/parameter_overrides.md
+++ b/website/docs/features/large-language-models/parameter_overrides.md
@@ -102,7 +102,7 @@ models:
         Write everything in Haiku like a pirate
 ```
 
-Any request to [HTTP `v1/chat/completion`](../../api/HTTP/post-chat-completions) will include the configured system prompt.
+Any request to [HTTP `v1/chat/completion`](../../api/HTTP/post-chat-completions) or `v1/responses` will include the configured system prompt. For `v1/responses`, the system prompt is set as the `instructions` field. If client-provided `instructions` are also included in the request, both are combined: the configured system prompt appears first, followed by the client instructions.
 
 ### Example: Enforcing default structured output and using system prompt
 


### PR DESCRIPTION
## Summary
- Update parameter overrides documentation to note that `system_prompt` also applies to `v1/responses` requests (mapped to the `instructions` field), and that client-provided `instructions` are preserved and concatenated after the configured system prompt (spiceai/spiceai#9884)

## Changes
- `website/docs/features/large-language-models/parameter_overrides.md`: Expand system prompt documentation to cover `v1/responses` endpoint behavior

## Test plan
- [ ] Verify the parameter overrides page renders correctly with the updated system prompt section
- [ ] Confirm the description accurately reflects the concatenation behavior from spiceai/spiceai#9884