### PR TITLE
fix: Add missing pg_connection_pool_min param to Postgres accelerator docs

### DIFF
--- a/website/docs/components/data-accelerators/postgres/index.md
+++ b/website/docs/components/data-accelerators/postgres/index.md
@@ -34,6 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_min`: Optional. The minimum number of connections to keep open in the pool, lazily created when requested. Default is `5`.
 - `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided in the `acceleration` section of a dataset.

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/postgres/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/postgres/index.md
@@ -34,6 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_min`: Optional. The minimum number of connections to keep open in the pool, lazily created when requested. Default is `5`.
 - `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/postgres/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/postgres/index.md
@@ -34,6 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_min`: Optional. The minimum number of connections to keep open in the pool, lazily created when requested. Default is `5`.
 - `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided in the `acceleration` section of a dataset.

--- a/website/versioned_docs/version-1.8.x/components/data-accelerators/postgres/index.md
+++ b/website/versioned_docs/version-1.8.x/components/data-accelerators/postgres/index.md
@@ -34,6 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_min`: Optional. The minimum number of connections to keep open in the pool, lazily created when requested. Default is `5`.
 - `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.

--- a/website/versioned_docs/version-1.9.x/components/data-accelerators/postgres/index.md
+++ b/website/versioned_docs/version-1.9.x/components/data-accelerators/postgres/index.md
@@ -34,6 +34,7 @@ The connection to PostgreSQL can be configured by providing the following `param
   - `prefer`: This mode will try to establish a secure TLS connection if possible, but will connect insecurely if the server does not support TLS.
   - `disable`: This mode will not attempt to use a TLS connection, even if the server supports it.
 - `pg_sslrootcert`: Optional parameter specifying the path to a custom PEM certificate that the connector will trust.
+- `pg_connection_pool_min`: Optional. The minimum number of connections to keep open in the pool, lazily created when requested. Default is `5`.
 - `connection_pool_size`: Optional. The maximum number of connections to keep open in the connection pool. Default is 10.
 
 Configuration `params` are provided either in the `acceleration` section of a dataset.


### PR DESCRIPTION
## Summary
- The `pg_connection_pool_min` parameter (default: `5`) is defined in the Postgres accelerator code but was never documented
- This parameter controls the minimum number of connections to keep open in the pool

## Changes
Added `pg_connection_pool_min` parameter documentation to the Postgres accelerator page for vNext and versioned docs from 1.8.x onward (when the parameter was introduced in commit 1a4ce3ef4).

## Reference
Verified against spiceai/spiceai trunk — `crates/runtime/src/dataaccelerator/postgres.rs` lines 92-94: `ParameterSpec::component("connection_pool_min").default("5")`.