### PR TITLE
docs: Extract Tool Registry into its own Feature page

### DIFF
--- a/website/docs/features/functions/index.md
+++ b/website/docs/features/functions/index.md
@@ -252,6 +252,10 @@ Returns a JSON array of user functions only (built-ins are excluded). Each entry
 
 Every declared function is automatically callable from LLMs as a tool with the same name and description. This lets a model reason in natural language and then invoke `haversine_km(...)` or `classify_intent(...)` directly.
 
+:::tip[Many functions? Use the Tool Registry]
+A Spicepod with many functions can quickly cross the threshold where injecting every function definition into every chat turn becomes expensive. The [Tool Registry](../tool-registry/index.md) replaces individual tool definitions with searchable `tool_search` / `tool_invoke` meta-tools, typically saving ~10× the per-turn tool-definition tokens. Set `tools: auto` on the model and the registry kicks in automatically once the function count crosses the threshold.
+:::
+
 To keep a function SQL-only:
 
 ```yaml

--- a/website/docs/features/index.md
+++ b/website/docs/features/index.md
@@ -33,6 +33,10 @@ Spice provides a set of features for building data-driven applications and AI ag
 
 [Functions](./functions/index.md) extend SQL with custom scalar functions declared in a Spicepod. Inline SQL bodies run in-process and can use any DataFusion built-in; remote `http://` / `https://` endpoints batch row inputs over JSON for delegating logic to ML models, internal services, or custom code. Every function is automatically callable from SQL and (by default) surfaced as an LLM tool.
 
+### Tool Registry
+
+[Tool Registry](./tool-registry/index.md) keeps per-turn token cost bounded as the runtime's tool catalog grows. It replaces individual tool definitions with searchable `tool_search` and `tool_invoke` meta-tools backed by a hybrid full-text, keyword, schema, and vector search. Applies uniformly to built-in tools, MCP tools, and Functions declared with `as_tool: true` — typically a ~10× reduction in tool-definition tokens for tool-heavy Spicepods.
+
 ### Monitoring and Observability
 
 [Observability](./observability/index.md) exposes Prometheus-compatible metrics, OpenTelemetry metric export, and distributed tracing with Zipkin. Integrations are available for Datadog, Grafana, and other monitoring platforms.

