### PR TITLE
docs: Document HTTP Basic auth header format (fixes #641)

### DIFF
--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -35,6 +35,14 @@ datasets:
       http_password: ${env:MY_HTTP_PASS}
 ```
 
+The username is taken from the `user-info` section of the `from` URL (`user@host`) or from the `http_username` parameter. The password comes from the `http_password` parameter. The connector then sends a standard [RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617) Basic authentication header on every request:
+
+```http
+Authorization: Basic <base64(username:password)>
+```
+
+For example, `static_username` with password `s3cret` produces `Authorization: Basic c3RhdGljX3VzZXJuYW1lOnMzY3JldA==`. Only one of `http_password` or user info in the URL can provide the password — setting both is not supported.
+
 ### Using Custom Headers
 
 Custom HTTP headers can be specified for authentication, API keys, or other requirements. Headers are treated as sensitive data and will not be logged.


### PR DESCRIPTION
## Summary
Fixes #641

The HTTP(s) connector doc showed how to supply `http_username`/`http_password` but didn't explain how they are combined into the outgoing `Authorization` header. This adds an explicit note that the connector sends a standard RFC 7617 `Authorization: Basic base64(username:password)` header, with a worked example.

## Changes

- `website/docs/components/data-connectors/https.md` — added a short paragraph and a header example under the "Using Basic Authentication" section.

## Reference

Verified against the Spice runtime source in `spiceai/spiceai`:

- `crates/runtime/src/dataconnector/https.rs` — username/password are set on the URL userinfo, which the HTTP client turns into an RFC 7617 Basic auth header.
- `crates/data_components/src/http/auth.rs:412` — calls `basic_auth(id, Some(secret))` which serializes to `Authorization: Basic <base64("id:secret")>`.

Base64 example verified: `base64("static_username:s3cret") == "c3RhdGljX3VzZXJuYW1lOnMzY3JldA=="`.

## Test plan
- [x] `cd website && npm run build` passes locally