### PR TITLE
fix: Correct Dashbord typo in Datadog monitoring docs

### DIFF
--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.10.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-1.10.x/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.11.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-1.11.x/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.5.x/clients/Datadog/index.md
+++ b/website/versioned_docs/version-1.5.x/clients/Datadog/index.md
@@ -43,6 +43,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.6.x/clients/datadog/index.md
+++ b/website/versioned_docs/version-1.6.x/clients/datadog/index.md
@@ -43,6 +43,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.7.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-1.7.x/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.8.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-1.8.x/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>

--- a/website/versioned_docs/version-1.9.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-1.9.x/monitoring/datadog/index.md
@@ -40,6 +40,6 @@ instances:
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard_import.png"/>
 
-3. Dashbord is now configured to display Spice.ai OSS key performance metrics
+3. Dashboard is now configured to display Spice.ai OSS key performance metrics
 
 <img width="800" src="/img/datadog/spice_datadog_dashboard.png"/>


### PR DESCRIPTION
## Summary
Partially addresses #506 — fixes the `Dashbord` → `Dashboard` typo called out in the issue.

The Datadog import-dashboard step read "Dashbord is now configured..." across the unversioned docs and all 7 versioned copies (`version-1.5.x` through `version-1.11.x`).

## Changes
- `website/docs/monitoring/datadog/index.md`
- `website/versioned_docs/version-1.5.x/clients/Datadog/index.md`
- `website/versioned_docs/version-1.6.x/clients/datadog/index.md`
- `website/versioned_docs/version-1.7.x/monitoring/datadog/index.md`
- `website/versioned_docs/version-1.8.x/monitoring/datadog/index.md`
- `website/versioned_docs/version-1.9.x/monitoring/datadog/index.md`
- `website/versioned_docs/version-1.10.x/monitoring/datadog/index.md`
- `website/versioned_docs/version-1.11.x/monitoring/datadog/index.md`

## Scope
This PR only addresses the typo. The other two items in #506 (broader grammatical/clarity improvements, and adding a description blockquote like the Tableau doc) are left open for a separate change.

## Test plan
- [ ] `cd website && npm run build` passes locally
- [ ] No remaining `Dashbord` occurrences under `website/`