### PR TITLE
docs: Add Azure Cosmos DB Data Connector and deployment guide

### DIFF
--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -1,0 +1,151 @@
+---
+title: 'Azure Cosmos DB Data Connector Deployment Guide'
+sidebar_label: 'Deployment Guide'
+description: 'Operating guide for the Azure Cosmos DB data connector in production: authentication, RU sizing, resilience, metrics, and observability.'
+sidebar_position: 10
+pagination_prev: null
+pagination_next: null
+tags:
+  - data-connectors
+  - cosmosdb
+  - azure
+  - nosql
+  - observability
+---
+
+Production operating guide for the Azure Cosmos DB (NoSQL / Core SQL API) data connector covering authentication, Request Unit (RU) cost, resilience tuning, observability, and troubleshooting.
+
+## Authentication & Secrets
+
+The connector currently supports key-based authentication only. Microsoft Entra ID and managed identity are tracked as a post-RC enhancement.
+
+| Parameter                      | Description                                                                                              |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `cosmosdb_connection_string`   | Full connection string from the Azure portal (`AccountEndpoint=...;AccountKey=...`). Takes precedence.   |
+| `cosmosdb_account_endpoint`    | Account endpoint URL when storing endpoint and key separately.                                           |
+| `cosmosdb_account_key`         | Primary or secondary account key.                                                                        |
+
+Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Scope read-only RBAC role assignments where possible: the connector only requires **Cosmos DB Built-in Data Reader** at the data plane level.
+
+### TLS
+
+Cosmos DB endpoints are HTTPS-only. The Azure-issued certificate is signed by a public CA, so no extra trust-store configuration is required. Self-hosted gateways or proxies in front of Cosmos must be trusted by the runtime's host OS / container.
+
+## Resilience Controls
+
+### Per-Account Concurrency Budget
+
+The connector enforces a per-account concurrency semaphore that is shared across every dataset targeting the same Cosmos endpoint. This matches Cosmos DB's per-account RU model — multiple datasets pointing at the same account compete for the same backend budget.
+
+| Parameter                  | Default | Notes                                                                                                                |
+| -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `max_concurrent_requests`  | `4`     | Per-account upper bound. Datasets configured with conflicting values keep the **first-seen** value and log a warning. |
+
+For workloads that fan out across many datasets, raise the budget (e.g. `8`–`16`) only after observing how it affects the account's provisioned RU/s consumption. Datasets that rarely query against the same account can each set their own value.
+
+### Retries and Backoff
+
+Retries apply to the **schema-inference sampling pass** at dataset registration. Errors surfaced *during* a streaming scan propagate immediately — a `FeedPager` cannot be safely rewound after rows have been emitted. Spice's dataset refresh layer handles retry at the query boundary.
+
+| Parameter         | Default       | Behavior                                                                                                                       |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `http_max_retries` | `3`           | Retries for HTTP 429, 5xx, and transient network failures. The connector honors `Retry-After` and `x-ms-retry-after-ms` headers; the effective sleep is `max(retry_after, backoff)`. |
+| `backoff_method`  | `exponential` | `exponential`: 500ms × 2ⁿ, capped at 30s. `fibonacci`: 500ms × Fₙ, capped at 30s.                                              |
+
+For accounts at provisioned RU limits, prefer `fibonacci` — it grows slower than exponential between attempts 3 and 5 and reduces head-of-line stalls for downstream datasets sharing the budget.
+
+### Permanent-Error Latch
+
+A 401 (unauthorized), 403 (forbidden), or 404 (not found) from any request flips a per-account flag that short-circuits subsequent requests. This avoids a thundering herd of failed calls when credentials are wrong or the database/container has been deleted.
+
+| Parameter                    | Default | Behavior                                                                                                  |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `disable_on_permanent_error` | `true`  | When `true`, latches the connector account-wide on 401/403/404 until Spice is restarted.                   |
+
+The latch is per-account-endpoint, not per-dataset — fixing the credentials and restarting clears the state. Set to `false` only in development when you want to see every failure surface immediately.
+
+## Capacity & Sizing
+
+### Request Units (RU)
+
+Every Cosmos DB read consumes RUs from the account's provisioned (or autoscale) budget. The Spice connector contributes RU consumption in three phases:
+
+1. **Dataset registration** — schema inference samples up to `schema_infer_max_records` documents (default `100`).
+2. **Per-query scans** — non-accelerated datasets stream the entire `query` result set on each query.
+3. **Acceleration refresh** — accelerated datasets stream the entire query at every `refresh_check_interval` (or `refresh_cron`).
+
+For accounts close to their RU ceiling:
+
+- **Accelerate the dataset** (`acceleration.enabled: true`) to amortize RU cost across queries.
+- **Narrow the dataset** with a custom `query: SELECT * FROM c WHERE ...` to push the predicate to Cosmos.
+- **Tune `refresh_check_interval`** to control how often the connector replays the scan against the account.
+- **Lower `schema_infer_max_records`** if the schema is stable and the default sample is an avoidable RU cost on dataset registration.
+
+Cosmos DB exposes RU consumption per query in the response headers. Monitor account-level RU/s in the Azure portal under **Insights → Throughput** — sustained 429 retries indicate the account is undersized for the Spice workload.
+
+### Schema Inference Cost
+
+Each dataset's schema inference samples documents once at registration. The cost is roughly `schema_infer_max_records × per-document RU cost`. For containers with large documents (multi-KB JSON), prefer a smaller sample (e.g. `50`) and pin the schema explicitly via `columns:` if needed.
+
+### Connection Pool
+
+The connector uses a single shared HTTP/2 connection pool to each account endpoint. Cosmos DB's gateway tolerates many concurrent streams over a single connection — the bottleneck is RU/s, not TCP sockets.
+
+## Metrics
+
+The Cosmos DB connector exposes one observable gauge that can be enabled per dataset:
+
+| Metric Name           | Description                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `inflight_operations` | Number of Cosmos DB operations currently holding a concurrency permit. Incremented per operation and held across retry-backoff sleeps. **Per-dataset**, not per-account. |
+
+Enable in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+    metrics:
+      - name: inflight_operations
+        enabled: true
+```
+
+See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+
+For broader observability, also monitor:
+
+- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
+- Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
+
+## Task History
+
+Cosmos DB requests participate in [task history](../../../reference/task_history) through the connector span. Each `_search` and `query` call is a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
+
+## Known Limitations
+
+- **Read-only**: Writes (`INSERT` / `UPDATE` / `DELETE`) are not supported.
+- **No filter / projection / limit pushdown**: SQL predicates are evaluated locally by DataFusion. Use a custom `query:` to narrow at the Cosmos side.
+- **Schema is frozen at registration**: Mapping changes after startup require a runtime restart.
+- **No change feed**: `RefreshMode::Changes` is not wired.
+- **Mid-stream retries are not safe**: Retries apply to the schema-inference pass only. Errors during a streaming scan propagate immediately; rely on dataset refresh-level retry instead.
+- **No fine-grained partition-key routing**: All scans are cross-partition.
+- **Microsoft Entra ID / managed identity unsupported**: Key-based auth only.
+- **No native temporal / decimal / binary types**: Round-trip as strings; cast in SQL.
+- **Cosmos emulator is not used in CI**: Tested against a live account; emulator coverage is tracked as a future enhancement.
+
+## Troubleshooting
+
+| Symptom                                                            | Likely cause                                                                              | Resolution                                                                                                                       |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `EmptyContainer` error at dataset load                             | The container has no documents, or the custom `query` returns zero rows.                  | Populate the container, broaden the `query`, or pin a schema via the dataset `columns:` configuration.                            |
+| Connector latched disabled — every query fails immediately         | A 401/403/404 was observed, and `disable_on_permanent_error` is `true` (the default).     | Fix the credential or restore the missing database/container, then restart `spice run`. Or set `disable_on_permanent_error: 'false'` during development. |
+| 429 retries dominate the request budget                            | Account RU/s is undersized for the Spice workload.                                        | Increase RU/s in Azure, accelerate the dataset, or lower `max_concurrent_requests` to back off.                                  |
+| RU consumption spikes on every restart                             | `schema_infer_max_records` × document size.                                               | Lower the sample size or pin a schema via `columns:`.                                                                            |
+| Schema doesn't include a field that exists in production           | The first `schema_infer_max_records` documents had `null` for that field.                  | Increase `schema_infer_max_records`, or pin the schema explicitly.                                                               |
+| `Invalid Azure Cosmos DB connection string`                        | Connection string was edited or trimmed.                                                   | Re-copy the full string from the Azure portal — `AccountEndpoint=...;AccountKey=...;` (note the trailing `;`).                    |
+| `Invalid dataset path` error at registration                       | `from:` does not match `cosmosdb:database.container`.                                      | Use `cosmosdb:database.container` or `cosmosdb:database/container`, or set `cosmosdb_database` and use `cosmosdb:container`.      |
+| Multiple datasets, one with a different `max_concurrent_requests`  | Spice keeps the **first-seen** value across datasets sharing an endpoint.                  | Set the same value on every dataset that targets the same account, or accept the warning logged at startup.                       |
+| Mid-stream scan failure leaves dataset partially loaded            | Cosmos returned an error after some rows had been emitted; mid-stream retry is not safe.   | The dataset refresh policy retries at the query boundary. For incidental failures, lower the `query` row count or accelerate.     |

--- a/website/docs/components/data-connectors/cosmosdb/index.md
+++ b/website/docs/components/data-connectors/cosmosdb/index.md
@@ -1,0 +1,231 @@
+---
+title: 'Azure Cosmos DB Data Connector'
+sidebar_label: 'Azure Cosmos DB Data Connector'
+description: 'Query Azure Cosmos DB (NoSQL / Core SQL API) containers as SQL tables in Spice. Read-only scan with schema inferred from a sample of documents.'
+tags:
+  - data-connectors
+  - cosmosdb
+  - azure
+  - nosql
+---
+
+The Azure Cosmos DB Data Connector exposes Cosmos DB containers (NoSQL / Core SQL API) as SQL tables in Spice. The connector samples a configurable number of documents at startup, infers an Arrow schema, and streams documents into DataFusion for federated SQL queries alongside data from other connectors.
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+```
+
+## Configuration
+
+### `from`
+
+The `from` field takes the form `cosmosdb:{database}.{container}` or `cosmosdb:{database}/{container}`. The connector also accepts a bare `{container}` when `cosmosdb_database` is provided in `params`.
+
+```yaml
+datasets:
+  - from: cosmosdb:store.orders
+    name: orders
+```
+
+### `name`
+
+The dataset name used as the table name within Spice. The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
+
+### `params`
+
+#### Authentication
+
+Provide either a full Cosmos DB connection string (preferred) or the discrete `account_endpoint` + `account_key` pair. Secrets must be sourced from a [secret store](../secret-stores) in production.
+
+| Parameter Name                 | Description                                                                                              | Required               |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `cosmosdb_connection_string`   | Full connection string copied from the Azure portal. Takes precedence over `account_endpoint` / `account_key`. | Either this or both endpoint+key |
+| `cosmosdb_account_endpoint`    | Account endpoint URL, e.g. `https://my-account.documents.azure.com:443/`.                                | When connection string isn't set |
+| `cosmosdb_account_key`         | Primary or secondary account key.                                                                        | When connection string isn't set |
+
+Microsoft Entra ID and managed-identity authentication are tracked as a post-RC enhancement and are not supported in the current release.
+
+#### Data Shape
+
+| Parameter Name                | Description                                                                                                                                          | Default            |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| `cosmosdb_database`           | Database name. When unset, parsed from the `from:` path (`database.container`).                                                                       | -                  |
+| `query`                       | Cosmos SQL query used to scan the container. Useful when the container is large and only a subset should be surfaced as a dataset.                    | `SELECT * FROM c`  |
+| `schema_infer_max_records`    | Number of documents sampled during schema inference at dataset registration. Larger samples produce a more precise schema at the cost of more RU consumption. | `100`              |
+
+#### Resilience
+
+The connector applies per-account concurrency limits, bounded retries with backoff, and a permanent-error latch that disables the connector account-wide on 401/403/404 responses.
+
+| Parameter Name                | Description                                                                                                                                                                                          | Default        |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `max_concurrent_requests`     | Maximum number of concurrent Cosmos DB requests per account endpoint, shared across all datasets pointing at the same account.                                                                       | `4`            |
+| `http_max_retries`            | Maximum number of retries for transient errors (HTTP 429, 5xx, network) during the schema-inference pass at dataset registration. Retries honor `Retry-After` and `x-ms-retry-after-ms` headers.    | `3`            |
+| `backoff_method`              | Backoff strategy between retries. `exponential` doubles the delay each attempt (capped at 30s); `fibonacci` follows the Fibonacci sequence (capped at 30s).                                          | `exponential`  |
+| `disable_on_permanent_error`  | When `true`, a permanent error (401/403/404) latches the connector into a disabled state and short-circuits subsequent requests until Spice is restarted.                                            | `true`         |
+
+See the [deployment guide](./deployment.md) for sizing, troubleshooting, and observability details.
+
+## Authentication
+
+### Connection String (recommended)
+
+Copy the connection string from the Azure portal under **Settings → Keys** for the Cosmos DB account, then reference it from a secret store:
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+```
+
+### Explicit Endpoint and Key
+
+When the endpoint and key are stored separately (for example in Key Vault), provide both:
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    params:
+      cosmosdb_account_endpoint: https://my-account.documents.azure.com:443/
+      cosmosdb_account_key: ${secrets:COSMOSDB_ACCOUNT_KEY}
+```
+
+If both styles are supplied, the connection string takes precedence.
+
+## Schema Inference
+
+Cosmos DB has no native schema. At dataset registration the connector runs the configured `query` (default `SELECT * FROM c`) limited to `schema_infer_max_records` documents and hands the result to Arrow's JSON inference. The inferred schema is locked for the lifetime of the runtime process.
+
+### JSON → Arrow type mapping
+
+| Cosmos / JSON value         | Arrow type   | Notes                                                                                                                                            |
+| --------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `"abc"`                     | `Utf8`       |                                                                                                                                                  |
+| Integer (`42`, `-7`)        | `Int64`      | Widens to `Float64` if any sampled document contains a decimal value for the same field.                                                         |
+| Floating (`3.14`, `1.0e9`)  | `Float64`    |                                                                                                                                                  |
+| `true` / `false`            | `Boolean`    |                                                                                                                                                  |
+| Object `{ ... }`            | `Struct`     | Nested objects are preserved as Arrow structs.                                                                                                   |
+| Array `[ ... ]`             | `List`       | The element type is inferred from the first non-null item; heterogeneous arrays may surface as `Utf8` or require a wider sample to disambiguate. |
+| All-null in sample          | `Null`       | Warn-dropped by default. Set `unsupported_type_action: string` to coerce to `Utf8`, or widen the sample so real values appear.                   |
+| System fields (`_rid`, ...) | stripped     | The system fields `_rid`, `_self`, `_etag`, `_attachments`, and `_ts` are stripped and never appear in the dataset schema.                       |
+
+Cosmos does not emit `Date`, `Time`, `Timestamp`, `Decimal`, or `Binary` natively — they round-trip as strings and should be handled with `CAST` at query time.
+
+### Tuning Schema Inference
+
+When optional fields are sparse in the first 100 documents but present in production data, increase `schema_infer_max_records`:
+
+```yaml
+datasets:
+  - from: cosmosdb:store.orders
+    name: orders
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+      schema_infer_max_records: '500'
+```
+
+Each unit increase costs additional Request Units (RUs) at startup. Pin a schema explicitly via `columns:` for the most precise control.
+
+## `unsupported_type_action`
+
+Optional. Controls behavior for fields that infer as `DataType::Null` (every sampled document had `null` for the field). Defaults to `warn`.
+
+- `error` — Fail dataset registration.
+- `warn` — Log a warning and drop the column. (Default.)
+- `ignore` — Silently drop the column.
+- `string` — Coerce the column to `Utf8`.
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    unsupported_type_action: string
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+```
+
+## Querying
+
+After registering a dataset, query it like any other Spice table:
+
+```sql
+SELECT id, name, price
+FROM products
+WHERE price > 100
+ORDER BY price DESC
+LIMIT 10;
+```
+
+```sql
+SELECT
+  category,
+  COUNT(*)   AS count,
+  AVG(price) AS avg_price
+FROM products
+GROUP BY category
+ORDER BY count DESC;
+```
+
+### Custom Cosmos SQL Queries
+
+When the container is large and only a subset should be surfaced as a dataset, push the predicate to Cosmos with a custom `query`:
+
+```yaml
+datasets:
+  - from: cosmosdb:store.orders
+    name: active_orders
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+      query: "SELECT * FROM c WHERE c.status = 'active'"
+```
+
+### Joins Across Containers
+
+Cosmos DB does not support joins across containers. Spice federates joins between Cosmos-backed datasets (and any other connector) in the local DataFusion engine:
+
+```sql
+SELECT
+  o.id    AS order_id,
+  p.name  AS product_name,
+  p.price AS unit_price
+FROM active_orders o
+JOIN products p ON o.product_id = p.id
+LIMIT 50;
+```
+
+### Acceleration
+
+Standard Spice acceleration (DuckDB, SQLite, Arrow in-memory, Cayenne) works on top of the Cosmos DB connector. Acceleration is recommended when the container is large or when query latency matters — it avoids per-query RU consumption against the Cosmos account.
+
+```yaml
+datasets:
+  - from: cosmosdb:store.products
+    name: products
+    params:
+      cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_check_interval: 1h
+```
+
+## Limitations
+
+- **Read-only**: Only `SELECT` scans are supported. Writes (`INSERT` / `UPDATE` / `DELETE`) are not implemented.
+- **No filter / projection / limit pushdown into Cosmos**: SQL predicates are evaluated locally by DataFusion after the documents have been streamed in. Use the `query` parameter to narrow at the Cosmos side.
+- **Schema is frozen at registration**: New fields added in Cosmos after startup are not picked up until the runtime restarts.
+- **No change feed**: `acceleration.refresh_mode: changes` is not supported.
+- **No native temporal / decimal / binary types**: Cosmos stores everything as JSON. Round-trip these as strings and `CAST` in SQL.
+- **Microsoft Entra ID / managed identity not supported**: Use account keys via connection string or `account_endpoint` + `account_key`.
+
+## Cookbook
+
+A copy-pasteable example Spicepod is in the runtime repo at [`examples/cosmosdb-connector/`](https://github.com/spiceai/spiceai/tree/trunk/examples/cosmosdb-connector).

--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -74,6 +74,7 @@ Supported Data Connectors include:
 | `scylladb`                         | ScyllaDB                              | Alpha             | CQL, Alternator (DynamoDB)   |
 | `adbc`                             | [ADBC][adbc]                          | Alpha             | Arrow (ADBC)                 |
 | `elasticsearch`                    | [Elasticsearch][elasticsearch]        | Alpha             | Elasticsearch REST           |
+| `cosmosdb`                         | [Azure Cosmos DB][cosmosdb]           | Release Candidate | Cosmos DB NoSQL / Core SQL   |
 
 [databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html
@@ -86,6 +87,7 @@ Supported Data Connectors include:
 [adbc]: https://arrow.apache.org/adbc/
 [ODPIC]: https://oracle.github.io/odpi/
 [elasticsearch]: ./elasticsearch/index.md
+[cosmosdb]: ./cosmosdb/index.md
 
 ## File Formats
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -93,6 +93,7 @@ Where:
   - [`http`, `https`](../../components/data-connectors/https)
   - [`clickhouse`](../../components/data-connectors/clickhouse)
   - [`graphql`](../../components/data-connectors/graphql)
+  - [`cosmosdb`](../../components/data-connectors/cosmosdb)
 
   If the Data Connector is not explicitly specified, it defaults to `spiceai`.
 

--- a/website/docs/tags.yml
+++ b/website/docs/tags.yml
@@ -90,6 +90,10 @@ configuration:
   label: 'Configuration'
   permalink: '/configuration'
   description: 'System configuration files and runtime settings.'
+cosmosdb:
+  label: 'Cosmos DB'
+  permalink: '/cosmosdb'
+  description: 'Azure Cosmos DB (NoSQL / Core SQL) data connector.'
 csharp:
   label: 'C#'
   permalink: '/csharp'


### PR DESCRIPTION
## Summary
- Add a new connector page at `data-connectors/cosmosdb/index.md` for the Azure Cosmos DB (NoSQL / Core SQL API) data connector
- Add a deployment guide at `data-connectors/cosmosdb/deployment.md` covering authentication, RU sizing, resilience, metrics, and troubleshooting
- Wire the new connector into the connector index, the datasets reference, and `tags.yml`

## Verified against the implementation
- Connector parameters confirmed against `crates/runtime/src/dataconnector/cosmosdb.rs`:
  - Component params: `account_endpoint`, `account_key`, `connection_string`, `database`
  - Runtime params: `query` (default `SELECT * FROM c`), `schema_infer_max_records` (default 100), `max_concurrent_requests` (default 4), `http_max_retries` (default 3), `backoff_method` (default `exponential`), `disable_on_permanent_error` (default `true`)
- Per-account concurrency semaphore + permanent-error latch behavior confirmed against the same file
- `inflight_operations` metric registered via `COSMOSDB_METRICS`
- JSON → Arrow type mapping pulled from `docs/dev/cosmosdb.md` in the runtime repo
- `unsupported_type_action` plumbing confirmed (warn-drop default for all-null sampled fields)

## Verification
- [x] Built locally with `rm -rf .docusaurus build && npm run build` — all pages generate, no broken links

## Test plan
- [ ] Render the new connector page and the deployment guide
- [ ] Verify the new sidebar entries appear under Data Connectors
- [ ] Verify the cookbook link (link to the runtime repo's example) resolves
- [ ] Verify the cross-link from the connector page to the deployment guide