### PR TITLE
docs: Add flatten_json and flatten_json_properties UDTF reference

### DIFF
--- a/website/docs/reference/sql/json.md
+++ b/website/docs/reference/sql/json.md
@@ -477,6 +477,124 @@ SELECT
 FROM products;
 ```
 
+## JSON Table Functions (UDTFs)
+
+Spice includes table-valued functions for decomposing JSON structures into relational rows. Each function is available as both a UDTF (in the `FROM` clause with literal input) and a scalar UDF returning a list of structs (for per-row use with `UNNEST`).
+
+### `flatten_json`
+
+Walks an arbitrary JSON value and emits one row per reachable leaf.
+
+```sql
+flatten_json(input Utf8 [, options...]) -> TABLE(
+    path         Utf8,
+    parent_path  Utf8,
+    key          Utf8,
+    value        Utf8,
+    type         Utf8     -- "object"|"array"|"string"|"number"|"integer"|"boolean"|"null"
+)
+```
+
+**Options (named arguments):**
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `max_depth` | UInt | `64` | Maximum recursion depth. |
+| `max_rows` | UInt | `1000000` | Per-document row cap. |
+| `max_bytes` | UInt | `8388608` | Input size limit (bytes). |
+| `path_style` | Utf8 | `"dot"` | `"dot"` or `"json-pointer"`. |
+| `include_internal` | Bool | `false` | Also emit interior object/array rows. |
+| `array_wildcard` | Bool | `false` | Collapse array indices to `[*]` instead of `[0]`, `[1]`, etc. |
+
+**UDTF example:**
+
+```sql
+SELECT path, value, type
+FROM flatten_json('{"user": {"name": "Alice", "scores": [95, 87]}}');
+```
+
+| path | value | type |
+| --- | --- | --- |
+| `user.name` | `Alice` | `string` |
+| `user.scores[0]` | `95` | `integer` |
+| `user.scores[1]` | `87` | `integer` |
+
+**Scalar UDF example (per-row with `UNNEST`):**
+
+```sql
+SELECT rows.path, rows.value, rows.type
+FROM (SELECT UNNEST(flatten_json(body)) AS rows FROM documents);
+```
+
+### `flatten_json_properties`
+
+Decomposes a JSON Schema document into one row per field, extracting metadata such as types, descriptions, required status, enums, and format.
+
+```sql
+flatten_json_properties(input Utf8 [, options...]) -> TABLE(
+    path         Utf8,
+    parent_path  Utf8,
+    name         Utf8,
+    description  Utf8,
+    type         Utf8,
+    required     Boolean,
+    format       Utf8,
+    enum_values  List<Utf8>,
+    metadata     Utf8
+)
+```
+
+Handles `properties` recursion, `items.properties` (arrays of objects), `additionalProperties` maps, `allOf`/`oneOf`/`anyOf` merging, and local `$ref` pointers with cycle detection.
+
+**Options (named arguments):**
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `max_depth` | UInt | `32` | Maximum recursion depth. |
+| `max_rows` | UInt | `100000` | Per-document row cap. |
+| `max_bytes` | UInt | `8388608` | Input size limit (bytes). |
+| `path_style` | Utf8 | `"dot"` | `"dot"` or `"json-pointer"`. |
+| `dialect` | Utf8 | `"json-schema"` | `"json-schema"` or `"openapi"` (metrics tagging). |
+| `include_internal` | Bool | `false` | Also emit container rows (objects, arrays). |
+| `expand_maps` | Bool | `false` | Walk into `additionalProperties` and emit child paths with a wildcard segment (e.g., `parent.[*].child`). |
+| `map_wildcard` | Utf8 | `"[*]"` | Wildcard segment for map values when `expand_maps` is `true`. |
+
+**Example:**
+
+```sql
+SELECT path, type, required, description
+FROM flatten_json_properties('{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string", "description": "User name"},
+    "age": {"type": "integer"}
+  },
+  "required": ["name"]
+}');
+```
+
+| path | type | required | description |
+| --- | --- | --- | --- |
+| `name` | `string` | `true` | `User name` |
+| `age` | `integer` | `false` | |
+
+**Expanding maps:**
+
+When a JSON Schema uses `additionalProperties` to describe map values, enable `expand_maps` to produce JSONPath-style paths:
+
+```sql
+SELECT path, type
+FROM flatten_json_properties(
+  '{"type": "object", "additionalProperties": {"type": "object", "properties": {"id": {"type": "string"}, "primary": {"type": "boolean"}}}}',
+  expand_maps => true
+);
+```
+
+| path | type |
+| --- | --- |
+| `[*].id` | `string` |
+| `[*].primary` | `boolean` |
+
 ## Further Reading
 
 - [datafusion-functions-json](https://github.com/datafusion-contrib/datafusion-functions-json) - The underlying JSON manipulation library


### PR DESCRIPTION
## Summary
- Added reference documentation for `flatten_json` UDTF — walks arbitrary JSON data and emits one row per leaf with path, value, and type
- Added reference documentation for `flatten_json_properties` UDTF — decomposes JSON Schema documents into relational rows with field metadata
- Documented the new `expand_maps` and `map_wildcard` options for `flatten_json_properties`, which enable JSONPath-style wildcard segments when walking `additionalProperties` maps

## Source PRs
- spiceai/spiceai#10452 — Add expand_maps option and flatten_json UDTF

## Changes
- `website/docs/reference/sql/json.md` — Added new "JSON Table Functions (UDTFs)" section with full reference for both functions, including options tables, output schemas, and examples

## Test plan
- [x] `npx docusaurus build` passes with no broken links
- [x] Version references are correct (vNext only — these are new features)
- [x] Function signatures and options verified against source code