--- a/website/docs/features/large-language-models/tools.md
+++ b/website/docs/features/large-language-models/tools.md
@@ -58,33 +58,13 @@ models:
 
 For details on tool groups, see [Tool Components](../../components/tools#tool-groups).
 
-### Searchable Tool Registry
+### Tool Registry
 
-When many tools are available, passing all tool definitions directly to the LLM can consume a large portion of the context window and reduce response quality. The searchable tool registry addresses this by replacing individual tool definitions with two meta-tools:
+When the runtime exposes many tools (multiple MCP servers, lots of dataset-bound tools, or many [Functions](../functions) declared with `as_tool: true`), passing every tool definition into every chat turn consumes a large portion of the context window and degrades selection accuracy. The **Tool Registry** replaces individual tool definitions with two meta-tools — `tool_search` and `tool_invoke` — backed by a hybrid search index over the runtime's tool catalog. This typically saves **~10×** the per-turn tool-definition tokens for tool-heavy Spicepods.
 
-- **`tool_search`** — Searches the registry for tools relevant to a query, returning the top matches with descriptions and parameter schemas.
-- **`tool_invoke`** — Invokes a tool returned by `tool_search` by name with the provided arguments.
+`tools: auto` enables the registry automatically when there are more than 20 tools and an embedding model is configured; `tools: search_registry` requires it.
 
-The registry uses hybrid search (full-text, keyword, parameter schema, and vector similarity) to find the most relevant tools for each query.
-
-#### Configuring `tool_embedding_model`
-
-When using `tools: search_registry`, an embedding model must be available. You can specify which embedding model to use with the `tool_embedding_model` parameter. If only one embedding model is configured in the Spicepod, it is used automatically.
-
-```yaml
-embeddings:
-  - name: tool_embeddings
-    from: openai:text-embedding-3-small
-
-models:
-  - name: my-model
-    from: openai:gpt-4o
-    params:
-      tools: search_registry
-      tool_embedding_model: tool_embeddings
-```
-
-When using `tools: auto`, the registry is used opportunistically — if an embedding model is available and the number of tools exceeds 20, `auto` switches to registry-based discovery. If no embedding model is configured, `auto` falls back to providing tools directly.
+See **[Tool Registry](../tool-registry)** for the full reference, including the hybrid-search algorithm, `tool_search` / `tool_invoke` parameters and response shapes, and guidance on when to prefer direct tools.
 
 ### Example: Specifying tools and tool groups
 

--- a/website/docs/features/tool-registry/index.md
+++ b/website/docs/features/tool-registry/index.md
@@ -1,0 +1,289 @@
+---
+title: 'Tool Registry'
+sidebar_label: 'Tool Registry'
+description: 'Reduce per-turn token cost and improve LLM tool selection accuracy by replacing individual tool definitions with searchable tool_search and tool_invoke meta-tools backed by hybrid full-text, keyword, schema, and vector search.'
+sidebar_position: 12
+pagination_prev: null
+pagination_next: null
+tags:
+  - tools
+  - functions
+  - udf
+  - search
+  - runtime
+---
+
+The Tool Registry is a runtime-level capability that replaces large lists of individual tool definitions with two **meta-tools** — `tool_search` and `tool_invoke` — backed by a hybrid search index over the runtime's tool catalog. It's used to keep per-turn token cost bounded as the catalog grows, while preserving the model's ability to discover and call any tool on demand.
+
+The registry indexes every tool that's callable from an LLM, regardless of where it came from:
+
+- Built-in Spice runtime tools (`sql`, `list_datasets`, `table_schema`, `search`, `random_sample`, …)
+- [MCP tools](../large-language-models/mcp.md) (servers connected over `sse` or `stdio`)
+- [Functions](../functions/index.md) declared in the Spicepod with `as_tool: true` (the default)
+- [`tools:`](../../reference/spicepod/tools) entries with `as_sql: true` (callable from both SQL and the LLM)
+
+If it can be called from a chat completion, it goes through the registry.
+
+## Why the Tool Registry?
+
+Each tool exposed to a model carries a name, a description, and a JSON Schema for its parameters. A typical tool is **200–500 tokens** of schema; a Spicepod with rich [MCP integrations](../large-language-models/mcp.md), several datasets exposed via `sql` / `table_schema` / `search`, and custom [user-defined functions](../functions/index.md) can quickly cross **50 tools** and **10,000+ tokens** of tool definitions injected into every chat turn.
+
+That cost is paid on every request:
+
+- **Tokens**: tool definitions are part of the system context, billed on every prompt.
+- **Latency**: more input tokens means slower first-token times.
+- **Accuracy**: research and practice both show LLM tool-selection accuracy degrades when the model is faced with dozens of similarly-named tools.
+- **Context window**: tool definitions compete with conversation history, retrieved documents, and reasoning scratch space.
+
+The Tool Registry replaces every individual tool definition with just two meta-tools:
+
+- **`tool_search(query, ...)`** — Searches the registry for tools relevant to a natural-language query. Returns the top N tools with their full schemas.
+- **`tool_invoke(tool_id, arguments)`** — Invokes a tool returned by `tool_search`.
+
+For a workload with 50 tools, this is roughly a **10× reduction** in tool-definition tokens injected per turn — the model now only sees the schemas of the tools it actively asks for.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as Model
+    participant R as Tool Registry
+    participant T as Selected Tool
+
+    U->>M: "How many orders shipped today?"
+    Note over M: Sees only tool_search,<br/>tool_invoke, list_datasets
+    M->>R: tool_search(query="count rows by date")
+    R-->>M: [{tool_id: "sql", score: 0.92, ...}, ...]
+    M->>R: tool_invoke(tool_id="sql", arguments={query: "..."})
+    R->>T: sql.call({query: "..."})
+    T-->>R: 1,247
+    R-->>M: {tool_id: "sql", result: 1247}
+    M-->>U: "1,247 orders shipped today."
+```
+
+`list_datasets` is always exposed directly alongside the meta-tools so the model can orient itself ("what tables exist?") in a single call without first asking the registry.
+
+## When to Use the Registry
+
+The registry is the right default for any model that has access to **a substantial number of tools** — particularly when those tools include:
+
+- Multiple [MCP servers](../large-language-models/mcp.md) each contributing several tools.
+- A Spicepod with many [Functions](../functions/index.md) declared as tools.
+- Multiple datasets, each contributing dataset-specific tools (e.g. via the [`tools:`](../../reference/spicepod/tools) section).
+
+It's **less useful** when:
+
+- The Spicepod has a small, focused tool set (under ~20 tools).
+- The model needs to chain tools without round-tripping through `tool_search` (saves one tool call per turn).
+- Deterministic tool exposure is required for evaluation or compliance reasons.
+
+For everything else — especially Spicepods that compose multiple tool sources — `tools: auto` is the recommended default.
+
+## Enabling the Registry
+
+The registry is controlled via the `tools` parameter on a model. Set it to `search_registry` to require registry-based discovery, or `auto` to let Spice decide:
+
+```yaml
+embeddings:
+  - name: tool_embeddings
+    from: openai:text-embedding-3-small
+
+models:
+  - name: my-model
+    from: openai:gpt-4o
+    params:
+      tools: search_registry
+      tool_embedding_model: tool_embeddings
+```
+
+`tools: auto` switches to the registry **only when both** of these are true:
+
+- The number of available tools exceeds **20** (`AUTO_SEARCH_TOOL_THRESHOLD`).
+- An embedding model is available.
+
+Otherwise `auto` falls back to providing tools directly — keeping small Spicepods ergonomic while large ones automatically benefit. See the [Tool Modes table](../large-language-models/tools.md#tool-modes) for the full set of values.
+
+### Configuring `tool_embedding_model`
+
+The registry's vector channel uses a configured embedding model:
+
+- **One embedding configured** → used automatically.
+- **Multiple embeddings configured** → `tool_embedding_model` is required and must name one of them.
+- **No embedding configured** → `tools: search_registry` is rejected; `tools: auto` falls back to direct tools with a warning log.
+
+```yaml
+embeddings:
+  - name: openai_embed
+    from: openai:text-embedding-3-small
+  - name: local_embed
+    from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2
+
+models:
+  - name: my-model
+    from: openai:gpt-4o
+    params:
+      tools: search_registry
+      tool_embedding_model: openai_embed # disambiguate
+```
+
+## How `tool_search` Ranks Results
+
+`tool_search` runs a **hybrid search** over four channels and fuses the results with [Reciprocal Rank Fusion (RRF)](../../reference/sql/search#reciprocal-rank-fusion-rrf):
+
+| Channel     | Signal                                                                                                                |
+| ----------- | --------------------------------------------------------------------------------------------------------------------- |
+| `full_text` | TF-IDF over tokenized tool name (×3 weight), description (×2), and parameters (×1).                                   |
+| `keyword`   | Exact-phrase and token matches against name / description / parameter text. Weighted by where the match lands.         |
+| `schema`    | Matches against the **parameter keys** in the tool's JSON Schema (e.g. `dataset`, `query`).                            |
+| `vector`    | Cosine similarity between the query embedding and per-tool document embeddings.                                       |
+
+Each channel produces a ranked list; RRF combines the ranks (not the scores) so a tool that places top-3 in two channels usually outranks one that places top-1 in a single channel. The final `score` is normalized to `0.0–1.0` against the highest-scoring tool in the result set.
+
+Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance. The runtime keeps an LRU cache (up to 64 entries) of search-tool instances keyed on `(runtime, embedding model, tools hash)` so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly.
+
+## `tool_search` Reference
+
+The model calls `tool_search` with a JSON object:
+
+| Parameter   | Type            | Description                                                                                                        |
+| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `query`     | `string` (required) | Natural-language description of the capability the model needs.                                                   |
+| `keywords`  | `string[]`      | Optional exact-match phrases that boost the keyword channel — useful for column or table names.                    |
+| `limit`     | `integer`       | Maximum results to return. Defaults to **5**, capped at **20**.                                                    |
+| `min_score` | `number`        | Optional minimum score (0.0–1.0). When the cutoff filters out everything, the registry still returns the unfiltered top match as a fallback so the model isn't left empty-handed. |
+
+Example call (issued by the model):
+
+```json
+{
+  "query": "count distinct values in a column",
+  "keywords": ["distinct", "count"],
+  "limit": 3
+}
+```
+
+### `tool_search` Response
+
+```json
+{
+  "query": "count distinct values in a column",
+  "keywords": ["distinct", "count"],
+  "search_mode": "hybrid_rrf",
+  "tools": [
+    {
+      "tool_id": "sql",
+      "description": "Execute SQL queries on the runtime.",
+      "parameters": { "type": "object", "properties": { "query": { "type": "string" } } },
+      "score": 1.0,
+      "matched_terms": ["count", "distinct", "sql"],
+      "match_sources": [
+        { "source": "full_text", "rank": 1, "score": 4.231 },
+        { "source": "keyword", "rank": 1, "score": 9.0 },
+        { "source": "vector", "rank": 1, "score": 0.812 }
+      ]
+    }
+  ]
+}
+```
+
+`match_sources` is intentionally surfaced — it lets the model (or a debugger) reason about *why* a tool was returned. A tool that only matched on `vector` but not `full_text` may be a semantic match for an unfamiliar phrasing; one that matched all four is a high-confidence hit.
+
+## `tool_invoke` Reference
+
+| Parameter   | Type     | Description                                                                                |
+| ----------- | -------- | ------------------------------------------------------------------------------------------ |
+| `tool_id`   | `string` | Tool name returned by `tool_search`.                                                       |
+| `arguments` | `object` | JSON object matching the selected tool's parameter schema. Defaults to `{}`.               |
+
+Example:
+
+```json
+{
+  "tool_id": "sql",
+  "arguments": { "query": "SELECT COUNT(DISTINCT customer_id) FROM orders" }
+}
+```
+
+### `tool_invoke` Response
+
+```json
+{
+  "tool_id": "sql",
+  "result": [{ "count": 1247 }]
+}
+```
+
+Errors propagate the underlying tool's error message, prefixed with the `tool_id` so the model can decide whether to retry, ask for a different tool, or surface the failure to the user.
+
+## Functions in the Registry
+
+Every [function](../functions/index.md) declared with `as_tool: true` (the default) is registered both as a SQL UDF and as a tool, and therefore participates in the registry. This means a Spicepod with many domain-specific UDFs benefits from the registry exactly the same way as one with many MCP tools — the model only sees the function definitions for the few it actually asks about.
+
+```yaml
+runtime:
+  functions:
+    enabled: true
+
+embeddings:
+  - name: tool_embeddings
+    from: openai:text-embedding-3-small
+
+functions:
+  - name: haversine_km
+    from: sql
+    description: Haversine great-circle distance in kilometres.
+    volatility: immutable
+    signature:
+      args:
+        - { name: lat1, type: float64 }
+        - { name: lon1, type: float64 }
+        - { name: lat2, type: float64 }
+        - { name: lon2, type: float64 }
+      returns: float64
+    body: |
+      6371 * acos(
+        cos(radians(lat1)) * cos(radians(lat2)) *
+        cos(radians(lon2) - radians(lon1)) +
+        sin(radians(lat1)) * sin(radians(lat2))
+      )
+  # ...many more
+
+models:
+  - name: my-model
+    from: openai:gpt-4o
+    params:
+      tools: auto # registry kicks in automatically once the function count crosses the threshold
+      tool_embedding_model: tool_embeddings
+```
+
+To keep a function out of the registry (and out of the LLM tool surface entirely) while still callable from SQL, set `as_tool: false`:
+
+```yaml
+functions:
+  - name: internal_hash
+    from: sql
+    as_tool: false
+    signature:
+      args: [{ name: x, type: int64 }]
+      returns: int64
+    body: 'x * 2654435761'
+```
+
+User-defined table functions (UDTFs) are SQL-only and are not currently registered as LLM tools, so they don't appear in the registry.
+
+## Reserved Tool Names and Conflicts
+
+`tool_search` and `tool_invoke` are reserved names. If a user-defined tool, function, or MCP tool registers under either name:
+
+- **`tools: search_registry`** → fails at startup with a clear error.
+- **`tools: auto`** → logs a warning and falls back to direct tools.
+
+Rename the offending tool, or set `as_tool: false` to keep it SQL-only.
+
+## Discovering What's in the Registry
+
+Two ways to inspect the catalog from outside the model:
+
+- **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';` lists every user-declared function, regardless of whether it's currently in the registry.
+- **From the HTTP API** — `GET /v1/functions` returns the functions registered as both SQL and tool entries.
+
+For tools (built-in plus MCP plus function-derived), the model can call `tool_search` with an open-ended query (e.g. `query: "*"`) — though in practice, asking for the tools relevant to the current step is what the model actually wants.


### PR DESCRIPTION
## Summary
The Tool Registry is cross-cutting infrastructure used by every LLM-callable tool source — built-in tools, MCP tools, and [Functions](https://github.com/spiceai/docs/blob/trunk/website/docs/features/functions/index.md) declared with \`as_tool: true\`. Pull it out of the LLM Tools page and give it a dedicated Feature page so users discovering Functions, LLM Tools, or building Spicepods with many tool sources all land on the same canonical reference.

## Changes
- **New** \`features/tool-registry/index.md\` — full reference covering:
  - **Why the Tool Registry?** — per-turn token cost, latency, accuracy, context-window competition, framed at ~10× reduction for tool-heavy Spicepods
  - Mermaid sequence diagram of the search → invoke flow
  - **When to use the registry** vs direct tools
  - **Enabling the registry** — \`tools: search_registry\` vs \`auto\`, the >20-tool threshold
  - **\`tool_embedding_model\`** resolution rules
  - **Hybrid search algorithm** — \`full_text\` TF-IDF (name×3 / description×2 / parameters×1), \`keyword\`, \`schema\` parameter-key matches, \`vector\` cosine similarity, fused with Reciprocal Rank Fusion
  - **\`tool_search\`** and **\`tool_invoke\`** parameter/response shapes with examples
  - **Functions in the registry** — same hybrid search applied to user-declared functions
  - **Reserved-name conflicts** in both modes
  - **Discovery** via \`list_udfs()\` and \`GET /v1/functions\`
- **Trim** \`features/large-language-models/tools.md\` — remove the inline Searchable Tool Registry section, keep the Tool Modes table, add a short callout linking to the new page
- **Add a Tool Registry tip** to \`features/functions/index.md\` in the "Functions as LLM tools" section
- **Add a Tool Registry entry** to \`features/index.md\`

## Verification
- [x] Built locally with \`rm -rf .docusaurus build && npm run build\` — Mermaid diagram renders, all cross-links resolve.

## Supersedes
This supersedes [#1640](https://github.com/spiceai/docs/pull/1640) which expanded the same content inline on the LLM Tools page. Closing #1640 once this is approved.

## Test plan
- [ ] Render the new Tool Registry page and verify the Mermaid diagram displays
- [ ] Verify the Tool Registry sidebar entry appears under Features
- [ ] Verify the LLM Tools page shows a clean Tool Modes table + Tool Registry callout
- [ ] Verify the Functions page has a Tool Registry tip in the "Functions as LLM tools" section
- [ ] Click each cross-link to confirm navigation works