### PR TITLE
docs: Add spice validate command and update spice init output

### DIFF
--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -43,6 +43,7 @@ spice [command] [--help]
 | [status](reference/status)         | Spice runtime status                                                   |
 | [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
 | [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest release               |
+| [validate](reference/validate)     | Validate a spicepod.yaml without starting the runtime                  |
 | [version](reference/version)       | Spice CLI version                                                      |
 | workers                            | Lists workers loaded by the Spice runtime                              |
 

--- a/website/docs/cli/reference/init.md
+++ b/website/docs/cli/reference/init.md
@@ -23,13 +23,21 @@ spice init [app_name]
 ```
 > spice init taxi-trips
 
-2025/01/09 16:43:02 INFO Initialized taxi-trips/spicepod.yaml
+Initialized taxi-trips/spicepod.yaml
+
+Next steps:
+  cd taxi-trips
+  spice dataset configure   # add a dataset interactively
+  spice run                 # start the runtime
+
+Docs: https://spiceai.org/docs/
 ```
 
-The command creates a `spicepod.yaml` with basic initial metadata about the app. For this example, the `spicepod.yaml` file is initialized to the following:
+The command creates a `spicepod.yaml` with basic initial metadata about the app, including a `yaml-language-server` schema directive for editor support (VS Code, Neovim, IntelliJ). For this example, the `spicepod.yaml` file is initialized to the following:
 ```yaml
 # File: ./taxi-trips/spicepod.yaml
 
+# yaml-language-server: $schema=https://raw.githubusercontent.com/spiceai/spiceai/trunk/.schema/spicepod.schema.json
 version: v2
 kind: Spicepod
 name: taxi-trips
@@ -40,13 +48,20 @@ If no app name is provided, Spice initializes the Spicepod in the current workin
 > spice init
 
 name: (taxi-trips)? 
-2025/01/09 16:48:37 INFO Initialized spicepod.yaml
+Initialized spicepod.yaml
+
+Next steps:
+  spice dataset configure   # add a dataset interactively
+  spice run                 # start the runtime
+
+Docs: https://spiceai.org/docs/
 ```
 
 After execution, the current working directory contains the file `spicepod.yaml` with the same configuration as the previous example:
 ```yaml
 # File: ./spicepod.yaml
 
+# yaml-language-server: $schema=https://raw.githubusercontent.com/spiceai/spiceai/trunk/.schema/spicepod.schema.json
 version: v2
 kind: Spicepod
 name: taxi-trips

--- a/website/docs/cli/reference/validate.md
+++ b/website/docs/cli/reference/validate.md
@@ -1,0 +1,55 @@
+---
+title: "validate"
+sidebar_label: "validate"
+pagination_prev: null
+pagination_next: null
+---
+Validate a `spicepod.yaml` without starting the runtime.
+
+Checks YAML syntax and schema, component references, duplicate component names, reserved keywords, and nested pod includes (`dependsOn`).
+
+### Usage
+
+```shell
+spice validate [path]
+```
+
+- `path`: Path to a `spicepod.yaml` file or a directory containing one. Defaults to the current directory (`.`).
+
+#### Flags
+
+- `-h`, `--help`   Print this help message
+
+### Examples
+
+Validate the spicepod in the current directory:
+
+```shell
+> spice validate
+
+OK my_app (datasets: 2, models: 1, views: 0, tools: 0, workers: 0)
+```
+
+Validate a specific directory:
+
+```shell
+> spice validate ./my-app
+
+OK my_app (datasets: 3, models: 0, views: 1, tools: 2, workers: 0)
+```
+
+Validate a specific file:
+
+```shell
+> spice validate path/to/spicepod.yaml
+
+OK taxi_trips (datasets: 1, models: 0, views: 0, tools: 0, workers: 0)
+```
+
+When validation fails, the error describes the issue:
+
+```shell
+> spice validate ./broken-app
+
+Invalid: spicepod validation failed: missing field `kind`
+```


### PR DESCRIPTION
## Summary
- Add new CLI reference page for `spice validate` — validates a spicepod.yaml without starting the runtime
- Add `validate` to the CLI command reference index table
- Update `spice init` docs to reflect new output (next steps guidance, yaml-language-server schema directive in generated spicepod.yaml)

## Source PRs
- spiceai/spiceai#10489 — feat(devx): make config errors, CLI, and REPL lead users to success

## Changes
- `website/docs/cli/reference/validate.md`: New page documenting the `spice validate` command (usage, flags, examples for success and failure)
- `website/docs/cli/reference/index.md`: Added `validate` row to the command reference table
- `website/docs/cli/reference/init.md`: Updated example output to show new next-steps guidance and yaml-language-server schema comment in generated spicepod.yaml

## Test plan
- [ ] Verified command usage and flags match source code (`bin/spice/src/commands/validate.rs`)
- [ ] Verified init output matches source code (`bin/spice/src/commands/init.rs`)
- [ ] Links are valid
- [ ] No versioned docs touched (this is an addition, not a correction)