### PR TITLE
fix: Add missing Basic Auth params to GraphQL deployment guide

### DIFF
--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -15,12 +15,14 @@ Production operating guide for the GraphQL data connector covering authenticatio
 
 ## Authentication & Secrets
 
-Authentication is endpoint-specific. The connector supports arbitrary HTTP headers via `graphql_auth_header`:
+Authentication is endpoint-specific. The connector supports bearer tokens, custom headers via `graphql_auth_header`, and HTTP Basic Auth:
 
 | Parameter                  | Description                                                                  |
 | -------------------------- | ---------------------------------------------------------------------------- |
 | `graphql_auth_header`      | Custom authorization header name. The value of `graphql_auth_token` is sent as this header's value. |
 | `graphql_auth_token`       | Bearer token for GraphQL requests. Typically `"${secrets:api_token}"`.        |
+| `graphql_auth_user`        | Username for HTTP Basic Auth.                                                 |
+| `graphql_auth_pass`        | Password for HTTP Basic Auth.                                                 |
 | `graphql_query`            | The GraphQL query to execute.                                                 |
 | `json_pointer`             | RFC-6901 JSON pointer to the row collection inside the response (e.g. `/data/repository/issues/nodes`). |
 


### PR DESCRIPTION
## Summary
- The GraphQL deployment guide's parameter table was missing `graphql_auth_user` and `graphql_auth_pass` parameters
- These parameters are defined in the connector's `ParameterSpec` (lib.rs lines 60-65) and documented in the main GraphQL connector index.md, but were omitted from the deployment guide

## Changes
- Added `graphql_auth_user` and `graphql_auth_pass` rows to the deployment guide parameter table
- Updated the intro text to mention Basic Auth support

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/data-connectors/connector-graphql/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-graphql/src/lib.rs) lines 60-65