### PR TITLE
fix: Correct github_max_comments_fetched default and cap values

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -273,8 +273,8 @@ datasets:
       # Specifies the types of comments to fetch: 'all', 'review', 'discussion', or 'none'. Defaults to 'none'.
       github_include_comments: none
       # Number of comments to fetch per discussion or review thread.
-      # Defaults to 100, and is capped at 100
-      github_max_comments_fetched: 100
+      # Defaults to 25, and is capped at 75
+      github_max_comments_fetched: 50
 ```
 
 #### Schema
@@ -354,7 +354,7 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       github_include_comments: all
-      github_max_comments_fetched: 100
+      github_max_comments_fetched: 75
     acceleration:
       enabled: true
 ```

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/github.md
@@ -273,8 +273,8 @@ datasets:
       # Specifies the types of comments to fetch: 'all', 'review', 'discussion', or 'none'. Defaults to 'none'.
       github_include_comments: none
       # Number of comments to fetch per discussion or review thread.
-      # Defaults to 100, and is capped at 100
-      github_max_comments_fetched: 100
+      # Defaults to 75, and is capped at 75
+      github_max_comments_fetched: 75
 ```
 
 #### Schema
@@ -354,7 +354,7 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       github_include_comments: all
-      github_max_comments_fetched: 100
+      github_max_comments_fetched: 75
     acceleration:
       enabled: true
 ```


### PR DESCRIPTION
## Summary
- `github_max_comments_fetched` docs claimed default=100 and cap=100 for all versions
- At v1.11.0 the cap was lowered to 75, and at trunk the default was lowered to 25
- Fixed vNext docs: default=25, cap=75
- Fixed v1.11.x docs: default=75, cap=75
- Older versioned docs (1.5.x-1.10.x) are correct at 100 and left unchanged

## Reference
Verified against spiceai/spiceai — `crates/runtime/src/dataconnector/github/mod.rs`:
- trunk: `DEFAULT_MAX_COMMENTS_FETCHED=25` (line 911), `MAX_COMMENTS_FETCHED=75` (line 916)
- v1.11.5: `MAX_COMMENTS_FETCHED=75` (line 785)
- v1.10.4: `MAX_COMMENTS_FETCHED=100`