### PR TITLE
docs: Update MCP transport from SSE to Streamable HTTP

### DIFF
--- a/website/docs/api/HTTP/mcp-event.api.mdx
+++ b/website/docs/api/HTTP/mcp-event.api.mdx
@@ -1,7 +1,7 @@
 ---
 id: mcp-event
 title: "Send message to MCP server"
-description: "Send message to the MCP endoint, for a given session."
+description: "Send a message to the MCP endpoint for a given session. Include the Mcp-Session-Id header to identify the session."
 sidebar_label: "Send message to MCP server"
 hide_title: true
 hide_table_of_contents: true
@@ -29,7 +29,7 @@ import Heading from "@theme/Heading";
 
 <MethodEndpoint
   method={"post"}
-  path={"/v1/mcp/sse"}
+  path={"/v1/mcp"}
   context={"endpoint"}
 >
   
@@ -37,7 +37,7 @@ import Heading from "@theme/Heading";
 
 
 
-Send message to the MCP endoint, for a given session.
+Send a message to the MCP endpoint for a given session. Include the `Mcp-Session-Id` header to identify the session.
 
 <Heading
   id={"request"}
@@ -48,7 +48,7 @@ Send message to the MCP endoint, for a given session.
 </Heading>
 
 <ParamsDetails
-  parameters={[{"name":"sessionId","in":"query","required":true}]}
+  parameters={[{"name":"Mcp-Session-Id","in":"header","required":true}]}
 >
   
 </ParamsDetails>
@@ -63,7 +63,7 @@ Send message to the MCP endoint, for a given session.
 <StatusCodes
   id={undefined}
   label={undefined}
-  responses={{"202":{"description":"Message accepted. Response will stream via SSE."},"404":{"description":"Session not found. No active session for the given `session_id`."},"413":{"description":"Payload too large. Maximum allowed size is 4MB."},"500":{"description":"Internal server error. An unexpected issue occurred."}}}
+  responses={{"202":{"description":"Message accepted. Response will stream via the Streamable HTTP connection."},"404":{"description":"Session not found. No active session for the given `Mcp-Session-Id`."},"413":{"description":"Payload too large. Maximum allowed size is 32 MiB."},"500":{"description":"Internal server error. An unexpected issue occurred."}}}
 >
   
 </StatusCodes>

--- a/website/docs/api/HTTP/operation-id.api.mdx
+++ b/website/docs/api/HTTP/operation-id.api.mdx
@@ -1,8 +1,8 @@
 ---
 id: operation-id
-title: "Establish an MCP SSE Connection"
-description: "Initiates a Server-Sent Events (SSE) connection using the Model Context Protocol (MCP) to interact with Spice tools."
-sidebar_label: "Establish an MCP SSE Connection"
+title: "Establish an MCP Streamable HTTP Connection"
+description: "Initiates a Streamable HTTP connection using the Model Context Protocol (MCP) to interact with Spice tools."
+sidebar_label: "Establish an MCP Streamable HTTP Connection"
 hide_title: true
 hide_table_of_contents: true
 api: eJzlU8Fu2zAM/RWCpxZwnGanzbchCIYCKxrA2akLGlVmYmKypEm0t8Lwvw90tjbrPmHWxdYT36Men0cUc8pYPWBnI+4LbCjbxFE4eKzw1rOwEcpgoKY0UFrU5AU2A3nJcFXXm2uwwXuyWgF9Zn8CaQnuQkMO1sEL/RTYpiDBBgdXd+vtNUgA9kLJWIEfLC3UkS2BhOBy+dXrgsvn3lv6I0NNAdbxrG+Nh0y+gY5yNifKMLCBw/a+3sFyWC07G5c50wGMbyCRJR4IEuUYfKYM0qbQn1qQljPU9QayJDJdiQWGSMnolW4brF6/HrnBAl8YsBqnAjuSNuixEwkWGI20WOGFPhaYZ/PU6BH75LDCViRWy6UL1rg2ZKne33y4wbcD+KwwNDSQC7FT689MpVp75FOf6OzgYbFQxkOJ017lbJ9Ynmc9E/nxG+n7XjH2x4DViMLiCCtMvRfu6B/pXUuQdS4NvB5xbMln0npvOi3/GI1tafGu1Oa5IS98ZEp/I1OBev0z8apcrcqbRe+zmCdHCsaQpTP+gnYzg5xbMB7u1tt5PuuXpL3tdkSrUfPyP4dWnqNap80vozPs1do5bePvVD7gsMJi/tcL1GTuC9TwKTKOTybTl+SmSbe/95TmzBQ4mMTzpDRBF3n/tNnhNP0CfeNyCQ==
