### PR TITLE
fix: Document missing snapshot acceleration parameters

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -379,6 +379,24 @@ Supported values:
 - `enabled` – Compact the database before creating each snapshot.
 - `disabled` (default) – Upload snapshots without compaction.
 
+## `acceleration.snapshots_creation_policy`
+
+Optional. Controls when new snapshots are created after data refreshes. Defaults to `on_change`.
+
+Supported values:
+
+- `on_change` (default) – Only create a new snapshot when the data has changed since the last snapshot.
+- `always` – Create a new snapshot after every refresh, regardless of whether the data has changed.
+
+## `acceleration.snapshots_reset_expiry_on_load`
+
+Optional. Controls whether the snapshot expiry timer is reset when loading from a snapshot during bootstrap. Defaults to `disabled`.
+
+Supported values:
+
+- `disabled` (default) – Snapshot expiry is not reset on load; the original expiry time is preserved.
+- `enabled` – Reset the snapshot expiry when it is loaded during bootstrap.
+
 ## `acceleration.refresh_mode`
 
 Optional. How to refresh the dataset. The following values are supported:

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -360,6 +360,24 @@ Supported values:
 - `enabled` – Compact the database before creating each snapshot.
 - `disabled` (default) – Upload snapshots without compaction.
 
+## `acceleration.snapshots_creation_policy`
+
+Optional. Controls when new snapshots are created after data refreshes. Defaults to `on_change`.
+
+Supported values:
+
+- `on_change` (default) – Only create a new snapshot when the data has changed since the last snapshot.
+- `always` – Create a new snapshot after every refresh, regardless of whether the data has changed.
+
+## `acceleration.snapshots_reset_expiry_on_load`
+
+Optional. Controls whether the snapshot expiry timer is reset when loading from a snapshot during bootstrap. Defaults to `disabled`.
+
+Supported values:
+
+- `disabled` (default) – Snapshot expiry is not reset on load; the original expiry time is preserved.
+- `enabled` – Reset the snapshot expiry when it is loaded during bootstrap.
+
 ## `acceleration.refresh_mode`
 
 Optional. How to refresh the dataset. The following values are supported:


### PR DESCRIPTION
## Summary
- Two acceleration snapshot parameters introduced in v1.11.0 were missing from the reference documentation:
  - `acceleration.snapshots_creation_policy` — controls whether snapshots are created after every refresh (`always`) or only when data changes (`on_change`, default)
  - `acceleration.snapshots_reset_expiry_on_load` — controls whether snapshot expiry is reset when loading during bootstrap (`disabled` default, `enabled`)

## Changes
- Added documentation for both parameters to the datasets reference in vNext and v1.11.x

## Reference
Verified against `spiceai/spiceai` at trunk and v1.11.5 — [`crates/spicepod/src/acceleration/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/acceleration/mod.rs#L155-L168) defines both enums with their defaults.