### PR TITLE
fix: Add Cayenne and Turso to snapshots supported engine list

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -363,7 +363,7 @@ Optional. The mode of acceleration. The following values are supported:
 
 ## `acceleration.snapshots`
 
-Optional. Controls how this dataset participates in managed acceleration snapshots. Requires the Spicepod to configure the top-level [`snapshots` block](.#snapshots), the acceleration engine to be `duckdb` or `sqlite`, and `mode: file` with a dataset-specific file path (for example `acceleration.params.duckdb_file: /nvme/my_dataset.db`).
+Optional. Controls how this dataset participates in managed acceleration snapshots. Requires the Spicepod to configure the top-level [`snapshots` block](.#snapshots), the acceleration engine to be `duckdb`, `sqlite`, `cayenne`, or `turso`, and `mode: file` with a dataset-specific file path (for example `acceleration.params.duckdb_file: /nvme/my_dataset.db`).
 
 Supported values:
 

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -118,7 +118,7 @@ datasets:
 
 ## `snapshots` {#snapshots}
 
-Optional. Configure managed acceleration snapshots that Spice can use to bootstrap file-based accelerations. When enabled, datasets that opt in with [`acceleration.snapshots`](spicepod/datasets#accelerationsnapshots) will download database files from the snapshot location if the local file is missing, and will optionally write new snapshots after each refresh. Only DuckDB and SQLite accelerations running in `mode: file` are supported, and each dataset must write to its own file path.
+Optional. Configure managed acceleration snapshots that Spice can use to bootstrap file-based accelerations. When enabled, datasets that opt in with [`acceleration.snapshots`](spicepod/datasets#accelerationsnapshots) will download database files from the snapshot location if the local file is missing, and will optionally write new snapshots after each refresh. DuckDB, SQLite, Cayenne, and Turso accelerations running in `mode: file` are supported, and each dataset must write to its own file path.
 
 ```yaml
 snapshots:


### PR DESCRIPTION
## Summary
- `acceleration.snapshots` reference (datasets.md) and the top-level `snapshots` block (index.md) both stated only DuckDB and SQLite are supported
- The implementation also supports Cayenne (via `CayenneSnapshotEngine`) and Turso
- Other docs pages (data-refresh.md, datasets reference line 439) already correctly list all four engines

## Changes
- Updated `datasets.md` line 366: `duckdb` or `sqlite` → `duckdb`, `sqlite`, `cayenne`, or `turso`
- Updated `index.md` line 121: `Only DuckDB and SQLite` → `DuckDB, SQLite, Cayenne, and Turso`

## Reference
Verified against spiceai/spiceai trunk — snapshot refresh mode implementation.