### PR TITLE
fix: Document missing Cayenne accelerator parameters

### DIFF
--- a/website/docs/components/data-accelerators/cayenne.md
+++ b/website/docs/components/data-accelerators/cayenne.md
@@ -75,7 +75,7 @@ datasets:
 | `cayenne_target_file_size_mb`     | Target size for individual Vortex files in MB. When writes exceed this size, a new Vortex file is created. Defaults to `256`. Smaller files enable better parallelism and predicate pushdown. |
 | `cayenne_metadata_dir`            | Custom directory for storing Cayenne metadata (SQLite catalog). Defaults to `{spice_data_path}/metadata`.                                                                                     |
 | `cayenne_metastore`               | Metastore backend type. Supports `sqlite` (default) or `turso` (requires `turso` feature flag).                                                                                               |
-| `cayenne_upload_concurrency`      | Maximum number of concurrent file uploads when writing multiple Vortex files. Defaults to `4`.                                                                                                |
+| `cayenne_upload_concurrency`      | Maximum number of concurrent file uploads when writing multiple Vortex files to S3 Express One Zone. Defaults to `4`.                                                                                                |
 | `sort_columns`                    | Comma-separated list of columns to sort data by on refresh operations. Improves segment pruning for frequently filtered columns.                                                              |
 | `unsupported_type_action`         | Action when encountering unsupported data types. Options: `error` (default), `string`, `warn`, `ignore`.                                                                                      |
 

--- a/website/docs/components/data-accelerators/cayenne.md
+++ b/website/docs/components/data-accelerators/cayenne.md
@@ -75,6 +75,7 @@ datasets:
 | `cayenne_target_file_size_mb`     | Target size for individual Vortex files in MB. When writes exceed this size, a new Vortex file is created. Defaults to `256`. Smaller files enable better parallelism and predicate pushdown. |
 | `cayenne_metadata_dir`            | Custom directory for storing Cayenne metadata (SQLite catalog). Defaults to `{spice_data_path}/metadata`.                                                                                     |
 | `cayenne_metastore`               | Metastore backend type. Supports `sqlite` (default) or `turso` (requires `turso` feature flag).                                                                                               |
+| `cayenne_upload_concurrency`      | Maximum number of concurrent file uploads when writing multiple Vortex files. Defaults to `4`.                                                                                                |
 | `sort_columns`                    | Comma-separated list of columns to sort data by on refresh operations. Improves segment pruning for frequently filtered columns.                                                              |
 | `unsupported_type_action`         | Action when encountering unsupported data types. Options: `error` (default), `string`, `warn`, `ignore`.                                                                                      |
 
@@ -90,6 +91,7 @@ datasets:
 | `cayenne_s3_session_token`  | AWS session token (optional, for temporary credentials).                                                                                        |
 | `cayenne_s3_endpoint`       | Custom S3 endpoint URL (optional, overrides auto-generated endpoint).                                                                           |
 | `cayenne_s3_client_timeout` | Request timeout duration (e.g., `30s`, `5m`). Defaults to `120s`.                                                                               |
+| `cayenne_s3_unsigned_payload` | Use unsigned payload for S3 Express One Zone requests. Defaults to `true`.                                                                    |
 | `cayenne_s3_allow_http`     | Set to `true` for testing with local S3-compatible storage. Defaults to `false`.                                                                |
 
 ## Performance Tuning


### PR DESCRIPTION
## Summary
- `cayenne_upload_concurrency` and `cayenne_s3_unsigned_payload` parameters exist in code but were not documented
- These are v2.0+ features, so only the vNext docs are updated

## Changes
- Added `cayenne_upload_concurrency` (default: `4`) to the main params table
- Added `cayenne_s3_unsigned_payload` (default: `true`) to the S3 Express One Zone Parameters table

## Reference
Verified against spiceai/spiceai at trunk:
- [`crates/runtime/src/dataaccelerator/cayenne/mod.rs:693-695`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataaccelerator/cayenne/mod.rs#L693) (`upload_concurrency` with default `"4"`)
- [`crates/runtime/src/dataaccelerator/cayenne/s3.rs:794-796`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataaccelerator/cayenne/s3.rs#L794) (`s3_unsigned_payload` with default `"true"`)