### PR TITLE
docs: Add MERGE INTO to SQL DML reference

### DIFF
--- a/website/docs/reference/sql/dml.md
+++ b/website/docs/reference/sql/dml.md
@@ -8,7 +8,7 @@ sidebar_position: 30
 Data Manipulation Language (DML) statements are used to insert, update, and delete data in tables. Spice supports DML operations on [write-capable data connectors](../../tags/write) configured with `access: read_write`.
 
 :::warning[Supported Operations]
-Spice currently supports `INSERT` statements for write-capable connectors. `UPDATE` and `DELETE` statements are not yet supported. For data modifications, use the source database directly or re-insert the corrected data.
+Spice supports `INSERT` for write-capable connectors and `MERGE INTO` for [Spice Cayenne](../../components/data-accelerators/cayenne) catalog tables. `UPDATE` and `DELETE` statements are not yet supported as standalone operations. For data modifications, use `MERGE INTO` or the source database directly.
 :::
 
 :::info
@@ -80,4 +80,59 @@ INSERT INTO archive_orders (order_id, customer_id, total, order_date)
 SELECT order_id, customer_id, total, order_date
 FROM orders
 WHERE order_date < '2024-01-01';
+```
+
+## MERGE INTO
+
+Update rows in a target table based on matching rows from a source table. Currently supported for [Spice Cayenne](../../components/data-accelerators/cayenne) catalog tables only.
+
+### Syntax
+
+```sql
+MERGE INTO target [AS alias]
+USING source [AS alias]
+ON <join_condition>
+WHEN MATCHED THEN UPDATE SET column1 = expr1 [, column2 = expr2, ...]
+```
+
+### Parameters
+
+- **`target`**: The table to update. Must be a Cayenne catalog table.
+- **`source`**: The table containing new values. Must be a Cayenne catalog table.
+- **`join_condition`**: A conjunction of equality predicates (e.g., `target.id = source.id AND target.region = source.region`).
+- **`column = expr`**: Column assignments applied to matched rows. Expressions can reference columns from both target and source tables using aliases.
+
+### Constraints
+
+- Only `WHEN MATCHED THEN UPDATE SET` is supported (no `INSERT`, `DELETE`, or `NOT MATCHED` clauses).
+- The `ON` clause must use equality predicates only, joined with `AND`.
+- The target table must not have `primary_key` or `on_conflict` configured.
+- In distributed deployments, both source and target tables must be partitioned by the same column, and the partition column must appear in the `ON` clause join keys.
+
+### Examples
+
+#### Update Matching Rows
+
+```sql
+MERGE INTO catalog.schema.customers AS t
+USING catalog.schema.customer_updates AS s
+ON t.id = s.id
+WHEN MATCHED THEN UPDATE SET name = s.name, email = s.email;
+```
+
+```text
++-------+
+| count |
++-------+
+| 42    |
++-------+
+```
+
+#### Composite Join Keys
+
+```sql
+MERGE INTO catalog.schema.inventory AS t
+USING catalog.schema.new_stock AS s
+ON t.product_id = s.product_id AND t.warehouse_id = s.warehouse_id
+WHEN MATCHED THEN UPDATE SET quantity = s.quantity, updated_at = s.updated_at;
 ```


### PR DESCRIPTION
## Summary
- Add MERGE INTO documentation to the SQL DML reference page
- Update the supported operations warning to include MERGE INTO

## Source PRs
- spiceai/spiceai#10105 — feat: Implement MERGE INTO for Cayenne catalog tables
- spiceai/spiceai#10106 — feat: Add distributed MERGE INTO support for Cayenne catalog tables

## Changes
- `website/docs/reference/sql/dml.md` — Added MERGE INTO section with syntax, parameters, constraints (phase 1 limitations), and examples; updated supported operations notice

## Test plan
- [ ] Syntax matches implementation
- [ ] Constraints accurately reflect phase 1 limitations
- [ ] Examples are clear