### PR TITLE
docs: Document rerank UDTF and rerankers spicepod section

### DIFF
--- a/website/docs/components/data-connectors/sharepoint.md
+++ b/website/docs/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/docs/features/search/index.md
+++ b/website/docs/features/search/index.md
@@ -25,6 +25,7 @@ Spice supports multiple search methods:
 - **Multi-Vector Search**: Search over columns of vectors, including ColBERT-style late-interaction queries.
 - **Full-Text Search**: Keyword-driven search optimized for text data retrieval.
 - **Hybrid Search**: Combine multiple search methods using Reciprocal Rank Fusion (RRF) for improved relevance.
+- **Reranking**: Reorder search results using dedicated reranker models or LLM-as-reranker for improved relevance.
 - **SQL Search**: Traditional SQL queries for precise and structured searches.
 
 ### Vector Search
@@ -126,5 +127,33 @@ LIMIT 5
 ```
 
 For complete RRF syntax and parameters, see [Search SQL Reference](../reference/sql/search#reciprocal-rank-fusion-rrf).
+
+### Reranking
+
+Reranking reorders search results using a dedicated reranker model (Cohere, Voyage, Jina, or a custom HTTP endpoint) or any registered chat model as an LLM-as-reranker. This two-stage retrieve-then-rerank pattern improves relevance beyond initial retrieval scores.
+
+**Requirements:**
+
+- A registered reranker (in the `rerankers:` spicepod section) or a registered chat model
+
+**Getting Started:**
+
+- [Reranking Docs](search/rerank)
+
+**Example SQL Rerank:**
+
+```sql
+SELECT * FROM rerank(
+  rrf(
+    vector_search(docs, 'delta lake time travel', limit => 50),
+    text_search(docs, 'delta lake time travel', limit => 50)
+  ),
+  document => 'content',
+  model    => 'cohere_rr',
+  limit    => 10
+);
+```
+
+For complete rerank syntax and parameters, see [Search SQL Reference](../reference/sql/search#reranking-rerank).
 
 <DocCardList />

--- a/website/docs/features/search/rerank.md
+++ b/website/docs/features/search/rerank.md
@@ -1,0 +1,138 @@
+---
+title: 'Reranking'
+sidebar_label: 'Reranking'
+description: 'Rerank search results using dedicated reranker models or LLM-as-reranker for improved relevance.'
+sidebar_position: 4
+tags:
+  - search
+  - reranking
+  - features
+---
+
+Reranking reorders a set of candidate results — from `vector_search`, `text_search`, `rrf`, or a plain table — using a dedicated reranker model. This produces more relevant rankings than the initial retrieval scores alone.
+
+## How It Works
+
+1. An initial search (vector, full-text, or hybrid) retrieves candidate documents.
+2. The `rerank()` UDTF sends each candidate's text to a reranker model alongside the query.
+3. The reranker scores each document for relevance and returns them in order.
+
+This two-stage pattern (retrieve then rerank) is standard in modern search and RAG pipelines.
+
+## Configuration
+
+### Reranker Models
+
+Define dedicated reranker models in the `rerankers:` section of the spicepod. Supported providers:
+
+| Provider prefix | Description |
+| --------------- | ----------- |
+| `cohere:`       | Cohere Rerank API (e.g., `cohere:rerank-v3.5`) |
+| `voyage:`       | Voyage Rerank API (e.g., `voyage:rerank-2`) |
+| `jina:`         | Jina Rerank API (e.g., `jina:jina-reranker-v2-base-multilingual`) |
+| `http://` / `https://` | Any HTTP endpoint implementing the standard rerank API schema |
+
+```yaml
+rerankers:
+  - from: cohere:rerank-v3.5
+    name: cohere_rr
+    params:
+      api_key: ${secrets:COHERE_API_KEY}
+
+  - from: voyage:rerank-2
+    name: voyage_rr
+    params:
+      api_key: ${secrets:VOYAGE_API_KEY}
+
+  - from: jina:jina-reranker-v2-base-multilingual
+    name: jina_rr
+    params:
+      api_key: ${secrets:JINA_API_KEY}
+
+  - from: https://rerank.internal/v1/rerank
+    name: byo_rr
+    params:
+      api_key: ${secrets:INTERNAL_RR_KEY}  # optional
+```
+
+### LLM-as-Reranker
+
+Any registered chat model can also be used as a reranker without additional configuration. When a model name resolves to a chat model instead of a dedicated reranker, Spice wraps it in an LLM-based reranking adapter.
+
+```yaml
+models:
+  - from: openai:gpt-4o-mini
+    name: gpt_mini
+```
+
+```sql
+SELECT * FROM rerank(
+  vector_search(kb, 'onboarding checklist', limit => 40),
+  document => 'content',
+  model    => 'gpt_mini',       -- resolves to the registered chat model
+  strategy => 'pointwise',      -- or 'listwise' (default)
+  limit    => 10
+);
+```
+
+The `strategy` parameter controls how the LLM scores documents:
+- **`listwise`** (default): sends all candidates in a single prompt and asks the LLM to rank them.
+- **`pointwise`**: sends each candidate individually and asks the LLM to score it.
+
+## SQL Usage
+
+```sql
+SELECT * FROM rerank(
+  <input>,
+  document => '<column>',
+  model    => '<reranker_name>',
+  limit    => <n>
+);
+```
+
+For the complete parameter reference, see [Reranking SQL Reference](../../reference/sql/search#reranking-rerank).
+
+## Examples
+
+### Hybrid Recall + Rerank
+
+```sql
+SELECT * FROM rerank(
+  rrf(
+    vector_search(docs, 'delta lake time travel', limit => 50),
+    text_search(docs, 'delta lake time travel', limit => 50)
+  ),
+  document => 'content',
+  model    => 'cohere_rr',
+  limit    => 10
+);
+```
+
+The query is automatically extracted from the nested search UDTFs — no need to specify `query` explicitly.
+
+### Bare-Table Rerank
+
+When reranking a plain table (not a search UDTF), provide the `query` explicitly:
+
+```sql
+SELECT * FROM rerank(
+  tickets,
+  query    => 'auth failures',
+  document => 'body',
+  model    => 'voyage_rr',
+  limit    => 5
+);
+```
+
+### Custom LLM Prompt
+
+```sql
+SELECT * FROM rerank(
+  vector_search(kb, 'onboarding checklist', limit => 40),
+  document        => 'content',
+  model           => 'gpt_mini',
+  strategy        => 'pointwise',
+  prompt_template => 'Rate 0-1: is this useful for a new hire?\nQuery: {query}\nDoc: {document}',
+  limit           => 10
+);
+```

--- a/website/docs/features/search/rerank.md
+++ b/website/docs/features/search/rerank.md
@@ -5,7 +5,6 @@ description: 'Rerank search results using dedicated reranker models or LLM-as-re
 sidebar_position: 4
 tags:
   - search
-  - reranking
   - features
 ---
 

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -20,6 +20,7 @@ This section documents search capabilities in Spice SQL, including vector search
 - [Reciprocal Rank Fusion (`rrf`)](#reciprocal-rank-fusion-rrf)
   - [Usage](#usage-2)
     - [Examples](#examples)
+- [Reranking (`rerank`)](#reranking-rerank)
 - [Lexical Search: LIKE, =, and Regex](#lexical-search-like--and-regex)
   - [LIKE (Pattern Matching)](#like-pattern-matching)
   - [= (Keyword/Exact Match)](#-keywordexact-match)
@@ -263,6 +264,85 @@ ORDER BY fused_score DESC;
   - **Exponential decay**: `e^(-decay_constant * age_in_units)` where age is in `decay_scale_secs`
   - **Linear decay**: `max(0, 1 - (age_in_units / decay_window_secs))`
 - **Auto-join**: When no `join_key` is specified, `rrf` infers the primary key from the underlying tables; if none is available, rows are joined by an auto-generated row identifier
+
+---
+
+## Reranking (`rerank`)
+
+Reranking reorders candidate results using a dedicated reranker model or an LLM-as-reranker for improved relevance. The input can be any search UDTF (`vector_search`, `text_search`, `rrf`) or a plain table.
+
+### Usage
+
+```sql
+SELECT *
+FROM rerank(
+    <input>,
+    document => 'column_name',
+    model    => 'reranker_name',
+    limit    => 10
+)
+```
+
+**Arguments:**
+
+| Parameter         | Type              | Required | Description |
+| ----------------- | ----------------- | -------- | ----------- |
+| `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
+| `model`           | String            | Yes      | Name of a registered reranker or chat model. |
+| `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
+| `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
+| `limit`           | Integer           | No       | Maximum number of results to return. |
+| `strategy`        | String            | No       | LLM reranking strategy: `'listwise'` (default) or `'pointwise'`. Only applies when the model resolves to a chat model. |
+| `prompt_template` | String            | No       | Custom prompt template for LLM-as-reranker. Use `{query}` and `{document}` placeholders. Only applies when the model resolves to a chat model. |
+
+#### Query Auto-Propagation
+
+When the input is a search UDTF (`vector_search`, `text_search`, or `rrf` wrapping search UDTFs), the query string is automatically extracted from the nested call. Single-string, `make_array(...)`, and `ARRAY[...]` query forms are all supported. For multi-query inputs, the first query string is used.
+
+For bare-table inputs, `query` must be provided explicitly.
+
+#### Examples
+
+**Rerank hybrid search results:**
+
+```sql
+SELECT * FROM rerank(
+    rrf(
+        vector_search(docs, 'delta lake time travel', limit => 50),
+        text_search(docs, 'delta lake time travel', limit => 50)
+    ),
+    document => 'content',
+    model    => 'cohere_rr',
+    limit    => 10
+);
+```
+
+**Rerank a plain table with an explicit query:**
+
+```sql
+SELECT * FROM rerank(
+    tickets,
+    query    => 'auth failures',
+    document => 'body',
+    model    => 'voyage_rr',
+    limit    => 5
+);
+```
+
+**LLM-as-reranker with custom prompt:**
+
+```sql
+SELECT * FROM rerank(
+    vector_search(kb, 'onboarding checklist', limit => 40),
+    document        => 'content',
+    model           => 'gpt_mini',
+    strategy        => 'pointwise',
+    prompt_template => 'Rate 0-1: is this useful for a new hire?\nQuery: {query}\nDoc: {document}',
+    limit           => 10
+);
+```
+
+See [Reranking](../../features/search/rerank) for configuration, provider setup, and additional examples.
 
 ---
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/sharepoint.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/sharepoint.md
@@ -84,6 +84,7 @@ from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 | `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
 | `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
 | `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
 | `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
 
 :::note


### PR DESCRIPTION
## Summary
- Add feature documentation for the new `rerank()` UDTF
- Add SQL reference for `rerank()` with full parameter table
- Update search overview to include reranking as a search method
- Document the `rerankers:` spicepod section with provider support (Cohere, Voyage, Jina, HTTP BYO)
- Document LLM-as-reranker with `strategy` and `prompt_template` options

## Source PRs
- spiceai/spiceai#10469 — Add rerank UDTF for hybrid search with query auto-propagation

## Changes
- `website/docs/features/search/rerank.md` (new): Feature docs covering configuration, providers, LLM-as-reranker, and usage examples
- `website/docs/features/search/index.md`: Added reranking to search methods overview with example
- `website/docs/reference/sql/search.md`: Added `rerank()` SQL reference section with parameter table and examples

## Test plan
- [ ] Parameter names match source code (input, model, document, query, limit, strategy, prompt_template)
- [ ] Provider prefixes match code (cohere:, voyage:, jina:, http://, https://)
- [ ] LLM strategies match code (listwise, pointwise)
- [ ] Links between feature docs and SQL reference are valid
- [ ] New page sidebar_position doesn't conflict with existing pages