### PR TITLE
fix: propagate JS SDK camelCase parameters to versioned docs (fixes #544)

### DIFF
--- a/website/versioned_docs/version-1.10.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.10.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.11.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.11.x/sdks/javascript/index.md
@@ -50,7 +50,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -64,6 +64,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.5.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.5.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.6.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.6.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.7.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.7.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.8.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.8.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```

--- a/website/versioned_docs/version-1.9.x/sdks/javascript/index.md
+++ b/website/versioned_docs/version-1.9.x/sdks/javascript/index.md
@@ -42,7 +42,7 @@ import { SpiceClient } from '@spiceai/spice';
 const main = async () => {
   const spiceClient = new SpiceClient();
 
-  const table = await spiceClient.query(
+  const table = await spiceClient.sql(
     'SELECT trip_distance, total_amount FROM taxi_trips ORDER BY trip_distance DESC LIMIT 10;'
   );
 
@@ -56,6 +56,6 @@ Or pass custom flight address:
 
 ```js
 const spiceClient = new SpiceClient({
-  flight_url: 'my_remote_spice_instance:50051'
+  flightUrl: 'my_remote_spice_instance:50051'
 });
 ```


### PR DESCRIPTION
## Summary
Fixes #544

[PR #1434](https://github.com/spiceai/docs/pull/1434) updated the unversioned JavaScript SDK docs to match the current `@spiceai/spice` API — specifically the `flightUrl` constructor parameter (camelCase, introduced in spice.js v2.x) and the `sql()` query method. The change was not propagated to the versioned copies.

All seven versioned docs (`version-1.5.x` through `version-1.11.x`) still showed `flight_url` (snake_case) and `spiceClient.query()`, which no longer matches what users get when they install the documented `@spiceai/spice` package.

## Changes

Updated the `SpiceClient` connection example in each versioned JavaScript SDK page:
- `spiceClient.query(` → `spiceClient.sql(`
- `flight_url:` → `flightUrl:`

Files:
- `website/versioned_docs/version-1.5.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.6.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.7.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.8.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.9.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.10.x/sdks/javascript/index.md`
- `website/versioned_docs/version-1.11.x/sdks/javascript/index.md`

## Reference

Verified against [spiceai/spice.js](https://github.com/spiceai/spice.js) — the current SDK exposes `flightUrl` in `SpiceClientConfig` and recommends `sql()` as the primary query method. The camelCase migration was done in [spiceai/spice.js#195](https://github.com/spiceai/spice.js/pull/195) (merged 2024-10-15), predating all Spice runtime versions currently documented.

## Test plan
- [x] `cd website && npm run build` passes locally (no broken links)
- [x] Correction applied across all seven `website/versioned_docs/version-*/` directories