### PR TITLE
fix: Correct IMAP ssl_mode default from tls to auto

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -102,7 +102,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
-| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `tls`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
+| `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- The IMAP connector docs stated the default `imap_ssl_mode` is `tls`, but the code uses `auto` as the default (`.default("auto")` in the ParameterSpec)
- This has been wrong since at least v1.5.0

## Changes
- Updated the `imap_ssl_mode` default from `tls` to `auto` across all 8 doc versions (vNext + 1.5.x through 1.11.x)

## Reference
Verified against `spiceai/spiceai` at `trunk` — [`crates/data-connectors/connector-imap/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-imap/src/lib.rs) (line 56: `.default("auto")`)

Also verified at tag `v1.5.0` — same default value.