### PR TITLE
docs: Document secret store params and parameter validation

### DIFF
--- a/website/docs/components/secret-stores/aws-secrets-manager/index.md
+++ b/website/docs/components/secret-stores/aws-secrets-manager/index.md
@@ -19,6 +19,32 @@ The store reads keys from the secret named in the selector. In the above example
 
 <img src="/img/secrets-aws-secrets-manager-2.png" alt="" width="800" />
 
+## Parameters
+
+| Parameter Name   | Description                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `region`         | Optional. The AWS region for the Secrets Manager API. Falls back to the SDK default credential chain if not set. |
+| `endpoint_url`   | Optional. Custom endpoint URL for the Secrets Manager API (e.g., for VPC endpoints, FIPS, or LocalStack).        |
+| `key`            | Optional. AWS access key ID. Must be set together with `secret`. Overrides the default credential chain.         |
+| `secret`         | Optional. AWS secret access key. Must be set together with `key`. Overrides the default credential chain.        |
+| `session_token`  | Optional. AWS session token for temporary (STS-issued) credentials. Only used when `key` and `secret` are set.   |
+
+Parameter values support `${ env:KEY }` references to load values from environment variables.
+
+```yaml
+secrets:
+  - from: aws_secrets_manager:my_secret_name
+    name: aws
+    params:
+      region: ${ env:AWS_REGION }
+      key: ${ env:AWS_ACCESS_KEY_ID }
+      secret: ${ env:AWS_SECRET_ACCESS_KEY }
+```
+
+:::note
+Unknown parameters are rejected with an error listing the supported parameter names. This helps catch typos — e.g., `regoin` instead of `region` will produce an immediate error instead of being silently ignored.
+:::
+
 ## Example
 
 A complete spicepod definition with a dataset that uses a secret from AWS Secrets Manager.

--- a/website/docs/components/secret-stores/env/index.md
+++ b/website/docs/components/secret-stores/env/index.md
@@ -65,7 +65,11 @@ MY_PG_USER=postgres
 MY_PG_PASSWORD=postgres
 ```
 
-### Additional Parameters
+### Parameters
+
+| Parameter Name | Description                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `file_path`    | Optional. Path to a specific `.env` file to load. When set, `.env` and `.env.local` in the project directory are not loaded. |
 
 To load environment variables from a specific `.env` file, use the `file_path` parameter. When a `file_path` parameter is specified, environment variables from `.env` or `.env.local` will not be loaded.
 

--- a/website/docs/components/secret-stores/index.md
+++ b/website/docs/components/secret-stores/index.md
@@ -28,7 +28,9 @@ Secret Stores can be configured using the `secrets` section of the `spicepod.yml
 
 The Secret Store type and name are specified using the `from` and `name` fields. The `name` can be referenced by other components, like datasets or models. Some Secret Stores support adding a selector delimited by a colon (`:`), For example, when using the Kubernetes Secret Store, `from: kubernetes:my_secret` selects and enables the `my_secret` secret only to be referenced.
 
-Additional parameters may be specified in the `params` field, which are typically specific to the secret store type.
+Additional parameters may be specified in the `params` field, which are specific to the secret store type. Unknown parameters are rejected with an error listing the supported parameter names, helping catch typos early.
+
+Parameter values support `${ env:KEY }` references to load values from environment variables at startup.
 
 Example:
 

--- a/website/docs/components/secret-stores/kubernetes/index.md
+++ b/website/docs/components/secret-stores/kubernetes/index.md
@@ -35,6 +35,24 @@ secrets:
     name: k8s_other
 ```
 
+## Parameters
+
+| Parameter Name | Description                                                                                                      |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `namespace`    | Optional. The Kubernetes namespace to read the secret from. Defaults to the namespace of the running pod's service account. |
+
+```yaml
+secrets:
+  - from: kubernetes:my_secret
+    name: k8s
+    params:
+      namespace: spice
+```
+
+:::note
+Unknown parameters are rejected with an error listing the supported parameter names.
+:::
+
 ## Kubernetes Secret Store Configuration
 
 Note: This method requires the Kubernetes service account, which is running the `spiced` pod, to have extended roles for secrets API access. Configure this service account with the necessary permissions to read secrets from the Kubernetes API.


### PR DESCRIPTION
## Summary
- Document new configurable parameters for secret stores: AWS Secrets Manager, Kubernetes, and Env
- Document parameter validation behavior (unknown params are rejected with helpful errors)
- Add `${ env:KEY }` reference support documentation for secret store params

## Source PRs
- spiceai/spiceai#10487 — feat(secrets): add ParameterSpec and more params for AWS secrets manager

## Changes
- `website/docs/components/secret-stores/index.md`: Added note about parameter validation and env variable references in params
- `website/docs/components/secret-stores/aws-secrets-manager/index.md`: Added Parameters section with `region`, `endpoint_url`, `key`, `secret`, `session_token` and usage example
- `website/docs/components/secret-stores/kubernetes/index.md`: Added Parameters section with `namespace` and usage example
- `website/docs/components/secret-stores/env/index.md`: Added formal parameters table for `file_path`

## Test plan
- [ ] Verified parameter names match source code ParameterSpec definitions
- [ ] Links are valid
- [ ] Table formatting renders correctly