@@ -23,13 +23,13 @@ import Heading from "@theme/Heading";
 <Heading
   as={"h1"}
   className={"openapi__heading"}
-  children={"Establish an MCP SSE Connection"}
+  children={"Establish an MCP Streamable HTTP Connection"}
 >
 </Heading>
 
 <MethodEndpoint
   method={"get"}
-  path={"/v1/mcp/sse"}
+  path={"/v1/mcp"}
   context={"endpoint"}
 >
   
@@ -37,10 +37,10 @@ import Heading from "@theme/Heading";
 
 
 
-Initiates a Server-Sent Events (SSE) connection using the Model Context Protocol (MCP) to interact with Spice tools.
+Initiates a Streamable HTTP connection using the Model Context Protocol (MCP) to interact with Spice tools.
 
 
-             Once connected, clients can send messages via `POST /v1/mcp/sse` and receive responses through this SSE stream.
+             Once connected, clients can send messages via `POST /v1/mcp` with an `Mcp-Session-Id` header and receive responses through this stream.
 
 <ParamsDetails
   parameters={undefined}

--- a/website/docs/components/tools/mcp.md
+++ b/website/docs/components/tools/mcp.md
@@ -3,18 +3,18 @@ title: 'Model Context Protocol Tools'
 sidebar_label: 'MCP Tools'
 ---
 
