### PR TITLE
docs: Add file_create and file_update acceleration modes

### DIFF
--- a/website/docs/features/data-acceleration/index.md
+++ b/website/docs/features/data-acceleration/index.md
@@ -30,17 +30,17 @@ Consider a high-volume e-trading frontend application backed by an AWS RDS datab
 
 **Refresh Latency**: The `refresh_check_interval` controls how frequently the runtime checks for new data. Shorter intervals increase load on the source database. For real-time requirements, use [Change Data Capture (CDC)](../cdc/index.md) instead of polling.
 
-**Schema Changes**: Spice infers the schema for each accelerated dataset at startup and does not apply schema changes at runtime. If the source schema changes (columns added, removed, or types changed) while the runtime is running, data refreshes will fail rather than silently applying the new schema. To pick up source schema changes, restart the runtime. See [Schema Inference](../components/data-connectors#schema-inference) for details.
+**Schema Changes**: Spice infers the schema for each accelerated dataset at startup and does not apply schema changes at runtime. If the source schema changes (columns added, removed, or types changed) while the runtime is running, data refreshes will fail rather than silently applying the new schema. To pick up source schema changes, restart the runtime, or use [`mode: file_update`](../../reference/spicepod/datasets#accelerationmode) which automatically detects schema changes on refresh and recreates the acceleration when incompatible changes are found. See [Schema Inference](../components/data-connectors#schema-inference) for details.
 
 **Engine Selection**: Choose the acceleration engine based on workload characteristics:
 
-| Engine     | Best For                                           | Mode               |
-| ---------- | -------------------------------------------------- | ------------------ |
-| `arrow`    | Read-heavy analytics, in-memory speed              | `memory`           |
-| `duckdb`   | Complex analytical queries, file-based persistence | `memory` or `file` |
-| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `file`             |
-| `postgres` | When a full SQL database is needed as accelerator  | External           |
-| `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file`             |
+| Engine     | Best For                                           | Mode                                              |
+| ---------- | -------------------------------------------------- | ------------------------------------------------- |
+| `arrow`    | Read-heavy analytics, in-memory speed              | `memory`                                          |
+| `duckdb`   | Complex analytical queries, file-based persistence | `memory`, `file`, `file_create`, or `file_update` |
+| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `file`, `file_create`, or `file_update`           |
+| `postgres` | When a full SQL database is needed as accelerator  | External                                          |
+| `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file`, `file_create`, or `file_update`           |
 
 ## Example
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -309,7 +309,9 @@ The acceleration engine to use, defaults to `arrow`. The following engines are s
 Optional. The mode of acceleration. The following values are supported:
 
 - `memory` - Store acceleration data in-memory. Not supported for Spice Cayenne (`cayenne`).
-- `file` - Store acceleration data in a file. Supported for Spice Cayenne (`cayenne`), `duckdb` and `sqlite` acceleration engines.
+- `file` - Store acceleration data in a file. Reuses any existing file on startup. Supported for Spice Cayenne (`cayenne`), `duckdb` and `sqlite` acceleration engines.
+- `file_create` - Always create a new acceleration file on startup, removing any existing file. When [snapshots](../../features/data-acceleration/snapshots) are enabled, the existing file is snapshotted before deletion. Supported for Spice Cayenne (`cayenne`), `duckdb` and `sqlite` acceleration engines.
+- `file_update` - Open an existing acceleration file if it exists, then check schema compatibility on refresh. If the source schema change is additive (new columns only), the existing file is kept. If the schema change is incompatible (columns removed, renamed, or type changed), the file is snapshotted (if [snapshots](../../features/data-acceleration/snapshots) are enabled) and recreated from scratch. Supported for Spice Cayenne (`cayenne`), `duckdb` and `sqlite` acceleration engines.
 
 ## `acceleration.snapshots`
 


### PR DESCRIPTION
## Summary
- Document the `file_create` and `file_update` acceleration modes in the datasets reference
- Update the engine selection table to show all supported modes per engine
- Mention `file_update` as a solution for schema change handling

## Source PRs
- spiceai/spiceai#10108 — Add mode: file_update acceleration mode
- (file_create was added earlier but never documented in the reference docs)

## Changes
- `website/docs/reference/spicepod/datasets.md` — Expanded `acceleration.mode` section with `file_create` and `file_update` entries
- `website/docs/features/data-acceleration/index.md` — Updated engine selection table with all file modes; added `file_update` mention in schema changes note

## Test plan
- [ ] Links are valid
- [ ] Version references are correct