### PR TITLE
fix: Correct MySQL deployment guide pool params, SSL modes, and metric name

### DIFF
--- a/website/docs/components/data-connectors/mysql/deployment.md
+++ b/website/docs/components/data-connectors/mysql/deployment.md
@@ -37,9 +37,8 @@ TLS is controlled via `mysql_sslmode`:
 | `disabled`    | No TLS.                                                          |
 | `preferred`   | Try TLS, fall back to plaintext. Not recommended for production. |
 | `required`    | Require TLS; do **not** verify the server certificate.           |
-| `verify_ca`   | Require TLS and verify the CA chain.                             |
 
-For production, use `verify_ca` with `mysql_sslrootcert` pointing to the CA bundle. The default is `required`, which encrypts the connection but does not validate the server's identity.
+For production, use `required` with `mysql_sslrootcert` pointing to the CA bundle. The default is `required`, which encrypts the connection but does not validate the server's identity.
 
 ## Resilience Controls
 
@@ -49,10 +48,10 @@ The connector uses a per-dataset connection pool with the following defaults:
 
 | Parameter                   | Default | Description                                    |
 | --------------------------- | ------- | ---------------------------------------------- |
-| `connection_pool_min_idle`  | `1`     | Minimum idle connections held by the pool.     |
-| `connection_pool_size`      | `5`     | Maximum connections the pool will open.        |
+| `mysql_pool_min`            | `1`     | Minimum idle connections held by the pool.     |
+| `mysql_pool_max`            | `5`     | Maximum connections the pool will open.        |
 
-Invalid values (non-integers) are logged as a warning and silently replaced with the defaults. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients.
+Invalid values (non-integers) are logged as a warning and silently replaced with the defaults. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients. `mysql_pool_min` must be less than or equal to `mysql_pool_max`; conflicting values are rejected at startup.
 
 ### Retry Behavior
 
@@ -60,7 +59,7 @@ Transient query failures are not automatically retried at the connector layer. D
 
 ## Capacity & Sizing
 
-- **Network**: MySQL traffic is TCP. Plan for the sum of `connection_pool_size` across all Spice datasets targeting the same MySQL instance when sizing database `max_connections`.
+- **Network**: MySQL traffic is TCP. Plan for the sum of `mysql_pool_max` across all Spice datasets targeting the same MySQL instance when sizing database `max_connections`.
 - **Memory**: Each pooled connection holds a small amount of client-side state. Result sets stream in batches; memory footprint for federated reads is bounded by DataFusion's record batch size (8192 rows default).
 - **Throughput**: For full-table materialization (acceleration refresh), query latency scales with the source table size and the presence of indexes on the refresh partitioning/ordering columns.
 
@@ -74,7 +73,7 @@ The MySQL connector exposes observable metrics for its connection pool. Enable t
 | `connections_in_pool`               | ObservableGauge | Idle connections sitting in the pool.                                                              |
 | `active_wait_requests`              | ObservableGauge | Requests waiting for a connection (saturation signal).                                             |
 | `create_failed`                     | Counter         | Connections that failed to be created.                                                             |
-| `discarded_excess_idle_connection`  | Counter         | Connections closed because the pool already had enough idle connections.                           |
+| `discarded_superfluous_connection`  | Counter         | Connections closed because the pool already had enough idle connections.                           |
 | `discarded_unestablished_connection`| Counter         | Connections closed because they could not be established.                                          |
 | `dirty_connection_return`           | Counter         | Connections returned to the pool in a dirty state (open transactions, pending queries, etc.).      |
 
@@ -82,7 +81,7 @@ Metric instruments are exposed with the prefix `dataset_mysql_`. Each instrument
 
 Key signals to alert on:
 
-- `active_wait_requests > 0` sustained → pool is saturated, increase `connection_pool_size` or the server's `max_connections`.
+- `active_wait_requests > 0` sustained → pool is saturated, increase `mysql_pool_max` or the server's `max_connections`.
 - `create_failed` increasing → credentials, network, or server availability problem.
 - `dirty_connection_return` increasing → a query is not cleaning up its transaction state; investigate long-running or aborted queries.
 
@@ -93,7 +92,7 @@ MySQL operations participate in Spice [task history](../../../reference/task_his
 ## Known Limitations
 
 - Only TCP connections are supported. Unix socket connections are not exposed through Spice configuration.
-- TLS with full hostname verification (`verify_identity`) is not a documented option; use `verify_ca` with a trusted CA bundle.
+- TLS with certificate verification (`verify_ca`, `verify_identity`) is not supported; only `disabled`, `preferred`, and `required` modes are available.
 - Large text/blob columns are fetched in their entirety per row; consider selecting only the columns you need when federating.
 - `mysql_sslmode: preferred` silently downgrades to plaintext on TLS negotiation failure and is not recommended for production.
 
@@ -102,7 +101,7 @@ MySQL operations participate in Spice [task history](../../../reference/task_his
 | Symptom                                                   | Likely cause                                              | Resolution                                                                                           |
 | --------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `Access denied for user`                                  | Incorrect credentials or user lacks `SELECT` on the DB.   | Verify credentials; confirm the user has read access on the required tables.                          |
-| `Too many connections`                                    | Sum of Spice pool sizes + other clients exceeds server `max_connections`. | Reduce `connection_pool_size` or raise the server limit.                                             |
-| Sustained `active_wait_requests > 0`                      | Pool saturation.                                          | Increase `connection_pool_size`; reduce concurrent dataset refreshes.                                |
-| `SSL connection error`                                    | Certificate mismatch with `mysql_sslmode: verify_ca`.     | Verify `mysql_sslrootcert` matches the server's issuing CA. Use `openssl s_client -connect` to inspect. |
-| Silent plaintext connection                               | `mysql_sslmode: preferred` falling back.                  | Switch to `required` or `verify_ca`.                                                                 |
+| `Too many connections`                                    | Sum of Spice pool sizes + other clients exceeds server `max_connections`. | Reduce `mysql_pool_max` or raise the server limit.                                             |
+| Sustained `active_wait_requests > 0`                      | Pool saturation.                                          | Increase `mysql_pool_max`; reduce concurrent dataset refreshes.                                |
+| `SSL connection error`                                    | Certificate mismatch or TLS negotiation failure.          | Verify `mysql_sslrootcert` matches the server's issuing CA. Use `openssl s_client -connect` to inspect. |
+| Silent plaintext connection                               | `mysql_sslmode: preferred` falling back.                  | Switch to `required`.                                                                                |


### PR DESCRIPTION
## Summary
- Connection pool parameter names were wrong: `connection_pool_min_idle`/`connection_pool_size` → `mysql_pool_min`/`mysql_pool_max` (defined as `ParameterSpec::component("pool_min")` and `component("pool_max")` in connector-mysql)
- `verify_ca` SSL mode was documented but is not implemented — the connector only supports `disabled`, `preferred`, and `required`
- Metric name was wrong: `discarded_excess_idle_connection` → `discarded_superfluous_connection`

## Changes
- Fixed pool parameter names and updated all references throughout the deployment guide
- Removed `verify_ca` from the SSL mode table and all references in troubleshooting/limitations
- Corrected the metric name in the metrics table

## Reference
Verified against spiceai/spiceai at trunk:
- [connector-mysql/src/lib.rs:92-95](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-mysql/src/lib.rs#L92-L95) (pool params)
- [catalogconnector/mysql.rs:172](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/mysql.rs#L172) (SSL mode validation)
- [connector-mysql/src/lib.rs:303](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-mysql/src/lib.rs#L303) (metric name)