### PR TITLE
fix: Remove false read-only claim from Dremio deployment guide

### DIFF
--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -56,7 +56,6 @@ Dremio queries participate in [task history](../../../reference/task_history) vi
 
 ## Known Limitations
 
-- **Read-only**: The connector is read-only; writes to Dremio are not supported.
 - **Temporary tables**: Dremio temporary objects are not visible to Spice; use Dremio views for shared logic.
 - **Reflection-aware routing**: The connector does not explicitly hint Dremio reflections; they are still applied by the coordinator transparently.
 


### PR DESCRIPTION
## Summary
The Dremio deployment guide's Known Limitations section stated "The connector is read-only; writes to Dremio are not supported." This is incorrect — the connector implements `read_write_provider` via FlightSQL `ReadWrite::table_provider`.

## Changes
- Removed the false "read-only" limitation from the deployment guide

## Reference
Verified against spiceai/spiceai trunk — `crates/data-connectors/connector-dremio/src/lib.rs` lines 231-242: `read_write_provider` implementation