### PR TITLE
fix: Add missing delta_lake_aws_session_token parameter to Delta Lake docs

### DIFF
--- a/website/docs/components/data-connectors/delta-lake.md
+++ b/website/docs/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 


### PR DESCRIPTION
## Summary
The Delta Lake connector accepts a `delta_lake_aws_session_token` parameter for AWS S3 temporary credentials, but this parameter is not documented in the AWS S3 parameters table.

## Changes
Added `delta_lake_aws_session_token` to the AWS S3 parameters table in the Delta Lake connector docs.

## Reference
Verified against spiceai/spiceai at trunk — `crates/data-connectors/connector-delta-lake/src/lib.rs` lines 76-78