### PR TITLE
docs: Add cookbook recipe links to connectors and accelerator pages (fixes #639)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -564,6 +564,10 @@ datasets:
         cayenne_target_file_size_mb: 32     # Smaller files for faster ingestion
 ```
 
+## Cookbook
+
+- A cookbook recipe to configure Cayenne as a data accelerator in Spice. [Cayenne Data Accelerator](https://github.com/spiceai/cookbook/tree/trunk/cayenne#readme)
+
 ## Related Documentation
 
 **Spice Documentation:**

--- a/website/docs/components/data-connectors/delta-lake/index.md
+++ b/website/docs/components/data-connectors/delta-lake/index.md
@@ -194,3 +194,7 @@ The table below shows the Delta Lake data types supported, along with the type m
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).
+
+## Cookbook
+
+- A cookbook recipe to configure Delta Lake as a data connector in Spice. [Delta Lake Data Connector](https://github.com/spiceai/cookbook/tree/trunk/delta-lake#readme)

--- a/website/docs/components/data-connectors/elasticsearch.md
+++ b/website/docs/components/data-connectors/elasticsearch.md
@@ -140,3 +140,7 @@ TLS is enabled automatically for `https://` endpoints.
 - Pushdown of SQL predicates to Elasticsearch query DSL is limited; complex filter expressions are evaluated locally by DataFusion after fetching results.
 
 Elasticsearch can also be configured as a [Vector Engine](../vectors/elasticsearch) for datasets sourced from other connectors (storing Spice-managed embeddings in Elasticsearch rather than querying an existing index).
+
+## Cookbook
+
+- A cookbook recipe to configure Elasticsearch as a data connector in Spice. [Elasticsearch Data Connector](https://github.com/spiceai/cookbook/tree/trunk/elasticsearch/connector#readme)

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -915,3 +915,7 @@ datasets:
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores/). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores/#using-secrets).
+
+## Cookbook
+
+- A cookbook recipe to configure an HTTP/HTTPS endpoint as a data connector in Spice. [HTTP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/http#readme)

--- a/website/docs/components/data-connectors/redshift.md
+++ b/website/docs/components/data-connectors/redshift.md
@@ -140,6 +140,10 @@ Redshift types are mapped to PostgreSQL types. See the [PostgreSQL connector doc
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For details, see the [secret stores documentation](../secret-stores/) and [using referenced secrets guide](../secret-stores/#using-secrets).
 
+## Cookbook
+
+- A cookbook recipe to configure Amazon Redshift as a data connector in Spice. [Redshift Data Connector](https://github.com/spiceai/cookbook/tree/trunk/redshift#readme)
+
 ## References
 
 - [Amazon Redshift Documentation](https://docs.aws.amazon.com/redshift/latest/mgmt/welcome.html)

--- a/website/docs/components/data-connectors/scylladb.md
+++ b/website/docs/components/data-connectors/scylladb.md
@@ -287,6 +287,10 @@ The following SQL operations cannot be pushed down to ScyllaDB and are performed
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).
 
+## Cookbook
+
+- A cookbook recipe to configure ScyllaDB as a data connector in Spice. [ScyllaDB Data Connector](https://github.com/spiceai/cookbook/tree/trunk/scylladb#readme)
+
 ## See Also
 
 - [ScyllaDB Documentation](https://docs.scylladb.com/)

--- a/website/docs/components/data-connectors/smb.md
+++ b/website/docs/components/data-connectors/smb.md
@@ -311,3 +311,7 @@ Enable debug logging to diagnose SMB connection issues:
 ```bash
 RUST_LOG=runtime_object_store::store::smb=debug spiced
 ```
+
+## Cookbook
+
+- A cookbook recipe to configure SMB as a data connector in Spice. [SMB Data Connector](https://github.com/spiceai/cookbook/tree/trunk/smb#readme)


### PR DESCRIPTION
## Summary
Fixes #639

Most connectors already include a `## Cookbook` section linking to the matching recipe in spiceai/cookbook, but seven connector/accelerator pages were missing that section despite the recipe existing. This PR adds the same `## Cookbook` section to those pages.

## Changes
| Page | Cookbook recipe |
|---|---|
| `data-connectors/delta-lake/index.md` | [`delta-lake`](https://github.com/spiceai/cookbook/tree/trunk/delta-lake#readme) |
| `data-connectors/elasticsearch.md` | [`elasticsearch/connector`](https://github.com/spiceai/cookbook/tree/trunk/elasticsearch/connector#readme) |
| `data-connectors/https.md` | [`http`](https://github.com/spiceai/cookbook/tree/trunk/http#readme) |
| `data-connectors/redshift.md` | [`redshift`](https://github.com/spiceai/cookbook/tree/trunk/redshift#readme) |
| `data-connectors/scylladb.md` | [`scylladb`](https://github.com/spiceai/cookbook/tree/trunk/scylladb#readme) |
| `data-connectors/smb.md` | [`smb`](https://github.com/spiceai/cookbook/tree/trunk/smb#readme) |
| `data-accelerators/cayenne/index.md` | [`cayenne`](https://github.com/spiceai/cookbook/tree/trunk/cayenne#readme) |

Connectors that still lack cookbook references (`abfs`, `adbc`, `ducklake`, `flightsql`, `nfs`, `memory`, `iceberg`) and the `turso` accelerator were not modified because no matching recipe currently exists in `spiceai/cookbook`.

## Test plan
- [x] `cd website && npm run build` passes locally with no broken-link errors
- [x] Each cookbook URL verified against `spiceai/cookbook` contents (every linked directory has a `README.md`)
- [x] Section placement matches existing convention (after `## Secrets`, before `## References` / `## See Also` / `## Related Documentation` where present)