### PR TITLE
fix: Clarify clickhouse_db is required when not using connection string

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -18,7 +18,7 @@ datasets:
 
 The `from` field for the ClickHouse connector takes the form of `from:db.dataset` where `db.dataset` is the path to the Dataset within ClickHouse. In the example above it would be `my.dataset`.
 
-If `db` is not specified in either the `from` field or the `clickhouse_db` parameter, it will default to the `default` database.
+The `clickhouse_db` parameter is required when not using `clickhouse_connection_string`. When using a connection string without a database path, it defaults to the `default` database.
 
 ### `name`
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/clickhouse.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/clickhouse.md
@@ -18,7 +18,7 @@ datasets:
 
 The `from` field for the ClickHouse connector takes the form of `from:db.dataset` where `db.dataset` is the path to the Dataset within ClickHouse. In the example above it would be `my.dataset`.
 
-If `db` is not specified in either the `from` field or the `clickhouse_db` parameter, it will default to the `default` database.
+The `clickhouse_db` parameter is required when not using `clickhouse_connection_string`. When using a connection string without a database path, it defaults to the `default` database.
 
 ### `name`
 


### PR DESCRIPTION
## Summary

- Fixes incorrect documentation stating that `clickhouse_db` defaults to the `default` database when not specified
- In the implementation (`connector-clickhouse/src/lib.rs` line 348 on trunk, `dataconnector/clickhouse.rs` line 304 on v1.11.5), `clickhouse_db` is required via `ok_or_else` when not using a connection string -- there is no fallback to `default`
- The default to `default` only applies when using `clickhouse_connection_string` without a database path

## Test plan

- [ ] Verify the updated text in `website/docs/components/data-connectors/clickhouse.md` renders correctly
- [ ] Verify the updated text in `website/versioned_docs/version-1.11.x/components/data-connectors/clickhouse.md` renders correctly