### PR TITLE
docs: Add Functions feature and Spicepod reference

### DIFF
--- a/website/docs/features/functions/index.md
+++ b/website/docs/features/functions/index.md
@@ -1,7 +1,7 @@
 ---
-title: 'User-Defined Functions'
-sidebar_label: 'User-Defined Functions'
-description: 'Define custom scalar SQL functions inline (SQL tier) or by calling remote HTTP services (Remote tier), automatically exposed as SQL UDFs and LLM tools.'
+title: 'Functions'
+sidebar_label: 'Functions'
+description: 'Define custom scalar SQL functions inline (SQL tier) or by calling remote HTTP services (Remote tier), automatically exposed as SQL functions and LLM tools.'
 sidebar_position: 11
 pagination_prev: null
 pagination_next: null
@@ -12,17 +12,17 @@ tags:
   - tools
 ---
 
-User-defined functions (UDFs) extend Spice's SQL engine with custom logic declared in your Spicepod. UDFs are scalar functions that can be:
+Functions extend Spice's SQL engine with custom scalar logic declared in your Spicepod. Each function can be:
 
 - **Called directly in SQL** like any built-in function (`SELECT my_fn(col) FROM ...`).
 - **Surfaced to LLMs as tools** for tool-calling workflows.
 - **Listed via SQL** with the `list_udfs()` UDTF and via the HTTP API at `GET /v1/functions`.
 
-UDFs are declared in the top-level `functions:` block of `spicepod.yaml`. The full YAML reference is on the [Functions Spicepod reference](../../reference/spicepod/functions.md) page.
+Functions are declared in the top-level `functions:` block of `spicepod.yaml`. The full YAML reference is on the [Functions Spicepod reference](../../reference/spicepod/functions.md) page.
 
 ## Quickstart
 
-Enable user-defined functions and declare a SQL function:
+Enable functions and declare a SQL function:
 
 ```yaml
 runtime:
@@ -47,11 +47,11 @@ Call it from SQL:
 SELECT double_it(21); -- 42
 ```
 
-The function is automatically registered both as a SQL UDF and as a callable LLM tool (set `as_tool: false` to keep it SQL-only).
+The function is automatically registered both as a SQL function and as a callable LLM tool (set `as_tool: false` to keep it SQL-only).
 
 ## Execution Tiers
 
-Spice supports two tiers for user-defined functions, selected by the `from:` field:
+Spice supports two tiers for functions, selected by the `from:` field:
 
 | Tier   | `from:` scheme        | Where it runs                       | When to use                                                                  |
 | ------ | --------------------- | ----------------------------------- | ---------------------------------------------------------------------------- |
