### PR TITLE
fix: Remove nonexistent duckdb_connection_string param from deployment guide

### DIFF
--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -19,8 +19,7 @@ DuckDB is an embedded engine; the connector reads a local DuckDB database file. 
 
 | Parameter          | Description                                                            |
 | ------------------ | ---------------------------------------------------------------------- |
-| `open`             | Absolute path to the DuckDB database file.                             |
-| `duckdb_connection_string` | Alternative: DuckDB connection URI with options.               |
+| `duckdb_open`      | Absolute path to the DuckDB database file. If omitted, uses in-memory mode. |
 
 Protect the DuckDB file with filesystem permissions. Store it on encrypted storage (LUKS/dm-crypt, EBS encryption, etc.) for data-at-rest protection. For data loaded from cloud object stores inside DuckDB, configure AWS/Azure/GCS credentials via DuckDB extensions rather than Spice parameters.
 


### PR DESCRIPTION
## Summary
- `duckdb_connection_string` was listed as an alternative parameter but doesn't exist in the connector code
- Parameter name `open` was missing the `duckdb_` prefix (it's a `ParameterSpec::component("open")`)

## Changes
- Removed the nonexistent `duckdb_connection_string` row from the parameter table
- Fixed parameter name to `duckdb_open`
- Added note about in-memory fallback when omitted

## Reference
Verified against spiceai/spiceai at trunk — [connector-duckdb/src/lib.rs:133](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-duckdb/src/lib.rs#L133)