### PR TITLE
fix: Add missing params to Cayenne catalog connector docs

### DIFF
--- a/website/docs/components/catalogs/cayenne.md
+++ b/website/docs/components/catalogs/cayenne.md
@@ -38,11 +38,14 @@ Use the `include` field to specify which tables to include from the catalog. The
 
 ## `params`
 
-| Parameter Name                | Description                                           | Default              |
-| ----------------------------- | ----------------------------------------------------- | -------------------- |
-| `cayenne_data_dir`            | Local directory for table data files (Vortex format). | Spice data directory |
-| `cayenne_metadata_dir`        | Local directory for Cayenne SQLite metadata.          | Spice data directory |
-| `cayenne_target_file_size_mb` | Target Vortex file size in MB.                        | `128`                |
+| Parameter Name                   | Description                                                                            | Default      |
+| -------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
+| `cayenne_data_dir`               | Local directory for table data files (Vortex format).                                  | Spice data directory |
+| `cayenne_metadata_dir`           | Local directory for Cayenne SQLite metadata.                                           | Spice data directory |
+| `cayenne_target_file_size_mb`    | Target Vortex file size in MB.                                                         | `128`        |
+| `cayenne_footer_cache_mb`        | Size of the in-memory Vortex footer cache in MB for query performance.                 | `128`        |
+| `cayenne_segment_cache_mb`       | Size of the in-memory Vortex segment cache in MB for caching decompressed data.        | `256`        |
+| `cayenne_compression_strategy`   | Compression algorithm for Vortex files. Options: `btrblocks`, `zstd`.                  | `btrblocks`  |
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Three parameters defined in the Cayenne catalog connector code were not documented:
  - `cayenne_footer_cache_mb` (default: `128`) — Vortex footer cache size
  - `cayenne_segment_cache_mb` (default: `256`) — Vortex segment cache size
  - `cayenne_compression_strategy` (default: `btrblocks`) — compression algorithm (`btrblocks` or `zstd`)

## Reference
Verified against spiceai/spiceai at trunk — `crates/runtime/src/catalogconnector/cayenne/mod.rs` lines 45-56