### PR TITLE
docs: Document CREATE TABLE ... LIKE for Cayenne catalog

### DIFF
--- a/website/docs/components/catalogs/cayenne.md
+++ b/website/docs/components/catalogs/cayenne.md
@@ -74,3 +74,44 @@ catalogs:
     params:
       cayenne_target_file_size_mb: '256'
 ```
+
+## Table Management
+
+### `CREATE TABLE ... LIKE`
+
+Create a new Cayenne catalog table that copies its schema and partitioning from an existing Cayenne catalog table.
+
+#### Syntax
+
+```sql
+CREATE TABLE [IF NOT EXISTS] new_table LIKE source_table
+```
+
+#### Behavior
+
+- Copies the source table's column schema.
+- Copies the source table's partition expression (if any).
+- In distributed mode, copies the source table's partition-to-executor assignments so that writes to both tables route to the same executors.
+- Primary keys are **not** copied. Staging and derived tables typically don't need them.
+
+#### Constraints
+
+- Both `source_table` and `new_table` must be in a Cayenne catalog. Using `LIKE` with a non-Cayenne source returns an error.
+- `LIKE` cannot be combined with `PARTITION BY` or `WITH` options. To create a table with a different partitioning, use a regular `CREATE TABLE` instead.
+
+#### Example
+
+```sql
+-- Source table with bucket-based partitioning
+CREATE TABLE cayenne_catalog.bench.orders (
+  order_id BIGINT,
+  customer_id BIGINT,
+  total DOUBLE
+) PARTITION BY (bucket(50, order_id));
+
+-- Staging table that inherits the same schema and partitioning
+CREATE TABLE IF NOT EXISTS cayenne_catalog.bench.orders_staging
+  LIKE cayenne_catalog.bench.orders;
+```
+
+This is the recommended way to create staging tables for [`MERGE INTO`](../../reference/sql/dml#merge-into) operations in distributed mode, ensuring the staging and target tables share partition routing.

--- a/website/docs/reference/sql/dml.md
+++ b/website/docs/reference/sql/dml.md
@@ -108,7 +108,7 @@ WHEN MATCHED THEN UPDATE SET column1 = expr1 [, column2 = expr2, ...]
 - The `ON` clause must use equality predicates only, joined with `AND`.
 - The target table must not have `primary_key` or `on_conflict` configured.
 - The source table must not contain duplicate rows for the same join key(s). If duplicates are detected, the MERGE operation fails with an error to prevent data loss. Deduplicate the source table before running MERGE.
-- In distributed deployments, both source and target tables must be partitioned by the same column, and the partition column must appear in the `ON` clause join keys.
+- In distributed deployments, both source and target tables must be partitioned by the same column, and the partition column must appear in the `ON` clause join keys. Use [`CREATE TABLE ... LIKE`](../../components/catalogs/cayenne#create-table--like) to create staging tables that share partition routing with the target table.
 
 ### Examples
 


### PR DESCRIPTION
## Summary
Documents the new `CREATE TABLE ... LIKE` SQL syntax for Cayenne catalog tables introduced in spiceai/spiceai#10180.

## Source PRs
- spiceai/spiceai#10180 — feat: Add CREATE TABLE ... (LIKE ...) support

## Changes
- `website/docs/components/catalogs/cayenne.md` — Added a **Table Management** section documenting `CREATE TABLE ... LIKE` syntax, behavior (copies schema, partition expression, and partition-to-executor assignments), constraints (Cayenne-only; cannot combine with `PARTITION BY` or `WITH`; primary keys not copied), and an example showing the staging-table pattern.
- `website/docs/reference/sql/dml.md` — Cross-linked from the MERGE INTO distributed-deployments constraint bullet so users authoring distributed merges discover the recommended way to create routing-aligned staging tables.

## Test plan
- [ ] Verified syntax and constraints against the source PR diff (`crates/cayenne` DDL handler and `parse_create_table` tests).
- [ ] Cross-link anchor `#create-table--like` resolves to the new heading.
- [ ] No broken links introduced (Docusaurus relative paths only).