### PR TITLE
docs: Add connect_timeout/client_timeout to Databricks catalog and deployment docs

### DIFF
--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -145,6 +145,8 @@ The following parameters control resilience and concurrency for the SQL Statemen
 
 | Parameter Name               | Description                                                                                                                         | Default      |
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `connect_timeout`            | Timeout for establishing TCP/TLS connections to the Databricks API. Accepts durations like `10s`.                                   | `10s`        |
+| `client_timeout`             | Per-HTTP-call timeout (statement submit, status poll, chunk fetch). Set to the longest expected single call, not total query duration. Accepts durations like `30s` or `2m`. | `30s`        |
 | `max_concurrent_requests`    | Maximum number of concurrent HTTP requests to the SQL Warehouse API.                                                                | `8`          |
 | `http_max_retries`           | Maximum number of HTTP-level retries for transient failures (429, 5xx).                                                             | `3`          |
 | `backoff_method`             | Backoff strategy for transient HTTP retries. Options: `fibonacci`, `exponential`.                                                   | `fibonacci`  |
@@ -153,7 +155,7 @@ The following parameters control resilience and concurrency for the SQL Statemen
 
 ### Delta Lake parameters
 
-- `client_timeout`: The timeout setting for the object store client. Applies when using `mode: delta_lake`.
+- `client_timeout`: HTTP client request timeout. In `delta_lake` mode, applies to the object store client. In `sql_warehouse` mode, applies per-HTTP-call. Accepts durations like `30s` or `5m`. Default: `30s`.
 
 #### AWS S3
 

--- a/website/docs/components/data-connectors/databricks/deployment.md
+++ b/website/docs/components/data-connectors/databricks/deployment.md
@@ -19,13 +19,15 @@ Production operating guide for the Databricks connector covering resilience tuni
 
 When using `mode: sql_warehouse`, the following parameters control HTTP retry behavior and concurrency limits for the Databricks SQL Statements API.
 
-| Parameter                    | Type    | Default     | Description                                                                |
-| ---------------------------- | ------- | ----------- | -------------------------------------------------------------------------- |
-| `max_concurrent_requests`    | integer | `8`         | Maximum concurrent HTTP requests to the SQL Warehouse API.                 |
-| `http_max_retries`           | integer | `3`         | Maximum HTTP-level retries for transient failures (429, 5xx).              |
-| `backoff_method`             | string  | `fibonacci` | Backoff strategy for transient HTTP retries: `fibonacci` or `exponential`. |
-| `statement_max_retries`      | integer | `14`        | Maximum poll retries when waiting for an async SQL statement to complete.  |
-| `disable_on_permanent_error` | boolean | `true`      | Permanently disable the connector on non-retryable errors (401, 403, 404). |
+| Parameter                    | Type     | Default     | Description                                                                |
+| ---------------------------- | -------- | ----------- | -------------------------------------------------------------------------- |
+| `connect_timeout`            | duration | `10s`       | Timeout for establishing TCP/TLS connections to the Databricks API.        |
+| `client_timeout`             | duration | `30s`       | Per-HTTP-call timeout (statement submit, status poll, chunk fetch). Set to the longest expected single call, not total query duration. |
+| `max_concurrent_requests`    | integer  | `8`         | Maximum concurrent HTTP requests to the SQL Warehouse API.                 |
+| `http_max_retries`           | integer  | `3`         | Maximum HTTP-level retries for transient failures (429, 5xx).              |
+| `backoff_method`             | string   | `fibonacci` | Backoff strategy for transient HTTP retries: `fibonacci` or `exponential`. |
+| `statement_max_retries`      | integer  | `14`        | Maximum poll retries when waiting for an async SQL statement to complete.  |
+| `disable_on_permanent_error` | boolean  | `true`      | Permanently disable the connector on non-retryable errors (401, 403, 404). |
 
 #### Example
 
@@ -39,6 +41,8 @@ catalogs:
       databricks_sql_warehouse_id: abc123def456
       databricks_client_id: ${env:DBX_CLIENT_ID}
       databricks_client_secret: ${env:DBX_CLIENT_SECRET}
+      connect_timeout: 10s
+      client_timeout: 2m
       max_concurrent_requests: '4'
       http_max_retries: '5'
       backoff_method: exponential


### PR DESCRIPTION
## Summary
- Add `connect_timeout` and `client_timeout` parameters to the Databricks deployment guide resilience table and example
- Add `connect_timeout` and `client_timeout` parameters to the Databricks catalog connector SQL Warehouse tuning table
- Update `client_timeout` description under Delta Lake parameters to reflect it applies in both modes

## Source PRs
- spiceai/spiceai#10495 — Add connect_timeout/client_timeout params to Databricks sql_warehouse mode
- spiceai/docs#1566 — Updated data connector index page (this PR covers the remaining pages)

## Changes
- `website/docs/components/data-connectors/databricks/deployment.md`: Added `connect_timeout` (duration, default `10s`) and `client_timeout` (duration, default `30s`) to the resilience controls table and YAML example
- `website/docs/components/catalogs/databricks.md`: Added `connect_timeout` and `client_timeout` to the SQL Warehouse connection tuning table; updated `client_timeout` description under Delta Lake parameters to note it applies in both `delta_lake` and `sql_warehouse` modes

## Test plan
- [ ] Verified parameter names and defaults match source code (`DEFAULT_HTTP_CONNECT_TIMEOUT = 10s`, `DEFAULT_HTTP_REQUEST_TIMEOUT = 30s`)
- [ ] Verified descriptions are consistent with the data connector index page (updated in #1566)
- [ ] Links are valid
- [ ] No versioned docs touched (this is an addition, not a correction)