### PR TITLE
fix: Correct DynamoDB time_format default to include milliseconds

### DIFF
--- a/website/versioned_docs/version-1.10.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/dynamodb.md
@@ -259,7 +259,7 @@ This parameter uses Go-style time formatting, which uses a reference time of `Mo
 
 | Format Pattern                  | Example Value                   | Description                                |
 |---------------------------------|---------------------------------|--------------------------------------------|
-| `2006-01-02T15:04:05Z07:00`     | `2024-03-15T14:30:00Z`          | ISO8601 / RFC3339 with timezone (default)  |
+| `2006-01-02T15:04:05.000Z07:00` | `2024-03-15T14:30:00.000Z`      | ISO8601 / RFC3339 with milliseconds and timezone (default) |
 | `2006-01-02T15:04:05.999Z07:00` | `2024-03-15T14:30:00.123-07:00` | ISO8601 with milliseconds and timezone     |
 | `2006-01-02T15:04:05`           | `2024-03-15T14:30:00`           | ISO8601 without timezone (naive timestamp) |
 | `2006-01-02 15:04:05`           | `2024-03-15 14:30:00`           | Date and time with space separator         |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/dynamodb.md
@@ -303,7 +303,7 @@ This parameter uses Go-style time formatting, which uses a reference time of `Mo
 
 | Format Pattern                  | Example Value                   | Description                                |
 | ------------------------------- | ------------------------------- | ------------------------------------------ |
-| `2006-01-02T15:04:05Z07:00`     | `2024-03-15T14:30:00Z`          | ISO8601 / RFC3339 with timezone (default)  |
+| `2006-01-02T15:04:05.000Z07:00` | `2024-03-15T14:30:00.000Z`      | ISO8601 / RFC3339 with milliseconds and timezone (default) |
 | `2006-01-02T15:04:05.999Z07:00` | `2024-03-15T14:30:00.123-07:00` | ISO8601 with milliseconds and timezone     |
 | `2006-01-02T15:04:05`           | `2024-03-15T14:30:00`           | ISO8601 without timezone (naive timestamp) |
 | `2006-01-02 15:04:05`           | `2024-03-15 14:30:00`           | Date and time with space separator         |

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/dynamodb.md
@@ -255,7 +255,7 @@ This parameter uses Go-style time formatting, which uses a reference time of `Mo
 
 | Format Pattern                  | Example Value                   | Description                                |
 |---------------------------------|---------------------------------|--------------------------------------------|
-| `2006-01-02T15:04:05Z07:00`     | `2024-03-15T14:30:00Z`          | ISO8601 / RFC3339 with timezone (default)  |
+| `2006-01-02T15:04:05.000Z07:00` | `2024-03-15T14:30:00.000Z`      | ISO8601 / RFC3339 with milliseconds and timezone (default) |
 | `2006-01-02T15:04:05.999Z07:00` | `2024-03-15T14:30:00.123-07:00` | ISO8601 with milliseconds and timezone     |
 | `2006-01-02T15:04:05`           | `2024-03-15T14:30:00`           | ISO8601 without timezone (naive timestamp) |
 | `2006-01-02 15:04:05`           | `2024-03-15 14:30:00`           | Date and time with space separator         |


### PR DESCRIPTION
## Summary
- Versioned docs (1.9.x, 1.10.x, 1.11.x) showed the default `time_format` as `2006-01-02T15:04:05Z07:00`, missing the `.000` millisecond component
- The correct default matches the code definition: `2006-01-02T15:04:05.000Z07:00`
- The vNext docs already had the correct value; this backfills the fix across all versioned docs

## Changes
- `version-1.11.x/components/data-connectors/dynamodb.md` — corrected default format pattern and example value
- `version-1.10.x/components/data-connectors/dynamodb.md` — corrected default format pattern and example value
- `version-1.9.x/components/data-connectors/dynamodb.md` — corrected default format pattern and example value

## Reference
Verified against `spiceai/spiceai` at trunk — `crates/runtime/src/dataconnector/dynamodb.rs` defines `DEFAULT_TIME_FORMAT = "2006-01-02T15:04:05.000Z07:00"`