### PR TITLE
fix: Remove duplicate xai row from models provider table

### DIFF
--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -18,7 +18,6 @@ Spice supports various model providers for traditional machine learning (ML) mod
 | [`azure`][azure]           | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`anthropic`][ant]         | Models hosted on Anthropic                   | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])    | Deprecated        | -            | -                               |
 

--- a/website/versioned_docs/version-1.11.x/components/models/index.md
+++ b/website/versioned_docs/version-1.11.x/components/models/index.md
@@ -18,7 +18,6 @@ Spice supports various model providers for traditional machine learning (ML) mod
 | [`azure`][azure]           | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`anthropic`][ant]         | Models hosted on Anthropic                   | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
 
 [openai]: ./openai.md


### PR DESCRIPTION
## Summary
- The `xai` model provider was listed twice in the models index table (rows at lines 14 and 21)
- Removed the duplicate row from both unversioned docs and version-1.11.x

## Changes
- `website/docs/components/models/index.md` — removed duplicate `xai` table row
- `website/versioned_docs/version-1.11.x/components/models/index.md` — removed duplicate `xai` table row

## Reference
Verified by inspecting the table — `xai` appeared at positions 3 and 10 in the provider list with identical content.