### PR TITLE
fix: Add missing connector prefix to azure_storage_client_secret in auth notes

### DIFF
--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -188,7 +188,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/docs/components/catalogs/unity-catalog/index.md
+++ b/website/docs/components/catalogs/unity-catalog/index.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/docs/components/data-connectors/databricks/index.md
+++ b/website/docs/components/data-connectors/databricks/index.md
@@ -143,7 +143,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.10.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.10.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.10.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.10.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -80,7 +80,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.11.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.11.x/components/catalogs/databricks.md
@@ -176,7 +176,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.11.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.11.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -80,7 +80,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.5.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.5.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.5.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.5.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
@@ -79,7 +79,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.6.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.6.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.6.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.6.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
@@ -79,7 +79,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.7.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.7.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.7.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.7.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
@@ -79,7 +79,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.8.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.8.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.8.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.8.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
@@ -79,7 +79,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.9.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.9.x/components/catalogs/databricks.md
@@ -172,7 +172,7 @@ catalogs:
 One of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.9.x/components/catalogs/unity-catalog.md
+++ b/website/versioned_docs/version-1.9.x/components/catalogs/unity-catalog.md
@@ -66,7 +66,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 One of the following auth values must be provided for Azure Blob:
 
 - `unity_catalog_azure_storage_account_key`, 
-- `unity_catalog_azure_storage_client_id` and `azure_storage_client_secret`, or 
+- `unity_catalog_azure_storage_client_id` and `unity_catalog_azure_storage_client_secret`, or 
 - `unity_catalog_azure_storage_sas_key`.
 :::
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/databricks.md
@@ -127,7 +127,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 **One** of the following auth values must be provided for Azure Blob:
 
 - `databricks_azure_storage_account_key`,
-- `databricks_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `databricks_azure_storage_client_id` and `databricks_azure_storage_client_secret`, or
 - `databricks_azure_storage_sas_key`.
   :::
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
@@ -79,7 +79,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 


### PR DESCRIPTION
## Summary
- Azure Blob authentication notes listed `azure_storage_client_secret` without the required connector prefix, while `client_id` in the same line had the prefix
- Affects Databricks, Delta Lake, Unity Catalog, and Databricks Catalog docs across all versions

## Changes
- `azure_storage_client_secret` → `databricks_azure_storage_client_secret` (in Databricks/Databricks Catalog docs)
- `azure_storage_client_secret` → `delta_lake_azure_storage_client_secret` (in Delta Lake docs)
- `azure_storage_client_secret` → `unity_catalog_azure_storage_client_secret` (in Unity Catalog docs)
- Fixed across all versioned docs (1.5.x through 1.11.x) and vNext (31 files total)

## Reference
Verified against spiceai/spiceai at trunk — parameters are defined via `ParameterSpec::component("azure_storage_client_secret")` which auto-prefixes with the connector name