### PR TITLE
fix: Document nanosecond timestamp range limitation for MSSQL and Oracle

### DIFF
--- a/website/docs/components/data-connectors/mssql.md
+++ b/website/docs/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will return an error. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/docs/components/data-connectors/oracle.md
+++ b/website/docs/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will return an error. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 


### PR DESCRIPTION
## Summary
Document that MSSQL and Oracle connector timestamp columns mapped to Arrow `Timestamp(Nanosecond)` will error for values outside the i64 nanosecond range (~1677–2262).

## Source PRs
- spiceai/spiceai#10335 — fix: error on MSSQL/Oracle timestamp nanosecond overflow
- spiceai/spiceai#10255 — fix: Use unit-appropriate timestamp methods in Turso RFC3339 parsing

## Changes
- `website/docs/components/data-connectors/mssql.md` — Added limitation noting `DATETIME2` and `DATETIMEOFFSET` columns will error for timestamps outside ~1677–2262
- `website/docs/components/data-connectors/oracle.md` — Added note that `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision will error for timestamps outside ~1677–2262

Note: The Turso accelerator docs already document this limitation (nanosecond-precision timestamps outside the range return `NULL`), so no Turso changes were needed.

## Test plan
- [ ] Links are valid
- [ ] Version references are correct
- [ ] Limitation text is consistent with actual implementation behavior (error on overflow, not silent corruption)