### PR TITLE
fix: Add missing heading text for DynamoDB Limitations section

### DIFF
--- a/website/docs/components/data-connectors/dynamodb.md
+++ b/website/docs/components/data-connectors/dynamodb.md
@@ -555,7 +555,7 @@ FROM (
 WHERE address.city = 'San Francisco';
 ```
 
-### 
+### Limitations
 
 :::warning[Limitations]
 


### PR DESCRIPTION
## Summary
- Fix empty `### ` heading before the Limitations warning block in the DynamoDB connector docs
- Added "Limitations" as the heading text

## Test plan
- [ ] Verify the DynamoDB connector page renders correctly with the heading