### PR TITLE
fix: Remove nonexistent dremio_token parameter from deployment guide

### DIFF
--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -15,14 +15,13 @@ Production operating guide for the Dremio data connector covering authentication
 
 ## Authentication & Secrets
 
-The Dremio connector connects over [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) with username/password or personal-access-token (PAT) authentication.
+The Dremio connector connects over [Arrow Flight SQL](https://arrow.apache.org/docs/format/FlightSql.html) with username/password authentication.
 
 | Parameter              | Description                                                                                                     |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `dremio_endpoint`      | Flight SQL endpoint, e.g. `grpc+tls://dremio.internal:32010`.                                                   |
-| `dremio_username`      | Dremio user (username/password auth).                                                                           |
+| `dremio_username`      | Dremio user.                                                                                                    |
 | `dremio_password`      | Dremio password. Use `${secrets:...}` from a secret store.                                                      |
-| `dremio_token`         | Alternatively, a PAT or session token.                                                                          |
 
 Use TLS endpoints (`grpc+tls://`) in production. Credentials must be sourced from a [secret store](../../secret-stores/).
 


### PR DESCRIPTION
## Summary
- `dremio_token` was documented for PAT/session-token auth, but this parameter doesn't exist in the connector code
- The connector only supports username/password authentication via `Credentials::new(username, password)`

## Changes
- Removed `dremio_token` row from the parameter table
- Updated intro text to reflect only username/password authentication is supported

## Reference
Verified against spiceai/spiceai at trunk — [connector-dremio/src/lib.rs:123-127](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-dremio/src/lib.rs#L123-L127) (only username, password, endpoint params defined)