### PR TITLE
docs: Add azure_storage_tenant_id to Delta Lake connector

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/index.md
+++ b/website/docs/components/data-connectors/delta-lake/index.md
@@ -80,7 +80,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 **One** of the following auth values must be provided for Azure Blob:
 
 - `delta_lake_azure_storage_account_key`,
-- `delta_lake_azure_storage_client_id` and `delta_lake_azure_storage_client_secret`, or
+- `delta_lake_azure_storage_client_id`, `delta_lake_azure_storage_client_secret`, and `delta_lake_azure_storage_tenant_id`, or
 - `delta_lake_azure_storage_sas_key`.
   :::
 
@@ -90,6 +90,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
 | `delta_lake_azure_storage_account_key`   | The Azure Storage master key for accessing the storage account.        |
 | `delta_lake_azure_storage_client_id`     | The service principal client id for accessing the storage account.     |
 | `delta_lake_azure_storage_client_secret` | The service principal client secret for accessing the storage account. |
+| `delta_lake_azure_storage_tenant_id`     | The service principal tenant id for accessing the storage account.     |
 | `delta_lake_azure_storage_sas_key`       | The shared access signature key for accessing the storage account.     |
 | `delta_lake_azure_storage_endpoint`      | Optional. The endpoint for the Azure Blob storage account.             |
 
@@ -146,6 +147,7 @@ Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g
     # OR Service Principal + Secret
     delta_lake_azure_storage_client_id: my_client_id
     delta_lake_azure_storage_client_secret: ${secrets:my_secret}
+    delta_lake_azure_storage_tenant_id: ${secrets:my_tenant_id}
 
     # OR SAS Key
     delta_lake_azure_storage_sas_key: my_sas_key


### PR DESCRIPTION
## Summary
- Add the missing `delta_lake_azure_storage_tenant_id` parameter to the Delta Lake connector's Azure Blob documentation
- Update the service-principal auth note to include `tenant_id` as a required companion parameter
- Add `tenant_id` to the Azure Blob example

## Source PRs
- spiceai/spiceai#10671 — Add Delta Lake Azure tenant parameter

## Changes
- `website/docs/components/data-connectors/delta-lake/index.md`: Added `delta_lake_azure_storage_tenant_id` to the Azure Blob parameters table, auth requirements note, and service principal example

## Test plan
- [x] Links are valid
- [x] Version references are correct (vNext only — parameter is new)