### PR TITLE
fix: Add missing Iceberg GCS storage and warehouse parameters

### DIFF
--- a/website/docs/components/data-connectors/iceberg.md
+++ b/website/docs/components/data-connectors/iceberg.md
@@ -119,6 +119,12 @@ SELECT COUNT(*) FROM transactions;
 | `iceberg_sigv4_enabled`        | Enable SigV4 (AWS Signature Version 4) authentication when connecting to the catalog. Automatically enabled if the URL in `from` is an AWS Glue catalog. Default: `false`                      |
 | `iceberg_signing_region`       | Region to use for SigV4 authentication. Extracted from the URL in `from` if not specified.                                                                                                     |
 | `iceberg_signing_name`         | Service name to use for SigV4 authentication. Default: `glue`.                                                                                                                                 |
+| `iceberg_warehouse`            | Name of the Iceberg warehouse. Used for catalog types that support it (e.g. Lakekeeper).                                                                                                       |
+| `iceberg_gcs_project_id`      | The Google Cloud project ID for GCS storage.                                                                                                                                                   |
+| `iceberg_gcs_credentials`     | Base64-encoded Google Cloud service account credentials JSON for GCS storage.                                                                                                                  |
+| `iceberg_gcs_token`           | OAuth2 token to use for GCS authentication.                                                                                                                                                    |
+| `iceberg_gcs_service_path`    | Custom endpoint URL for GCS (for emulators or custom endpoints).                                                                                                                               |
+| `iceberg_gcs_no_auth`         | Set to `true` to allow anonymous access to GCS (for public buckets).                                                                                                                           |
 | `metadata_path`                | The path including scheme to the metadata file for the Hadoop table. Must specify a path to a `.json` file. For example, `s3a://my-bucket/warehouse/namespace/table/metadata/v1.metadata.json` |
 
 ## Authentication


### PR DESCRIPTION
## Summary
- The Iceberg connector documentation was missing 6 parameters that are defined in the code:
  - `iceberg_warehouse`: For catalog types that support named warehouses (e.g. Lakekeeper)
  - `iceberg_gcs_project_id`: Google Cloud project ID for GCS storage
  - `iceberg_gcs_credentials`: Base64-encoded service account credentials JSON
  - `iceberg_gcs_token`: OAuth2 token for GCS authentication
  - `iceberg_gcs_service_path`: Custom endpoint URL for GCS
  - `iceberg_gcs_no_auth`: Allow anonymous access to public GCS buckets

## Changes
- Added all 6 missing parameters to the `params` table in the Iceberg connector documentation

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/runtime/src/catalogconnector/iceberg.rs` lines 209-254](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/iceberg.rs#L209-L254)