### PR TITLE
fix: Correct Snowflake keypair auth parameter requirements

### DIFF
--- a/website/docs/components/data-connectors/snowflake.md
+++ b/website/docs/components/data-connectors/snowflake.md
@@ -50,9 +50,9 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_auth_type`              | Optional, specifies the authentication type: `snowflake` (default, password-based) or `keypair`                 |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key`            | Optional, specifies the Snowflake private key content as a string (for key-pair auth)                           |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key file (for key-pair auth)                                  |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase (for encrypted keys)                                   |
+| `snowflake_private_key`            | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key_path`. Specifies the private key content as a string. |
+| `snowflake_private_key_path`       | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key`. Specifies the path to the private key file. |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
@@ -50,9 +50,9 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_auth_type`              | Optional, specifies the authentication type: `snowflake` (default, password-based) or `keypair`                 |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key`            | Optional, specifies the Snowflake private key content as a string (for key-pair auth)                           |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key file (for key-pair auth)                                  |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase (for encrypted keys)                                   |
+| `snowflake_private_key`            | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key_path`. Specifies the private key content as a string. |
+| `snowflake_private_key_path`       | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key`. Specifies the path to the private key file. |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
@@ -49,8 +49,8 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
 | `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key_path`       | Optional, specifies the path to Snowflake private key                                                           |
-| `snowflake_private_key_passphrase` | Optional, specifies the Snowflake private key passphrase                                                        |
+| `snowflake_private_key_path`       | Required when `snowflake_auth_type` is `keypair`. Specifies the path to the private key file.                   |
+| `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
 


### PR DESCRIPTION
## Summary
- `snowflake_private_key` and `snowflake_private_key_path` were marked as "Optional" but one of them is **required** when `snowflake_auth_type` is `keypair`
- The two parameters are **mutually exclusive** — specifying both causes a `MutuallyExclusivePrivateKeyParams` error
- `snowflake_private_key_passphrase` was marked as "Optional" but is **required** when the private key file is encrypted (PKCS#8 encrypted format)

## Changes
- Updated parameter descriptions across vNext and all versioned docs (v1.5.x through v1.11.x) to correctly state the conditional requirements
- vNext and v1.11.x: updated all three parameters (`snowflake_private_key`, `snowflake_private_key_path`, `snowflake_private_key_passphrase`)
- v1.5.x through v1.10.x: updated `snowflake_private_key_path` and `snowflake_private_key_passphrase` (these versions don't have `snowflake_private_key`)

## Reference
Verified against spiceai/spiceai at `trunk` — [`crates/db_connection_pool/src/snowflakepool.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/db_connection_pool/src/snowflakepool.rs) lines 237-267