### PR TITLE
docs: Update GitHub connector and CLI completions documentation

### DIFF
--- a/website/docs/cli/reference/completion.md
+++ b/website/docs/cli/reference/completion.md
@@ -1,25 +1,45 @@
 ---
-title: "Completion"
-sidebar_label: "completion"
+title: "Completions"
+sidebar_label: "completions"
 pagination_prev: null
 pagination_next: null
 ---
 
-Generate the autocompletion script for spice for the specified shell.
-See each sub-command's help for details on how to use the generated script.
+Generate shell completion scripts for the Spice CLI.
 
 ### Usage
 
 ```shell
-spice completion [command]
+spice completions [shell]
 ```
 
-Available `command`s
+The `shell` argument specifies which shell to generate completions for. If omitted, the shell is auto-detected from the `$SHELL` environment variable.
 
-- bash
-- fish
-- powershell
-- zsh
+Available shells:
+
+- `bash`
+- `zsh`
+- `fish`
+- `elvish`
+- `powershell`
+
+The completion script is written to stdout, allowing it to be piped or redirected to a file.
+
+### Examples
+
+```shell
+# Generate bash completions
+spice completions bash > /etc/bash_completion.d/spice
+
+# Generate zsh completions
+spice completions zsh > ~/.zfunc/_spice
+
+# Generate fish completions
+spice completions fish > ~/.config/fish/completions/spice.fish
+
+# Auto-detect shell
+spice completions
+```
 
 #### Flags
 

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -23,7 +23,7 @@ spice [command] [--help]
 | [chat](reference/chat)             | Chat with an LLM                                                       |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
