### PR TITLE
fix: Add missing flightsql_tls_ca_certificate_file parameter to FlightSQL docs

### DIFF
--- a/website/docs/components/data-connectors/flightsql.md
+++ b/website/docs/components/data-connectors/flightsql.md
@@ -35,6 +35,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `flightsql_endpoint` | The Apache Flight endpoint used to connect to the Flight SQL server.                                                                                                                                                                                 |
 | `flightsql_username` | Optional. The username to use in the underlying Apache flight Handshake Request to authenticate to the server (see [reference](https://arrow.apache.org/docs/format/Flight.html#authentication)).                                                    |
 | `flightsql_password` | Optional. The password to use in the underlying Apache flight Handshake Request to authenticate to the server. Use the [secret replacement syntax](../secret-stores/) to load the password from a secret store, e.g. `${secrets:my_flightsql_pass}`. |
+| `flightsql_tls_ca_certificate_file` | Optional. Path to a CA certificate file (PEM format) to use for TLS verification instead of system certificates. |
 
 ## Secrets
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/flightsql.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/flightsql.md
@@ -35,6 +35,7 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `flightsql_endpoint` | The Apache Flight endpoint used to connect to the Flight SQL server.                                                                                                                                                                                 |
 | `flightsql_username` | Optional. The username to use in the underlying Apache flight Handshake Request to authenticate to the server (see [reference](https://arrow.apache.org/docs/format/Flight.html#authentication)).                                                    |
 | `flightsql_password` | Optional. The password to use in the underlying Apache flight Handshake Request to authenticate to the server. Use the [secret replacement syntax](../secret-stores/) to load the password from a secret store, e.g. `${secrets:my_flightsql_pass}`. |
+| `flightsql_tls_ca_certificate_file` | Optional. Path to a CA certificate file (PEM format) to use for TLS verification instead of system certificates. |
 
 ## Secrets
 


### PR DESCRIPTION
## Summary
- The `flightsql_tls_ca_certificate_file` parameter was added in v1.11.0 (spiceai/spiceai#9073) but was never documented
- This parameter allows specifying a custom CA certificate (PEM format) for TLS verification instead of system certificates

## Changes
- Added `flightsql_tls_ca_certificate_file` to the params table in FlightSQL connector docs (vNext and 1.11.x)

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/data-connectors/connector-flightsql/src/lib.rs` lines 87-88](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-flightsql/src/lib.rs#L87-L88)