### PR TITLE
fix: Remove broken Document Formats link in SharePoint connector docs

### DIFF
--- a/website/docs/components/data-connectors/sharepoint.md
+++ b/website/docs/components/data-connectors/sharepoint.md
@@ -46,7 +46,7 @@ Returns
 ````
 
 :::warning[Limitations]
-The sharepoint connector does not yet support creating a dataset from a single file (e.g. an Excel spreadsheet). Datasets must be created from a folder of documents (see [Document Formats](./#document-formats)).
+The sharepoint connector does not yet support creating a dataset from a single file (e.g. an Excel spreadsheet). Datasets must be created from a folder of documents.
 :::
 
 ## Configuration

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/sharepoint.md
@@ -46,7 +46,7 @@ Returns
 ````
 
 :::warning[Limitations]
-The sharepoint connector does not yet support creating a dataset from a single file (e.g. an Excel spreadsheet). Datasets must be created from a folder of documents (see [Document Formats](./#document-formats)).
+The sharepoint connector does not yet support creating a dataset from a single file (e.g. an Excel spreadsheet). Datasets must be created from a folder of documents.
 :::
 
 ## Configuration


### PR DESCRIPTION
## Summary
- The SharePoint connector docs referenced a `#document-formats` anchor that does not exist on the page, resulting in a broken link
- Removed the broken link while preserving the limitation note about folder-based datasets

## Changes
- Fixed in vNext (`website/docs/`) and versioned docs (`version-1.11.x`)
- Only these two versions contain the broken link

## Reference
Verified by searching all versioned docs — the broken `#document-formats` anchor has no corresponding heading in any version of the SharePoint connector page.