### PR TITLE
fix: Remove incorrect access_mode parameter reference from DuckDB deployment docs

### DIFF
--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -27,7 +27,7 @@ Protect the DuckDB file with filesystem permissions. Store it on encrypted stora
 
 ### File Concurrency
 
-DuckDB supports a single writer with many readers per database file. If the file is shared with another process that holds a write lock, the connector returns an I/O error on open. Co-locate the writer and the Spice reader on the same host, or use DuckDB's read-only mode (`access_mode: read_only`) when federating a file produced by an upstream ETL job.
+DuckDB supports a single writer with many readers per database file. The Spice DuckDB data connector always opens the database in read-only mode, so it will not conflict with other readers. However, if another process holds a write lock, the connector may return an I/O error on open. Co-locate the writer and the Spice reader on the same host and ensure the writer releases its lock before the connector opens the file.
 
 ### Crash Recovery
 


### PR DESCRIPTION
## Summary
- The DuckDB deployment guide referenced `access_mode: read_only` as if it were a configurable parameter users should set
- The Spice DuckDB data connector always opens files in `ReadOnly` mode (hardcoded) — there is no `access_mode` parameter available to users

## Changes
- Clarified that the connector always uses read-only mode, rather than suggesting users need to configure it
- Removed the misleading `access_mode: read_only` inline code reference

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/data-connectors/connector-duckdb/src/lib.rs:100`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-duckdb/src/lib.rs#L100) shows `DuckDbConnectionPool::new_file(path, &AccessMode::ReadOnly)` is hardcoded