### PR TITLE
docs: Document MySQL connector type limitations (fixes #548)

### DIFF
--- a/website/docs/components/data-connectors/mysql/index.md
+++ b/website/docs/components/data-connectors/mysql/index.md
@@ -189,6 +189,12 @@ The table below shows the MySQL data types supported, along with the type mappin
 
 :::
 
+## Limitations
+
+- MySQL has no native nested or array column types (see the [MySQL data types reference](https://dev.mysql.com/doc/refman/8.4/en/data-types.html)), so columns containing Arrow `Struct`, `List`, or `LargeList` values are not supported by this connector.
+- [MySQL spatial types](https://dev.mysql.com/doc/refman/8.4/en/spatial-types.html) (`GEOMETRY`, `POINT`, `LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, `GEOMETRYCOLLECTION`) are not currently supported — only the types listed in the [Types](#types) table are mapped to Arrow.
+- Nested or array-valued data should be stored in a `JSON` column, which is read as `LargeUtf8` and can be decoded with SQL JSON functions.
+
 ## Examples
 
 ### Connecting using username and password


### PR DESCRIPTION
## Summary
Fixes #548

Adds a Limitations section to the MySQL connector doc noting that MySQL has no native nested or array column types, so Arrow `Struct`/`List`/`LargeList` values are unsupported, and that MySQL spatial types (`GEOMETRY`, `POINT`, etc.) are not currently mapped to Arrow. Points users to the `JSON` column type as the workaround for nested data.

## Changes

- `website/docs/components/data-connectors/mysql/index.md` — added a new `## Limitations` section between the type mapping table and `## Examples`.

## Reference

- [MySQL data types reference](https://dev.mysql.com/doc/refman/8.4/en/data-types.html) — MySQL itself lacks native Struct/List column types.
- [MySQL spatial types](https://dev.mysql.com/doc/refman/8.4/en/spatial-types.html) — listed in the issue; confirmed absent from the connector's type mapping table at `website/docs/components/data-connectors/mysql/index.md`.

## Test plan
- [x] `cd website && npm run build` passes locally