### PR TITLE
fix: Correct PostgreSQL type mappings and fix broken code block

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -35,6 +35,7 @@ datasets:
       pg_pass: ${secrets:PG_PASSWORD}
     acceleration:
       enabled: true
+```
 
 ```bash
 echo "PG_PASSWORD=your_password" > .env
@@ -127,9 +128,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/postgres/index.md
@@ -132,9 +132,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/postgres/index.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/postgres/index.md
@@ -91,9 +91,9 @@ The table below shows the PostgreSQL data types supported, along with the type m
 | `uuid`          | `Utf8`                           |
 | `bytea`         | `Binary`                         |
 | `bool`          | `Boolean`                        |
-| `json`          | `LargeUtf8`                      |
+| `json`          | `Utf8`                           |
 | `timestamp`     | `Timestamp(Nanosecond, None)`    |
-| `timestampz`    | `Timestamp(Nanosecond, TimeZone` |
+| `timestamptz`   | `Timestamp(Nanosecond, UTC)`     |
 | `date`          | `Date32`                         |
 | `time`          | `Time64(Nanosecond)`             |
 | `interval`      | `Interval(MonthDayNano)`         |


### PR DESCRIPTION
## Summary
- `json` PostgreSQL type maps to `Utf8`, not `LargeUtf8` (verified in `datafusion-table-providers` `postgres/schema.rs`)
- Fixed `timestampz` typo to `timestamptz` (the correct PostgreSQL type name)
- Fixed `timestamptz` Arrow type from `Timestamp(Nanosecond, TimeZone` (unclosed/wrong) to `Timestamp(Nanosecond, UTC)` (matches code: `DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into()))`)
- Fixed unclosed YAML code block in vNext quickstart section

## Changes
Fixed across all versioned docs (1.5.x through 1.11.x) and vNext docs.

## Reference
Verified against `datafusion-table-providers` at rev `2ef02fe` (used by spiceai/spiceai trunk) — `core/src/sql/arrow_sql_gen/postgres/schema.rs` lines 69-72 and 87.