### PR TITLE
fix: Add missing reinitializations metric to DynamoDB connector docs

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/index.md
+++ b/website/docs/components/data-connectors/dynamodb/index.md
@@ -641,6 +641,7 @@ The following [Component Metrics](../../features/observability/component_metrics
 | `records_consumed_total` | Counter | Total number of records consumed from the stream                           |
 | `lag_ms`                 | Gauge   | Current lag in milliseconds between stream watermark and the current time  |
 | `errors_transient_total` | Counter | Total number of transient errors encountered while polling from the stream |
+| `reinitializations_on_lag_exceeds_shard_retention_total` | Counter | Total rebootstrap operations triggered due to expired shards |
 
 These metrics are not enabled by default, enable them by setting the metrics parameter:
 ```yaml
@@ -655,6 +656,7 @@ datasets:
    - name: records_consumed_total
    - name: lag_ms
    - name: errors_transient_total
+   - name: reinitializations_on_lag_exceeds_shard_retention_total
 ```
 
 You can find an example dashboard for DynamoDB Streams in [monitoring/grafana-dashboard.json](https://github.com/spiceai/spiceai/blob/trunk/monitoring/grafana-dashboard.json).


### PR DESCRIPTION
## Summary
- The `reinitializations_on_lag_exceeds_shard_retention_total` metric is defined in the DynamoDB connector code but was missing from the index page metrics table and YAML example.

## Changes
- Added `reinitializations_on_lag_exceeds_shard_retention_total` to the metrics table and the example YAML in `dynamodb/index.md`.

## Reference
Verified against spiceai/spiceai at trunk — [dynamodb.rs lines 1072-1075](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/dynamodb.rs)