### PR TITLE
fix: Correct Arrow hash_index YAML indentation in accelerator docs

### DIFF
--- a/website/docs/components/data-accelerators/arrow/index.md
+++ b/website/docs/components/data-accelerators/arrow/index.md
@@ -47,8 +47,8 @@ datasets:
     acceleration:
       engine: arrow
       primary_key: order_id
-    params:
-      hash_index: enabled
+      params:
+        hash_index: enabled
 ```
 
 See [Hash Index](../../features/data-acceleration/hash-index) for configuration details, supported data types, and performance characteristics.

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/arrow.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/arrow.md
@@ -47,8 +47,8 @@ datasets:
     acceleration:
       engine: arrow
       primary_key: order_id
-    params:
-      hash_index: enabled
+      params:
+        hash_index: enabled
 ```
 
 See [Hash Index](../../features/data-acceleration/hash-index) for configuration details, supported data types, and performance characteristics.


### PR DESCRIPTION
## Summary
The Arrow accelerator `hash_index` YAML example showed `params:` at the dataset level (sibling to `acceleration:`), but the code reads `hash_index` from `acceleration.params`. Users following the example would place the parameter at the wrong YAML level, causing it to be silently ignored.

## Changes
- Moved `params: hash_index: enabled` to be nested under `acceleration:` in both vNext and v1.11.x Arrow accelerator docs

## Reference
Verified against spiceai/spiceai trunk — `crates/runtime/src/dataaccelerator/arrow.rs` line 103: `acceleration.params.get("hash_index")`