### PR TITLE
fix: Add nanosecond timestamp range limitation to MSSQL and Oracle versioned docs

### DIFF
--- a/website/versioned_docs/version-1.10.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/mssql.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/mssql.md
@@ -12,6 +12,7 @@ The Microsoft SQL Server Data Connector enables federated/accelerated SQL querie
 
 1. The connector supports SQL Server authentication (SQL Login and Password) only.
 1. Spatial types (`geography`) are not supported, and columns with these types will be ignored.
+1. `DATETIME2` and `DATETIMEOFFSET` columns are mapped to Arrow `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/oracle.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/oracle.md
@@ -117,6 +117,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 :::note
 
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
+- `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will silently return `1970-01-01 UTC`. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 
 :::
 


### PR DESCRIPTION
## Summary
- Propagate the MSSQL/Oracle nanosecond timestamp range limitation note to all versioned docs (1.5.x–1.11.x)
- Commit d5341c47 only added the note to `website/docs/` (vNext) — the same limitation existed in all prior versions
- Versioned docs use accurate wording for those versions: "will silently return `1970-01-01 UTC`" (the pre-fix behavior), vs vNext's "will return an error" (the post-fix behavior from spiceai/spiceai#10335)

## Source PRs
- spiceai/spiceai#10335 — fix: error on MSSQL/Oracle timestamp nanosecond overflow

## Changes
- `website/versioned_docs/version-{1.5.x,1.6.x,1.7.x,1.8.x,1.9.x,1.10.x,1.11.x}/components/data-connectors/mssql.md` — added `DATETIME2`/`DATETIMEOFFSET` nanosecond range limitation to the Limitations section
- `website/versioned_docs/version-{1.5.x,1.6.x,1.7.x,1.8.x,1.9.x,1.10.x,1.11.x}/components/data-connectors/oracle.md` — added `TIMESTAMP`/`TIMESTAMP WITH TIME ZONE`/`TIMESTAMP WITH LOCAL TIME ZONE` nanosecond range limitation to the Notes section

## Test plan
- [x] Verified note placement matches the structure in `website/docs/` (unversioned)
- [x] Links are valid (no cross-references added)
- [x] Version-appropriate wording used (silent epoch-zero behavior for released versions)