### PR TITLE
fix: Remove pg_application_name from PostgreSQL deployment parameter table

### DIFF
--- a/website/docs/components/data-connectors/postgres/deployment.md
+++ b/website/docs/components/data-connectors/postgres/deployment.md
@@ -25,7 +25,6 @@ The connector uses the native PostgreSQL wire protocol with username/password au
 | `pg_user`          | Database user.                                                               |
 | `pg_pass`          | Password. Use `${secrets:...}` to resolve from a configured secret store.    |
 | `pg_connection_string` | Alternative to the individual parameters.                                |
-| `pg_application_name`  | Application identifier reported in `pg_stat_activity`. Defaults to the Spice.ai version. |
 
 Passwords must be sourced from a secret store in production. See [Secret Stores](../../secret-stores/) for configuration options (environment variables, file, Kubernetes, AWS Secrets Manager, HashiCorp Vault).
 


### PR DESCRIPTION
## Summary
- Removed `pg_application_name` from the Authentication & Secrets parameter table — this value is not a configurable parameter; it is hardcoded to the Spice.ai version string in the connector code

## Changes
The deployment guide's parameter table listed `pg_application_name` as if it were user-configurable, but the Application Name section later in the same document correctly states "This value is not configurable." Removed the contradictory table row.

## Reference
Verified against `spiceai/spiceai` at `trunk` — [`connector-postgres/src/lib.rs` lines 85–129 (PARAMETERS) and 143–146 (hardcoded insertion)](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/lib.rs#L85-L146)