### PR TITLE
fix: Add terminating semicolons to standalone SQL examples (fixes #444)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -207,7 +207,7 @@ When a query includes a `WHERE` clause, Spice Cayenne evaluates whether each seg
 For a table with segments containing timestamp ranges `[2024-01-01, 2024-01-15]`, `[2024-01-16, 2024-01-31]`, `[2024-02-01, 2024-02-15]`, a query:
 
 ```sql
-SELECT * FROM events WHERE timestamp > '2024-01-20'
+SELECT * FROM events WHERE timestamp > '2024-01-20';
 ```
 
 Prunes the first segment (max < 2024-01-20) and reads only the second and third segments.

--- a/website/docs/components/data-connectors/sharepoint.md
+++ b/website/docs/components/data-connectors/sharepoint.md
@@ -20,7 +20,7 @@ datasets:
 #### Example
 
 ```sql
-SELECT * FROM important_documents limit 1
+SELECT * FROM important_documents limit 1;
 ```
 
 Returns

--- a/website/docs/features/data-acceleration/partitioning.md
+++ b/website/docs/features/data-acceleration/partitioning.md
@@ -28,7 +28,7 @@ This example uses a `bucket` user-defined function (UDF) to hash the `PULocation
 This enables partition pruning for queries that filter on the column referenced in the `partition_by` expression:
 
 ```sql
-SELECT * FROM taxi_trips WHERE PULocationID IN (1, 2, 3, 4, 5)
+SELECT * FROM taxi_trips WHERE PULocationID IN (1, 2, 3, 4, 5);
 ```
 
 This will result in a scan plan that only reads from the partitions that contain the values from the `IN` list.

--- a/website/docs/features/query-federation/parameterized-queries.mdx
+++ b/website/docs/features/query-federation/parameterized-queries.mdx
@@ -31,7 +31,7 @@ Instead of embedding values directly in SQL strings, parameterized queries use p
 Spice uses positional placeholders following the PostgreSQL convention:
 
 ```sql
-SELECT * FROM users WHERE id = $1 AND status = $2
+SELECT * FROM users WHERE id = $1 AND status = $2;
 ```
 
 Parameters are bound in order: `$1` receives the first parameter, `$2` the second, and so on.

--- a/website/docs/features/query-federation/url-tables.md
+++ b/website/docs/features/query-federation/url-tables.md
@@ -40,7 +40,7 @@ runtime:
 Query a single file by specifying its full URL:
 
 ```sql
-SELECT * FROM 's3://my-bucket/data/sales.parquet' LIMIT 10
+SELECT * FROM 's3://my-bucket/data/sales.parquet' LIMIT 10;
 ```
 
 ### Directory or Prefix
@@ -49,10 +49,10 @@ Query all files under a directory or prefix by including a trailing slash:
 
 ```sql
 -- All files in a directory
-SELECT * FROM 's3://my-bucket/data/'
+SELECT * FROM 's3://my-bucket/data/';
 
 -- All files in a bucket
-SELECT * FROM 's3://my-bucket/'
+SELECT * FROM 's3://my-bucket/';
 ```
 
 ### Glob Patterns
@@ -61,10 +61,10 @@ Use glob patterns to match specific files:
 
 ```sql
 -- All parquet files in a directory
-SELECT * FROM 's3://my-bucket/data/*.parquet'
+SELECT * FROM 's3://my-bucket/data/*.parquet';
 
 -- Files matching a pattern across subdirectories
-SELECT * FROM 's3://my-bucket/year=2024/month=*/data.parquet'
+SELECT * FROM 's3://my-bucket/year=2024/month=*/data.parquet';
 ```
 
 ### Hive-Style Partitions
@@ -74,7 +74,7 @@ Hive-style partitions are automatically inferred from the path structure, enabli
 ```sql
 -- If data is stored at s3://bucket/data/year=2024/month=01/file.parquet
 -- the year and month columns are available for filtering
-SELECT * FROM 's3://my-bucket/data/' WHERE year = '2024' AND month = '01'
+SELECT * FROM 's3://my-bucket/data/' WHERE year = '2024' AND month = '01';
 ```
 
 ## Authentication
@@ -102,7 +102,7 @@ export AZURE_STORAGE_ACCOUNT=mystorageaccount
 Alternatively, include the account name in the URL:
 
 ```sql
-SELECT * FROM 'abfss://container@mystorageaccount.dfs.core.windows.net/path/file.parquet'
+SELECT * FROM 'abfss://container@mystorageaccount.dfs.core.windows.net/path/file.parquet';
 ```
 
 Additional authentication options:
@@ -125,7 +125,7 @@ runtime:
 -- Query a public S3 dataset
 SELECT VendorID, passenger_count, trip_distance
 FROM 's3://spiceai-public-datasets/taxi_small_samples/taxi_sample.parquet'
-LIMIT 5
+LIMIT 5;
 ```
 
 ### Azure Blob Storage Query
@@ -148,7 +148,7 @@ Or include the account in the URL:
 ```sql
 SELECT *
 FROM 'abfss://mycontainer@mystorageaccount.dfs.core.windows.net/data/'
-LIMIT 10
+LIMIT 10;
 ```
 
 ### Cross-Source Query
@@ -172,7 +172,7 @@ datasets:
 -- Join a registered dataset with an ad-hoc S3 query
 SELECT o.order_id, o.customer_id, s.product_name
 FROM orders o
-JOIN 's3://my-bucket/products.parquet' s ON o.product_id = s.id
+JOIN 's3://my-bucket/products.parquet' s ON o.product_id = s.id;
 ```
 
 ## Considerations

--- a/website/docs/features/search/index.md
+++ b/website/docs/features/search/index.md
@@ -49,7 +49,7 @@ SELECT id, extra_column, score
 FROM vector_search(my_table, 'search query')
 WHERE date_published > '2021-01-01'
 ORDER BY score DESC
-LIMIT 5
+LIMIT 5;
 ```
 
 For complete SQL UDTF specifications, see [Vector-Based Search SQL UDTF](search/vector-search#sql-udtf).
@@ -72,7 +72,7 @@ Multi-vector search operates on columns that store many vectors per row, such as
 SELECT product_id, name, score
 FROM vector_search(products, ['hiking', 'waterproof'], tags)
 ORDER BY score DESC
-LIMIT 10
+LIMIT 10;
 ```
 
 ### Full-Text Search
@@ -94,7 +94,7 @@ SELECT id, extra_column, score
 FROM text_search(my_table, 'search terms')
 WHERE date_published > '2021-01-01'
 ORDER BY score DESC
-LIMIT 5
+LIMIT 5;
 ```
 
 For detailed SQL UDTF instructions, see [Full-Text Search SQL UDTF](search/full-text#searching-with-sql).
@@ -123,7 +123,7 @@ FROM rrf(
     join_key => 'id'  -- join key for optimal performance
 )
 ORDER BY fused_score DESC
-LIMIT 5
+LIMIT 5;
 ```
 
 For complete RRF syntax and parameters, see [Search SQL Reference](../reference/sql/search#reciprocal-rank-fusion-rrf).

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -297,7 +297,7 @@ SELECT
   "p_comment"
 FROM
   spiceai_sandbox.tpch.part
-LIMIT 1
+LIMIT 1;
 ```
 
 If the monitoring query fails a warning is emitted in the logs, an error is propagated to the `task_history` table and the `dataset_unavailable_time_ms` metric is incremented for the failing dataset.

--- a/website/docs/reference/sql/select.md
+++ b/website/docs/reference/sql/select.md
@@ -78,14 +78,14 @@ SELECT list can be an expression or wildcards.
 Example:
 
 ```sql
-SELECT a, b, a + b FROM table
+SELECT a, b, a + b FROM table;
 ```
 
 The `DISTINCT` quantifier can be added to make the query return all distinct rows.
 By default `ALL` will be used, which returns all the rows.
 
 ```sql
-SELECT DISTINCT person, age FROM employees
+SELECT DISTINCT person, age FROM employees;
 ```
 
 ### FROM clause
@@ -95,7 +95,7 @@ The `FROM` clause is used to specify which table to select data from.
 Example:
 
 ```sql
-SELECT t.a FROM table AS t
+SELECT t.a FROM table AS t;
 ```
 
 ### WHERE clause
@@ -105,7 +105,7 @@ The `WHERE` clause is used define the conditions to filter the query results.
 Example:
 
 ```sql
-SELECT a FROM table WHERE a > 10
+SELECT a FROM table WHERE a > 10;
 ```
 
 ### JOIN clause
@@ -218,7 +218,7 @@ included, the query with a `GROUP BY` clause is the same as `SELECT DISTINCT`.
 Example:
 
 ```sql
-SELECT a, b, MAX(c) FROM table GROUP BY a, b
+SELECT a, b, MAX(c) FROM table GROUP BY a, b;
 ```
 
 Some aggregation functions accept optional ordering requirement, such as `ARRAY_AGG`. If a requirement is given,
@@ -227,7 +227,7 @@ aggregation is calculated in the order of the requirement.
 Example:
 
 ```sql
-SELECT a, b, ARRAY_AGG(c, ORDER BY d) FROM table GROUP BY a, b
+SELECT a, b, ARRAY_AGG(c, ORDER BY d) FROM table GROUP BY a, b;
 ```
 
 #### `GROUP BY ALL`
@@ -237,7 +237,7 @@ Use GROUP BY ALL to group by every column in the SELECT list that isn’t inside
 Example:
 
 ```sql
-SELECT a, b, MAX(c) FROM table GROUP BY ALL
+SELECT a, b, MAX(c) FROM table GROUP BY ALL;
 ```
 
 ### HAVING clause
@@ -247,7 +247,7 @@ The `HAVING` clause can be used with `GROUP BY` to eliminate groups that don't s
 Example:
 
 ```sql
-SELECT a, b, MAX(c) FROM table GROUP BY a, b HAVING MAX(c) > 10
+SELECT a, b, MAX(c) FROM table GROUP BY a, b HAVING MAX(c) > 10;
 ```
 
 ### QUALIFY clause
@@ -286,7 +286,7 @@ SELECT
     a,
     b,
     c
-FROM table2
+FROM table2;
 ```
 
 ### ORDER BY clause
@@ -318,7 +318,7 @@ Example:
 
 ```sql
 SELECT age, person FROM table
-LIMIT 10
+LIMIT 10;
 ```
 
 ### EXCLUDE, EXCEPT, REPLACE, and ILIKE clauses

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -245,7 +245,7 @@ Spice supports generating `EXPLAIN` plans, which can be used to debug SQL that m
 Generate an explain plan by adding the `EXPLAIN` keyword before the query:
 
 ```sql
-explain select * from taxi_trips
+explain select * from taxi_trips;
 ```
 
 ```console


### PR DESCRIPTION
## Summary

Fixes #444

Adds terminating `;` to single-statement SQL code blocks where the example shows an executable query without a terminator. Restores style consistency with surrounding examples that already terminate every statement.

## Scope

The original issue was filed against the broader docs body. A targeted scan turned up 35 `sql`-fenced blocks lacking a final `;`. This PR fixes the **executable single-statement examples** (28 blocks across 9 files) and **leaves the rest as-is by design**:

- **Syntax templates / function signatures** with BNF placeholders (`[ ... ]`, `{ ... | ... }`, `<placeholder>`) in `reference/sql/dml.md`, `reference/sql/subqueries.md`, `reference/sql/search.md` — these are syntax docs, not statements, so a `;` is incorrect.
- **Query + result blocks** where the SQL inside is already terminated and the block continues with rendered tabular output (e.g., `select.md` JOIN examples) — already correct.
- **NRQL** examples mistagged as `sql` in `monitoring/new-relic/index.md` — NRQL doesn't use `;`. Filed separately if a re-tag is wanted.

## Files changed

- `components/data-accelerators/cayenne/index.md`
- `components/data-connectors/sharepoint.md`
- `features/data-acceleration/partitioning.md`
- `features/query-federation/parameterized-queries.mdx`
- `features/query-federation/url-tables.md` (8 blocks)
- `features/search/index.md` (4 blocks)
- `reference/spicepod/datasets.md`
- `reference/sql/select.md` (10 blocks)
- `troubleshooting/index.md`

## Versioning

Style consistency is applied to the **unversioned** docs only. Versioned snapshots (`website/versioned_docs/version-*/`) are intentionally left untouched — they reflect what was published at each release and this is not an accuracy bug.

## Test plan

- [x] `cd website && npm run build` passes locally (no link or render regressions)
- [x] Re-scan after edits: only intentionally-skipped syntax templates and NRQL block remain
- [ ] CI green