@@ -229,7 +229,7 @@ The corresponding Arrow display forms (e.g. `Int64`, `List(Int64)`, `Decimal128(
 SELECT * FROM list_udfs() WHERE source = 'user';
 ```
 
-The `list_udfs()` UDTF returns every UDF registered in the runtime, including built-ins. Filter by `source = 'user'` to see only user-defined functions:
+The `list_udfs()` UDTF returns every function registered in the runtime, including built-ins. Filter by `source = 'user'` to see only declared functions:
 
 | Column        | Description                                                           |
 | ------------- | --------------------------------------------------------------------- |

--- a/website/docs/features/index.md
+++ b/website/docs/features/index.md
@@ -29,9 +29,9 @@ Spice provides a set of features for building data-driven applications and AI ag
 
 [Search](./search/index.md) supports three methods: vector search (semantic similarity using embeddings), full-text search (keyword matching with BM25 scoring), and hybrid search (combining both with Reciprocal Rank Fusion). All search methods are accessible through SQL UDTFs like `vector_search()` and `text_search()`.
 
-### User-Defined Functions
+### Functions
 
-[User-Defined Functions](./user-defined-functions/index.md) extend SQL with custom scalar functions declared in a Spicepod. Inline SQL bodies run in-process and can use any DataFusion built-in; remote `http://` / `https://` endpoints batch row inputs over JSON for delegating logic to ML models, internal services, or custom code. Every function is automatically callable from SQL and (by default) surfaced as an LLM tool.
+[Functions](./functions/index.md) extend SQL with custom scalar functions declared in a Spicepod. Inline SQL bodies run in-process and can use any DataFusion built-in; remote `http://` / `https://` endpoints batch row inputs over JSON for delegating logic to ML models, internal services, or custom code. Every function is automatically callable from SQL and (by default) surfaced as an LLM tool.
 
 ### Monitoring and Observability
 

--- a/website/docs/features/index.md
+++ b/website/docs/features/index.md
@@ -29,6 +29,10 @@ Spice provides a set of features for building data-driven applications and AI ag
 
 [Search](./search/index.md) supports three methods: vector search (semantic similarity using embeddings), full-text search (keyword matching with BM25 scoring), and hybrid search (combining both with Reciprocal Rank Fusion). All search methods are accessible through SQL UDTFs like `vector_search()` and `text_search()`.
 
+### User-Defined Functions
+
+[User-Defined Functions](./user-defined-functions/index.md) extend SQL with custom scalar functions declared in a Spicepod. Inline SQL bodies run in-process and can use any DataFusion built-in; remote `http://` / `https://` endpoints batch row inputs over JSON for delegating logic to ML models, internal services, or custom code. Every function is automatically callable from SQL and (by default) surfaced as an LLM tool.
+
 ### Monitoring and Observability
 
 [Observability](./observability/index.md) exposes Prometheus-compatible metrics, OpenTelemetry metric export, and distributed tracing with Zipkin. Integrations are available for Datadog, Grafana, and other monitoring platforms.

--- a/website/docs/features/user-defined-functions/index.md
+++ b/website/docs/features/user-defined-functions/index.md
@@ -1,0 +1,358 @@
+---
+title: 'User-Defined Functions'
+sidebar_label: 'User-Defined Functions'
+description: 'Define custom scalar SQL functions inline (SQL tier) or by calling remote HTTP services (Remote tier), automatically exposed as SQL UDFs and LLM tools.'
+sidebar_position: 11
+pagination_prev: null
+pagination_next: null
+tags:
+  - functions
+  - udf
+  - sql
+  - tools
+---
+
+User-defined functions (UDFs) extend Spice's SQL engine with custom logic declared in your Spicepod. UDFs are scalar functions that can be:
+
+- **Called directly in SQL** like any built-in function (`SELECT my_fn(col) FROM ...`).
+- **Surfaced to LLMs as tools** for tool-calling workflows.
+- **Listed via SQL** with the `list_udfs()` UDTF and via the HTTP API at `GET /v1/functions`.
+
+UDFs are declared in the top-level `functions:` block of `spicepod.yaml`. The full YAML reference is on the [Functions Spicepod reference](../../reference/spicepod/functions.md) page.
+
+## Quickstart
+
+Enable user-defined functions and declare a SQL function:
+
+```yaml
+runtime:
+  functions:
+    enabled: true # Required — registration is off by default
+
+functions:
+  - name: double_it
+    from: sql
+    description: Double a 64-bit integer.
+    volatility: immutable
+    signature:
+      args:
+        - { name: x, type: int64 }
+      returns: int64
+    body: 'x * 2'
+```
+
+Call it from SQL:
+
+```sql
+SELECT double_it(21); -- 42
+```
+
+The function is automatically registered both as a SQL UDF and as a callable LLM tool (set `as_tool: false` to keep it SQL-only).
+
+## Execution Tiers
+
+Spice supports two tiers for user-defined functions, selected by the `from:` field:
+
+| Tier   | `from:` scheme        | Where it runs                       | When to use                                                                  |
+| ------ | --------------------- | ----------------------------------- | ---------------------------------------------------------------------------- |
+| SQL    | `sql`                 | In-process, in the DataFusion engine | Pure expressions, math, string transforms, business logic over column values. |
+| Remote | `http://`, `https://` | A remote HTTP + JSON service        | Custom logic in another language, ML inference, calls to internal APIs.       |
+
+### SQL tier (`from: sql`)
+
+The function `body` is a single SQL expression evaluated against the function's arguments. It can call any DataFusion built-in function (math, string, datetime, JSON, regex, etc.).
+
+```yaml
+functions:
+  - name: haversine_km
+    from: sql
+    description: Haversine great-circle distance in kilometres.
+    volatility: immutable
+    signature:
+      args:
+        - { name: lat1, type: float64 }
+        - { name: lon1, type: float64 }
+        - { name: lat2, type: float64 }
+        - { name: lon2, type: float64 }
+      returns: float64
+    body: |
+      6371 * acos(
+        cos(radians(lat1)) * cos(radians(lat2)) *
+        cos(radians(lon2) - radians(lon1)) +
+        sin(radians(lat1)) * sin(radians(lat2))
+      )
+```
+
+```sql
+SELECT haversine_km(37.7749, -122.4194, 40.7128, -74.0060) AS km;
+-- 4129.085647...
+```
+
+#### External SQL files with `body_ref`
+
+For non-trivial SQL, keep the body in its own file with proper editor support:
+
+```yaml
+functions:
+  - name: shipping_class
+    from: sql
+    signature:
+      args:
+        - { name: weight_g, type: int64 }
+        - { name: country, type: utf8 }
+      returns: utf8
+    body_ref: ./functions/shipping_class.sql
+```
+
+`body_ref` is read from the local filesystem at registration time. For portable spicepods loaded from object storage, use inline `body:` instead.
+
+### Remote tier (`from: http://...`)
+
+The runtime POSTs row batches to the configured endpoint and reads the resulting values. Use this tier to delegate logic to a service in another language, an ML model server, or an internal API.
+
+```yaml
+functions:
+  - name: classify_intent
+    from: http://classifier.internal/v1/classify
+    description: Classify a user prompt via a remote service.
+    volatility: volatile
+    signature:
+      args:
+        - { name: prompt, type: utf8 }
+      returns: utf8
+    params:
+      timeout: 5s
+      batch_size: 256
+      batch_concurrency: 4
+      auth_bearer: ${secrets:CLASSIFIER_TOKEN}
+```
+
+```sql
+SELECT user_id, classify_intent(latest_message) AS intent
+FROM conversations
+WHERE date = today();
+```
+
+#### Wire contract
+
+The runtime sends a single HTTP `POST` per batch with `Content-Type: application/json`:
+
+**Request body:**
+
+```json
+{
+  "rows": [
+    { "prompt": "How do I cancel my subscription?" },
+    { "prompt": "What's the weather in Paris?" }
+  ]
+}
+```
+
+**Response body** (HTTP `200`):
+
+```json
+{
+  "values": ["billing", "smalltalk"]
+}
+```
+
+`values.len()` must equal `rows.len()` — a mismatch is treated as an error. Each row contains every declared argument under its argument `name`. Output values are decoded into the declared `returns` Arrow type using Arrow's JSON reader.
+
+#### Remote `params:` knobs
+
+| Parameter           | Default | Description                                                                                            |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `timeout`           | `30s`   | Per-call timeout. Accepts plain integer seconds or `Ns` / `Nms` suffix strings.                        |
+| `batch_size`        | `1024`  | Maximum rows per HTTP request. Capped at `100 000`.                                                    |
+| `batch_concurrency` | `4`     | Maximum in-flight HTTP batches per function invocation. Capped at `64`.                                |
+| `auth_bearer`       | unset   | When set, the runtime adds `Authorization: Bearer <value>` to each request. Use `${secrets:...}`.       |
+
+Calls to remote functions require the runtime to be configured with [`runtime.auth.api-key`](../../reference/spicepod/runtime#runtimeauth) — they execute under the read-write API key context.
+
+## Volatility
+
+Volatility tells the optimizer how the function behaves across calls. Pick the strongest level that's actually true — the default (`volatile`) is the safest but disables constant folding, query-level caching, and pushdown.
+
+| Volatility  | Meaning                                                                | Optimizer behavior                                                     |
+| ----------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `immutable` | Same inputs always yield the same output. E.g. `abs`, `upper`.         | May be constant-folded at plan time and cached aggressively.            |
+| `stable`    | Stable within a single query but may change across queries. E.g. `now()`. | Cached per query, not constant-folded.                                  |
+| `volatile`  | (default) Unpredictable on every call. E.g. `random()`.                | Never cached, never constant-folded, never pushed across executors.      |
+
+Set volatility explicitly on every function — it strongly affects performance:
+
+```yaml
+functions:
+  - name: shout
+    from: sql
+    volatility: immutable # opts into constant folding & caching
+    signature:
+      args: [{ name: s, type: utf8 }]
+      returns: utf8
+    body: 'upper(s)'
+```
+
+## Types
+
+Argument and return types use Arrow logical types. Both Spicepod aliases and Arrow display forms are accepted.
+
+**Scalar aliases:**
+
+| Spicepod alias               | Arrow type                |
+| ---------------------------- | ------------------------- |
+| `int8` / `int16` / `int32` (or `int`) / `int64`     | `Int8` … `Int64`           |
+| `uint8` / `uint16` / `uint32` / `uint64`           | `UInt8` … `UInt64`         |
+| `float32` (or `float`) / `float64` (or `double`)   | `Float32`, `Float64`       |
+| `utf8` (or `string`) / `large_utf8`                | `Utf8`, `LargeUtf8`        |
+| `boolean` (or `bool`)                              | `Boolean`                  |
+| `binary` / `large_binary`                          | `Binary`, `LargeBinary`    |
+| `date32` / `date64`                                | `Date32`, `Date64`         |
+
+**Complex types:**
+
+| Spicepod alias               | Arrow type                                      |
+| ---------------------------- | ----------------------------------------------- |
+| `list<int64>`                | `List(Int64)`                                   |
+| `large_list<utf8>`           | `LargeList(Utf8)`                               |
+| `struct<name:utf8, age:int32>` | `Struct(name: Utf8, age: Int32)`             |
+| `decimal(38, 10)`            | `Decimal128(38, 10)`                            |
+| `decimal256(76, 20)`         | `Decimal256(76, 20)`                            |
+| `timestamp(us, utc)`         | `Timestamp(Microsecond, Some("UTC"))`           |
+
+The corresponding Arrow display forms (e.g. `Int64`, `List(Int64)`, `Decimal128(38, 10)`) are also accepted.
+
+## Discovering registered functions
+
+### From SQL
+
+```sql
+SELECT * FROM list_udfs() WHERE source = 'user';
+```
+
+The `list_udfs()` UDTF returns every UDF registered in the runtime, including built-ins. Filter by `source = 'user'` to see only user-defined functions:
+
+| Column        | Description                                                           |
+| ------------- | --------------------------------------------------------------------- |
+| `name`        | Function identifier.                                                  |
+| `source`      | `user` for declared functions, `builtin` for Spice/DataFusion ones.    |
+| `kind`        | `scalar` for user functions, `NULL` for built-ins.                    |
+| `volatility`  | `immutable` / `stable` / `volatile`.                                  |
+| `from`        | `sql`, `http://...`, or `https://...`.                                |
+| `description` | The declared description, if any.                                     |
+
+### From the HTTP API
+
+```bash
+curl http://localhost:8090/v1/functions
+```
+
+Returns a JSON array of user functions only (built-ins are excluded). Each entry includes `name`, `kind`, `volatility`, `from`, and `description`. The endpoint returns an empty array when `runtime.functions.enabled` is `false`.
+
+## Functions as LLM tools
+
+Every declared function is automatically callable from LLMs as a tool with the same name and description. This lets a model reason in natural language and then invoke `haversine_km(...)` or `classify_intent(...)` directly.
+
+To keep a function SQL-only:
+
+```yaml
+functions:
+  - name: internal_hash
+    from: sql
+    as_tool: false # Hidden from the tool registry; still callable from SQL
+    signature:
+      args: [{ name: x, type: int64 }]
+      returns: int64
+    body: 'x * 2654435761'
+```
+
+The reverse — a `tools:` entry that's also callable from SQL — is supported via `as_sql: true` on a tool. See [Tools Spicepod reference](../../reference/spicepod/tools).
+
+## Examples
+
+### String normalization (SQL tier, immutable)
+
+```yaml
+functions:
+  - name: shout
+    from: sql
+    volatility: immutable
+    signature:
+      args: [{ name: s, type: utf8 }]
+      returns: utf8
+    body: 'upper(s)'
+```
+
+```sql
+SELECT shout('hello world'); -- "HELLO WORLD"
+```
+
+### Geospatial helper (SQL tier, immutable)
+
+See `haversine_km` above. Because it is `immutable`, repeated calls with the same arguments are constant-folded.
+
+### Remote ML classifier (Remote tier, volatile)
+
+```yaml
+functions:
+  - name: classify_intent
+    from: https://classifier.internal/v1/classify
+    volatility: volatile
+    signature:
+      args: [{ name: prompt, type: utf8 }]
+      returns: utf8
+    params:
+      timeout: 5s
+      batch_size: 256
+      auth_bearer: ${secrets:CLASSIFIER_TOKEN}
+```
+
+```sql
+SELECT id, classify_intent(message) AS intent
+FROM support_tickets
+WHERE created_at >= now() - INTERVAL '1' DAY;
+```
+
+The runtime batches up to 256 rows per HTTP call and issues up to four batches in parallel.
+
+### Returning a struct (SQL tier)
+
+```yaml
+functions:
+  - name: split_full_name
+    from: sql
+    volatility: immutable
+    signature:
+      args: [{ name: full, type: utf8 }]
+      returns: struct<first:utf8, last:utf8>
+    body: |
+      named_struct(
+        'first', split_part(full, ' ', 1),
+        'last',  split_part(full, ' ', 2)
+      )
+```
+
+### List-typed arguments (SQL tier)
+
+```yaml
+functions:
+  - name: total_quantity
+    from: sql
+    volatility: immutable
+    signature:
+      args: [{ name: quantities, type: list<int64> }]
+      returns: int64
+    body: 'array_sum(quantities)'
+```
+
+## Troubleshooting
+
+| Symptom                                                            | Likely cause                                                                                  | Resolution                                                                                                  |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Function appears defined but `SELECT my_fn(...)` errors with "function not found" | `runtime.functions.enabled` is not set to `true`.                                              | Add `runtime.functions.enabled: true` to the spicepod.                                                       |
+| `the from scheme '...' is unsupported`                             | `from:` is not `sql`, `http://`, or `https://`.                                                | Use one of the supported schemes.                                                                            |
+| `body: and body_ref: are mutually exclusive`                       | Both fields are set on a SQL function.                                                         | Provide exactly one.                                                                                         |
+| `failed to parse function body as a SQL expression`                 | The body is not a single valid DataFusion SQL expression.                                      | The body must be one expression (no statements), referencing arguments by name.                              |
+| `body expression evaluates to type ... not coercible to declared return type ...` | The body's computed type doesn't match `returns:`.                                              | Adjust the body, declare a wider numeric `returns:`, or cast inside the body.                                  |
+| Remote function returns `expected N values, got M`                  | The HTTP service returned the wrong number of `values`.                                        | The service must return exactly one value per input row, in input order.                                     |
+| Remote function calls fail with auth errors                         | `runtime.auth.api-key` is not configured, or `auth_bearer` is missing/invalid.                 | Configure runtime auth and supply a valid bearer token via `${secrets:...}`.                                |
+| Function registered but not surfaced as a tool                      | `as_tool: false` is set, or the function is `enabled: false`.                                  | Remove `as_tool: false`; ensure `enabled: true` (default).                                                   |

--- a/website/docs/reference/spicepod/functions.md
+++ b/website/docs/reference/spicepod/functions.md
@@ -4,9 +4,9 @@ sidebar_label: 'Functions'
 description: 'User-defined functions YAML reference'
 ---
 
-User-defined functions extend Spice's SQL engine with custom scalar functions. Each entry in the top-level `functions:` block is registered as a callable SQL UDF and (by default) as an LLM tool.
+Functions extend Spice's SQL engine with custom scalar logic. Each entry in the top-level `functions:` block is registered as a callable SQL function and (by default) as an LLM tool.
 
-For an overview, examples, and execution-tier details, see [User-Defined Functions](../../features/user-defined-functions).
+For an overview, examples, and execution-tier details, see [Functions](../../features/functions).
 
 :::warning[Registration is off by default]
 The `functions:` section is only honored when [`runtime.functions.enabled`](./runtime#runtimefunctions) is set to `true`.
@@ -14,7 +14,7 @@ The `functions:` section is only honored when [`runtime.functions.enabled`](./ru
 
 ## `functions`
 
-The `functions:` section in your configuration declares one or more user-defined scalar functions.
+The `functions:` section in your configuration declares one or more scalar functions.
 
 Example:
 
@@ -46,7 +46,7 @@ Source URI selecting the execution tier:
 - `sql` — Inline SQL body executed in-process.
 - `http://...` / `https://...` — Remote endpoint invoked over HTTP + JSON.
 
-Other schemes are rejected at startup. See [Execution Tiers](../../features/user-defined-functions#execution-tiers).
+Other schemes are rejected at startup. See [Execution Tiers](../../features/functions#execution-tiers).
 
 ### `enabled`
 
@@ -70,7 +70,7 @@ Optional. Defaults to `volatile`. Controls how the optimizer treats the function
 | `stable`    | Stable within a single query but may change across queries. Cached per query.                |
 | `volatile`  | (default) Unpredictable on every call. Never cached.                                         |
 
-Choose the strongest level that's actually true. See [Volatility](../../features/user-defined-functions#volatility).
+Choose the strongest level that's actually true. See [Volatility](../../features/functions#volatility).
 
 ### `signature`
 
@@ -91,7 +91,7 @@ Optional. Positional argument list. Empty for niladic functions.
 Each entry has:
 
 - `name` — Argument name. Used inside SQL `body` expressions and as the JSON key for remote tier requests.
-- `type` — Arrow type. Accepts Spicepod aliases (`int64`, `utf8`, `list<int64>`, `decimal(38,10)`, `timestamp(us, utc)`) and Arrow display forms (`Int64`, `List(Int64)`, etc.). See [Types](../../features/user-defined-functions#types).
+- `type` — Arrow type. Accepts Spicepod aliases (`int64`, `utf8`, `list<int64>`, `decimal(38,10)`, `timestamp(us, utc)`) and Arrow display forms (`Int64`, `List(Int64)`, etc.). See [Types](../../features/functions#types).
 
 #### `signature.returns`
 
@@ -183,4 +183,4 @@ After startup, registered functions can be inspected:
 - **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';`
 - **From the HTTP API** — `GET /v1/functions` returns a JSON array of user functions.
 
-See [Discovering registered functions](../../features/user-defined-functions#discovering-registered-functions).
+See [Discovering registered functions](../../features/functions#discovering-registered-functions).

--- a/website/docs/reference/spicepod/functions.md
+++ b/website/docs/reference/spicepod/functions.md
@@ -1,0 +1,186 @@
+---
+title: 'Functions (User-Defined Functions)'
+sidebar_label: 'Functions'
+description: 'User-defined functions YAML reference'
+---
+
+User-defined functions extend Spice's SQL engine with custom scalar functions. Each entry in the top-level `functions:` block is registered as a callable SQL UDF and (by default) as an LLM tool.
+
+For an overview, examples, and execution-tier details, see [User-Defined Functions](../../features/user-defined-functions).
+
+:::warning[Registration is off by default]
+The `functions:` section is only honored when [`runtime.functions.enabled`](./runtime#runtimefunctions) is set to `true`.
+:::
+
+## `functions`
+
+The `functions:` section in your configuration declares one or more user-defined scalar functions.
+
+Example:
+
+```yaml
+runtime:
+  functions:
+    enabled: true
+
+functions:
+  - name: double_it
+    from: sql
+    description: Double a 64-bit integer.
+    volatility: immutable
+    signature:
+      args:
+        - { name: x, type: int64 }
+      returns: int64
+    body: 'x * 2'
+```
+
+### `name`
+
+A unique identifier for the function. The name is used to register the UDF in the SQL session and as the tool name when surfaced to LLMs.
+
+### `from`
+
+Source URI selecting the execution tier:
+
+- `sql` — Inline SQL body executed in-process.
+- `http://...` / `https://...` — Remote endpoint invoked over HTTP + JSON.
+
+Other schemes are rejected at startup. See [Execution Tiers](../../features/user-defined-functions#execution-tiers).
+
+### `enabled`
+
+Optional. Defaults to `true`. Set to `false` to keep the declaration in the spicepod without registering the function — useful for staged rollouts. Disabled functions are also hidden from `list_udfs()` and `GET /v1/functions`.
+
+### `description`
+
+Optional. Free-form description surfaced in `list_udfs()`, `GET /v1/functions`, and the LLM tool registry.
+
+### `kind`
+
+Optional. Defaults to `scalar`. Only scalar functions are supported in the current beta.
+
+### `volatility`
+
+Optional. Defaults to `volatile`. Controls how the optimizer treats the function across calls.
+
+| Value       | Description                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------ |
+| `immutable` | Same inputs always yield the same output. May be constant-folded and cached.                |
+| `stable`    | Stable within a single query but may change across queries. Cached per query.                |
+| `volatile`  | (default) Unpredictable on every call. Never cached.                                         |
+
+Choose the strongest level that's actually true. See [Volatility](../../features/user-defined-functions#volatility).
+
+### `signature`
+
+Required. Typed argument list and return type.
+
+```yaml
+signature:
+  args:
+    - { name: lat1, type: float64 }
+    - { name: lon1, type: float64 }
+  returns: float64
+```
+
+#### `signature.args`
+
+Optional. Positional argument list. Empty for niladic functions.
+
+Each entry has:
+
+- `name` — Argument name. Used inside SQL `body` expressions and as the JSON key for remote tier requests.
+- `type` — Arrow type. Accepts Spicepod aliases (`int64`, `utf8`, `list<int64>`, `decimal(38,10)`, `timestamp(us, utc)`) and Arrow display forms (`Int64`, `List(Int64)`, etc.). See [Types](../../features/user-defined-functions#types).
+
+#### `signature.returns`
+
+Required for scalar functions. The Arrow type of the function's output, in the same format as argument types.
+
+### `body`
+
+Inline SQL expression body. Required when `from: sql` (unless `body_ref` is set instead). Must be a single SQL expression (not a statement) referencing the function's arguments by name.
+
+```yaml
+body: |
+  6371 * acos(
+    cos(radians(lat1)) * cos(radians(lat2)) *
+    cos(radians(lon2) - radians(lon1)) +
+    sin(radians(lat1)) * sin(radians(lat2))
+  )
+```
+
+The body can call any DataFusion built-in scalar function (math, string, datetime, JSON, regex, etc.).
+
+Mutually exclusive with `body_ref`. Must not be set for non-SQL `from:` schemes.
+
+### `body_ref`
+
+Path to a local filesystem file whose contents are the SQL body. Resolved relative to the runtime's current working directory at registration time.
+
+```yaml
+body_ref: ./functions/shipping_class.sql
+```
+
+`body_ref` is not read from object stores when a spicepod is loaded remotely — use inline `body:` for portable remote spicepods.
+
+Mutually exclusive with `body`.
+
+### `params`
+
+Optional. Tier-specific parameters. Supports `${secrets:KEY}` and `${env:KEY}` interpolation at registration time.
+
+For the **Remote tier** (`from: http://...` / `https://...`):
+
+| Parameter           | Default | Description                                                                          |
+| ------------------- | ------- | ------------------------------------------------------------------------------------ |
+| `timeout`           | `30s`   | Per-call timeout. Plain integer seconds or `Ns` / `Nms` strings.                     |
+| `batch_size`        | `1024`  | Maximum rows per HTTP request. Capped at `100 000`.                                  |
+| `batch_concurrency` | `4`     | Maximum in-flight HTTP batches per invocation. Capped at `64`.                       |
+| `auth_bearer`       | unset   | When set, adds `Authorization: Bearer <value>` to each request. Use `${secrets:...}`. |
+
+The SQL tier does not currently use `params`.
+
+### `metadata`
+
+Optional. Free-form key/value pairs surfaced alongside the function definition. Useful for tagging, ownership, or custom metadata consumers.
+
+```yaml
+metadata:
+  owner: data-platform
+  jira: DATA-1234
+```
+
+### `as_tool`
+
+Optional. Defaults to `true`. When `true`, the function is registered as an LLM tool with the same name and description and becomes callable from chat completions, `POST /v1/tools/<name>`, and the `/v1/tools` listing.
+
+Set to `false` to keep the function SQL-only:
+
+```yaml
+functions:
+  - name: internal_hash
+    from: sql
+    as_tool: false
+    signature:
+      args: [{ name: x, type: int64 }]
+      returns: int64
+    body: 'x * 2654435761'
+```
+
+### `dependsOn`
+
+Optional. Names of other Spicepod components that must be loaded before this function (e.g. a dataset the function queries internally).
+
+### `metrics`
+
+Optional. Per-function metrics configuration. See [Component Metrics](../../features/observability/component_metrics).
+
+## Discovering registered functions
+
+After startup, registered functions can be inspected:
+
+- **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';`
+- **From the HTTP API** — `GET /v1/functions` returns a JSON array of user functions.
+
+See [Discovering registered functions](../../features/user-defined-functions#discovering-registered-functions).

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -147,7 +147,7 @@ runtime:
 
 ## `runtime.functions`
 
-Controls whether [user-defined functions](../../features/user-defined-functions) declared in the top-level `functions:` section (and `tools:` entries with `as_sql: true`) are registered with the SQL engine. Defaults to disabled.
+Controls whether [functions](../../features/functions) declared in the top-level `functions:` section (and `tools:` entries with `as_sql: true`) are registered with the SQL engine. Defaults to disabled.
 
 ```yaml
 runtime:

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -145,6 +145,24 @@ runtime:
     http_requests_per_minute_limit: 200
 ```
 
+## `runtime.functions`
+
+Controls whether [user-defined functions](../../features/user-defined-functions) declared in the top-level `functions:` section (and `tools:` entries with `as_sql: true`) are registered with the SQL engine. Defaults to disabled.
+
+```yaml
+runtime:
+  functions:
+    enabled: true
+```
+
+| Parameter | Optional | Default | Description                                                                                       |
+| --------- | -------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `enabled` | Yes      | `false` | When `true`, the runtime registers `functions:` entries and exposes them via SQL and `/v1/functions`. |
+
+When disabled, the `functions:` block is parsed but not registered, `list_udfs()` returns no `user`-source rows, and `GET /v1/functions` returns an empty array.
+
+See the [Functions Spicepod reference](./functions) for the function declaration schema.
+
 ## `runtime.shutdown_timeout`
 
 Controls how long Spice waits for connections to be gracefully drained and for components to shut down cleanly during runtime termination. Defaults to 30 seconds.

--- a/website/docs/tags.yml
+++ b/website/docs/tags.yml
@@ -218,6 +218,10 @@ ftp:
   label: 'FTP'
   permalink: '/ftp'
   description: 'FTP and SFTP file transfer protocol data connectors.'
+functions:
+  label: 'Functions'
+  permalink: '/functions'
+  description: 'User-defined SQL scalar functions and remote function endpoints.'
 getting-started:
   label: 'Getting Started'
   permalink: '/getting-started'
@@ -514,6 +518,10 @@ turso:
   label: 'Turso'
   permalink: '/turso'
   description: 'Turso data accelerator integration.'
+udf:
+  label: 'UDF'
+  permalink: '/udf'
+  description: 'User-defined functions registered with the SQL engine.'
 unity-catalog:
   label: 'Unity Catalog'
   permalink: '/unity-catalog'


### PR DESCRIPTION
## Summary
- Add a new feature page at `features/user-defined-functions/` with a quickstart, both execution tiers (SQL and Remote), volatility guidance, type reference, discovery via `list_udfs()` and `GET /v1/functions`, LLM tool integration, worked examples, and troubleshooting
- Add a new Spicepod reference page at `reference/spicepod/functions.md` documenting every field of the `functions:` block
- Document `runtime.functions.enabled` in the runtime reference
- Cross-link from `features/index.md`
- Register `functions` and `udf` tags in `tags.yml`

## What's covered

The UDF feature in Spice supports two execution tiers, both surfacing as scalar SQL functions:

1. **SQL tier** (`from: sql`) — inline DataFusion SQL expression bodies; supports `body_ref:` for external `.sql` files
2. **Remote tier** (`from: http://...` / `https://...`) — HTTP + JSON wire contract with batched row execution and concurrency controls (`timeout`, `batch_size`, `batch_concurrency`, `auth_bearer`)

Examples include string normalization, the haversine distance formula, a remote ML classifier, struct-returning functions, and list-typed arguments.

The docs also cover:
- Volatility (`immutable` / `stable` / `volatile`) and its impact on optimization
- The full Arrow type alias surface (scalar aliases, `list<>`, `large_list<>`, `struct<>`, `decimal(p,s)`, `decimal256(p,s)`, `timestamp(unit, tz)`)
- `as_tool: true` / `false` for controlling LLM tool exposure
- Discovery via the `list_udfs()` UDTF and `GET /v1/functions`

## Verification
- [x] Built locally with `npm run build` — all pages generate, no broken links

## Test plan
- [ ] Render the new feature page and verify code blocks/tables format correctly
- [ ] Verify the new sidebar entries appear in both Features and Spicepod Reference sections
- [ ] Click cross-links between feature page, Spicepod reference, and runtime reference