### PR TITLE
fix: Correct Databricks mode values, client_timeout default, and GCS param name

### DIFF
--- a/website/docs/components/data-connectors/databricks.md
+++ b/website/docs/components/data-connectors/databricks.md
@@ -62,12 +62,12 @@ Use the [secret replacement syntax](../secret-stores/) to reference a secret, e.
 
 | Parameter Name                | Description                                                                                                                                                                                                                                                                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mode`                        | The execution mode for querying against Databricks. The default is `spark_connect`. Possible values:<br /> <ul><li>`spark_connect`: Use Spark Connect to query against Databricks. Requires a Spark cluster to be available.</li><li>`delta_lake`: Query directly from Delta Tables. Requires the object store credentials to be provided.</li></ul> |
-| `databricks_endpoint`         | The endpoint of the Databricks instance. Required for both modes.                                                                                                                                                                                                                                                                                    |
+| `mode`                        | The execution mode for querying against Databricks. The default is `spark_connect`. Possible values:<br /> <ul><li>`spark_connect`: Use Spark Connect to query against Databricks. Requires a Spark cluster to be available.</li><li>`delta_lake`: Query directly from Delta Tables. Requires the object store credentials to be provided.</li><li>`sql_warehouse`: Use the SQL Statement Execution API to query against a Databricks SQL Warehouse.</li></ul> |
+| `databricks_endpoint`         | The endpoint of the Databricks instance. Required for all modes.                                                                                                                                                                                                                                                                                     |
 | `databricks_sql_warehouse_id` | The ID of the SQL Warehouse in Databricks to use for the query. Only valid when `mode` is `sql_warehouse`.                                                                                                                                                                                                                                           |
 | `databricks_cluster_id`       | The ID of the compute cluster in Databricks to use for the query. Only valid when `mode` is `spark_connect`.                                                                                                                                                                                                                                         |
 | `databricks_use_ssl`          | If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.                                                                                                                                                                                                                                                              |
-| `client_timeout`              | Optional. Applicable only in `delta_lake` mode. Specifies timeout for object store operations. Default value is `30s` E.g. `client_timeout: 60s`                                                                                                                                                                                                     |
+| `client_timeout`              | Optional. Applicable only in `delta_lake` mode. Specifies timeout for object store operations. E.g. `client_timeout: 60s`                                                                                                                                                                                                                            |
 | `databricks_token`            | The Databricks API token to authenticate with the Unity Catalog API. Can't be used with `databricks_client_id` and `databricks_client_secret`.                                                                                                                                                                                                       |
 | `databricks_client_id`        | The Databricks Service Principal Client ID. Can't be used with `databricks_token`.                                                                                                                                                                                                                                                                   |
 | `databricks_client_secret`    | The Databricks Service Principal Client Secret. Can't be used with `databricks_token`.                                                                                                                                                                                                                                                               |
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types


### PR DESCRIPTION
## Summary
- Added missing `sql_warehouse` to `mode` parameter's possible values list — the code supports `spark_connect`, `delta_lake`, and `sql_warehouse`, but docs only listed the first two
- Changed `databricks_endpoint` description from "Required for both modes" to "Required for all modes" (there are three modes)
- Removed false `30s` default claim from `client_timeout` — the code defines no default for this parameter
- Fixed GCS parameter name from `google_service_account` to `databricks_google_service_account` in the params table (the code uses `ParameterSpec::component("google_service_account")` which adds the `databricks_` prefix)
- Fixed GCS example from `databricks_google_service_account_path` to `databricks_google_service_account` (no `_path` suffix)

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/data-connectors/connector-databricks/src/lib.rs` lines 123-186](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-databricks/src/lib.rs)