### PR TITLE
fix: Mark imap_password as Required instead of Optional

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -98,7 +98,7 @@ The IMAP connector supports the following connection and authentication paramete
 | Parameter Name  | Description                                                                                                                  |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `imap_username` | Optional. The username to use for the IMAP connection. Defaults to the value of the `from:` mailbox field.                   |
-| `imap_password` | Optional. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
+| `imap_password` | Required. The password to use for the IMAP connection, in plaintext authentication mode.                                     |
 | `imap_host`     | Optional. The host or IP address of the IMAP server to connect to. Not required for known connections like Outlook or Gmail. |
 | `imap_port`     | Optional. The port of the IMAP server to connect to. Defaults to `993`.                                                                         |
 | `imap_mailbox`  | Optional. The mailbox to read mail from. Defaults to `INBOX`, the standard email inbox.                                      |


### PR DESCRIPTION
## Summary
- The `imap_password` parameter was documented as "Optional" but the IMAP connector requires it — the code returns a `PasswordRequired` error if not provided
- Fixed across all versioned docs (1.5.x through 1.11.x) and unversioned (vNext)

## Changes
- Changed "Optional" to "Required" in the `imap_password` row of the parameter table in all 8 `imap.md` files

## Reference
Verified against spiceai/spiceai at `trunk` — [`connector-imap/src/lib.rs` lines 76-77, 182-197](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-imap/src/lib.rs)