### PR TITLE
fix: Remove non-existent rate control parameters from GraphQL connector docs

### DIFF
--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -36,7 +36,7 @@ Use HTTPS endpoints in production. Self-signed certificates require a trusted CA
 
 ### Retry Behavior
 
-HTTP-level retries follow the shared `resilient_http` policy: 408/429/5xx plus transient network errors are retried with fibonacci backoff capped at 300s. The connector respects `Retry-After`, `retry-after-ms`, and `x-retry-after-ms` headers.
+The GraphQL connector retries transient errors (HTTP 408 and 5xx) and connection-level failures with exponential backoff. HTTP 429 responses are surfaced as rate-limit errors and are **not** automatically retried — reduce refresh frequency or narrow the query when rate-limited.
 
 ### Pagination
 
@@ -56,8 +56,7 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 The GraphQL connector does not register connector-specific instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
+- Spice query execution metrics (e.g. `query_duration_ms`) from `runtime.metrics`.
 - The upstream GraphQL provider's rate-limit dashboards.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/docs/components/data-connectors/graphql/index.md
+++ b/website/docs/components/data-connectors/graphql/index.md
@@ -130,20 +130,6 @@ datasets:
 | not set | not set | set | HTTP Basic Auth |
 | not set | not set | not set | No auth |
 
-### Rate Control Parameters
-
-The GraphQL connector supports shared HTTP rate control to limit concurrency and request rate per upstream origin. These parameters can be set per-dataset (in `params`) or globally (in `runtime.params`). Dataset-level settings override the global defaults.
-
-| Parameter Name              | Description                                                                                                                                                                                  |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
-| `requests_per_second_limit` | Maximum number of HTTP requests per second to the same upstream origin. Overrides `runtime.params.http_requests_per_second_limit`. If both are unset, no per-second rate limit is applied.    |
-| `requests_per_minute_limit` | Maximum number of HTTP requests per minute to the same upstream origin. Overrides `runtime.params.http_requests_per_minute_limit`. If both are unset, no per-minute rate limit is applied.    |
-| `rate_control_jitter_min`   | Minimum random delay added before HTTP requests when rate control is active. Accepts durations such as `5ms` or `0ms`. Defaults to `5ms` when a request-rate limit is configured.            |
-| `rate_control_jitter_max`   | Maximum random delay added before HTTP requests when rate control is active. Accepts durations such as `10ms` or `0ms`. Defaults to `10ms` when a request-rate limit is configured.          |
-
-Multiple datasets targeting the same GraphQL endpoint share the same rate controller.
-
 ## Pagination
 
 The GraphQL Data Connector supports automatic pagination of the response for queries using [cursor pagination](https://graphql.org/learn/pagination/).


### PR DESCRIPTION
## Summary
- Remove five rate control parameters (`max_concurrent_requests`, `requests_per_second_limit`, `requests_per_minute_limit`, `rate_control_jitter_min`, `rate_control_jitter_max`) from the GraphQL connector docs that do not exist in the connector's `ParameterSpec` definitions or anywhere in the GraphQL connector code
- Fix the deployment guide's retry behavior description: the connector does NOT use a shared `resilient_http` policy, does NOT respect `Retry-After` headers, and does NOT retry HTTP 429 responses
- Remove references to non-existent metrics (`query_processed_rows`, `query_failures_total`)

## Reference
Verified against spiceai/spiceai trunk — `crates/data-connectors/connector-graphql/src/lib.rs` (lines 53-75, only 7 parameters defined) and `crates/data_components/src/graphql/` (no rate control, no Retry-After handling, 429 explicitly not retried per `mod.rs` lines 113-116).