### PR TITLE
fix: Use correct field name refresh_check_interval in dataset examples

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.5.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.5.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -114,7 +114,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.6.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.6.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -114,7 +114,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.7.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.7.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.8.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.8.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/datasets.md
@@ -59,7 +59,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 ## `from`
@@ -113,7 +113,7 @@ name: taxi_trips
 type: overwrite
 acceleration:
   enabled: true
-  refresh: 1h
+  refresh_check_interval: 1h
 ```
 
 **ref used in spicepod.yaml**


### PR DESCRIPTION
## Summary
- Dataset reference examples used `refresh: 1h` as an acceleration field, but the correct spicepod field name is `refresh_check_interval`
- The `refresh` key is silently ignored by serde deserialization, meaning users copying this example would get no automatic data refresh
- Fixed in vNext docs and all versioned docs (1.5.x through 1.11.x) — the field has been `refresh_check_interval` since at least v1.5

## Changes
- Replaced `refresh: 1h` with `refresh_check_interval: 1h` in two YAML examples in `reference/spicepod/datasets.md` across all doc versions

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/spicepod/src/acceleration/mod.rs` line 250](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/acceleration/mod.rs#L250) defines `pub refresh_check_interval: Option<String>`