### PR TITLE
fix: Correct Delta Lake client_timeout default, GCS param name, and deployment prefixes

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/deployment.md
+++ b/website/docs/components/data-connectors/delta-lake/deployment.md
@@ -19,9 +19,9 @@ The Delta Lake connector reads Delta tables directly from an underlying object s
 
 | Object store            | Auth parameters                                                                                                                                |
 | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| **S3** / S3-compatible  | `aws_region`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_endpoint`. Defaults to the AWS credential chain when unset. |
-| **Azure ADLS**          | `azure_storage_account_name`, `azure_storage_account_key`, `azure_storage_client_id`, `azure_storage_client_secret`, `azure_storage_sas_key`, `azure_storage_endpoint`. |
-| **Google Cloud Storage**| `google_service_account`.                                                                                                                      |
+| **S3** / S3-compatible  | `delta_lake_aws_region`, `delta_lake_aws_access_key_id`, `delta_lake_aws_secret_access_key`, `delta_lake_aws_session_token`, `delta_lake_aws_endpoint`. Defaults to the AWS credential chain when unset. |
+| **Azure ADLS**          | `delta_lake_azure_storage_account_name`, `delta_lake_azure_storage_account_key`, `delta_lake_azure_storage_client_id`, `delta_lake_azure_storage_client_secret`, `delta_lake_azure_storage_sas_key`, `delta_lake_azure_storage_endpoint`. |
+| **Google Cloud Storage**| `delta_lake_google_service_account`.                                                                                                                      |
 | **Local filesystem**    | No auth. Ensure the Spice process has read permission on the Delta table directory.                                                            |
 
 Credentials must be sourced from a [secret store](../../secret-stores/) in production. For AWS deployments, prefer instance-profile or IRSA-based auth (leave `aws_access_key_id` unset).

--- a/website/docs/components/data-connectors/delta-lake/index.md
+++ b/website/docs/components/data-connectors/delta-lake/index.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/duckdb.md
@@ -41,7 +41,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 - `connection_pool_size` (integer, default: `10` or the number of datasets sharing the same DuckDB file, whichever is larger): Controls the maximum number of connections to keep open in the connection pool for concurrent query execution.
 - `on_refresh_recompute_statistics` (string, default: `enabled`): Triggers automatic `ANALYZE` execution after data refreshes. This keeps DuckDB optimizer statistics up-to-date for efficient query plans and performance. Set to `disabled` to turn automatic statistics recomputation off. See [DuckDB ANALYZE statement documentation](https://duckdb.org/docs/stable/sql/statements/analyze).
 - `partition_mode` (string, default: `files`): Controls how partitioned data is stored. Can only be used with `partition_by`. Set to `tables` to store partitions as separate tables within a single DuckDB database, improving resource usage through single shared connection pool for all partitions. Default `files` mode creates separate database files per partition with individual connection pools and generally faster query performance.
-- `duckdb_partitioned_write_flush_threshold` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
+- `duckdb_partitioned_write_flush_threshold_rows` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
 - `optimizer_duckdb_aggregate_pushdown` (string, default: `disabled`): Enables aggregate pushdown optimization to execute supported aggregate queries directly in DuckDB. Set to `enabled` to push down aggregations for improved query performance on supported functions like `count`, `sum`, `avg`, `min`, and `max`. Requires `query_federation` to be `disabled`.
 
 Refer to the [datasets configuration reference](../../reference/spicepod/datasets#acceleration) for additional supported fields.
@@ -90,7 +90,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -97,7 +97,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -155,7 +155,7 @@ Use the [secret replacement syntax](/docs/components/secret-stores) to reference
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/duckdb.md
@@ -41,7 +41,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 - `connection_pool_size` (integer, default: `10` or the number of datasets sharing the same DuckDB file, whichever is larger): Controls the maximum number of connections to keep open in the connection pool for concurrent query execution.
 - `on_refresh_recompute_statistics` (string, default: `enabled`): Triggers automatic `ANALYZE` execution after data refreshes. This keeps DuckDB optimizer statistics up-to-date for efficient query plans and performance. Set to `disabled` to turn automatic statistics recomputation off. See [DuckDB ANALYZE statement documentation](https://duckdb.org/docs/stable/sql/statements/analyze).
 - `partition_mode` (string, default: `files`): Controls how partitioned data is stored. Can only be used with `partition_by`. Set to `tables` to store partitions as separate tables within a single DuckDB database, improving resource usage through single shared connection pool for all partitions. Default `files` mode creates separate database files per partition with individual connection pools and generally faster query performance.
-- `duckdb_partitioned_write_flush_threshold` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
+- `duckdb_partitioned_write_flush_threshold_rows` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
 - `on_refresh_sort_columns` (string, default: none): Sorts data after each refresh by the specified columns, improving DuckDB [zone map](https://duckdb.org/2025/05/14/sorting-for-fast-selective-queries) (min/max) statistics for query pruning and significantly faster lookup queries. Format: `column1 ASC, column2 DESC` or `column1, column2` (defaults to ASC). Specified columns must exist in the dataset schema, and sort direction must be `ASC` or `DESC`.
 - `optimizer_duckdb_aggregate_pushdown` (string, default: `disabled`): Enables aggregate pushdown optimization to execute supported aggregate queries directly in DuckDB. Set to `enabled` to push down aggregations for improved query performance on supported functions like `count`, `sum`, `avg`, `min`, and `max`. Requires `query_federation` to be `disabled`.
 
@@ -92,7 +92,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -97,7 +97,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -155,7 +155,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.5.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.5.x/components/data-accelerators/duckdb.md
@@ -85,7 +85,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -96,7 +96,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -154,7 +154,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.6.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.6.x/components/data-accelerators/duckdb.md
@@ -85,7 +85,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -96,7 +96,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -154,7 +154,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.7.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.7.x/components/data-accelerators/duckdb.md
@@ -85,7 +85,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -96,7 +96,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -154,7 +154,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.8.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.8.x/components/data-accelerators/duckdb.md
@@ -85,7 +85,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -96,7 +96,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -154,7 +154,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.9.x/components/data-accelerators/duckdb.md
+++ b/website/versioned_docs/version-1.9.x/components/data-accelerators/duckdb.md
@@ -41,7 +41,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 - `connection_pool_size` (integer, default: `10` or the number of datasets sharing the same DuckDB file, whichever is larger): Controls the maximum number of connections to keep open in the connection pool for concurrent query execution.
 - `on_refresh_recompute_statistics` (string, default: `enabled`): Triggers automatic `ANALYZE` execution after data refreshes. This keeps DuckDB optimizer statistics up-to-date for efficient query plans and performance. Set to `disabled` to turn automatic statistics recomputation off. See [DuckDB ANALYZE statement documentation](https://duckdb.org/docs/stable/sql/statements/analyze).
 - `partition_mode` (string, default: `files`): Controls how partitioned data is stored. Can only be used with `partition_by`. Set to `tables` to store partitions as separate tables within a single DuckDB database, improving resource usage through single shared connection pool for all partitions. Default `files` mode creates separate database files per partition with individual connection pools and generally faster query performance.
-- `duckdb_partitioned_write_flush_threshold` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
+- `duckdb_partitioned_write_flush_threshold_rows` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
 
 Refer to the [datasets configuration reference](../../reference/spicepod/datasets.md#acceleration) for additional supported fields.
 
@@ -89,7 +89,7 @@ datasets:
         duckdb_memory_limit: '4GB'
 ```
 
-Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duck_memory_limit` so ensure adequate memory is provisioned.
+Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
@@ -59,7 +59,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 | Parameter Name   | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| `client_timeout` | Optional. Specifies timeout for object store operations. Default value is `30s`. E.g. `client_timeout: 60s` |
+| `client_timeout` | Optional. Specifies timeout for object store operations. No default; uses the underlying HTTP client timeout when not set. E.g. `client_timeout: 60s` |
 
 ## Delta Lake object store parameters
 
@@ -96,7 +96,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `delta_lake_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -154,7 +154,7 @@ Use the [secret replacement syntax](../secret-stores/index.md) to reference a se
 
 ```yaml
 params:
-  delta_lake_google_service_account_path: /path/to/service-account.json
+  delta_lake_google_service_account: /path/to/service-account.json
 ```
 
 ## Types


### PR DESCRIPTION
## Summary
- Docs claimed `client_timeout` defaults to `30s` — no default exists in code; only set when explicitly provided
- Versioned docs used wrong GCS parameter name `delta_lake_google_service_account_path` instead of `delta_lake_google_service_account`
- Deployment guide auth table omitted the required `delta_lake_` prefix on all parameters

## Changes
- Removed false `30s` default claim from `client_timeout` description across all versions (current docs + 1.5.x through 1.11.x)
- Fixed GCS parameter name in versioned docs: table entry `google_service_account` → `delta_lake_google_service_account`, and example `delta_lake_google_service_account_path` → `delta_lake_google_service_account`
- Added `delta_lake_` prefix to deployment guide auth table parameters for S3, Azure ADLS, and GCS

## Reference
Verified against spiceai/spiceai at trunk:
- `crates/data-connectors/connector-delta-lake/src/lib.rs` (ParameterSpec definitions)
- `crates/runtime-object-store/src/builder.rs` line 282 (`client_timeout` only set when present, no `.default()` call)