### PR TITLE
fix: Remove incorrect 'writes not supported' claim from DynamoDB deployment guide

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/deployment.md
+++ b/website/docs/components/data-connectors/dynamodb/deployment.md
@@ -79,7 +79,7 @@ Stream polling and bootstrap operations emit spans that participate in [task his
 ## Known Limitations
 
 - **Global Secondary Indexes**: Not exposed as separate datasets. Query the base table and let DataFusion filter.
-- **Conditional writes / writes**: Read-only connector; writes are not supported.
+- **Conditional writes**: DynamoDB conditional expressions (e.g., `attribute_exists`) are not supported in DML operations.
 - **Cross-region streams**: Must configure `dynamodb_region` to match the region of the source table; cross-region access requires resource policies and is not recommended.
 - **Table with `StreamSpecification` disabled**: CDC mode is unavailable; fall back to full-table refresh.
 


### PR DESCRIPTION
## Summary
- The DynamoDB deployment guide's Known Limitations section stated "Read-only connector; writes are not supported"
- DML support (INSERT, UPDATE, DELETE) was added in spiceai/spiceai#10470
- The connector now supports `write_parallelism`-controlled parallel writes via `BatchWriteItem`, `PutItem`, `UpdateItem`, and `DeleteItem`

## Changes
- Updated the limitation entry to reflect that only conditional writes (DynamoDB conditional expressions) are unsupported, not writes in general

## Reference
Verified against spiceai/spiceai at `trunk` — `crates/runtime/src/dataconnector/dynamodb.rs` (implements `read_write_provider`)

## Related
- #1573 documents DML support in `index.md`
- #1572 corrects other parameter/metric inaccuracies in the same file