### PR TITLE
fix: Correct snowflake_password from Optional to Required for default auth

### DIFF
--- a/website/docs/components/data-connectors/snowflake.md
+++ b/website/docs/components/data-connectors/snowflake.md
@@ -49,7 +49,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_auth_type`              | Optional, specifies the authentication type: `snowflake` (default, password-based) or `keypair`                 |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key`            | Optional, specifies the Snowflake private key content as a string (for key-pair auth)                           |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key file (for key-pair auth)                                  |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase (for encrypted keys)                                   |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
@@ -49,7 +49,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_auth_type`              | Optional, specifies the authentication type: `snowflake` (default, password-based) or `keypair`                 |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key`            | Optional, specifies the Snowflake private key content as a string (for key-pair auth)                           |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key file (for key-pair auth)                                  |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase (for encrypted keys)                                   |

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
@@ -48,7 +48,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_password`               | Optional, specifies the Snowflake password to use for accessing Snowflake data                                  |
+| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
 | `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
 | `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
 


### PR DESCRIPTION
## Summary
- `snowflake_password` is documented as "Optional" but is actually **required** when `snowflake_auth_type` is `snowflake` (the default)
- The code errors with `MissingRequiredSecret { name: "password" }` if password is not provided with the default auth type

## Changes
Updated parameter description to: "Required when `snowflake_auth_type` is `snowflake` (default)" across all versioned docs and vNext.

## Reference
Verified against spiceai/spiceai trunk — `crates/db_connection_pool/src/snowflakepool.rs` lines 131-132 (default auth_type is "snowflake") and lines 197-200 (password is required via `.context(MissingRequiredSecretSnafu)`).