### PR TITLE
fix: Correct Postgres deployment guide CDC claim from Debezium to native WAL

### DIFF
--- a/website/docs/components/data-connectors/postgres/deployment.md
+++ b/website/docs/components/data-connectors/postgres/deployment.md
@@ -95,7 +95,7 @@ PostgreSQL operations participate in Spice [task history](../../../reference/tas
 
 - Only TCP connections are supported. Unix sockets are not exposed through Spice configuration.
 - `pg_sslmode: prefer` silently downgrades to plaintext and is not recommended for production.
-- `LISTEN/NOTIFY` is not exposed; Postgres CDC is handled through [Debezium](../debezium) rather than the Postgres connector directly.
+- `LISTEN/NOTIFY` is not exposed. CDC is supported natively via logical replication (WAL streaming) — see the [replication parameters](index.md#replication-parameters) in the connector docs.
 - Server-side cursors are used for federated reads; long-running queries hold a backend for their duration.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- The Postgres deployment guide's Known Limitations incorrectly stated: "Postgres CDC is handled through Debezium rather than the Postgres connector directly"
- The Postgres connector natively implements CDC via WAL streaming (logical replication), added in spiceai/spiceai#10364
- The connector implements `supports_changes_stream()` → `true` and `changes_stream()` directly, with 5 dedicated replication parameters (`pg_replication_slot`, `pg_publication`, etc.)

## Changes
- Updated the Known Limitations bullet to state that CDC is supported natively via logical replication and link to the replication parameters section

## Reference
Verified against spiceai/spiceai at `trunk` — `crates/data-connectors/connector-postgres/src/lib.rs` and `crates/data-connectors/connector-postgres/src/replication.rs`