### PR TITLE
docs: Document DynamoDB DML support and write_parallelism parameter

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/index.md
+++ b/website/docs/components/data-connectors/dynamodb/index.md
@@ -75,6 +75,7 @@ The DynamoDB data connector supports the following configuration parameters:
 | `endpoint_url`                         | Optional. Custom endpoint URL for DynamoDB-compatible services (e.g., DynamoDB Local, ScyllaDB Alternator).                                                                                                                                                |
 | `lag_exceeds_shard_retention_behavior` | Optional. Behavior when stream lag exceeds shard retention (24h). One of `error` (default — marks dataset as Error), `ready_before_load` (marks Ready then re-bootstraps), or `ready_after_load` (re-bootstraps then marks Ready).                         |
 | `time_format`                          | Optional. Go-style time format used for parsing/formatting timestamps. See [Time Format](#time-format)                                                                                                                                                     |
+| `write_parallelism`                    | Optional. Number of parallel operations for writing and deleting data to DynamoDB. Default: `10`                                                                                                                                                           |
 
 ### Authentication
 
@@ -199,11 +200,15 @@ The IAM role or user needs the following permissions to access DynamoDB tables:
 
 ### Permission Details
 
-| Permission               | Purpose                                                           |
-| ------------------------ | ----------------------------------------------------------------- |
-| `dynamodb:Scan`          | Required. Allows reading all items from the table                 |
-| `dynamodb:Query`         | Required. Allows reading items from the table using partition key |
-| `dynamodb:DescribeTable` | Required. Allows fetching table metadata and schema information   |
+| Permission               | Purpose                                                                  |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `dynamodb:Scan`          | Required. Allows reading all items from the table                        |
+| `dynamodb:Query`         | Required. Allows reading items from the table using partition key        |
+| `dynamodb:DescribeTable` | Required. Allows fetching table metadata and schema information          |
+| `dynamodb:PutItem`       | Required for INSERT. Allows writing new items to the table               |
+| `dynamodb:UpdateItem`    | Required for UPDATE. Allows modifying existing items in the table        |
+| `dynamodb:DeleteItem`    | Required for DELETE. Allows removing items from the table                |
+| `dynamodb:BatchWriteItem`| Required for batch INSERT/DELETE. Allows batch write operations           |
 
 ### Example IAM Policies
 
@@ -466,6 +471,27 @@ Will produce the following Spice dataset:
 - The `json_object` metadata only accepts `"*"` as its value, which captures all unspecified columns
 - Only one column can have the `json_object` metadata. Specifying multiple columns with `json_object` will result in an error
 
+:::
+
+## Data Manipulation (DML)
+
+The DynamoDB connector supports `INSERT`, `UPDATE`, and `DELETE` operations.
+
+```sql
+-- Insert a new item
+INSERT INTO users (id, email, name) VALUES (42, 'user@example.com', 'Jane');
+
+-- Update existing items
+UPDATE users SET name = 'Jane Doe' WHERE id = 42;
+
+-- Delete items
+DELETE FROM users WHERE id = 42;
+```
+
+Write operations use the table's primary key (partition key and optional sort key) to identify items. The `write_parallelism` parameter controls how many DynamoDB API calls are issued concurrently for batch operations (default: `10`).
+
+:::note
+INSERT uses `BatchWriteItem` for efficiency. UPDATE and DELETE use per-item API calls (`UpdateItem` / `DeleteItem`) issued in parallel chunks sized by `write_parallelism`.
 :::
 
 ## Examples


### PR DESCRIPTION
## Summary
- Document INSERT, UPDATE, and DELETE support for the DynamoDB connector
- Add `write_parallelism` parameter to the configuration table (default: `10`)
- Add required IAM permissions for write operations (`PutItem`, `UpdateItem`, `DeleteItem`, `BatchWriteItem`)

## Source PRs
- spiceai/spiceai#10470 — DynamoDB DML

## Changes
- `website/docs/components/data-connectors/dynamodb/index.md`: Added DML section with SQL examples, `write_parallelism` param, and write IAM permissions

## Test plan
- [ ] Verified parameter name and default match source code (`ParameterSpec::runtime("write_parallelism").default("10")`)
- [ ] DML operations listed match implementation (INSERT via BatchWriteItem, UPDATE via UpdateItem, DELETE via DeleteItem)
- [ ] IAM permissions match the AWS API calls used in the code