### PR TITLE
docs: Add ClickHouse data type mapping table with Date32 support

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -63,6 +63,32 @@ The ClickHouse data connector can be configured by providing the following `para
 | `clickhouse_secure`            | Optional. Specifies the SSL/TLS behavior for the connection, supported values:<br /> <ul><li>`true`: (default) This mode requires an SSL connection. If a secure connection cannot be established, server will not connect.</li><li>`false`: This mode will not attempt to use an SSL connection, even if the server supports it.</li></ul> |
 | `connection_timeout`           | Optional. Specifies the connection timeout in milliseconds. Default is `10000` (10 seconds).                                                                                                                                                                                                                                                |
 
+## Types
+
+The table below shows the ClickHouse data types supported, along with the type mapping to Apache Arrow types in Spice.
+
+| ClickHouse Type  | Arrow Type                  |
+| ---------------- | --------------------------- |
+| `Bool`           | `Boolean`                   |
+| `Int8`           | `Int8`                      |
+| `Int16`          | `Int16`                     |
+| `Int32`          | `Int32`                     |
+| `Int64`          | `Int64`                     |
+| `UInt8`          | `UInt8`                     |
+| `UInt16`         | `UInt16`                    |
+| `UInt32`         | `UInt32`                    |
+| `UInt64`         | `UInt64`                    |
+| `Float32`        | `Float32`                   |
+| `Float64`        | `Float64`                   |
+| `Decimal`        | `Decimal128` / `Decimal256` |
+| `String`         | `Utf8`                      |
+| `FixedString`    | `Utf8`                      |
+| `UUID`           | `Utf8`                      |
+| `Date`           | `Date32`                    |
+| `Date32`         | `Date32`                    |
+| `DateTime`       | `Timestamp(Second, None)`   |
+| `Nullable(T)`    | Mapped inner type `T`       |
+
 ## Examples
 
 ### Connecting to localhost


### PR DESCRIPTION
## Summary
- Add a data types section to the ClickHouse connector documentation listing all supported ClickHouse types and their Apache Arrow mappings
- Includes the newly added `Date32` type support

## Source PRs
- spiceai/spiceai#10132 — feat: Add ClickHouse Date32 type support

## Changes
- `website/docs/components/data-connectors/clickhouse.md` — Added "Types" section with a complete type mapping table between ClickHouse and Apache Arrow types

## Test plan
- [ ] Type mappings verified against source code (`crates/db_connection_pool/src/dbconnection/clickhouseconn.rs`)
- [ ] Table format matches existing connector docs (MySQL, PostgreSQL)
- [ ] Links are valid