-| [completion](reference/completion) | Generate the autocompletion script for the specified shell             |
+| [completions](reference/completion) | Generate shell completion scripts                                     |
 | [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
 | [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |

--- a/website/docs/components/data-connectors/github.md
+++ b/website/docs/components/data-connectors/github.md
@@ -15,14 +15,14 @@ The GitHub Data Connector enables federated SQL queries on various GitHub resour
 
 The `from` field specifies the GitHub resource to query. It supports the following formats:
 
-| Format                                         | Description                                               |
-| ---------------------------------------------- | --------------------------------------------------------- |
-| `github:github.com/<owner>/<repo>/files/<ref>` | Query files from a repository at a specific branch or tag |
-| `github:github.com/<owner>/<repo>/issues`      | Query issues from a repository                            |
-| `github:github.com/<owner>/<repo>/pulls`       | Query pull requests from a repository                     |
-| `github:github.com/<owner>/<repo>/commits`     | Query commits from a repository                           |
-| `github:github.com/<owner>/<repo>/stargazers`  | Query stargazers from a repository                        |
-| `github:github.com/<organization>/members`     | Query members from an organization                        |
+| Format                                                | Description                                                           |
+| ----------------------------------------------------- | --------------------------------------------------------------------- |
+| `github:github.com/<owner>/<repo>/files[/<ref>]`      | Query files from a repository, optionally at a specific branch or tag |
+| `github:github.com/<owner>/<repo>/issues`              | Query issues from a repository                                        |
+| `github:github.com/<owner>/<repo>/pulls`               | Query pull requests from a repository                                 |
+| `github:github.com/<owner>/<repo>/commits[/<ref>]`    | Query commits from a repository, optionally from a specific branch    |
+| `github:github.com/<owner>/<repo>/stargazers`          | Query stargazers from a repository                                    |
+| `github:github.com/<organization>/members`             | Query members from an organization                                    |
 
 ### `name`
 
@@ -34,7 +34,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 
 | Parameter Name | Description                                                                                                                                                                                                    |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github_token` | Required. GitHub personal access token to use to connect to the GitHub API. [Learn more](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). |
+| `github_token` | GitHub personal access token to use to connect to the GitHub API. Required for issues, pulls, commits, stargazers, and members. Optional for files against public repositories (subject to lower rate limits). [Learn more](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens). |
 
 #### GitHub App Installation
 
@@ -111,7 +111,9 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is enabled for the `committed_date` and `ref` columns. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`. `ref` supports exact match only, like `WHERE ref = 'main'`.
+
+Files support filter push down on the `ref` column. `ref` supports exact match only, like `WHERE ref = 'main'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 
@@ -135,21 +137,30 @@ All other filters are supported when `github_query_mode` is set to `search`, but
 :::warning[Limitations]
 
 - `content` column is fetched only when acceleration is enabled.
-- Querying GitHub files does not support filter push down, which may result in long query times when acceleration is disabled.
+- Querying GitHub files does not support filter push down on columns other than `ref`, which may result in long query times when acceleration is disabled.
 - Setting `github_query_mode` to `search` is not supported.
 
 :::
 
-- `ref` - Required. Specifies the GitHub branch or tag to fetch files from.
+- `ref` - Optional. Specifies the GitHub branch or tag to fetch files from. Can be specified in the dataset path (e.g., `files/<ref>`) or as a SQL filter (`WHERE ref = '<value>'`). If not specified, the repository's default branch is used.
 - `include` - Optional. Specifies a pattern to include specific files. Supports glob patterns. If not specified, all files are included by default.
 
 ```yaml
 datasets:
-  - from: github:github.com/<owner>/<repo>/files/<ref>
+  # Without ref - uses the repository's default branch
+  - from: github:github.com/<owner>/<repo>/files
     name: spiceai.files
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       include: '**/*.json; **/*.yaml'
+    acceleration:
+      enabled: true
+
+  # With ref - pins to a specific branch or tag
+  - from: github:github.com/<owner>/<repo>/files/<ref>
+    name: spiceai.files_tagged
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
     acceleration:
       enabled: true
 ```
@@ -162,6 +173,7 @@ datasets:
 | path         | Utf8      | YES         |
 | size         | Int64     | YES         |
 | sha          | Utf8      | YES         |
+| ref          | Utf8      | NO          |
 | mode         | Utf8      | YES         |
 | url          | Utf8      | YES         |
 | download_url | Utf8      | YES         |
@@ -390,28 +402,44 @@ Time: 0.036530584 seconds. 1 rows.
 
 :::
 
+A specific branch or tag can be specified in the dataset path (e.g., `commits/<ref>`) or as a SQL filter (`WHERE ref = '<value>'`). If not specified, the repository's default branch is used.
+
 ```yaml
 datasets:
+  # Commits from the default branch
   - from: github:github.com/<owner>/<repo>/commits
     name: spiceai.commits
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+
+  # Commits from a specific branch
+  - from: github:github.com/<owner>/<repo>/commits/develop
+    name: spiceai.commits_develop
     params:
       github_token: ${secrets:GITHUB_TOKEN}
 ```
 
 #### Schema
 
-| Column Name       | Data Type | Is Nullable |
-| ----------------- | --------- | ----------- |
-| additions         | Int64     | YES         |
-| author_email      | Utf8      | YES         |
-| author_name       | Utf8      | YES         |
-| committed_date    | Timestamp | YES         |
-| deletions         | Int64     | YES         |
-| id                | Utf8      | YES         |
-| message           | Utf8      | YES         |
-| message_body      | Utf8      | YES         |
-| message_head_line | Utf8      | YES         |
-| sha               | Utf8      | YES         |
+| Column Name                      | Data Type | Is Nullable |
+| -------------------------------- | --------- | ----------- |
+| additions                        | Int64     | YES         |
+| author_email                     | Utf8      | YES         |
+| author_name                      | Utf8      | YES         |
+| committed_date                   | Timestamp | YES         |
+| committer_name                   | Utf8      | YES         |
+| committer_email                  | Utf8      | YES         |
+| committer_date                   | Timestamp | YES         |
+| deletions                        | Int64     | YES         |
+| changed_files                    | Int64     | YES         |
+| id                               | Utf8      | YES         |
+| message                          | Utf8      | YES         |
+| message_body                     | Utf8      | YES         |
+| message_head_line                | Utf8      | YES         |
+| sha                              | Utf8      | YES         |
+| ref                              | Utf8      | YES         |
+| associated_pull_request_number   | Int64     | YES         |
+| status                           | Utf8      | YES         |
 
 #### Example
 


### PR DESCRIPTION
## Summary

- **CLI Reference**: Update `spice completion` to `spice completions` to match the restored Rust CLI command. Adds `elvish` shell support, auto-detection behavior, and usage examples ([spiceai/spiceai#10024](https://github.com/spiceai/spiceai/pull/10024))
- **GitHub Connector**: Document improved ref handling, new schema columns, and optional authentication ([spiceai/spiceai#10023](https://github.com/spiceai/spiceai/pull/10023)):
  - `ref` is now optional in the files dataset path (auto-detects default branch)
  - Commits dataset path supports optional `/<ref>` suffix
  - New `ref` column added to both files and commits schemas
  - 7 new commits columns: `committer_name`, `committer_email`, `committer_date`, `changed_files`, `associated_pull_request_number`, `status`, `ref`
  - `WHERE ref = '<value>'` filter pushdown documented for files and commits
  - `github_token` noted as optional for files on public repositories

Other reviewed PRs (no docs changes needed):
- [spiceai/spiceai#10061](https://github.com/spiceai/spiceai/pull/10061) - DynamoDB DML revert (DML was never documented)
- [spiceai/spiceai#10054](https://github.com/spiceai/spiceai/pull/10054) - DynamoDB/GraphQL bug fixes (internal correctness)
- [spiceai/spiceai#10009](https://github.com/spiceai/spiceai/pull/10009) - ISO8601 time_format fix (bug fix only)
- [spiceai/spiceai#10015](https://github.com/spiceai/spiceai/pull/10015) - Data correctness audit fixes (internal)
- [spiceai/spiceai#10048](https://github.com/spiceai/spiceai/pull/10048) - Update delegation/dict normalization (bug fix)

## Test plan

- [ ] Verify the `from` format table renders correctly with optional `[/<ref>]` syntax
- [ ] Verify the files and commits schema tables render with new columns
- [ ] Verify the CLI reference index links correctly to the updated completion page
- [ ] Verify the filter push down section accurately describes ref filter support