### PR TITLE
fix: Note scylladb_ssl parameter is not yet implemented

### DIFF
--- a/website/docs/components/data-connectors/scylladb.md
+++ b/website/docs/components/data-connectors/scylladb.md
@@ -74,7 +74,7 @@ The ScyllaDB data connector can be configured by providing the following `params
 | `scylladb_user`       | Username for authentication.                                       | No       | -       |
 | `scylladb_pass`       | Password for authentication.                                       | No       | -       |
 | `scylladb_datacenter` | Preferred datacenter for connection routing.                       | No       | -       |
-| `scylladb_ssl`        | Enable SSL/TLS for connections.                                    | No       | `false` |
+| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | `false` |
 | `connection_timeout`  | Connection timeout in milliseconds.                                | No       | `10000` |
 
 ## Types

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/scylladb.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/scylladb.md
@@ -74,7 +74,7 @@ The ScyllaDB data connector can be configured by providing the following `params
 | `scylladb_user`       | Username for authentication.                                       | No       | -       |
 | `scylladb_pass`       | Password for authentication.                                       | No       | -       |
 | `scylladb_datacenter` | Preferred datacenter for connection routing.                       | No       | -       |
-| `scylladb_ssl`        | Enable SSL/TLS for connections.                                    | No       | `false` |
+| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | `false` |
 | `connection_timeout`  | Connection timeout in milliseconds.                                | No       | `10000` |
 
 ## Types


### PR DESCRIPTION
## Summary
- The `scylladb_ssl` parameter is defined in the `ParameterSpec` array but never read or applied during session builder configuration
- Users setting `scylladb_ssl: true` will not get SSL/TLS connections — the parameter is silently ignored

## Changes
- Added a note to the `scylladb_ssl` description clarifying the parameter has no effect
- Fixed in both vNext and 1.11.x docs

## Reference
Verified against spiceai/spiceai at `trunk` — `scylladb_ssl` is defined at [connector-scylladb/src/lib.rs:129-131](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-scylladb/src/lib.rs) but never retrieved via `params.get("ssl")` in the `create_scylladb_connector()` function (lines 324-447).