### PR TITLE
fix: Use correct ducklake_connection_string parameter name in examples

### DIFF
--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -85,7 +85,7 @@ datasets:
   - from: ducklake:customer
     name: customer
     params:
-      connection_string: /path/to/metadata.ducklake
+      ducklake_connection_string: /path/to/metadata.ducklake
 ```
 
 ### Reading from S3
@@ -115,7 +115,7 @@ datasets:
   - from: ducklake:customer
     name: customer
     params:
-      connection_string: "postgres:dbname=ducklake_catalog host=localhost user=postgres password=postgres"
+      ducklake_connection_string: "postgres:dbname=ducklake_catalog host=localhost user=postgres password=postgres"
 ```
 
 ### Multiple tables with YAML anchors
@@ -152,7 +152,7 @@ datasets:
 :::warning[Limitations]
 
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
-- The `connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
+- The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.
 
 :::


### PR DESCRIPTION
## Summary
- Two YAML examples and a limitation note used the unprefixed `connection_string` instead of the correct `ducklake_connection_string` parameter name
- The DuckLake connector defines `connection_string` as a `ParameterSpec::component()` parameter, which requires the `ducklake_` prefix when used in configuration

## Changes
- Fixed the local file system example (line 88)
- Fixed the PostgreSQL metadata backend example (line 118)
- Fixed the limitation note reference (line 155)

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/runtime/src/dataconnector/ducklake.rs` line 88](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/ducklake.rs#L88)