### PR TITLE
fix: Add pg_ prefix to connection_pool_min in Postgres accelerator deployment guide

### DIFF
--- a/website/docs/components/data-accelerators/postgres/deployment.md
+++ b/website/docs/components/data-accelerators/postgres/deployment.md
@@ -43,7 +43,7 @@ The accelerator creates and writes tables in the configured database. Grant the 
 
 | Parameter                 | Default | Description                                                             |
 | ------------------------- | ------- | ----------------------------------------------------------------------- |
-| `connection_pool_min`     | `5`     | Minimum idle connections held by the pool.                              |
+| `pg_connection_pool_min`  | `5`     | Minimum idle connections held by the pool.                              |
 | `connection_pool_size`    | `10`    | Maximum connections the pool will open.                                 |
 
 `connection_pool_min <= connection_pool_size` is enforced at startup; mismatched values are rejected as configuration errors.


### PR DESCRIPTION
## Summary
- The deployment guide listed `connection_pool_min` without the `pg_` prefix
- This parameter is `ParameterSpec::component("connection_pool_min")` with prefix `"pg"`, so users must specify it as `pg_connection_pool_min`
- The main accelerator index.md already correctly documents it as `pg_connection_pool_min`
- `connection_pool_size` is correctly shown without prefix (it's a `ParameterSpec::runtime` parameter)

## Reference
Verified against spiceai/spiceai trunk — `crates/runtime/src/dataaccelerator/postgres.rs` lines 93-97.