### PR TITLE
fix: Correct Databricks GCS parameter name in v1.11.x example

### DIFF
--- a/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types


### PR DESCRIPTION
## Summary
- The Delta Lake (GCP) example in the v1.11.x versioned docs used the non-existent parameter `databricks_google_service_account_path` instead of the correct `databricks_google_service_account`
- The params table in the same doc correctly lists `google_service_account`, but the YAML example had the wrong name with an extra `_path` suffix

## Changes
- Fixed the GCP example to use `databricks_google_service_account` instead of `databricks_google_service_account_path`

## Reference
Verified against spiceai/spiceai at tag `v1.11.5` — `crates/runtime/src/dataconnector/databricks.rs` line 463: `ParameterSpec::component("google_service_account")`