### PR TITLE
fix: Add missing imap_port default value (993) to IMAP connector docs

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -100,7 +100,7 @@ The IMAP connector supports the following connection and authentication paramete
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
 | `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
-| `imap_port`     | Optional. The port of the IMAP server to connect to.                                                                         |
+| `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |
 | `imap_ssl_mode` | Optional. The IMAP SSL mode to use. Defaults to `auto`, permitted values of `tls`, `starttls`, `disabled` or `auto`.          |
 


### PR DESCRIPTION
## Summary
- The IMAP connector code defines a default port of `993` via `ParameterSpec::component("port").default("993")`, but the documentation omitted this default value
- Users had no way to know the default port without reading the source code

## Changes
- Added "Defaults to `993`." to the `imap_port` parameter description across all versioned and unversioned docs (8 files total)

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/data-connectors/connector-imap/src/lib.rs:52-54`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-imap/src/lib.rs#L52-L54)