### PR TITLE
fix: Correct ClickHouse type mapping (remove unsupported Date32, fix Decimal)

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -84,12 +84,11 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `UInt64`         | `UInt64`                    |
 | `Float32`        | `Float32`                   |
 | `Float64`        | `Float64`                   |
-| `Decimal`        | `Decimal128` / `Decimal256` |
+| `Decimal`        | `Decimal128`                |
 | `String`         | `Utf8`                      |
 | `FixedString`    | `Utf8`                      |
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
-| `Date32`         | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 


### PR DESCRIPTION
## Summary
- Removed `Date32` row from the type mapping table: the underlying `clickhouse-rs` crate has no `Date32` `SqlType` variant, so this ClickHouse type cannot be read by the connector.
- Changed `Decimal` mapping from `Decimal128 / Decimal256` to `Decimal128`: the code exclusively uses `Decimal128Builder` and `DataType::Decimal128` — there is no `Decimal256` support.

## Changes
- `website/docs/components/data-connectors/clickhouse.md`: Removed `Date32` row; corrected `Decimal` arrow type.

## Reference
Verified against `spiceai/spiceai` at `trunk`:
- `crates/arrow_sql_gen/src/clickhouse.rs` — `map_column_to_data_type` function (lines 513-530) only handles `SqlType::Date`, not `Date32`. Always produces `DataType::Decimal128` for `SqlType::Decimal`.
- `clickhouse-rs` `SqlType` enum has no `Date32` variant.

Versioned docs (`website/versioned_docs/`) do not contain the type mapping table, so only the vNext file is affected.