### PR TITLE
fix: Correct Delta Lake deployment guide parameter names

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/deployment.md
+++ b/website/docs/components/data-connectors/delta-lake/deployment.md
@@ -20,8 +20,8 @@ The Delta Lake connector reads Delta tables directly from an underlying object s
 | Object store            | Auth parameters                                                                                                                                |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | **S3** / S3-compatible  | `aws_region`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_endpoint`. Defaults to the AWS credential chain when unset. |
-| **Azure ADLS**          | `azure_storage_account_name`, `azure_storage_account_key`, `azure_storage_client_id`, `azure_storage_client_secret`, `azure_storage_tenant_id`, `azure_storage_sas_key`. |
-| **Google Cloud Storage**| `google_service_account_key`, `google_service_account_key_path`.                                                                               |
+| **Azure ADLS**          | `azure_storage_account_name`, `azure_storage_account_key`, `azure_storage_client_id`, `azure_storage_client_secret`, `azure_storage_sas_key`, `azure_storage_endpoint`. |
+| **Google Cloud Storage**| `google_service_account`.                                                                                                                      |
 | **Local filesystem**    | No auth. Ensure the Spice process has read permission on the Delta table directory.                                                            |
 
 Credentials must be sourced from a [secret store](../../secret-stores/) in production. For AWS deployments, prefer instance-profile or IRSA-based auth (leave `aws_access_key_id` unset).


### PR DESCRIPTION
## Summary
- Removed `azure_storage_tenant_id` from the Azure ADLS parameter list — this parameter does not exist in the Delta Lake connector's `ParameterSpec` definitions
- Replaced `google_service_account_key` and `google_service_account_key_path` with `google_service_account` — the actual GCS parameter name defined in the connector code
- Added `azure_storage_endpoint` to the Azure parameter list — this parameter exists in the code but was missing from the deployment guide

## Reference
Verified against `spiceai/spiceai` at `trunk` — [`connector-delta-lake/src/lib.rs` lines 76–121](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-delta-lake/src/lib.rs#L76-L121)

The index.md reference page already lists the correct parameter names; only the deployment guide summary table was incorrect.