### PR TITLE
fix: Remove duplicate Cayenne entry and add missing engine modes

### DIFF
--- a/website/docs/components/data-accelerators/cayenne.md
+++ b/website/docs/components/data-accelerators/cayenne.md
@@ -52,7 +52,7 @@ Use [S3 Express One Zone](#aws-s3-express-one-zone-storage) when persistence of 
 
 ## Configuration
 
-To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne only supports `mode: file` and stores data on disk.
+To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne supports `mode: file`, `mode: file_create`, and `mode: file_update` and stores data on disk.
 
 ```yaml
 datasets:

--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -29,10 +29,9 @@ By default, datasets are locally materialized using in-memory Arrow records.
 
 | Name       | Description                     | Status            | Engine Modes     |
 | ---------- | ------------------------------- | ----------------- | ---------------- |
-| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `file`           |
+| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `file`, `file_create`, `file_update` |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file` |
-| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `file`           |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate | N/A              |
 | `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |
 | `turso`    | Embedded [Turso][turso]         | Beta              | `memory`, `file` |

--- a/website/docs/components/data-connectors/delta-lake.md
+++ b/website/docs/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
@@ -34,7 +34,7 @@ For detailed Vortex performance benchmarks, visit [bench.vortex.dev](https://ben
 
 ## Configuration
 
-To use Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Cayenne only supports `mode: file` and stores data on disk.
+To use Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Cayenne supports `mode: file`, `mode: file_create`, and `mode: file_update` and stores data on disk.
 
 ```yaml
 datasets:
@@ -61,7 +61,7 @@ Cayenne uses Vortex's advanced columnar format, which provides:
 Consider the following limitations when using Cayenne acceleration:
 
 - **Alpha Status**: Cayenne is in active development. Configuration options may change between releases.
-- **File Mode Only**: Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
+- **File Mode Only**: Cayenne only supports `mode: file`, `mode: file_create`, and `mode: file_update` and does not support in-memory (`mode: memory`) acceleration.
 - **No `on_conflict` Support**: Cayenne does not yet support the [`on_conflict`](../../reference/spicepod/datasets#accelerationon_conflict) configuration for handling duplicate keys during data refresh.
 - **Data Cleanup Requires `retention_sql`**: Data deletion and cleanup operations require configuring [`retention_sql`](../../reference/spicepod/datasets#accelerationretention_sql) to define retention policies. Manual `DELETE` statements can also be executed directly.
 - **No Snapshot Support**: Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots) for bootstrapping from object storage.

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/index.md
@@ -32,7 +32,7 @@ Supported Data Accelerators include:
 | Name       | Description                     | Status               | Engine Modes     |
 | ---------- | ------------------------------- | -------------------- | ---------------- |
 | `arrow`    | In-Memory Arrow Records         | Stable               | `memory`         |
-| `cayenne`  | [Cayenne][cayenne]              | Alpha (v1.9.0-rc.1+) | `file`           |
+| `cayenne`  | [Cayenne][cayenne]              | Alpha (v1.9.0-rc.1+) | `file`, `file_create`, `file_update` |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Stable               | `memory`, `file` |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate    | N/A              |
 | `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate    | `memory`, `file` |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
@@ -52,7 +52,7 @@ Use [S3 Express One Zone](#aws-s3-express-one-zone-storage) when persistence of 
 
 ## Configuration
 
-To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne only supports `mode: file` and stores data on disk.
+To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne supports `mode: file`, `mode: file_create`, and `mode: file_update` and stores data on disk.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/index.md
@@ -30,7 +30,7 @@ By default, datasets are locally materialized using in-memory Arrow records.
 | Name       | Description                     | Status            | Engine Modes     |
 | ---------- | ------------------------------- | ----------------- | ---------------- |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
-| `cayenne`  | [Spice Cayenne][cayenne]        | Beta              | `file`           |
+| `cayenne`  | [Spice Cayenne][cayenne]        | Beta              | `file`, `file_create`, `file_update` |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file` |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate | N/A              |
 | `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -70,6 +70,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 | `delta_lake_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `delta_lake_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `delta_lake_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `delta_lake_aws_session_token`     | Optional. The AWS session token for S3 object store.                                           |
 | `delta_lake_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `delta_lake_aws_allow_http`        | Optional. Enables insecure HTTP connections to `delta_lake_aws_endpoint`. Defaults to `false`. |
 


### PR DESCRIPTION
## Summary
- The Supported Data Accelerators table had a duplicate row for Cayenne
- Cayenne engine modes were documented as only `file`, but the implementation also supports `file_create` and `file_update`

## Changes
- Removed duplicate Cayenne row from data-accelerators index
- Updated Cayenne engine modes to include `file_create` and `file_update`
- Updated cayenne.md to reflect all supported modes
- Applied the same fixes to versioned docs (version-1.11.x and version-1.10.x)

## Reference
Verified against spiceai/spiceai at trunk — `crates/runtime/src/dataaccelerator/cayenne/mod.rs` lines 996, 1324