### PR TITLE
fix: Correct SQLite deployment guide pragma documentation

### DIFF
--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -37,7 +37,17 @@ Raise this when you observe `database is locked` errors under sustained concurre
 
 ### Journal Mode
 
-The SQLite accelerator leans on SQLite's default durability settings. The Spice-level accelerator does not override `journal_mode`, `synchronous`, or `checkpoint` pragmas; for custom durability tuning, set pragmas via a custom connection string or post-startup SQL.
+For file-mode databases, the connection pool automatically sets the following pragmas on each connection:
+
+| Pragma           | Value    | Purpose                                            |
+| ---------------- | -------- | -------------------------------------------------- |
+| `journal_mode`   | `WAL`    | Enables concurrent readers during writes.          |
+| `synchronous`    | `NORMAL` | Balances durability with write performance.        |
+| `cache_size`     | `-20000` | Sets the page cache to ~20 MB.                     |
+| `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
+| `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
+
+These are no-ops for in-memory databases. For custom durability tuning beyond these defaults, set pragmas via a custom connection string or post-startup SQL.
 
 ### Federation Across Files
 
@@ -46,7 +56,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: SQLite's page cache defaults are modest; set `PRAGMA cache_size = -<KB>` via the connection string for read-heavy workloads on large databases.
+- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`). For read-heavy workloads on large databases, increase this via `PRAGMA cache_size = -<KB>` in post-startup SQL.
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics


### PR DESCRIPTION
## Summary
The deployment guide stated that the SQLite accelerator "does not override `journal_mode`, `synchronous`, or `checkpoint` pragmas." This is incorrect — the connection pool automatically sets several pragmas for file-mode databases.

## Changes
- Replaced the incorrect claim with a table documenting the actual pragmas set by the connection pool: `journal_mode=WAL`, `synchronous=NORMAL`, `cache_size=-20000`, `foreign_keys=true`, `temp_store=memory`.
- Updated the Capacity & Sizing section to reflect the real `cache_size` default of ~20 MB instead of referring to "modest defaults."

## Reference
Verified against `datafusion-table-providers` (pinned rev `5790adc`) at `core/src/sql/db_connection_pool/sqlitepool.rs` lines 166-172, where all five pragmas are set unconditionally for file-mode connections.

Only the vNext deployment guide is affected — no versioned copies of this file exist.