### PR TITLE
fix: Correct graphql_query description and example in versioned docs

### DIFF
--- a/website/versioned_docs/version-1.10.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/graphql.md
@@ -50,13 +50,13 @@ The GraphQL data connector can be configured by providing the following `params`
 | `graphql_auth_token` | The authentication token to use to connect to the GraphQL server. Uses bearer authentication.                                                                                   |
 | `graphql_auth_user`  | The username to use for basic auth. E.g. `graphql_auth_user: my_user`                                                                                                           |
 | `graphql_auth_pass`  | The password to use for basic auth. E.g. `graphql_auth_pass: ${secrets:my_graphql_auth_pass}`                                                                                   |
-| `graphql_query`      | The username to use for basic auth. See [examples](#examples) for a sample GraphQL query                                                                                        |
+| `graphql_query`      | The GraphQL query to execute. See [examples](#examples) for a sample GraphQL query                                                                                        |
 | `json_pointer`       | The [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) into the response body. When `graphql_query` is [paginated](#pagination), the `json_pointer` can be inferred. |
 
 #### GraphQL Query Example
 
 ```yaml
-query: |
+graphql_query: |
   {
     some {
       nodes {


### PR DESCRIPTION
## Summary
- `graphql_query` parameter description was a copy-paste error from `graphql_auth_user`, saying "The username to use for basic auth" instead of describing the GraphQL query parameter
- The GraphQL Query Example used unprefixed `query: |` instead of the required `graphql_query: |` (component parameters require the `graphql_` prefix)

Both issues were present in all versioned docs (1.5.x through 1.11.x). The vNext docs already had the correct values.

## Changes
- Fixed `graphql_query` description to "The GraphQL query to execute" across 7 versioned doc files
- Fixed example to use `graphql_query: |` instead of `query: |` across 7 versioned doc files

## Reference
Verified against spiceai/spiceai — `connector-graphql/src/lib.rs` line 67: `ParameterSpec::component("query").required()` (component type requires `graphql_` prefix)