### PR TITLE
docs: Add Azure ADLS and GCS support for snapshot storage

### DIFF
--- a/website/docs/features/data-acceleration/snapshots.md
+++ b/website/docs/features/data-acceleration/snapshots.md
@@ -51,7 +51,7 @@ Every accelerated dataset must write to its own file (for example, `/nvme/my_dat
 
 ## Configure snapshot storage
 
-Snapshots are controlled with a top-level `snapshots` block in the Spicepod. The location must point to a folder on S3 or the local filesystem. When the location is an S3 bucket, the configuration accepts any S3 dataset parameters under `params`.
+Snapshots are controlled with a top-level `snapshots` block in the Spicepod. The location can point to S3, Azure ADLS Gen2, Google Cloud Storage, or the local filesystem.
 
 ```yaml
 snapshots:
@@ -61,6 +61,17 @@ snapshots:
   params:
     s3_auth: iam_role                     # Defaults to iam_role for snapshots
 ```
+
+### Supported storage backends
+
+| Backend | URL scheme | Environment variables |
+| --- | --- | --- |
+| Amazon S3 | `s3://` | Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.) |
+| Azure ADLS Gen2 | `abfss://`, `abfs://` | `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_FEDERATED_TOKEN_FILE` |
+| Google Cloud Storage | `gs://` | `GOOGLE_APPLICATION_CREDENTIALS`, Workload Identity |
+| Local filesystem | Absolute or relative path | N/A |
+
+When the location is an S3 bucket, the configuration accepts any [S3 dataset parameters](../../components/data-connectors/s3) under `params`. Azure and GCS locations also accept their respective connector parameters under `params` for explicit credential overrides. When no explicit credentials are supplied, Spice reads standard environment variables for each cloud provider.
 
 ### Failure behavior
 

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `true`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 
@@ -147,7 +147,7 @@ Controls what happens when Spice cannot load the most recent snapshot on startup
 
 ### `snapshots.params`
 
-Optional key-value map passed to the snapshot storage layer. When `location` points to S3, the configuration accepts any of the [S3 dataset parameters](../components/data-connectors/s3). Snapshots default to `s3_auth: iam_role`, which differs from the S3 dataset default of `public`.
+Optional key-value map passed to the snapshot storage layer. When `location` points to S3, the configuration accepts any of the [S3 dataset parameters](../components/data-connectors/s3). Snapshots default to `s3_auth: iam_role`, which differs from the S3 dataset default of `public`. Azure ADLS and GCS locations also accept their respective connector parameters for explicit credential overrides; when no overrides are supplied, Spice reads standard environment variables for each cloud provider.
 
 ## `models`
 


### PR DESCRIPTION
## Summary
- Snapshot storage now documents Azure ADLS Gen2 (`abfss://`, `abfs://`) and Google Cloud Storage (`gs://`) as supported backends alongside S3 and local filesystem
- Added a supported storage backends table with URL schemes and environment variables for each provider
- Updated the spicepod reference for `snapshots.location` and `snapshots.params` to mention all supported schemes

## Source PRs
- spiceai/spiceai#10486 — Fix Azure and GCS acceleration snapshot object store credential handling

## Changes
- `website/docs/features/data-acceleration/snapshots.md` — Added storage backends table, updated "Configure snapshot storage" section
- `website/docs/reference/spicepod/index.md` — Updated `snapshots.location` and `snapshots.params` descriptions to include Azure/GCS

## Test plan
- [x] `npx docusaurus build` passes with no broken links
- [x] Version references are correct (vNext only — this is a new feature)