### PR TITLE
fix: Add databricks_ prefix to google_service_account in versioned docs

### DIFF
--- a/website/versioned_docs/version-1.10.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/databricks.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/databricks.md
@@ -144,7 +144,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 
 | Parameter Name           | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 ## Examples
 
@@ -218,7 +218,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
     mode: delta_lake
     databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
     databricks_token: ${secrets:my_token}
-    databricks_google_service_account_path: /path/to/service-account.json
+    databricks_google_service_account: /path/to/service-account.json
 ```
 
 ## Types


### PR DESCRIPTION
## Summary
- The GCS parameter table listed `google_service_account` without the required `databricks_` prefix — since it is a `ParameterSpec::component()` param, users must use `databricks_google_service_account`
- The GCS YAML examples in v1.5.x through v1.10.x used `databricks_google_service_account_path` (a nonexistent parameter name with `_path` suffix)

Both issues would cause silent configuration failures for Databricks GCS users.

## Changes
- Added `databricks_` prefix to `google_service_account` in parameter tables across 7 versioned doc files
- Fixed GCS examples from `databricks_google_service_account_path` to `databricks_google_service_account` in 6 versioned doc files

## Reference
Verified against spiceai/spiceai at v1.11.5 — `crates/runtime/src/dataconnector/databricks.rs` line 463: `ParameterSpec::component("google_service_account")` with prefix "databricks"