### PR TITLE
docs: Update default query memory limit to 90%

### DIFF
--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -133,11 +133,11 @@ Refresh modes affect memory usage as follows:
 
 ## DataFusion Query Memory Management
 
-Spice uses DataFusion as its query execution engine. By default, DataFusion does not enforce strict memory limits, which can lead to unbounded usage. Spice addresses this through configurable memory limits and spill-to-disk support.
+Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of total system memory** (container-aware). This can be tuned through the `runtime.query.memory_limit` configuration.
 
 ### Memory Limit Configuration
 
-The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. Once the memory limit is reached, supported query operations spill data to disk.
+The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of total system memory. Once the memory limit is reached, supported query operations spill data to disk.
 
 ```yaml
 runtime:

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -380,7 +380,7 @@ runtime:
 
 ### Memory Limit
 
-Set `memory_limit` based on available container/machine memory minus accelerator requirements:
+If not specified, `memory_limit` defaults to 90% of total system memory (container-aware). For deployments with co-located accelerators, set an explicit limit based on available memory:
 
 ```text
 runtime memory_limit = Total Memory - Accelerator Memory - OS/Runtime Overhead (30%)

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -272,7 +272,9 @@ This configuration permits requests only from the `https://example.com` origin.
 
 ## `runtime.query.memory_limit`
 
-The `memory_limit` parameter sets a memory usage cap for the Spice runtime query engine. This limit applies **only** to the query engine and should be used in addition to other memory configuration options, such as `duckdb_memory_limit`. When `memory_limit` is specified, the value of `runtime.query.temp_directory` determines the directory DataFusion uses for spilling intermediate data to disk.
+The `memory_limit` parameter sets a memory usage cap for the Spice runtime query engine. This limit applies **only** to the query engine and should be used in addition to other memory configuration options, such as `duckdb_memory_limit`. When the limit is reached, DataFusion spills intermediate data to disk using the directory configured in `runtime.query.temp_directory`.
+
+If not specified, defaults to **90% of total system memory** (container-aware).
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary
- Document that the default `runtime.query.memory_limit` is 90% of total system memory (container-aware)
- Update three pages that reference query memory management

## Source PRs
- spiceai/spiceai#10112 — fix: Update default query memory limit to 90% from 70%

## Changes
- `website/docs/reference/spicepod/runtime.md` — Added default value note to `runtime.query.memory_limit` section
- `website/docs/reference/memory.md` — Updated DataFusion memory management section with 90% default
- `website/docs/reference/performance-tuning.md` — Added default info to memory limit subsection

## Test plan
- [ ] Default value matches implementation (90%)
- [ ] All three pages are consistent