### PR TITLE
docs: Add spice completions CLI reference and update memory pool docs

### DIFF
--- a/website/docs/cli/reference/completions.md
+++ b/website/docs/cli/reference/completions.md
@@ -1,0 +1,63 @@
+---
+title: "completions"
+sidebar_label: "completions"
+pagination_prev: null
+pagination_next: null
+---
+
+Generate shell completions for the Spice CLI.
+
+By default, `spice completions` auto-detects the user's shell and writes the completion script to the standard completion directory for that shell. If the shell cannot be detected, specify it as an argument.
+
+### Usage
+
+```shell
+spice completions [shell] [flags]
+```
+
+`shell` - the shell to generate completions for. Supported values: `bash`, `zsh`, `fish`, `elvish`, `powershell`. If omitted, the shell is detected from the `$SHELL` environment variable.
+
+#### Flags
+
+- `--stdout`  Print completions to stdout instead of writing to a file (useful for piping)
+- `-h`, `--help`   Print this help message
+
+### Default completion directories
+
+When writing to a file, `spice completions` uses the following directories by default:
+
+| Shell      | Directory                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| bash       | `~/.local/share/bash-completion/completions/spice` (Homebrew on macOS if available)               |
+| zsh        | `~/.local/share/zsh/site-functions/_spice` (Homebrew on macOS if available)                       |
+| fish       | `~/.config/fish/completions/spice.fish`                                                           |
+| elvish     | `~/.config/elvish/lib/spice.elv`                                                                  |
+| powershell | `~/.config/powershell/completions/spice.ps1`                                                      |
+
+Parent directories are created automatically if they do not exist.
+
+### Examples
+
+#### Auto-detect shell and install completions
+
+```shell
+spice completions
+```
+
+#### Generate completions for a specific shell
+
+```shell
+spice completions zsh
+```
+
+#### Print completions to stdout
+
+```shell
+spice completions bash --stdout
+```
+
+#### Pipe completions to a custom file
+
+```shell
+spice completions zsh --stdout > ~/.zfunc/_spice
+```

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -21,6 +21,7 @@ spice [command] [--help]
 | [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                          |
 | [catalogs](reference/catalogs)     | List [catalogs](../../components/catalogs) loaded by the Spice runtime |
 | [chat](reference/chat)             | Chat with an LLM                                                       |
+| [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
 | [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |

--- a/website/docs/components/data-accelerators/cayenne.md
+++ b/website/docs/components/data-accelerators/cayenne.md
@@ -175,7 +175,7 @@ Spice Cayenne is DataFusion query-native, meaning all query execution uses [Apac
 - **Automatic memory management**: Query memory is tracked and spilled to disk when limits are exceeded
 - **Dynamic filter pushdown**: Filters from TopK, Join, and Aggregate operators push down to file scans
 
-DataFusion's [FairSpillPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.FairSpillPool.html) divides memory evenly among partitions, providing predictable memory usage under concurrent query load.
+DataFusion's [GreedyMemoryPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.GreedyMemoryPool.html) allows memory reservations on a first-come, first-served basis, improving throughput for high-concurrency queries with many partitions.
 
 ### High-Performance Columnar Storage
 

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -146,7 +146,7 @@ runtime:
     temp_directory: /tmp/spice  # Directory for spill files
 ```
 
-Spice uses [Apache DataFusion](https://datafusion.apache.org/) as its query execution engine, which provides vectorized, multi-threaded query execution with automatic memory management. DataFusion's [FairSpillPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.FairSpillPool.html) divides memory evenly among partitions, so higher `target_partitions` values result in less memory per partition.
+Spice uses [Apache DataFusion](https://datafusion.apache.org/) as its query execution engine, which provides vectorized, multi-threaded query execution with automatic memory management. DataFusion's [GreedyMemoryPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.GreedyMemoryPool.html) allows memory reservations on a first-come, first-served basis up to the configured limit, improving throughput for high-concurrency queries with many partitions.
 
 ### Spill-to-Disk
 

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -221,7 +221,7 @@ Spice uses [Apache DataFusion](https://datafusion.apache.org/) as its query exec
 
 DataFusion automatically parallelizes queries across available CPU cores. By default, the number of partitions equals the number of CPU cores, providing maximum parallelism.
 
-DataFusion's [FairSpillPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.FairSpillPool.html) divides the configured `memory_limit` evenly among partitions. With more CPU cores, each partition receives less memory, which may increase spilling for memory-intensive queries.
+DataFusion's [GreedyMemoryPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.GreedyMemoryPool.html) allows memory reservations on a first-come, first-served basis up to the configured `memory_limit`. This approach improves throughput for high-concurrency queries with many partitions compared to dividing memory evenly.
 
 ### Join Algorithm Selection
 


### PR DESCRIPTION
## Summary
- Add new CLI reference page for `spice completions` command with auto-detection of shell completion directories and `--stdout` flag
- Update CLI reference index to include the `completions` command
- Update `FairSpillPool` references to `GreedyMemoryPool` in memory, performance tuning, and Cayenne accelerator documentation

## Related PRs
- [spiceai/spiceai#10068](https://github.com/spiceai/spiceai/pull/10068) - `spice completions` auto-detects shell directory and writes file
- [spiceai/spiceai#10082](https://github.com/spiceai/spiceai/pull/10082) - Use GreedyMemoryPool instead of FairSpillPool

## Test plan
- [ ] Verify `completions.md` renders correctly in the docs site
- [ ] Verify CLI reference index shows the new completions entry
- [ ] Verify GreedyMemoryPool links resolve to valid DataFusion docs