### PR TITLE
fix: Document mongodb_srv parameter for MongoDB Atlas and SRV discovery

### DIFF
--- a/website/docs/components/data-connectors/mongodb.md
+++ b/website/docs/components/data-connectors/mongodb.md
@@ -88,6 +88,7 @@ The MongoDB data connector can be configured by providing the following `params`
 | `mongodb_time_zone`                | Optional. Specifies connection time zone. Default is `UTC`. Accepts: <br /><ul><li>Fixed offsets (e.g., `+02:00`).</li><li>IANA time zone names (e.g., `America/Los_Angeles`)</li></ul>                                                                                                                                                                                                                                                                                                                      |
 | `mongodb_auth_source`              | Optional. Authentication source database. Overrides the default auth source in the connection string.                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `mongodb_direct_connection`        | Optional. Whether to connect directly to a single MongoDB host instead of discovering the topology. Accepts `true` or `false`.                                                                                                                                                                                                                                                                                                                                                                               |
+| `mongodb_srv`                      | Optional. Use the `mongodb+srv://` connection scheme for DNS SRV record discovery (MongoDB Atlas). Auto-detected (and `mongodb_port` is ignored) when `mongodb_host` ends with `.mongodb.net`. Accepts `true` or `false`. Default: `false`.                                                                                                                                                                                                                                                                  |
 | `mongodb_unnest_depth`             | Optional. Maximum nesting depth for unnesting embedded documents into a flattened structure. Higher values expand deeper nested fields. Default: `0`                                                                                                                                                                                                                                                                                                                                                         |
 | `mongodb_num_docs_to_infer_schema` | Optional. Number of documents to use to infer the schema. Defaults to 400.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `mongodb_pool_min`                 | The minimum number of connections to keep open in the pool, lazily created when requested. Default: `1`                                                                                                                                                                                                                                                                                                                                                                                                      |
@@ -219,6 +220,34 @@ datasets:
       mongodb_connection_string: mongodb://${secrets:my_user}:${secrets:my_password}@localhost:27017/my_db?authSource=admin
 ```
 
+### Connecting to MongoDB Atlas (SRV)
+
+When `mongodb_host` ends with `.mongodb.net`, `mongodb_srv` is automatically enabled and `mongodb_port` is ignored — `mongodb+srv://` discovers host/port via DNS SRV records.
+
+```yaml
+datasets:
+  - from: mongodb:my_collection
+    name: my_dataset
+    params:
+      mongodb_host: cluster0.abc123.mongodb.net
+      mongodb_db: my_database
+      mongodb_user: my_user
+      mongodb_pass: ${secrets:mongodb_pass}
+```
+
+Set `mongodb_srv: true` explicitly for non-Atlas hosts that are configured with SRV records:
+
+```yaml
+datasets:
+  - from: mongodb:my_collection
+    name: my_dataset
+    params:
+      mongodb_srv: true
+      mongodb_host: mongo.example.com
+      mongodb_db: my_database
+      mongodb_user: my_user
+      mongodb_pass: ${secrets:mongodb_pass}
+```
 
 ### With custom connection pool settings
 


### PR DESCRIPTION
## Summary

The MongoDB connector supports an `mongodb_srv` parameter (added in spiceai/spiceai#10317) that enables the `mongodb+srv://` connection scheme for DNS SRV record discovery. This is the standard way to connect to MongoDB Atlas. It is auto-detected for `*.mongodb.net` hosts, but was completely missing from the docs, leaving Atlas users without guidance on how to connect.

## Changes

- Add `mongodb_srv` row to the `params` table on the MongoDB Data Connector page, documenting the auto-detection behavior for `.mongodb.net` hosts (where `mongodb_port` is ignored) and the default (`false`).
- Add a "Connecting to MongoDB Atlas (SRV)" example section showing both the auto-detected configuration and the explicit `mongodb_srv: true` override for non-Atlas SRV hosts.

## Reference

Verified against spiceai/spiceai at `trunk`:

- Parameter definition: [`crates/data-connectors/connector-mongodb/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-mongodb/src/lib.rs#L103-L105)
- Auto-detection logic and port-ignored warning: [`crates/data-connectors/connector-mongodb/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-mongodb/src/lib.rs#L133-L187)
- Introduced in: spiceai/spiceai#10317 (MongoDB SRV support)

Change only applies to unversioned (vNext) docs — the feature is post-`v1.11.5` and is not in any released tag yet.