### PR TITLE
Add Distributions reference page

### DIFF
--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -44,15 +44,15 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 
 ## Distribution Availability
 
-| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
-| ---------------------- | ---------------- | ----------- | ---------- |
-| Default (Data + AI)    | ✅                | ✅           | ✅          |
-| Data-only              | Nightly only     | ✅           | ✅          |
-| NAS (SMB + NFS)        | Local build only | ❌           | ✅          |
-| Metal (macOS)          | ✅                | ✅           | ✅          |
-| CUDA (Linux)           | Local build only | ✅           | ✅          |
-| Allocator variants     | Local build only | ✅           | ✅          |
-| ODBC connector         | Local build only | ✅           | ✅          |
+| Distribution / Variant | Image Tag | Open Source | Spice Cloud | Enterprise |
+| --- | --- | --- | --- | --- |
+| Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
+| Data-only | `latest-data` | Nightly only | ✅ | ✅ |
+| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| Metal (macOS) | — | Local build only | ✅ | ✅ |
+| CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
+| Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
+| ODBC connector | — | Local build only | ✅ | ✅ |
 
 ## Default Distribution
 

--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -1,0 +1,268 @@
+---
+title: 'Spice Runtime Distributions'
+sidebar_label: 'Distributions'
+sidebar_position: 31
+description: 'Distribution variants of the Spice runtime for different use cases and deployment scenarios, including data-only, GPU-accelerated, NAS, and allocator variants.'
+pagination_prev: null
+pagination_next: null
+---
+
+The Spice open source project provides multiple distribution variants to support different use cases and deployment scenarios.
+
+:::note
+The Spice runtime is **64-bit only**. 32-bit platforms are not supported.
+:::
+
+## Image Channels
+
+| Channel                                                                                                  | Image                             | Description                             |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------- |
+| [DockerHub](https://hub.docker.com/r/spiceai/spiceai)                                                    | `spiceai/spiceai`                 | Official release images                 |
+| [GitHub Container Registry](https://github.com/spiceai/spiceai/pkgs/container/spiceai)                   | `ghcr.io/spiceai/spiceai`         | Official release images                 |
+| [GitHub Container Registry (Nightly)](https://github.com/spiceai/spiceai/pkgs/container/spiceai-nightly) | `ghcr.io/spiceai/spiceai-nightly` | Nightly builds with additional variants |
+| [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i)                          | —                                 | Enterprise image                        |
+| Azure Marketplace                                                                                        | —                                 | Enterprise image (coming soon)          |
+| [Spice Cloud Platform](https://spice.ai/pricing)                                                         | —                                 | Uses Enterprise image                   |
+| [Spice.ai Enterprise](https://spice.ai/pricing)                                                          | —                                 | Uses Enterprise image                   |
+
+:::note
+Some variant distributions are only available in **nightly images** (data) or exclusively through the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing) (NAS, CUDA, allocator variants).
+:::
+
+## Supported Platforms and Hardware Requirements
+
+| Platform | Architecture            | Minimum CPU Features                   | Build Prerequisites |
+| -------- | ----------------------- | -------------------------------------- | ------------------- |
+| Linux    | x86_64                  | AVX2, FMA, BMI1/2, LZCNT, POPCNT       | —                   |
+| Linux    | aarch64 (arm64)         | NEON, FP16 (FEAT_FP16), FHM (FEAT_FHM) | `clang`, `lld`      |
+| macOS    | aarch64 (Apple Silicon) | Native (build host)                    | —                   |
+| Windows  | x86_64 (MSVC)           | —                                      | MSVC toolchain      |
+
+:::note
+Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supported on Windows natively — use WSL instead.
+:::
+
+## Distribution Availability
+
+| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
+| ---------------------- | ---------------- | ----------- | ---------- |
+| Default (Data + AI)    | ✅                | ✅           | ✅          |
+| Data-only              | Nightly only     | ✅           | ✅          |
+| NAS (SMB + NFS)        | Local build only | ❌           | ✅          |
+| Metal (macOS)          | ✅                | ✅           | ✅          |
+| CUDA (Linux)           | Local build only | ✅           | ✅          |
+| Allocator variants     | Local build only | ✅           | ✅          |
+| ODBC connector         | Local build only | ✅           | ✅          |
+
+## Default Distribution
+
+The default distribution includes all features including AI/ML model support. This is the recommended distribution for most users.
+
+**Included Features:**
+
+- All standard data connectors (PostgreSQL, MySQL, DuckDB, SQLite, ClickHouse, etc.)
+- Embedded data accelerators (Spice Cayenne, DuckDB, SQLite)
+- AI/ML model inference (LLMs, embeddings)
+- Search capabilities (Vector and BM-25 Full-Text-Search)
+- Default memory allocator (snmalloc)
+
+:::note
+The PostgreSQL data accelerator is only available in nightly builds. The PostgreSQL data connector is included in all distributions.
+:::
+
+**Installation:**
+
+```bash
+curl https://install.spiceai.org | /bin/bash
+```
+
+**Docker:**
+
+```bash
+docker pull ghcr.io/spiceai/spiceai:latest
+# or
+docker pull spiceai/spiceai:latest
+```
+
+## Data Distribution
+
+The data distribution excludes AI/ML model support, resulting in a smaller binary size and reduced attack surface. Use this when data federation and acceleration capabilities are needed without AI features.
+
+:::note
+**Open Source:** Available in nightly builds only. **[Cloud Platform & Enterprise](https://spice.ai/pricing):** Production-ready data distribution available.
+:::
+
+**Included Features:**
+
+- All data connectors
+- All data accelerators
+- Default memory allocator (snmalloc)
+
+**Excluded Features:**
+
+- AI/ML model inference
+- LLM support
+- Embedding models
+
+**Docker (Nightly):**
+
+```bash
+docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
+```
+
+**Local Build:**
+
+```bash
+make install-data-only
+```
+
+## GPU-Accelerated Distributions
+
+### Metal (macOS)
+
+For macOS systems with Apple Silicon, the Metal distribution enables GPU-accelerated AI/ML inference.
+
+**Included Features:**
+
+- All default features
+- Metal GPU acceleration for model inference
+
+**Local Build:**
+
+```bash
+make install-metal
+```
+
+### CUDA (Linux)
+
+For Linux systems with NVIDIA GPUs, CUDA distributions enable GPU-accelerated AI/ML inference. Multiple CUDA compute capability versions are available.
+
+:::note
+CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+**Included Features:**
+
+- All default features
+- CUDA GPU acceleration for model inference
+
+**Supported Compute Capabilities:**
+
+- 80 (A100, A30)
+- 86 (RTX 30xx, A40, A10)
+- 87 (Jetson Orin)
+- 89 (RTX 40xx, L40, L4)
+- 90 (H100, H200)
+
+**Local Build:**
+
+```bash
+CUDA_COMPUTE_CAP=89 make install-cuda
+```
+
+## NAS Distribution
+
+The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+
+:::note
+The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+**Included Features:**
+
+- All default features
+- SMB data connector
+- NFS data connector
+
+**Local Build:**
+
+```bash
+make install-nas
+```
+
+## Allocator Variants
+
+Different memory allocators can significantly impact performance depending on workload characteristics.
+
+:::note
+Allocator variants are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+### snmalloc (Default)
+
+The default allocator, optimized for concurrent workloads.
+
+### jemalloc
+
+Alternative allocator that may perform better for certain memory allocation patterns.
+
+### mimalloc
+
+Microsoft's mimalloc allocator, designed for performance and security.
+
+### System Allocator
+
+Uses the system's default allocator (glibc malloc on Linux).
+
+## Platform Support
+
+| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
+| Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
+| Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
+| macOS aarch64 (Apple Silicon) | ✅       | Nightly         | Enterprise only | ✅     | ❌                |
+| Windows (WSL)                 | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
+| Windows (Native)              | ❌       | Enterprise only | Enterprise only | ❌     | Enterprise only  |
+
+:::note
+Native Windows support for the Spice runtime is available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users on Windows should use Windows Subsystem for Linux (WSL).
+:::
+
+## Choosing a Distribution
+
+| Use Case                                | Recommended Distribution |
+| --------------------------------------- | ------------------------ |
+| General purpose with AI capabilities    | Default                  |
+| Data federation only, minimal footprint | Data (nightly)           |
+| Network attached storage (SMB/NFS)      | NAS                      |
+| macOS with GPU acceleration             | Metal                    |
+| Linux with NVIDIA GPU                   | CUDA                     |
+| Memory allocation benchmarking          | Allocator variants       |
+
+## Additional Connectors
+
+Some connectors require additional dependencies and are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing):
+
+- **ODBC** - Connect to any ODBC-compatible data source
+
+These can be built locally for development and testing:
+
+```bash
+make install-odbc
+```
+
+## Platform-Specific Notes
+
+### Linux arm64
+
+- **FP16 (FEAT_FP16)** is required because the `gemm` matrix multiplication library (used by the Candle ML framework) contains half-precision ARM inline assembly that requires the `fullfp16` CPU feature. This is supported on AWS Graviton2+, Ampere Altra, Apple M-series (via Linux VM), and most ARMv8.2-A+ processors.
+- **lld** is required as the linker because the spiced debug binary is large enough to exceed GNU ld's ±128 MiB branch range for `R_AARCH64_CALL26` relocations. lld automatically inserts range extension thunks.
+- Install prerequisites on Ubuntu/Debian: `sudo apt-get install -y clang lld`
+
+### Linux x86_64
+
+- Release builds target AVX2+ for optimized SIMD performance, covering Intel Haswell (2013+) and AMD Excavator (2015+) processors, including all current AWS x86_64 instance families (C6/C7/C8).
+
+## Building Custom Distributions
+
+Custom distributions with specific feature combinations can be built:
+
+```bash
+# Build with specific features
+SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build-runtime
+
+# Build with non-default features added to defaults
+SPICED_NON_DEFAULT_FEATURES="odbc" make install
+```
+
+See the project [Makefile](https://github.com/spiceai/spiceai/blob/trunk/Makefile) for all available build targets and options.

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -1,7 +1,7 @@
 ---
 title: 'Managing Memory Usage'
 sidebar_label: 'Memory'
-sidebar_position: 31
+sidebar_position: 32
 description: 'Guidelines and best practices for managing memory usage and optimizing performance in Spice deployments.'
 keywords:
   - memory
@@ -250,32 +250,22 @@ Spice Cayenne and Arrow both use DataFusion as the query execution engine and sh
 
 ## Memory Allocators
 
-Spice supports multiple memory allocators, each with different performance characteristics. The allocator is selected at build time and available through different Docker image tags.
+The Spice runtime supports multiple memory allocators that affect how the process allocates and frees memory at the system level. The choice of allocator can significantly impact performance depending on workload characteristics such as concurrency, allocation size distribution, and fragmentation behavior.
 
-| Allocator          | Docker Tag Suffix | Characteristics                                     | Best For                                   |
-| ------------------ | ----------------- | --------------------------------------------------- | ------------------------------------------ |
-| snmalloc (default) | (none)            | High performance, low fragmentation, multi-threaded | Most workloads                             |
-| jemalloc           | `-jemalloc`       | Predictable performance, good memory profiling      | Memory-constrained environments, debugging |
-| System allocator   | `-sysalloc`       | Uses OS default allocator                           | Compatibility, minimal overhead            |
+| Allocator             | Description                                                  | Best For                                      |
+| --------------------- | ------------------------------------------------------------ | --------------------------------------------- |
+| snmalloc (default)    | Optimized for concurrent workloads with low fragmentation    | General-purpose, high-concurrency deployments |
+| jemalloc              | Mature allocator with strong profiling support               | Workloads with varied allocation patterns     |
+| mimalloc              | Microsoft's allocator, designed for performance and security | Performance-sensitive deployments             |
+| System (glibc malloc) | Uses the OS default allocator                                | Compatibility testing, debugging              |
 
-**Usage Example:**
+The default distribution uses snmalloc. Alternative allocators are available as separate [distribution variants](./distributions#allocator-variants), each published as a distinct Docker image tag.
 
-```bash
-# Default (snmalloc)
-docker pull spiceai/spiceai:latest
+:::note
+Allocator variants are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
 
-# jemalloc variant
-docker pull spiceai/spiceai:latest-jemalloc
-
-# System allocator variant
-docker pull spiceai/spiceai:latest-sysalloc
-```
-
-**Recommendations:**
-
-- Use the default (snmalloc) for most production workloads
-- Use jemalloc when memory profiling or debugging memory issues
-- Use sysalloc for maximum compatibility with system monitoring tools
+The memory allocator operates independently from the query memory management described above. `runtime.query.memory_limit` controls DataFusion's query execution memory pool, while the allocator determines how the runtime process itself requests and releases memory from the operating system.
 
 ## Results Cache Memory
 

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -1,7 +1,7 @@
 ---
 title: 'Performance Tuning'
 sidebar_label: 'Performance Tuning'
-sidebar_position: 32
+sidebar_position: 33
 description: 'Comprehensive guide to optimizing query performance, acceleration, and resource utilization in Spice deployments.'
 keywords:
   - performance

--- a/website/versioned_docs/version-1.11.x/reference/distributions.md
+++ b/website/versioned_docs/version-1.11.x/reference/distributions.md
@@ -44,15 +44,15 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 
 ## Distribution Availability
 
-| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
-| ---------------------- | ---------------- | ----------- | ---------- |
-| Default (Data + AI)    | ✅                | ✅           | ✅          |
-| Data-only              | Nightly only     | ✅           | ✅          |
-| NAS (SMB + NFS)        | Local build only | ❌           | ✅          |
-| Metal (macOS)          | ✅                | ✅           | ✅          |
-| CUDA (Linux)           | Local build only | ✅           | ✅          |
-| Allocator variants     | Local build only | ✅           | ✅          |
-| ODBC connector         | Local build only | ✅           | ✅          |
+| Distribution / Variant | Image Tag | Open Source | Spice Cloud | Enterprise |
+| --- | --- | --- | --- | --- |
+| Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
+| Data-only | `latest-data` | Nightly only | ✅ | ✅ |
+| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| Metal (macOS) | — | Local build only | ✅ | ✅ |
+| CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
+| Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
+| ODBC connector | — | Local build only | ✅ | ✅ |
 
 ## Default Distribution
 

--- a/website/versioned_docs/version-1.11.x/reference/distributions.md
+++ b/website/versioned_docs/version-1.11.x/reference/distributions.md
@@ -1,0 +1,268 @@
+---
+title: 'Spice Runtime Distributions'
+sidebar_label: 'Distributions'
+sidebar_position: 31
+description: 'Distribution variants of the Spice runtime for different use cases and deployment scenarios, including data-only, GPU-accelerated, NAS, and allocator variants.'
+pagination_prev: null
+pagination_next: null
+---
+
+The Spice open source project provides multiple distribution variants to support different use cases and deployment scenarios.
+
+:::note
+The Spice runtime is **64-bit only**. 32-bit platforms are not supported.
+:::
+
+## Image Channels
+
+| Channel                                                                                                  | Image                             | Description                             |
+| -------------------------------------------------------------------------------------------------------- | --------------------------------- | --------------------------------------- |
+| [DockerHub](https://hub.docker.com/r/spiceai/spiceai)                                                    | `spiceai/spiceai`                 | Official release images                 |
+| [GitHub Container Registry](https://github.com/spiceai/spiceai/pkgs/container/spiceai)                   | `ghcr.io/spiceai/spiceai`         | Official release images                 |
+| [GitHub Container Registry (Nightly)](https://github.com/spiceai/spiceai/pkgs/container/spiceai-nightly) | `ghcr.io/spiceai/spiceai-nightly` | Nightly builds with additional variants |
+| [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-jmf6jskjvnq7i)                          | —                                 | Enterprise image                        |
+| Azure Marketplace                                                                                        | —                                 | Enterprise image (coming soon)          |
+| [Spice Cloud Platform](https://spice.ai/pricing)                                                         | —                                 | Uses Enterprise image                   |
+| [Spice.ai Enterprise](https://spice.ai/pricing)                                                          | —                                 | Uses Enterprise image                   |
+
+:::note
+Some variant distributions are only available in **nightly images** (data) or exclusively through the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing) (NAS, CUDA, allocator variants).
+:::
+
+## Supported Platforms and Hardware Requirements
+
+| Platform | Architecture            | Minimum CPU Features                   | Build Prerequisites |
+| -------- | ----------------------- | -------------------------------------- | ------------------- |
+| Linux    | x86_64                  | AVX2, FMA, BMI1/2, LZCNT, POPCNT       | —                   |
+| Linux    | aarch64 (arm64)         | NEON, FP16 (FEAT_FP16), FHM (FEAT_FHM) | `clang`, `lld`      |
+| macOS    | aarch64 (Apple Silicon) | Native (build host)                    | —                   |
+| Windows  | x86_64 (MSVC)           | —                                      | MSVC toolchain      |
+
+:::note
+Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supported on Windows natively — use WSL instead.
+:::
+
+## Distribution Availability
+
+| Distribution / Variant | Open Source      | Spice Cloud | Enterprise |
+| ---------------------- | ---------------- | ----------- | ---------- |
+| Default (Data + AI)    | ✅                | ✅           | ✅          |
+| Data-only              | Nightly only     | ✅           | ✅          |
+| NAS (SMB + NFS)        | Local build only | ❌           | ✅          |
+| Metal (macOS)          | ✅                | ✅           | ✅          |
+| CUDA (Linux)           | Local build only | ✅           | ✅          |
+| Allocator variants     | Local build only | ✅           | ✅          |
+| ODBC connector         | Local build only | ✅           | ✅          |
+
+## Default Distribution
+
+The default distribution includes all features including AI/ML model support. This is the recommended distribution for most users.
+
+**Included Features:**
+
+- All standard data connectors (PostgreSQL, MySQL, DuckDB, SQLite, ClickHouse, etc.)
+- Embedded data accelerators (Spice Cayenne, DuckDB, SQLite)
+- AI/ML model inference (LLMs, embeddings)
+- Search capabilities (Vector and BM-25 Full-Text-Search)
+- Default memory allocator (snmalloc)
+
+:::note
+The PostgreSQL data accelerator is only available in nightly builds. The PostgreSQL data connector is included in all distributions.
+:::
+
+**Installation:**
+
+```bash
+curl https://install.spiceai.org | /bin/bash
+```
+
+**Docker:**
+
+```bash
+docker pull ghcr.io/spiceai/spiceai:latest
+# or
+docker pull spiceai/spiceai:latest
+```
+
+## Data Distribution
+
+The data distribution excludes AI/ML model support, resulting in a smaller binary size and reduced attack surface. Use this when data federation and acceleration capabilities are needed without AI features.
+
+:::note
+**Open Source:** Available in nightly builds only. **[Cloud Platform & Enterprise](https://spice.ai/pricing):** Production-ready data distribution available.
+:::
+
+**Included Features:**
+
+- All data connectors
+- All data accelerators
+- Default memory allocator (snmalloc)
+
+**Excluded Features:**
+
+- AI/ML model inference
+- LLM support
+- Embedding models
+
+**Docker (Nightly):**
+
+```bash
+docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
+```
+
+**Local Build:**
+
+```bash
+make install-data-only
+```
+
+## GPU-Accelerated Distributions
+
+### Metal (macOS)
+
+For macOS systems with Apple Silicon, the Metal distribution enables GPU-accelerated AI/ML inference.
+
+**Included Features:**
+
+- All default features
+- Metal GPU acceleration for model inference
+
+**Local Build:**
+
+```bash
+make install-metal
+```
+
+### CUDA (Linux)
+
+For Linux systems with NVIDIA GPUs, CUDA distributions enable GPU-accelerated AI/ML inference. Multiple CUDA compute capability versions are available.
+
+:::note
+CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+**Included Features:**
+
+- All default features
+- CUDA GPU acceleration for model inference
+
+**Supported Compute Capabilities:**
+
+- 80 (A100, A30)
+- 86 (RTX 30xx, A40, A10)
+- 87 (Jetson Orin)
+- 89 (RTX 40xx, L40, L4)
+- 90 (H100, H200)
+
+**Local Build:**
+
+```bash
+CUDA_COMPUTE_CAP=89 make install-cuda
+```
+
+## NAS Distribution
+
+The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+
+:::note
+The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+**Included Features:**
+
+- All default features
+- SMB data connector
+- NFS data connector
+
+**Local Build:**
+
+```bash
+make install-nas
+```
+
+## Allocator Variants
+
+Different memory allocators can significantly impact performance depending on workload characteristics.
+
+:::note
+Allocator variants are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
+
+### snmalloc (Default)
+
+The default allocator, optimized for concurrent workloads.
+
+### jemalloc
+
+Alternative allocator that may perform better for certain memory allocation patterns.
+
+### mimalloc
+
+Microsoft's mimalloc allocator, designed for performance and security.
+
+### System Allocator
+
+Uses the system's default allocator (glibc malloc on Linux).
+
+## Platform Support
+
+| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
+| Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
+| Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
+| macOS aarch64 (Apple Silicon) | ✅       | Nightly         | Enterprise only | ✅     | ❌                |
+| Windows (WSL)                 | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
+| Windows (Native)              | ❌       | Enterprise only | Enterprise only | ❌     | Enterprise only  |
+
+:::note
+Native Windows support for the Spice runtime is available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users on Windows should use Windows Subsystem for Linux (WSL).
+:::
+
+## Choosing a Distribution
+
+| Use Case                                | Recommended Distribution |
+| --------------------------------------- | ------------------------ |
+| General purpose with AI capabilities    | Default                  |
+| Data federation only, minimal footprint | Data (nightly)           |
+| Network attached storage (SMB/NFS)      | NAS                      |
+| macOS with GPU acceleration             | Metal                    |
+| Linux with NVIDIA GPU                   | CUDA                     |
+| Memory allocation benchmarking          | Allocator variants       |
+
+## Additional Connectors
+
+Some connectors require additional dependencies and are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing):
+
+- **ODBC** - Connect to any ODBC-compatible data source
+
+These can be built locally for development and testing:
+
+```bash
+make install-odbc
+```
+
+## Platform-Specific Notes
+
+### Linux arm64
+
+- **FP16 (FEAT_FP16)** is required because the `gemm` matrix multiplication library (used by the Candle ML framework) contains half-precision ARM inline assembly that requires the `fullfp16` CPU feature. This is supported on AWS Graviton2+, Ampere Altra, Apple M-series (via Linux VM), and most ARMv8.2-A+ processors.
+- **lld** is required as the linker because the spiced debug binary is large enough to exceed GNU ld's ±128 MiB branch range for `R_AARCH64_CALL26` relocations. lld automatically inserts range extension thunks.
+- Install prerequisites on Ubuntu/Debian: `sudo apt-get install -y clang lld`
+
+### Linux x86_64
+
+- Release builds target AVX2+ for optimized SIMD performance, covering Intel Haswell (2013+) and AMD Excavator (2015+) processors, including all current AWS x86_64 instance families (C6/C7/C8).
+
+## Building Custom Distributions
+
+Custom distributions with specific feature combinations can be built:
+
+```bash
+# Build with specific features
+SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build-runtime
+
+# Build with non-default features added to defaults
+SPICED_NON_DEFAULT_FEATURES="odbc" make install
+```
+
+See the project [Makefile](https://github.com/spiceai/spiceai/blob/trunk/Makefile) for all available build targets and options.

--- a/website/versioned_docs/version-1.11.x/reference/memory.md
+++ b/website/versioned_docs/version-1.11.x/reference/memory.md
@@ -1,7 +1,7 @@
 ---
 title: 'Managing Memory Usage'
 sidebar_label: 'Memory'
-sidebar_position: 31
+sidebar_position: 32
 description: 'Guidelines and best practices for managing memory usage and optimizing performance in Spice deployments.'
 keywords:
   - memory
@@ -250,32 +250,22 @@ Spice Cayenne and Arrow both use DataFusion as the query execution engine and sh
 
 ## Memory Allocators
 
-Spice supports multiple memory allocators, each with different performance characteristics. The allocator is selected at build time and available through different Docker image tags.
+The Spice runtime supports multiple memory allocators that affect how the process allocates and frees memory at the system level. The choice of allocator can significantly impact performance depending on workload characteristics such as concurrency, allocation size distribution, and fragmentation behavior.
 
-| Allocator          | Docker Tag Suffix | Characteristics                                     | Best For                                   |
-| ------------------ | ----------------- | --------------------------------------------------- | ------------------------------------------ |
-| snmalloc (default) | (none)            | High performance, low fragmentation, multi-threaded | Most workloads                             |
-| jemalloc           | `-jemalloc`       | Predictable performance, good memory profiling      | Memory-constrained environments, debugging |
-| System allocator   | `-sysalloc`       | Uses OS default allocator                           | Compatibility, minimal overhead            |
+| Allocator             | Description                                                  | Best For                                      |
+| --------------------- | ------------------------------------------------------------ | --------------------------------------------- |
+| snmalloc (default)    | Optimized for concurrent workloads with low fragmentation    | General-purpose, high-concurrency deployments |
+| jemalloc              | Mature allocator with strong profiling support               | Workloads with varied allocation patterns     |
+| mimalloc              | Microsoft's allocator, designed for performance and security | Performance-sensitive deployments             |
+| System (glibc malloc) | Uses the OS default allocator                                | Compatibility testing, debugging              |
 
-**Usage Example:**
+The default distribution uses snmalloc. Alternative allocators are available as separate [distribution variants](./distributions#allocator-variants), each published as a distinct Docker image tag.
 
-```bash
-# Default (snmalloc)
-docker pull spiceai/spiceai:latest
+:::note
+Allocator variants are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+:::
 
-# jemalloc variant
-docker pull spiceai/spiceai:latest-jemalloc
-
-# System allocator variant
-docker pull spiceai/spiceai:latest-sysalloc
-```
-
-**Recommendations:**
-
-- Use the default (snmalloc) for most production workloads
-- Use jemalloc when memory profiling or debugging memory issues
-- Use sysalloc for maximum compatibility with system monitoring tools
+The memory allocator operates independently from the query memory management described above. `runtime.query.memory_limit` controls DataFusion's query execution memory pool, while the allocator determines how the runtime process itself requests and releases memory from the operating system.
 
 ## Results Cache Memory
 

--- a/website/versioned_docs/version-1.11.x/reference/performance-tuning.md
+++ b/website/versioned_docs/version-1.11.x/reference/performance-tuning.md
@@ -1,7 +1,7 @@
 ---
 title: 'Performance Tuning'
 sidebar_label: 'Performance Tuning'
-sidebar_position: 32
+sidebar_position: 33
 description: 'Comprehensive guide to optimizing query performance, acceleration, and resource utilization in Spice deployments.'
 keywords:
   - performance


### PR DESCRIPTION
Adds a Distributions reference page documenting runtime distribution variants, image channels, and platform support.

## Changes

### New: `distributions.md` (root + v1.11)
- **Image Channels** table: DockerHub, GHCR, GHCR Nightly, AWS Marketplace (Enterprise), Azure Marketplace (coming soon), Spice Cloud Platform, Spice.ai Enterprise
- **Distribution Availability** matrix across Open Source / Spice Cloud / Enterprise
- Sections for Default, Data, Metal, CUDA, NAS distributions and Allocator variants
- **Platform Support** matrix per distribution per OS/arch
- **Choosing a Distribution** guide
- Platform-specific notes (Linux arm64, Linux x86_64)
- Building custom distributions

### Updated: `memory.md` (root + v1.11)
- Added **Memory Allocators** section with comparison table (snmalloc, jemalloc, mimalloc, system)
- Cross-references the new distributions page for Docker image tags and availability
- Clarifies allocator vs. query memory pool distinction
- Removed duplicate old Memory Allocators section

### Fixed: Sidebar ordering
- System Requirements (30) → Distributions (31) → Memory (32) → Performance Tuning (33)
- Resolves position collision between distributions and performance-tuning