### PR TITLE
fix: Remove non-existent flight_channel_secret from SpiceAI connector docs

### DIFF
--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -21,7 +21,6 @@ The connector authenticates to the Spice.ai Cloud Platform using an API key supp
 | ---------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `spiceai_api_key`      | Spice.ai Cloud Platform API key. Use `${secrets:...}` to resolve from a configured secret store.                |
 | `endpoint`             | Flight endpoint URL. Defaults to the production cluster. Override for VPC / regional endpoints.                 |
-| `flight_channel_secret` | Optional shared secret for Flight gRPC channel authentication, used by internal or on-prem deployments.         |
 
 API keys must be sourced from a [secret store](../../secret-stores/) in production. Rotate keys from the Spice.ai Console and update the secret store without restarting the runtime if the secret store supports live reloads.
 


### PR DESCRIPTION
## Summary
- The `flight_channel_secret` parameter is listed in the SpiceAI Cloud Platform connector deployment guide but does not exist in the connector implementation
- No `ParameterSpec` definition, no usage anywhere in the spiceai/spiceai codebase

## Changes
- Removed the `flight_channel_secret` row from the Authentication & Secrets parameter table in `deployment.md`

## Reference
Verified against spiceai/spiceai at `trunk` — [`dataconnector/spiceai.rs` lines 154-158](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/spiceai.rs) defines only `api_key`, `token`, and `endpoint` as connector parameters