### PR TITLE
docs: Document shared HTTP rate control parameters for connectors

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -77,6 +77,8 @@ With GitHub App Installation authentication, the connector's functionality depen
 
 ## Advanced Configuration
 
+### Rate Limiting
+
 When using multiple GitHub datasets sharing the same GitHub token or GitHub app credentials, it is possible to exceed GitHub's primary and secondary rate limits. To mitigate this, use the `github_max_concurrent_connections` runtime parameter. This connections limit applies per GitHub token and per GitHub app installation, following GitHub's rate limit policy.
 
 Example Configuration:
@@ -103,6 +105,18 @@ datasets:
       enabled: true
 # ... other configuration ...
 ```
+
+The GitHub connector also supports the shared HTTP rate control parameters for per-dataset concurrency and request rate limits:
+
+| Parameter Name              | Description                                                                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `requests_per_second_limit` | Maximum number of HTTP requests per second to the same upstream origin. Overrides `runtime.params.http_requests_per_second_limit`. If both are unset, no per-second rate limit is applied.    |
+| `requests_per_minute_limit` | Maximum number of HTTP requests per minute to the same upstream origin. Overrides `runtime.params.http_requests_per_minute_limit`. If both are unset, no per-minute rate limit is applied.    |
+| `rate_control_jitter_min`   | Minimum random delay added before HTTP requests when rate control is active. Defaults to `5ms` when a request-rate limit is configured.                                                      |
+| `rate_control_jitter_max`   | Maximum random delay added before HTTP requests when rate control is active. Defaults to `10ms` when a request-rate limit is configured.                                                     |
+
+Multiple datasets targeting the same GitHub endpoint share the same rate controller.
 
 ## Filter Push Down
 

--- a/website/docs/components/data-connectors/graphql/index.md
+++ b/website/docs/components/data-connectors/graphql/index.md
@@ -130,6 +130,20 @@ datasets:
 | not set | not set | set | HTTP Basic Auth |
 | not set | not set | not set | No auth |
 
+### Rate Control Parameters
+
+The GraphQL connector supports shared HTTP rate control to limit concurrency and request rate per upstream origin. These parameters can be set per-dataset (in `params`) or globally (in `runtime.params`). Dataset-level settings override the global defaults.
+
+| Parameter Name              | Description                                                                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `requests_per_second_limit` | Maximum number of HTTP requests per second to the same upstream origin. Overrides `runtime.params.http_requests_per_second_limit`. If both are unset, no per-second rate limit is applied.    |
+| `requests_per_minute_limit` | Maximum number of HTTP requests per minute to the same upstream origin. Overrides `runtime.params.http_requests_per_minute_limit`. If both are unset, no per-minute rate limit is applied.    |
+| `rate_control_jitter_min`   | Minimum random delay added before HTTP requests when rate control is active. Accepts durations such as `5ms` or `0ms`. Defaults to `5ms` when a request-rate limit is configured.            |
+| `rate_control_jitter_max`   | Maximum random delay added before HTTP requests when rate control is active. Accepts durations such as `10ms` or `0ms`. Defaults to `10ms` when a request-rate limit is configured.          |
+
+Multiple datasets targeting the same GraphQL endpoint share the same rate controller.
+
 ## Pagination
 
 The GraphQL Data Connector supports automatic pagination of the response for queries using [cursor pagination](https://graphql.org/learn/pagination/).

--- a/website/docs/components/data-connectors/https.md
+++ b/website/docs/components/data-connectors/https.md
@@ -171,6 +171,35 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `auth_scopes`              | Optional. Space-separated OAuth2 scopes to request when refreshing (e.g. `read:data offline_access`). Omit to inherit the scopes bound to the refresh token.                                                                                                                                                                                                                                                                              |
 | `auth_client_auth`         | Optional. How client credentials are sent to the token endpoint: `basic` (HTTP Basic header, default per RFC 6749 §2.3.1) or `body` (`client_id`/`client_secret` in the form body). Default: `basic`.                                                                                                                                                                                                                                     |
 
+#### Rate Control Parameters
+
+HTTP-based connectors share a rate control system that limits concurrency and request rate per upstream origin. These parameters can be set per-dataset (in `params`) or globally (in `runtime.params`). Dataset-level settings override the global defaults.
+
+| Parameter Name              | Description                                                                                                                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `requests_per_second_limit` | Maximum number of HTTP requests per second to the same upstream origin. Overrides `runtime.params.http_requests_per_second_limit`. If both are unset, no per-second rate limit is applied.    |
+| `requests_per_minute_limit` | Maximum number of HTTP requests per minute to the same upstream origin. Overrides `runtime.params.http_requests_per_minute_limit`. If both are unset, no per-minute rate limit is applied.    |
+| `rate_control_jitter_min`   | Minimum random delay added before HTTP requests when rate control is active. Accepts durations such as `5ms` or `0ms`. Defaults to `5ms` when a request-rate limit is configured.            |
+| `rate_control_jitter_max`   | Maximum random delay added before HTTP requests when rate control is active. Accepts durations such as `10ms` or `0ms`. Defaults to `10ms` when a request-rate limit is configured.          |
+
+Multiple datasets targeting the same origin share the same rate controller, ensuring the limits apply across all datasets for that origin.
+
+```yaml
+runtime:
+  params:
+    http_max_concurrent_requests: 10
+    http_requests_per_second_limit: 5
+
+datasets:
+  - from: https://api.example.com/v1
+    name: api_data
+    params:
+      file_format: json
+      allowed_request_paths: '/data/**'
+      max_concurrent_requests: 3        # Override: this dataset uses at most 3 concurrent requests
+```
+
 #### Pagination Parameters
 
 | Parameter Name                 | Description                                                                                                                                                                                                                                                                       |

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -125,6 +125,26 @@ Use `sql` for the lowest latency with identical queries that do not include dyna
 
 Use `xxh3` (the default) for its superior speed in most scenarios. Use `ahash`, `xxh64` or `xxh128` for reduced collision probability when caching a large number of queries. Use `blake3` when cryptographic security is required. Use `siphash` when protection against hash flooding attacks is a priority.
 
+## `runtime.params`
+
+Optional. Global key-value parameters for the runtime. HTTP-based connectors (HTTP/HTTPS, GraphQL, GitHub) support the following rate control defaults:
+
+| Parameter Name                    | Description                                                                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http_max_concurrent_requests`    | Default maximum concurrent HTTP requests per upstream origin. Can be overridden per-dataset with `max_concurrent_requests`.                                    |
+| `http_requests_per_second_limit`  | Default maximum HTTP requests per second per upstream origin. Can be overridden per-dataset with `requests_per_second_limit`.                                  |
+| `http_requests_per_minute_limit`  | Default maximum HTTP requests per minute per upstream origin. Can be overridden per-dataset with `requests_per_minute_limit`.                                  |
+| `http_rate_control_jitter_min`    | Default minimum random delay before HTTP requests when rate control is active. Defaults to `5ms` when a rate limit is configured. Can be overridden per-dataset. |
+| `http_rate_control_jitter_max`    | Default maximum random delay before HTTP requests when rate control is active. Defaults to `10ms` when a rate limit is configured. Can be overridden per-dataset. |
+
+```yaml
+runtime:
+  params:
+    http_max_concurrent_requests: 10
+    http_requests_per_second_limit: 5
+    http_requests_per_minute_limit: 200
+```
+
 ## `runtime.shutdown_timeout`
 
 Controls how long Spice waits for connections to be gracefully drained and for components to shut down cleanly during runtime termination. Defaults to 30 seconds.


### PR DESCRIPTION
## Summary
- Document the shared HTTP rate control system for HTTP, GraphQL, and GitHub connectors
- Add per-dataset parameters: `max_concurrent_requests`, `requests_per_second_limit`, `requests_per_minute_limit`, `rate_control_jitter_min`, `rate_control_jitter_max`
- Add global runtime parameters: `http_max_concurrent_requests`, `http_requests_per_second_limit`, `http_requests_per_minute_limit`, `http_rate_control_jitter_min`, `http_rate_control_jitter_max`

## Source PRs
- spiceai/spiceai#10648 — Add shared HTTP rate control for connectors

## Changes
- `website/docs/components/data-connectors/https.md` — Added rate control parameters table
- `website/docs/components/data-connectors/graphql/index.md` — Added rate control parameters section
- `website/docs/components/data-connectors/github/index.md` — Added rate control parameters alongside existing `github_max_concurrent_connections`
- `website/docs/reference/spicepod/runtime.md` — Added `runtime.params` section with HTTP rate control defaults

## Test plan
- [ ] Links are valid
- [ ] Version references are correct