-Spice integrates with tools and services using the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). MCP tools can be configured to run internally or connect to external servers over HTTP using the Server-Sent Events (SSE) protocol.
+Spice integrates with tools and services using the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP). MCP tools can be configured to run internally or connect to external servers over HTTP using the [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport.
 
 ## Overview
 
 MCP helps extend the capabilities of the Spice runtime by enabling integration with external tools and services. This includes:
 
 1. Running stdio-based MCP servers internally.
-2. Connecting to external MCP servers over SSE.
+2. Connecting to external MCP servers over Streamable HTTP.
 
 ## Configuring MCP Tools
 
-To configure MCP tools, define them in the `tools` section of your `spicepod.yaml` file. The `from` field specifies the transport mechanism, such as `mcp:npx` for stdio-based tools or an HTTP URL for SSE-based tools.
+To configure MCP tools, define them in the `tools` section of your `spicepod.yaml` file. The `from` field specifies the transport mechanism, such as `mcp:npx` for stdio-based tools or an HTTP URL for Streamable HTTP-based tools.
 
 ### Example: Adding an MCP Tool (Stdio)
 
@@ -28,14 +28,14 @@ tools:
       mcp_args: -y @modelcontextprotocol/server-google-maps
 ```
 
-### Example: Connecting to an External MCP Server (SSE)
+### Example: Connecting to an External MCP Server (Streamable HTTP)
 
-This example shows how to connect to an external MCP server over SSE:
+This example shows how to connect to an external MCP server over Streamable HTTP:
 
 ```yaml
 tools:
   - name: external_mcp_server
-    from: mcp:http://example.com/v1/mcp/sse
+    from: mcp:http://example.com/v1/mcp
 ```
 
 ## Using MCP Tools with Models
@@ -52,14 +52,14 @@ models:
 
 ## Spice as an MCP Server
 
-Spice can also act as an MCP server, exposing its tools over SSE. This enables other Spice instances or external systems to connect and use the tools.
+Spice can also act as an MCP server, exposing its tools over Streamable HTTP. This enables other Spice instances or external systems to connect and use the tools.
 
 ### Example: Connecting to Another Spice Instance via MCP
 
 ```yaml
 tools:
   - name: spice_instance
-    from: mcp:http://localhost:8090/v1/mcp/sse
+    from: mcp:http://localhost:8090/v1/mcp
 ```
 
 ## Configuration Options
@@ -68,7 +68,7 @@ tools:
 
 The `from` field specifies the transport mechanism for the MCP tool:
 
-- **SSE**: Use an HTTP URL ending with `/sse` (e.g., `http://localhost:8090/v1/mcp/sse`).
+- **Streamable HTTP**: Use an HTTP URL pointing to the MCP endpoint (e.g., `http://localhost:8090/v1/mcp`).
 - **Stdio**: Use commands like `mcp:npx` or `mcp:docker`. Additional arguments can be passed via `params.mcp_args`.
 
 ### `params`

--- a/website/docs/features/large-language-models/mcp.md
+++ b/website/docs/features/large-language-models/mcp.md
@@ -11,7 +11,7 @@ tags:
   - mcp
 ---
 
-The Model Context Protocol (MCP) helps integrate external tools and services into the Spice runtime. MCP tools can be run internally or connected over HTTP using the Server-Sent Events (SSE) protocol.
+The Model Context Protocol (MCP) helps integrate external tools and services into the Spice runtime. MCP tools can be run internally or connected over HTTP using the [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport.
 
 ![Spice.ai Open Source Model-Context-Protocol (MCP) support](/img/features/mcp.png)
 
@@ -20,13 +20,13 @@ The Model Context Protocol (MCP) helps integrate external tools and services int
 MCP enables Spice to:
 
 1. Run stdio-based MCP servers internally.
-2. Connect to external MCP servers over SSE.
+2. Connect to external MCP servers over Streamable HTTP.
 
 This flexibility helps extend the capabilities of language models by providing access to external tools and services.
 
 ## Configuring MCP Tools
 
-To configure MCP tools, define them in the `tools` section of your `spicepod.yaml` file. The `from` field specifies the transport mechanism (e.g., `mcp:npx` for stdio or an HTTP URL for SSE).
+To configure MCP tools, define them in the `tools` section of your `spicepod.yaml` file. The `from` field specifies the transport mechanism (e.g., `mcp:npx` for stdio or an HTTP URL for Streamable HTTP).
 
 ### Example: Adding an MCP Tool
 
@@ -43,7 +43,7 @@ tools:
 ```yaml
 tools:
   - name: external_mcp_server
-    from: mcp:http://example.com/v1/mcp/sse
+    from: mcp:http://example.com/v1/mcp
 ```
 
 ## Using MCP Tools with Models
@@ -60,14 +60,14 @@ models:
 
 ## Spice as an MCP Server
 
-Spice can also act as an MCP server, exposing its tools over SSE. This enables other Spice instances or external systems to connect and use the tools.
+Spice can also act as an MCP server, exposing its tools over Streamable HTTP. This enables other Spice instances or external systems to connect and use the tools.
 
 ### Example: Connecting to another Spice instance via MCP
 
 ```yaml
 tools:
   - name: spice_instance
-    from: mcp:http://localhost:8090/v1/mcp/sse
+    from: mcp:http://localhost:8090/v1/mcp
 ```
 
 ## Additional Configuration Options
@@ -76,7 +76,7 @@ tools:
 
 The `from` field specifies the transport mechanism for the MCP tool:
 
-- **SSE**: Use an HTTP URL ending with `/sse` (e.g., `http://localhost:8090/v1/mcp/sse`).
+- **Streamable HTTP**: Use an HTTP URL pointing to the MCP endpoint (e.g., `http://localhost:8090/v1/mcp`).
 - **Stdio**: Use commands like `mcp:npx` or `mcp:docker`. Additional arguments can be passed via `params.mcp_args`.
 
 ### `params`


### PR DESCRIPTION
## Summary
- Update MCP documentation to reflect the transport change from SSE to Streamable HTTP
- Update endpoint references from `/v1/mcp/sse` to `/v1/mcp`
- Update API docs to reflect `Mcp-Session-Id` header (replacing `sessionId` query parameter) and corrected payload limit (32 MiB)

## Source PRs
- spiceai/spiceai#10491 — Upgrade rmcp to upstream 1.5.0; switch MCP server to Streamable HTTP

## Changes
- `website/docs/features/large-language-models/mcp.md`: Updated all SSE references to Streamable HTTP, updated endpoint URLs
- `website/docs/components/tools/mcp.md`: Same updates as above for the tools reference page
- `website/docs/api/HTTP/operation-id.api.mdx`: Updated endpoint path, title, and description
- `website/docs/api/HTTP/mcp-event.api.mdx`: Updated endpoint path, session parameter (header instead of query), payload limit, and response descriptions

Versioned docs were intentionally not updated — older versions correctly documented SSE which was the transport used in those releases.

## Test plan
- [ ] Verified endpoint paths match source code
- [ ] Links are valid
- [ ] Version references are correct (only vNext updated)