### PR TITLE
docs: Document searchable tool registry mode and tool_embedding_model

### DIFF
--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -36,15 +36,19 @@ models:
   - name: full-runtime
     from: openai:gpt-4o
     params:
-      tools: auto # Use all default tools
+      tools: auto # Automatically choose direct or registry-based discovery
 ```
 
 #### Available tool groups
 
-| Name         | Description                                                                                  |
-| ------------ | -------------------------------------------------------------------------------------------- |
-| `auto`       | All default tools (see above table)                                                          |
-| `memory`     | Memory tools for storing and retrieving information across conversations.                    |
-| [`MCP`][mcp] | Tools provided from an MCP server. Can be run within Spice, or connected to over HTTP(s) SSE |
+| Name              | Description                                                                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `auto`            | Automatically choose between direct tools and searchable registry discovery based on the number of tools and embedding model availability.           |
+| `all`             | All built-in and Spicepod-configured tools, provided directly to the LLM.                                                                           |
+| `search_registry` | Use searchable tool registry discovery via `tool_search` and `tool_invoke` meta-tools. Requires an embedding model (see `tool_embedding_model`).    |
+| `memory`          | Memory tools for storing and retrieving information across conversations.                                                                            |
+| [`MCP`][mcp]      | Tools provided from an MCP server. Can be run within Spice, or connected to over HTTP(s) SSE                                                        |
 
 [mcp]: tools/mcp
+
+For details on `auto`, `all`, and `search_registry` tool modes, see [Language Model Tools](../features/large-language-models/tools#tool-modes).

--- a/website/docs/features/large-language-models/tools.md
+++ b/website/docs/features/large-language-models/tools.md
@@ -15,6 +15,17 @@ Spice provides tools that help LLMs interact with the runtime. To specify these 
 
 For a list of available tools, or how to define additional tools, see [Tool Components](../../components/tools).
 
+### Tool Modes
+
+The `tools` parameter on a model controls how tools are provided to the LLM:
+
+| Value | Description |
+| --- | --- |
+| `auto` | Automatically choose between direct tools and searchable registry discovery. When the number of available tools exceeds 20 and an embedding model is available, `auto` switches to registry-based discovery; otherwise it uses direct tools. |
+| `all` | Provide all built-in and Spicepod-configured tools directly to the LLM. |
+| `search_registry` | Use searchable registry discovery. The LLM receives `tool_search` and `tool_invoke` meta-tools instead of individual tool definitions. Requires an embedding model (see `tool_embedding_model`). |
+| `<tool1>, <tool2>, ...` | Provide only the named tools directly. |
+
 ### Example: Specifying Tools for a Model
 
 ```yaml
@@ -25,16 +36,55 @@ models:
       tools: list_datasets, sql, table_schema
 ```
 
-### Example: Specifying tools via a Tool Group
+### Example: Using all default tools directly
 
 ```yaml
-- name: full-runtime
-  from: openai:gpt-4o
-  params:
-    tools: auto # Use all default tools
+models:
+  - name: full-runtime
+    from: openai:gpt-4o
+    params:
+      tools: all
+```
+
+### Example: Using auto mode (default)
+
+```yaml
+models:
+  - name: full-runtime
+    from: openai:gpt-4o
+    params:
+      tools: auto
 ```
 
 For details on tool groups, see [Tool Components](../../components/tools#tool-groups).
+
+### Searchable Tool Registry
+
+When many tools are available, passing all tool definitions directly to the LLM can consume a large portion of the context window and reduce response quality. The searchable tool registry addresses this by replacing individual tool definitions with two meta-tools:
+
+- **`tool_search`** — Searches the registry for tools relevant to a query, returning the top matches with descriptions and parameter schemas.
+- **`tool_invoke`** — Invokes a tool returned by `tool_search` by name with the provided arguments.
+
+The registry uses hybrid search (full-text, keyword, parameter schema, and vector similarity) to find the most relevant tools for each query.
+
+#### Configuring `tool_embedding_model`
+
+When using `tools: search_registry`, an embedding model must be available. You can specify which embedding model to use with the `tool_embedding_model` parameter. If only one embedding model is configured in the Spicepod, it is used automatically.
+
+```yaml
+embeddings:
+  - name: tool_embeddings
+    from: openai:text-embedding-3-small
+
+models:
+  - name: my-model
+    from: openai:gpt-4o
+    params:
+      tools: search_registry
+      tool_embedding_model: tool_embeddings
+```
+
+When using `tools: auto`, the registry is used opportunistically — if an embedding model is available and the number of tools exceeds 20, `auto` switches to registry-based discovery. If no embedding model is configured, `auto` falls back to providing tools directly.
 
 ### Example: Specifying tools and tool groups
 

--- a/website/docs/reference/spicepod/models.md
+++ b/website/docs/reference/spicepod/models.md
@@ -115,6 +115,14 @@ Example uses include:
 - Enabling language models to perform actions against Spice (e.g. making SQL queries), via language model tool use, see [runtime tools](../../features/large-language-models/tools).
 - Invoking language models directly from SQL queries using the [`ai()` function](../sql/scalar_functions#ai-and-embed).
 
+#### `params.tools`
+
+Which tools should be made available to the model. Supported values: `auto`, `all`, `search_registry`, or a comma-separated list of specific tool names. See [Tool Modes](../../features/large-language-models/tools#tool-modes).
+
+#### `params.tool_embedding_model`
+
+The name of an embedding model (defined in the `embeddings` section) to use for searchable tool discovery. Required when `tools: search_registry` is set. When `tools: auto` is used, this model enables registry-based discovery if the tool count exceeds the auto-search threshold (20 tools). If only one embedding model is configured, it is used automatically.
+
 ### `datasets`
 
 Optional. A list of [dataset names](./datasets#name) that this model should be applied to. For ML models, this preselects the dataset to use for inference.


### PR DESCRIPTION
## Summary
- Document new `tools: search_registry` and `tools: all` model parameter values for LLM tool discovery
- Document `tool_embedding_model` model parameter for configuring the embedding model used by searchable tool registry
- Update tool groups table to include `all` and `search_registry`
- Add "Tool Modes" section and "Searchable Tool Registry" section to LLM tools feature page

## Source PRs
- spiceai/spiceai#10647 — Add searchable registry mode for LLM tools

## Changes
- `website/docs/features/large-language-models/tools.md` — Added tool modes table, searchable tool registry section with configuration examples
- `website/docs/components/tools/index.md` — Updated tool groups table with `all` and `search_registry` entries
- `website/docs/reference/spicepod/models.md` — Added `params.tools` and `params.tool_embedding_model` parameter documentation

## Test plan
- [ ] Links are valid
- [ ] Version references are correct