### PR TITLE
docs: Document LLM prompt caching parameters

### DIFF
--- a/website/docs/features/large-language-models/parameter_overrides.md
+++ b/website/docs/features/large-language-models/parameter_overrides.md
@@ -194,3 +194,23 @@ Example response:
 ```
 
 Visit [OpenAI Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs) for more information on how to use structured output formats.
+
+### Prompt Caching
+
+Spice supports provider-aware prompt caching to reduce latency and cost for repeated prompts. Set `prompt_cache_key` on a model to enable the provider's native caching mechanism.
+
+```yaml
+models:
+  - from: openai:gpt-4o
+    name: my_model
+    params:
+      prompt_cache_key: "schema-context"
+```
+
+When `prompt_cache_key` is set as a model default, it is injected into every Chat API and Responses API request to that model (unless the request itself provides one). The key is mapped into the appropriate provider-native mechanism — for example, Anthropic's `cache_control`, xAI's `x-grok-conv-id` header, or Bedrock's `CachePoint` block. See the [full provider mapping](../../reference/spicepod/models#paramsprompt_cache_key).
+
+For the OpenAI Responses API, `prompt_cache_retention` can also be set to request a retention duration (e.g. `"24h"`).
+
+The `prompt_cache_key` can also be passed per-request in the [`/v1/nsql` API](../../api/HTTP/post-nsql) body to enable caching for text-to-SQL queries.
+
+For local models using mistral-rs, paged-attention scheduling is enabled automatically on supported backends (CUDA + Unix) for KV-cache prefix reuse — no configuration is needed.

--- a/website/docs/reference/spicepod/models.md
+++ b/website/docs/reference/spicepod/models.md
@@ -123,6 +123,41 @@ Which tools should be made available to the model. Supported values: `auto`, `al
 
 The name of an embedding model (defined in the `embeddings` section) to use for searchable tool discovery. Required when `tools: search_registry` is set. When `tools: auto` is used, this model enables registry-based discovery if the tool count exceeds the auto-search threshold (20 tools). If only one embedding model is configured, it is used automatically.
 
+#### `params.prompt_cache_key`
+
+Optional. A stable key forwarded to the LLM provider to enable prompt/prefix caching. When set, Spice maps this key into the provider-native caching mechanism:
+
+| Provider | Behavior |
+| --- | --- |
+| OpenAI / Azure OpenAI | Passed through on Chat and Responses API requests |
+| Anthropic | Adds `cache_control: { type: "ephemeral" }` to the request |
+| Google Gemini | Maps to `cached_content.name` (must be a valid cached-content resource name) |
+| xAI (Grok) | Sent as the `x-grok-conv-id` HTTP header |
+| AWS Bedrock (Converse) | Appends a native `CachePoint` block |
+| Databricks (hosted Claude) | Adds Claude-style `cache_control` to the last content part |
+| Local (mistral-rs) | Paged-attention scheduling is enabled automatically on supported backends (CUDA + Unix) |
+
+```yaml
+models:
+  - from: openai:gpt-4o
+    name: my_model
+    params:
+      prompt_cache_key: "schema-context"
+```
+
+#### `params.prompt_cache_retention`
+
+Optional. Retention hint for prompt caching, applicable to the OpenAI Responses API only. For example, `"24h"` requests that the cached content be retained for 24 hours.
+
+```yaml
+models:
+  - from: openai:gpt-4o
+    name: my_model
+    params:
+      prompt_cache_key: "schema-context"
+      prompt_cache_retention: "24h"
+```
+
 ### `datasets`
 
 Optional. A list of [dataset names](./datasets#name) that this model should be applied to. For ML models, this preselects the dataset to use for inference.


### PR DESCRIPTION
## Summary
- Add documentation for the new `prompt_cache_key` and `prompt_cache_retention` model parameters
- Document provider-specific caching behavior (OpenAI, Anthropic, Google, xAI, Bedrock, Databricks, local models)
- Add prompt caching section to the LLM parameter overrides feature page

## Source PRs
- spiceai/spiceai#10645 — Add provider-aware LLM prompt caching

## Changes
- `website/docs/reference/spicepod/models.md`: Added `params.prompt_cache_key` and `params.prompt_cache_retention` sections with provider mapping table
- `website/docs/features/large-language-models/parameter_overrides.md`: Added "Prompt Caching" section with usage examples

## Test plan
- [x] Links are valid
- [x] Version references are correct (vNext only — feature is new)