### PR TITLE
docs(otel): note metric filtering matches post-prefix names

### DIFF
--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -239,6 +239,10 @@ runtime:
 
 When `metrics` is empty or omitted, all available metrics are exported.
 
+:::caution Filtering happens after `metric_prefix` is applied
+The whitelist is matched against the **final** metric name, after `runtime.telemetry.metric_prefix` has been prepended. If you set `metric_prefix: 'spiceai.'`, the entries under `metrics:` must include the prefix (e.g. `spiceai.query_duration_ms`), otherwise nothing will match and no metrics will be exported.
+:::
+
 For full configuration details, see the [runtime.telemetry reference](../reference/spicepod/runtime#runtimetelemetry).
 
 ## Available Metrics

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -75,6 +75,10 @@ runtime:
 
 The runtime metric `query_duration_ms` is then exported as `spiceai.query_duration_ms`.
 
+:::caution Combining `metric_prefix` with metric filtering
+If you also set [`runtime.telemetry.otel_exporter.metrics`](/docs/next/reference/spicepod/runtime#runtimetelemetryotel_exporter) to whitelist specific metrics, the entries must include the prefix. The filter runs after the prefix is applied, so e.g. `query_duration_ms` will not match when `metric_prefix: 'spiceai.'` is set — use `spiceai.query_duration_ms` instead.
+:::
+
 ### Add Custom Tags via Resource Attributes
 
 Attach custom key/value pairs to every metric using [`runtime.telemetry.properties`](/docs/next/reference/spicepod/runtime#runtimetelemetryproperties). Spice sends these as OpenTelemetry resource attributes:

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -435,6 +435,10 @@ runtime:
         - dataset_load_state
 ```
 
+:::caution Filtering happens after `metric_prefix` is applied
+The whitelist is matched against the **final** metric name, after [`runtime.telemetry.metric_prefix`](#runtimetelemetrymetric_prefix) has been prepended. If you set `metric_prefix: 'spiceai.'`, the entries under `metrics:` must include the prefix (e.g. `spiceai.query_duration_ms`), otherwise nothing will match and no metrics will be exported.
+:::
+
 **Authenticated exporters:**
 
 For collectors that require authentication, set the `headers` map. Load credentials from a [secret store](../../components/secret-stores) via `${secrets:...}` rather than committing them to source.


### PR DESCRIPTION
## Description

Adds a caution note in three places explaining that the `runtime.telemetry.otel_exporter.metrics` whitelist is matched against the **final** metric name — i.e. after `runtime.telemetry.metric_prefix` has been prepended.

This is a common foot-gun: configuring `metric_prefix: 'spiceai.'` together with an unprefixed whitelist (e.g. `query_duration_ms`) silently drops every batch because nothing matches.

## Files changed

- `website/docs/reference/spicepod/runtime.md` — under the `otel_exporter` metric filtering example
- `website/docs/features/observability/index.md` — in the "Metric Filtering" section
- `website/docs/monitoring/datadog/index.md` — under "Namespace Spice Metrics with a Prefix"

## Background

The prefix is applied as an OTel SDK View on the `MeterProvider` (`bin/spiced/src/lib.rs`), so by the time the `FilteringExporter` (`crates/runtime/src/otel_push_exporter.rs`) sees the batch, every metric is already prefixed.