### PR TITLE
docs(https): document caching_ttl params and 30s default for caching mode

### DIFF
--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -181,6 +181,40 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `pagination_query_params`      | Optional. Query parameter template for client-driven pagination. Supports `{offset}`, `{limit}`, and `{page}` variables (e.g., `offset={offset}&limit={limit}`). Requires `pagination_page_size`. Mutually exclusive with `pagination_next_pointer` and `pagination_token_param`. |
 | `pagination_page_size`         | Optional. Number of items per page for query-parameter pagination. Must be a positive integer. Expands `{limit}` in `pagination_query_params` and detects the last page (fewer results than `page_size` means done). Requires `pagination_query_params`.                          |
 
+### Caching Mode Parameters
+
+When using [`refresh_mode: caching`](../../features/data-acceleration/refresh-modes/caching), cache freshness is controlled by additional parameters placed under `acceleration.params` — **not** under the top-level `params` block.
+
+| Parameter                            | Description                                                                                                                                                       | Default    |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `caching_ttl`                        | How long cached data is considered fresh. After this period, data becomes stale and a background refresh is triggered. **Defaults to `30s`.**                     | `30s`      |
+| `caching_stale_while_revalidate_ttl` | How long after `caching_ttl` expires to continue serving stale data while a background refresh runs. If omitted, queries wait for fresh data once TTL expires.    | None       |
+| `caching_stale_if_error`             | When set to `enabled`, serves expired cached data if the upstream source returns an error rather than failing the query.                                           | `disabled` |
+
+:::warning[`caching_ttl` defaults to 30 seconds]
+If you set `refresh_check_interval: 15m` but leave `caching_ttl` at its default, cached entries are considered stale after only **30 seconds** — not 15 minutes. Always set `caching_ttl` explicitly to match your intended freshness window.
+:::
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_cache
+    params:
+      file_format: json
+      allowed_request_paths: '/data/**'
+      request_query_filters: enabled
+    acceleration:
+      enabled: true
+      refresh_mode: caching
+      refresh_check_interval: 15m
+      on_zero_results: use_source
+      params:
+        caching_ttl: 15m                        # explicit — default is only 30s
+        caching_stale_while_revalidate_ttl: 5m  # serve stale data while refreshing
+```
+
+See [Caching Refresh Mode](../../features/data-acceleration/refresh-modes/caching) for full TTL semantics, stale-while-revalidate behaviour, and cache persistence options.
+
 ## HTTP Response Headers
 
 When querying HTTP(s) datasets, Spice respects standard HTTP caching headers in responses. The connector supports the following cache-related response headers:


### PR DESCRIPTION
## Summary

Related: spiceai/spiceai#10591.

The HTTP connector docs did not mention `caching_ttl`, `caching_stale_while_revalidate_ttl`, or `caching_stale_if_error` — the parameters that control cache freshness when using `refresh_mode: caching`. Users configuring `refresh_check_interval: 15m` had no indication from the HTTP docs that the default `caching_ttl` of **30 seconds** would cause their cached data to be evicted almost immediately.

## Changes

Adds a **Caching Mode Parameters** subsection to the `params` Configuration section of `https.md` containing:

- A parameters table for `caching_ttl` (30s default), `caching_stale_while_revalidate_ttl`, and `caching_stale_if_error`
- A warning callout highlighting that `caching_ttl` defaults to 30s and should be set explicitly
- A worked example showing correct explicit `caching_ttl` configuration
- A cross-reference to the full Caching Refresh Mode docs

## Test plan

- [ ] Verify the new section renders correctly in the docs site
- [ ] Confirm the cross-reference link to `refresh-modes/caching` resolves correctly