### PR TITLE
docs: Comprehensive partitioning, partition transforms, and pruning rules

### DIFF
--- a/website/docs/features/data-acceleration/index.md
+++ b/website/docs/features/data-acceleration/index.md
@@ -18,6 +18,8 @@ Locally accelerated datasets can also have [primary key constraints](data-accele
 
 [Acceleration snapshots](data-acceleration/snapshots) (preview) help file-mode accelerations become ready in seconds by bootstrapping from managed snapshots stored in object storage such as Amazon S3.
 
+For larger datasets, [partitioning](data-acceleration/partitioning) splits the acceleration into smaller physical units (Hive-style files, per-partition tables, or in-memory tables) keyed by an expression. Queries that filter on the partitioning column read only the relevant partitions, dramatically reducing scan size.
+
 ## Example Use Case
 
 Consider a high-volume e-trading frontend application backed by an AWS RDS database containing a table of trades. To retrieve all trades over the last 24 hours, the application would need to query the remote database and transfer the data over the network. By accelerating the trades table locally using the [AWS RDS Data Connector](https://github.com/spiceai/cookbook/tree/trunk/mysql/rds-aurora#readme), the data is brought to the application, saving round trip time and data transfer time.

--- a/website/docs/features/data-acceleration/partitioning.md
+++ b/website/docs/features/data-acceleration/partitioning.md
@@ -1,13 +1,11 @@
 ---
 title: 'Partitioning'
 sidebar_label: 'Partitioning'
-description: 'Partitioning for accelerated datasets'
+description: 'Partition accelerated datasets to make filtered queries faster by reading only the relevant partitions.'
 sidebar_position: 4
 ---
 
-Accelerations can be partitioned using an arbitrary expression to group rows together into separate files.
-This enables Spice to avoid reading unnecessary partitions, making particular queries faster.
-To partition your accelerations, add the `partition_by` acceleration parameter:
+Partitioning splits an accelerated dataset into multiple physical units (files, tables, or in-memory tables) keyed by an expression evaluated per row. Queries that filter on the partitioning expression — or on a column it references — only read the partitions that can match, dramatically reducing the data scanned.
 
 ```yaml
 datasets:
@@ -23,26 +21,336 @@ datasets:
         - bucket(50, PULocationID)
 ```
 
-This example uses a `bucket` user-defined function (UDF) to hash the `PULocationID` column and put each row into one of 50 partition files.
+This config writes 50 separate DuckDB files, each containing the rows whose `PULocationID` hashes to the same bucket. A query like `WHERE PULocationID = 132` only opens the single bucket file that could contain `132`.
 
-This enables partition pruning for queries that filter on the column referenced in the `partition_by` expression:
+## How partitioning works
 
-```sql
-SELECT * FROM taxi_trips WHERE PULocationID IN (1, 2, 3, 4, 5);
+1. **At refresh time**, Spice evaluates each `partition_by` expression for every row and routes the row to a partition keyed by the expression's value.
+2. **At query time**, Spice rewrites filters that reference the partition column or expression into a partition selection, and only reads partitions that could satisfy the filter ([partition pruning](#partition-pruning)).
+3. **Composite partitioning** (Arrow and Cayenne) layers multiple expressions hierarchically — e.g. `year` then `month` — to combine pruning across dimensions.
+
+Partitioning is most useful when:
+
+- Queries reliably filter on a small subset of values (`region = 'EU'`, `tenant_id IN (...)`, `created_at >= today() - INTERVAL '7 days'`).
+- A single column has high cardinality and partitioning by it directly would create too many tiny files — `bucket(N, col)` collapses to `N` partitions.
+- The dataset grows large enough that scanning the whole acceleration on every query is expensive.
+
+## Configuration
+
+### `partition_by`
+
+Lives directly under `acceleration:` (not under `acceleration.params:`). It's a list of expressions; each entry is either a plain string or a single-entry `{ name: expression }` mapping:
+
+```yaml
+acceleration:
+  enabled: true
+  engine: arrow
+  partition_by:
+    # Anonymous expression — auto-named "expr0", "expr1", …
+    - "YEAR(created_at)"
+    # Named expression
+    - month: "MONTH(created_at)"
 ```
 
-This will result in a scan plan that only reads from the partitions that contain the values from the `IN` list.
+Multi-entry mappings (`- year: "…", month: "…"` on one list item) are rejected at load time.
 
-:::warning[Limitations]
+### `partition_mode` (DuckDB only)
 
-- Partitioning is currently limited to `engine: duckdb` or `engine: cayenne` with `mode: file`.
-- `partition_by` currently only supports 1 expression for partitioning.
-- Expression must reference exactly one column from the dataset.
-- Expression must produce a scalar value.
-- Expression cannot contain a subquery.
-- Partition pruning is limited to specific filter expressions such as:
-  - `WHERE foo = bar`
-  - `WHERE foo IN (bar, baz, ...)`
-  - `WHERE foo NOT IN (bar, baz, ...)`
+Under `acceleration.params.partition_mode`. Selects how DuckDB physically lays out partitions:
 
+| Value    | Layout                                                                                               | Default |
+| -------- | ---------------------------------------------------------------------------------------------------- | ------- |
+| `files`  | Each partition is its own DuckDB file in a Hive-style directory (`column=value/…`).                  | ✓       |
+| `tables` | Single DuckDB file with one table per partition (discovered via `information_schema.tables`).        |         |
+
+```yaml
+acceleration:
+  enabled: true
+  engine: duckdb
+  mode: file
+  partition_by:
+    - bucket(50, PULocationID)
+  params:
+    partition_mode: tables   # default is `files`
+```
+
+### Supported engines
+
+| Engine    | Required `mode:` | Multi-expression | Layout                                          |
+| --------- | ---------------- | ---------------- | ----------------------------------------------- |
+| `arrow`   | (memory; default)| Yes              | One Arrow `MemTable` per partition value.       |
+| `duckdb`  | `file`           | No (single only) | Hive-style files (`partition_mode: files`) or per-partition tables (`partition_mode: tables`). |
+| `cayenne` | `file`           | Yes              | One Vortex table per partition; catalog in a SQLite metadata file. |
+
+`sqlite`, `postgres`, and `turso` accelerators do **not** support `partition_by`.
+
+## Partition transforms
+
+`partition_by` accepts any DataFusion-compatible scalar SQL expression that returns a String, integer, Boolean, or Timestamp and references exactly one column from the dataset. The most common partition transforms are:
+
+### `bucket(num_buckets, column)`
+
+Hashes `column` into `num_buckets` deterministic buckets.
+
+- `num_buckets` must be a positive integer literal `≤ 1,000,000`.
+- The return type matches `num_buckets` — `bucket(50, …)` (Int64 literal) returns `Int64`; `bucket(50::int32, …)` returns `Int32`.
+- Same input always maps to the same bucket for a given `num_buckets` (uses ahash with a fixed seed).
+- Use for: high-cardinality columns where direct partitioning would create too many partitions (`user_id`, `account_id`, `device_id`).
+
+```yaml
+partition_by:
+  - bucket(100, user_id)
+```
+
+See the [`bucket` reference](../../reference/sql/scalar_functions#bucket) for the full SQL signature.
+
+### `truncate(width, value)`
+
+Truncates to the next-lower multiple of `width`. Iceberg's truncate transform.
+
+- `width` must be a positive `Int64` literal.
+- `value` may be any signed/unsigned integer, `Decimal128`/`Decimal256`, `Utf8` (string), or `Binary`. For strings/binary, returns the first `width` units.
+- Returns the same type as `value`.
+- Use for: floor-bucketing wide numeric ranges (`truncate(1000, amount)`), or grouping strings by prefix (`truncate(2, country_code)`).
+
+```yaml
+partition_by:
+  - truncate(1000, amount)
+```
+
+See the [`truncate` reference](../../reference/sql/scalar_functions#truncate) for examples.
+
+### `date_part(unit, column)` and `date_trunc(unit, column)`
+
+Built-in DataFusion datetime functions. Useful for time-based partitioning at year, month, day, or hour granularity.
+
+- `date_part('year', col)` returns the integer year (e.g. `2026`).
+- `date_trunc('day', col)` returns the timestamp truncated to the start of the day.
+
+```yaml
+partition_by:
+  - date_part('year', l_shipdate)
+```
+
+```yaml
+partition_by:
+  - day: "date_trunc('day', created_at)"
+```
+
+`YEAR(col)`, `MONTH(col)`, `DAY(col)`, etc. are aliases of `date_part(...)` and work identically.
+
+:::note Filter pruning for `date_part()` is not yet implemented
+A `date_part('year', l_shipdate)` partition still produces correctly-distributed partitions, but a filter like `WHERE l_shipdate >= '2026-01-01'` does not currently translate to a partition pruning. Queries return correct results — they just scan more partitions than necessary. If your filter is on the bare partition expression (`WHERE date_part('year', l_shipdate) = 2026`), the equality form does prune.
 :::
+
+### Modulo (`column % N`)
+
+A plain modulo expression also produces stable, partition-prunable buckets:
+
+```yaml
+partition_by:
+  - "id % 16"
+```
+
+Range filters on the base column (`id BETWEEN 0 AND 1000`) are pruned for `%` partitions.
+
+### Plain column reference
+
+A bare column name partitions one partition per distinct value — useful for low-cardinality columns:
+
+```yaml
+partition_by:
+  - region
+```
+
+Pruning supports equality, `IN`, `NOT IN`, and range filters on the column.
+
+## Composite partitioning (Arrow + Cayenne)
+
+Arrow and Cayenne accelerations accept multiple `partition_by` expressions. Spice partitions hierarchically — first by the leftmost expression, then by the next, and so on.
+
+```yaml
+acceleration:
+  enabled: true
+  engine: cayenne
+  mode: file
+  partition_by:
+    - year: "date_part('year', created_at)"
+    - month: "date_part('month', created_at)"
+    - region: region
+```
+
+A query with `WHERE region = 'EU' AND date_part('year', created_at) = 2026` prunes on both axes.
+
+DuckDB partitioned acceleration rejects multiple expressions with `PartitionByRequired` (single-expression only).
+
+## Partition pruning
+
+Spice attempts to translate query-time filters into a partition selection. The matrix below summarizes which filter shapes prune which partition transforms:
+
+| Filter shape                         | Plain column / `truncate` / `date_trunc` / `% N` | `bucket(N, col)`                              |
+| ------------------------------------ | ------------------------------------------------ | --------------------------------------------- |
+| `col = X`                            | ✓                                                | ✓ (filter substituted into bucket expression) |
+| `col != X`                           | ✓                                                | ✗ (no pruning)                                |
+| `col IN (a, b, …)`                   | ✓                                                | ✓                                             |
+| `col NOT IN (a, b, …)`               | ✓                                                | ✗ (no pruning)                                |
+| `col < X` / `<= X` / `> X` / `>= X`  | ✓                                                | ✓ only for **bounded** ranges (both lower and upper) |
+| `col BETWEEN a AND b`                | ✓                                                | ✓ (when range expands to ≤ a few thousand Int32 values) |
+| `col = a OR col = b OR …`            | ✓                                                | ✓                                             |
+| `partition_expr = X` (e.g. `bucket(50, c) = 7`) | ✓                                     | ✓                                             |
+| `expr1_filter AND expr2_filter` (composite partitions) | ✓                              | ✓                                             |
+
+Pruning notes:
+
+- **Filter on the base column is substituted into the partition expression.** `WHERE user_id = 42` against a `bucket(100, user_id)` partition evaluates `bucket(100, 42)` once and reads only that partition.
+- **Bucket inequality pruning** enumerates candidate values within a bounded `Int32` range (capped at `MAX_BUCKET_ENUMERATION_I32` candidate values). Open-ended ranges (`col < X` with no lower bound) and non-`Int32` types fall back to no pruning.
+- **`date_part()` filter pruning is not yet implemented** for time-range filters. Equality on the partition expression still prunes; range filters on the base column do not.
+- **Filters that don't fully resolve at the partition layer** are passed through to the data layer — pruning is best-effort and never returns wrong rows.
+
+## Engine-specific behavior
+
+### Arrow (`engine: arrow`)
+
+In-memory MemTable per partition value. Partitions are rebuilt on every refresh. The simplest engine to start with for moderate datasets that fit in RAM. `hash_index` and `sort_columns` are propagated per partition.
+
+### DuckDB files mode (`engine: duckdb`, `partition_mode: files`)
+
+Each partition value becomes its own DuckDB file under a Hive-style directory layout (e.g. `accelerator_dir/dataset/year=2026/data.duckdb`). Useful when you want OS-level visibility of partitions and per-partition I/O.
+
+Requires `mode: file`. Single-expression only.
+
+### DuckDB tables mode (`engine: duckdb`, `partition_mode: tables`)
+
+A single DuckDB file with one table per partition value. Cheaper to manage operationally (one file to back up, one connection pool to size), but loses per-partition file-level isolation.
+
+Requires `mode: file`. Single-expression only.
+
+### Cayenne (`engine: cayenne`)
+
+Each partition is a separate Cayenne (Vortex) table; the partition catalog is tracked in a SQLite metadata file. Cayenne supports composite partitioning natively and is the right pick for very large datasets where Arrow would not fit in memory.
+
+Requires `mode: file`.
+
+## Changing `partition_by` after refresh
+
+Once partitions exist on disk, changing `partition_by` is rejected:
+
+> The `partition_by` expressions are different from the expressions used to create the existing partition files. Revert the `partition_by` expressions, delete the partition files, or change the location the partition files are stored to create new partitions.
+
+To re-partition:
+
+1. Stop the runtime.
+2. Delete the partitioned acceleration directory or point `accelerator_dir` at a fresh location.
+3. Update `partition_by`.
+4. Restart — Spice will rebuild from the source.
+
+There is no automatic in-place re-partitioning.
+
+## Validation rules
+
+A `partition_by` expression is rejected at startup if any of the following hold:
+
+- Result type is not `String`, an integer (signed or unsigned), `Boolean`, or `Timestamp`.
+- Expression references zero or multiple dataset columns.
+- Expression contains a subquery, `OUTER REFERENCE`, `UNNEST`, window function, aggregate function, `EXISTS`, `GROUPING SET`, or `PLACEHOLDER`.
+- Expression aliases the column (`col AS partition_key`).
+
+For DuckDB engines, additionally:
+
+- `mode:` must be `file`.
+- Only one `partition_by` expression is allowed.
+
+## Examples
+
+### High-cardinality hash partitioning
+
+Partition events by user, collapsing millions of users into 100 stable buckets:
+
+```yaml
+datasets:
+  - from: s3://my-bucket/events/
+    name: events
+    params:
+      file_format: parquet
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      partition_by:
+        - bucket(100, user_id)
+```
+
+```sql
+-- Reads the single bucket that hashes user_id 42:
+SELECT COUNT(*) FROM events WHERE user_id = 42;
+
+-- Reads at most 4 bucket files:
+SELECT * FROM events WHERE user_id IN (1, 2, 3, 4);
+```
+
+### Time-based partitioning by year
+
+```yaml
+acceleration:
+  enabled: true
+  engine: duckdb
+  mode: file
+  partition_by:
+    - date_part('year', l_shipdate)
+```
+
+```sql
+-- Equality on the partition expression prunes:
+SELECT * FROM lineitem WHERE date_part('year', l_shipdate) = 2026;
+```
+
+### Composite year/month partitioning (Cayenne)
+
+```yaml
+acceleration:
+  enabled: true
+  engine: cayenne
+  mode: file
+  partition_by:
+    - year: "date_part('year', created_at)"
+    - month: "date_part('month', created_at)"
+```
+
+### Truncate-based numeric partitioning
+
+```yaml
+acceleration:
+  enabled: true
+  engine: arrow
+  partition_by:
+    - "truncate(1000, order_total_cents)"
+```
+
+```sql
+-- Range pruning works because truncate is monotonic:
+SELECT * FROM orders WHERE order_total_cents BETWEEN 5000 AND 9999;
+```
+
+### Plain column partitioning by region
+
+```yaml
+acceleration:
+  enabled: true
+  engine: arrow
+  partition_by:
+    - region
+```
+
+```sql
+-- One partition read:
+SELECT * FROM events WHERE region = 'EU';
+```
+
+## Related
+
+- [`bucket` SQL reference](../../reference/sql/scalar_functions#bucket)
+- [`truncate` SQL reference](../../reference/sql/scalar_functions#truncate)
+- [`date_part` SQL reference](../../reference/sql/scalar_functions#date_part)
+- [`date_trunc` SQL reference](../../reference/sql/scalar_functions#date_trunc)
+- [Data refresh modes](./data-refresh) — `time_partition_column` for time-pruned refreshes
+- [Sharded deployment](../../deployment/architectures/sharded) — partitioning across multiple Spice instances rather than within one acceleration

--- a/website/docs/reference/sql/scalar_functions.md
+++ b/website/docs/reference/sql/scalar_functions.md
@@ -3681,12 +3681,12 @@ bucket(num_buckets, value)
 
 #### Arguments
 
-- **num_buckets**: Positive integer indicating how many buckets to distribute values across. Values less than 1 produce an error.
+- **num_buckets**: Positive integer literal indicating how many buckets to distribute values across. Must be in the range `[1, 1_000_000]`. The literal's integer type (`Int8` … `Int64`, `UInt8` … `UInt64`) determines the return type.
 - **value**: Expression to hash. Accepts strings, numbers, and other scalar types supported by the query engine.
 
 #### Return Type
 
-Returns an `Int64` in the range `[0, num_buckets - 1]`. The same input value always maps to the same bucket for a given `num_buckets`.
+Returns an integer in the range `[0, num_buckets - 1]`, matching the integer type of `num_buckets`. The same input value always maps to the same bucket for a given `num_buckets` (the hash uses a fixed seed, so buckets are stable across processes and runtime restarts).
 
 #### Example
 
@@ -3711,7 +3711,7 @@ datasets:
 
 ### `truncate`
 
-Rounds numeric values down to the nearest multiple of the specified width. Useful when partitioning timestamps or numeric identifiers into wider ranges.
+Iceberg-style truncate transform. For numeric values, rounds down to the nearest multiple of `width`. For strings and binary, returns the first `width` characters/bytes. Useful for partitioning by wide numeric ranges or string prefixes.
 
 ```sql
 truncate(width, value)
@@ -3719,21 +3719,30 @@ truncate(width, value)
 
 #### Arguments
 
-- **width**: Positive numeric value that defines the bucket size (for example, `10`, `900`, or `3600`).
-- **value**: Numeric expression to truncate. Works with integers, decimals, and timestamps cast to integers (for example, epoch seconds).
+- **width**: Positive `Int64` literal that defines the bucket size or, for strings/binary, the number of leading units to retain. Maximum: `i64::MAX / 2`.
+- **value**: Expression to truncate. Accepts:
+  - Signed integers: `Int8`, `Int16`, `Int32`, `Int64`
+  - Unsigned integers: `UInt8`, `UInt16`, `UInt32`, `UInt64`
+  - Decimals: `Decimal128`, `Decimal256`
+  - Strings: `Utf8`
+  - Binary: `Binary`
 
 #### Return Type
 
-Returns a numeric value of the same type as `value`, rounded down so that the result is evenly divisible by `width`.
+Returns the same type as `value`. For numbers, the result is the largest multiple of `width` that is less than or equal to `value`. For strings/binary, the result is the first `width` characters/bytes.
 
 #### Example
 
 ```sql
+-- Numeric: floor-bucket integers into ranges of 10
 SELECT truncate(10, 101) AS truncated_id;  -- returns 100
 
 -- Truncate event timestamps to the start of each hour (3600 seconds)
 SELECT truncate(3600, extract(epoch FROM event_time)) AS hour_start
 FROM events;
+
+-- String: keep the first 2 characters (e.g., country prefix)
+SELECT truncate(2, 'United Kingdom');  -- returns 'Un'
 ```
 
 ---

--- a/website/src/partials/deployment/architectures/_sharded.mdx
+++ b/website/src/partials/deployment/architectures/_sharded.mdx
@@ -27,3 +27,16 @@ The Spice Runtime instances can be sharded based on specific criteria, such as b
 
 **Example Use Case**
 A multi-tenant application where each customer has a dedicated Spice Runtime instance. This helps ensure that heavy usage by one customer does not impact others, and allows for customer-specific optimizations.
+
+**Sharding vs. partitioning**
+
+Sharding splits load across **multiple Spice instances**, each backing a logical slice of the system (a customer, a region, a workload). Each shard runs an independent runtime with its own datasets, accelerations, and resources.
+
+Within a single Spice instance, [acceleration partitioning](../../features/data-acceleration/partitioning) splits a single dataset into multiple physical units (files, tables, or in-memory tables) so that filtered queries only read the relevant subset. The two are complementary: a shard can also use partitioning internally to keep individual datasets pruneable.
+
+| Concern                    | Sharded deployment                                       | Acceleration partitioning                                       |
+| -------------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| Splits across…             | Multiple runtimes/processes                               | One acceleration on one runtime                                 |
+| Routing                    | Application picks which Spice instance to query           | Spice prunes partitions automatically based on filter pushdown  |
+| Failure isolation          | Per-shard                                                 | None — single runtime                                           |
+| Use when                   | Tenants/regions have very different load or data volumes  | A single dataset is too large to scan whole on every query      |


### PR DESCRIPTION
## Summary

Rewrite the partitioning page with comprehensive coverage of how `partition_by` actually works in the runtime. Adds documentation for partition transforms (`bucket`, `truncate`, `date_part`, `date_trunc`, modulo), composite partitioning, the partition pruning matrix per filter shape, engine-specific behavior, and validation rules. Also fixes two inaccuracies in the `scalar_functions` reference for `bucket` and `truncate`.

## Changes

### `website/docs/features/data-acceleration/partitioning.md` (rewritten)

Sections added:
- **How partitioning works** — refresh-time routing, query-time pruning, when to use it
- **Configuration** — exact YAML placement of `partition_by` (under `acceleration:`) and `partition_mode` (under `acceleration.params:`); supported engines table (`arrow`, `duckdb` files/tables, `cayenne`)
- **Partition transforms** — `bucket(num_buckets, column)`, `truncate(width, value)`, `date_part(...)`, `date_trunc(...)`, modulo, plain column reference; each with valid types and example YAML
- **Composite partitioning** — multi-expression support on Arrow + Cayenne; DuckDB single-expression-only restriction
- **Partition pruning** — full matrix of which filter shapes prune which transforms (equality, `IN`/`NOT IN`, range filters, `OR`-chains, `AND` across composite partitions); `bucket()` inequality pruning bounded-range-only rule; `date_part()` filter pruning not-yet-implemented note
- **Engine-specific behavior** — Arrow MemTable, DuckDB files-mode (Hive layout), DuckDB tables-mode, Cayenne (SQLite metadata catalog)
- **Schema evolution** — `PartitionByExpressionsChanged` rejection and the manual re-partition workflow
- **Validation rules** — types accepted, single-column requirement, prohibited expression shapes
- **Examples** — high-cardinality bucketing, date-based partitioning, composite year/month, truncate, plain column

### `website/docs/reference/sql/scalar_functions.md`

- Correct `bucket` return type: it matches the `num_buckets` literal type (`Int8`…`Int64` / `UInt8`…`UInt64`), not always `Int64`. Document the `1..=1_000_000` valid range and fixed-seed determinism.
- Correct `truncate` accepted types: also accepts `Utf8` (strings) and `Binary` for prefix truncation, in addition to integers and decimals. Add a string example.

### `website/docs/features/data-acceleration/index.md`

- Link to the new partitioning page from the benefits intro.

### `website/src/partials/deployment/architectures/_sharded.mdx`

- Add a "Sharding vs. partitioning" section distinguishing deployment-level sharding (multiple Spice runtimes) from acceleration-level partitioning (one acceleration split into partitions). Includes a comparison table.

## Verification

All claims verified against the spiceai/spiceai source:

- `bucket` return type and `MAX_NUM_BUCKETS` (`crates/runtime-datafusion-udfs/src/bucket.rs:121-133`, `:35`)
- `truncate` accepted types (`crates/runtime-datafusion-udfs/src/truncate.rs:135-148`)
- `partition_by` YAML deserialization syntax (`crates/spicepod/src/partitioning.rs:38-90`)
- Engine selection per `partition_by` and `partition_mode` (`crates/runtime/src/component/dataset/acceleration.rs:418-433`, `crates/runtime/src/dataaccelerator/partitioned_duckdb.rs:69-99`)
- Partition pruning supported filter shapes (`crates/runtime-table-partition/src/provider/pruning.rs:228-600`)
- DuckDB single-expression restriction (`crates/runtime/src/dataaccelerator/partitioned_duckdb.rs:157-160`)
- Schema-evolution rejection error (`crates/runtime-table-partition/src/creator.rs:49-52`)
- Real spicepod example placement (`test/spicepods/tpch/sf1/accelerated/s3[parquet]-duckdb[file]-partitioned.yaml`)

## Test plan

- [ ] Verified parameter names, defaults, and accepted types against Rust source
- [ ] Pruning matrix entries match `pruning.rs` evaluation rules
- [ ] Cross-links resolve
- [ ] Markdown renders correctly