### PR TITLE
docs: Expand LLM Tools docs with full Tool Registry section

### DIFF
--- a/website/docs/features/large-language-models/tools.md
+++ b/website/docs/features/large-language-models/tools.md
@@ -58,18 +58,49 @@ models:
 
 For details on tool groups, see [Tool Components](../../components/tools#tool-groups).
 
-### Searchable Tool Registry
+### Tool Registry
 
-When many tools are available, passing all tool definitions directly to the LLM can consume a large portion of the context window and reduce response quality. The searchable tool registry addresses this by replacing individual tool definitions with two meta-tools:
+#### Why the Tool Registry?
 
-- **`tool_search`** — Searches the registry for tools relevant to a query, returning the top matches with descriptions and parameter schemas.
-- **`tool_invoke`** — Invokes a tool returned by `tool_search` by name with the provided arguments.
+Each tool exposed to a model carries a name, a description, and a JSON Schema for its parameters. A typical tool is **200–500 tokens** of schema; a Spicepod with rich [MCP integrations](./mcp), several datasets exposed via `sql` / `table_schema` / `search`, and custom [user-defined functions](../functions) can quickly cross **50 tools** and **10,000+ tokens** of tool definitions injected into every chat turn.
 
-The registry uses hybrid search (full-text, keyword, parameter schema, and vector similarity) to find the most relevant tools for each query.
+That cost is paid on every request:
 
-#### Configuring `tool_embedding_model`
+- **Tokens**: tool definitions are part of the system context, billed on every prompt.
+- **Latency**: more input tokens = slower first-token times.
+- **Accuracy**: research and practice both show LLM tool selection accuracy degrades when faced with dozens of similarly-named tools.
+- **Context window**: tool definitions compete with conversation history, retrieved documents, and reasoning scratch space.
 
-When using `tools: search_registry`, an embedding model must be available. You can specify which embedding model to use with the `tool_embedding_model` parameter. If only one embedding model is configured in the Spicepod, it is used automatically.
+The **Tool Registry** addresses this by replacing every individual tool definition with just **two meta-tools**:
+
+- **`tool_search(query, ...)`** — Searches the registry for tools relevant to a natural-language query. Returns the top N tools with their full schemas.
+- **`tool_invoke(tool_id, arguments)`** — Invokes a tool returned by `tool_search`.
+
+For a workload with 50 tools, this is roughly a **10× reduction** in tool-definition tokens injected per turn — the model now only sees the schemas of the tools it actively asks for.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as Model
+    participant R as Tool Registry
+    participant T as Selected Tool
+
+    U->>M: "How many orders shipped today?"
+    Note over M: Sees only tool_search,<br/>tool_invoke, list_datasets
+    M->>R: tool_search(query="count rows by date")
+    R-->>M: [{tool_id: "sql", score: 0.92, ...}, ...]
+    M->>R: tool_invoke(tool_id="sql", arguments={query: "..."})
+    R->>T: sql.call({query: "..."})
+    T-->>R: 1,247
+    R-->>M: {tool_id: "sql", result: 1247}
+    M-->>U: "1,247 orders shipped today."
+```
+
+`list_datasets` is always exposed directly alongside the meta-tools, so the model can orient itself ("what tables exist?") in a single call without first asking the registry.
+
+#### Enabling the Registry
+
+Set `tools: search_registry` to require registry-based discovery, or `tools: auto` to let Spice decide:
 
 ```yaml
 embeddings:
@@ -84,7 +115,143 @@ models:
       tool_embedding_model: tool_embeddings
 ```
 
-When using `tools: auto`, the registry is used opportunistically — if an embedding model is available and the number of tools exceeds 20, `auto` switches to registry-based discovery. If no embedding model is configured, `auto` falls back to providing tools directly.
+`tools: auto` switches to the registry **only when both** of these are true:
+
+- The number of available tools exceeds **20** (`AUTO_SEARCH_TOOL_THRESHOLD`).
+- An embedding model is available.
+
+Otherwise `auto` falls back to providing tools directly — keeping small Spicepods ergonomic while large ones automatically benefit.
+
+#### Configuring `tool_embedding_model`
+
+The registry's vector channel uses a configured embedding model:
+
+- **One embedding configured** → used automatically.
+- **Multiple embeddings configured** → `tool_embedding_model` is required and must name one of them.
+- **No embedding configured** → `tools: search_registry` is rejected; `tools: auto` falls back to direct tools with a warning log.
+
+```yaml
+embeddings:
+  - name: openai_embed
+    from: openai:text-embedding-3-small
+  - name: local_embed
+    from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+
+models:
+  - name: my-model
+    from: openai:gpt-4o
+    params:
+      tools: search_registry
+      tool_embedding_model: openai_embed # disambiguate
+```
+
+#### How `tool_search` Ranks Results
+
+`tool_search` runs a **hybrid search** over four channels and fuses the results with [Reciprocal Rank Fusion (RRF)](../../reference/sql/search#reciprocal-rank-fusion-rrf):
+
+| Channel     | Signal                                                                                       |
+| ----------- | -------------------------------------------------------------------------------------------- |
+| `full_text` | TF-IDF over tokenized tool name (×3 weight), description (×2), and parameters (×1).          |
+| `keyword`   | Exact-phrase and token matches against name / description / parameter text. Weighted by where the match lands. |
+| `schema`    | Matches against the **parameter keys** in the tool's JSON Schema (e.g. `dataset`, `query`).  |
+| `vector`    | Cosine similarity between the query embedding and per-tool document embeddings.              |
+
+Each channel produces a ranked list; RRF combines the ranks (not the scores) so a tool that places top-3 in two channels usually outranks one that places top-1 in a single channel. The final `score` is normalized to `0.0–1.0` against the highest-scoring tool in the result set.
+
+Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance. The runtime keeps an LRU cache (up to 64 entries) of search-tool instances keyed on `(runtime, embedding model, tools hash)` so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly.
+
+#### `tool_search` Parameters
+
+The model calls `tool_search` with a JSON object:
+
+| Parameter   | Type            | Description                                                                                  |
+| ----------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `query`     | `string` (required) | Natural-language description of the capability the model needs.                              |
+| `keywords`  | `string[]`      | Optional exact-match phrases that boost the keyword channel — useful for column or table names. |
+| `limit`     | `integer`       | Maximum results to return. Defaults to **5**, capped at **20**.                              |
+| `min_score` | `number`        | Optional minimum score (0.0–1.0). When the cutoff filters out everything, the connector still returns the unfiltered top match as a fallback so the model isn't left empty-handed. |
+
+Example call (issued by the model):
+
+```json
+{
+  "query": "count distinct values in a column",
+  "keywords": ["distinct", "count"],
+  "limit": 3
+}
+```
+
+#### `tool_search` Response
+
+```json
+{
+  "query": "count distinct values in a column",
+  "keywords": ["distinct", "count"],
+  "search_mode": "hybrid_rrf",
+  "tools": [
+    {
+      "tool_id": "sql",
+      "description": "Execute SQL queries on the runtime.",
+      "parameters": { "type": "object", "properties": { "query": { "type": "string" } } },
+      "score": 1.0,
+      "matched_terms": ["count", "distinct", "sql"],
+      "match_sources": [
+        { "source": "full_text", "rank": 1, "score": 4.231 },
+        { "source": "keyword", "rank": 1, "score": 9.0 },
+        { "source": "vector", "rank": 1, "score": 0.812 }
+      ]
+    }
+  ]
+}
+```
+
+`match_sources` is intentionally surfaced — it lets the model (or a debugger) reason about *why* a tool was returned. A tool that only matched on `vector` but not `full_text` may be a semantic match for an unfamiliar phrasing; one that matched all four is a high-confidence hit.
+
+#### `tool_invoke` Parameters
+
+| Parameter   | Type     | Description                                                                                |
+| ----------- | -------- | ------------------------------------------------------------------------------------------ |
+| `tool_id`   | `string` | Tool name returned by `tool_search`.                                                       |
+| `arguments` | `object` | JSON object matching the selected tool's parameter schema. Defaults to `{}`.               |
+
+Example:
+
+```json
+{
+  "tool_id": "sql",
+  "arguments": { "query": "SELECT COUNT(DISTINCT customer_id) FROM orders" }
+}
+```
+
+#### `tool_invoke` Response
+
+```json
+{
+  "tool_id": "sql",
+  "result": [{ "count": 1247 }]
+}
+```
+
+Errors propagate the underlying tool's error message, prefixed with the `tool_id` so the model can decide whether to retry, ask for a different tool, or surface the failure to the user.
+
+#### Reserved Tool Names and Conflicts
+
+`tool_search` and `tool_invoke` are reserved names. If a user-defined tool or MCP tool registers under either name:
+
+- **`tools: search_registry`** → fails at startup with a clear error.
+- **`tools: auto`** → logs a warning and falls back to direct tools.
+
+Rename the offending tool, or set `as_tool: false` to keep it SQL-only.
+
+#### When to Use Direct Tools Instead
+
+`tools: all` is the right choice when:
+
+- The Spicepod has a small, focused tool set (under ~20 tools).
+- The model needs to chain tools without round-tripping through `tool_search` (saves one tool call per turn).
+- You want deterministic tool exposure for evaluation or compliance reasons.
+
+For everything else — especially Spicepods that compose multiple MCP servers or expose dozens of dataset-bound tools — `tools: auto` is the recommended default.
 
 ### Example: Specifying tools and tool groups
 


### PR DESCRIPTION
## Summary
Significantly expand the Tool Registry section of the LLM Tools feature docs. The previous content was a brief mention of `tool_search` / `tool_invoke`; this PR adds:

- **Why the registry matters** — per-turn token cost of tool definitions, latency, accuracy degradation with many tool choices, context-window competition. Frames the **~10x reduction** in tool-definition tokens for tool-heavy Spicepods.
- **Mermaid sequence diagram** showing the full search → invoke flow.
- **Hybrid search algorithm** — the four channels (`full_text` TF-IDF with name×3 / description×2 / parameters×1 weights, `keyword` exact-phrase + token, `schema` parameter-key match, `vector` cosine similarity) and how Reciprocal Rank Fusion combines them.
- **`tool_search` parameter reference** — `query`, `keywords`, `limit` (default 5, capped at 20), `min_score` (with the always-return-best-match fallback behavior), plus the full response shape including `match_sources`.
- **`tool_invoke` parameter reference** — request and response shape.
- **Reserved name conflict handling** — `tool_search` / `tool_invoke` collisions in both `search_registry` and `auto` modes.
- **Auto-mode threshold** — `>20` tools + embedding availability gate.
- **Lazy embedding computation** and the LRU cache (64 entries) keyed on runtime + embedding model + tools-hash.
- **When to use direct tools** — guidance on when `tools: all` is the right call.

## Verified against the implementation
- `crates/runtime/src/tools/registry.rs`: `AUTO_SEARCH_TOOL_THRESHOLD = 20`, `DEFAULT_SEARCH_LIMIT = 5`, `MAX_SEARCH_LIMIT = 20`, `TOOL_REGISTRY_SEARCH_TOOL_CACHE_MAX_ENTRIES = 64`, `LIST_DATASETS_TOOL_NAME` always direct.
- TF-IDF channel weights (`* 3`, `* 2`, `* 1`).
- The four-channel + RRF hybrid search behavior.
- Reserved-name handling: errors in `search_registry`, falls back with warning in `auto`.
- `tool_search` returns `search_mode: hybrid_rrf` and the documented JSON shape.

## Verification
- [x] Built locally with `rm -rf .docusaurus build && npm run build` — Mermaid diagram renders, no broken links.

## Test plan
- [ ] Render the Tool Registry section and verify the Mermaid diagram displays.
- [ ] Verify the cross-link to the SQL search RRF reference resolves.
- [ ] Verify the cross-link to the Functions feature page (`../functions`) resolves.