### PR TITLE
docs: Comprehensive Spice.ai connector docs (Cloud + Spice-to-Spice / sidecar)

### DIFF
--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -1,7 +1,7 @@
 ---
-title: 'Spice.ai Cloud Platform Data Connector Deployment Guide'
+title: 'Spice.ai Data Connector Deployment Guide'
 sidebar_label: 'Deployment Guide'
-description: 'Operating guide for the Spice.ai Cloud Platform connector in production: API keys, Flight endpoints, message sizing, and observability.'
+description: 'Operating guide for the Spice.ai connector in production: API keys, Flight endpoints, message sizing, sidecar topology, and observability.'
 sidebar_position: 10
 pagination_prev: null
 pagination_next: null
@@ -11,53 +11,142 @@ tags:
   - observability
 ---
 
-Production operating guide for the [Spice.ai Cloud Platform](https://spice.ai) data connector covering authentication, Arrow Flight transport, and operational tuning.
+Production operating guide for the [Spice.ai Data Connector](./index.md), covering both the **Spice → Spice Cloud Platform** and **Spice → Spice (self-hosted / cluster-sidecar)** topologies. The connector uses [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html) over gRPC for both.
+
+## Topology decision
+
+| Use case                                                           | Topology               | Endpoint                                         |
+| ------------------------------------------------------------------ | ---------------------- | ------------------------------------------------ |
+| Federate datasets hosted on the managed Spice.ai Cloud Platform     | Spice → Spice Cloud    | `https://<region>-prod-aws-flight.spiceai.io` (auto) |
+| Per-pod sidecar federating to a heavier upstream Spice runtime      | Spice → Spice (sidecar)| `https://upstream.cluster.svc:50051`             |
+| Edge runtime federating cold queries to a core Spice                | Spice → Spice          | Cluster-internal `https://...`                   |
+| Local development against a Spice on `localhost`                    | Spice → Spice          | `http://localhost:50051`                          |
+
+Both topologies use the same `spiceai`-prefixed parameters and the same `spice.ai:` `from:` URI scheme. See the [connector reference](./index.md#configuration) for the full parameter list and URI formats.
 
 ## Authentication & Secrets
 
-The connector authenticates to the Spice.ai Cloud Platform using an API key supplied via the `spiceai_api_key` parameter. Endpoints default to the Spice.ai production cluster; override via `endpoint` for VPC or regional endpoints.
+The connector authenticates to the upstream Spice runtime using `spiceai_api_key`. The same parameter covers both Cloud and self-hosted upstreams:
 
-| Parameter              | Description                                                                                                     |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `spiceai_api_key`      | Spice.ai Cloud Platform API key. Use `${secrets:...}` to resolve from a configured secret store.                |
-| `endpoint`             | Flight endpoint URL. Defaults to the production cluster. Override for VPC / regional endpoints.                 |
+| Topology     | Source of the key                                        | Required?                |
+| ------------ | -------------------------------------------------------- | ------------------------ |
+| Cloud        | Spice.ai Console; written to `.env` by `spice login`     | Yes                      |
+| Self-hosted  | Listed in the upstream's `runtime.auth.api-key.keys`     | Only if upstream has auth enabled (otherwise anonymous) |
 
-API keys must be sourced from a [secret store](../../secret-stores/) in production. Rotate keys from the Spice.ai Console and update the secret store without restarting the runtime if the secret store supports live reloads.
+| Parameter                         | Description                                                                                                                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `spiceai_api_key`                 | API key. Resolved from any [secret store](../../secret-stores/) via `${secrets:...}`.                                                                              |
+| `spiceai_token`                   | Legacy alias for `spiceai_api_key`.                                                                                                                                |
+| `spiceai_region`                  | Cloud region (e.g. `us-east-1`). Required for Cloud unless `spiceai_endpoint` is set.                                                                              |
+| `spiceai_endpoint`                | Override the Flight endpoint URL. Schemes: `http://`, `https://`, `grpc+tls://`.                                                                                   |
+| `spiceai_flight_endpoint`         | Legacy alias for `spiceai_endpoint`.                                                                                                                               |
+| `spiceai_tls_ca_certificate_file` | Path to a CA PEM file for verifying a self-hosted upstream that uses a private CA. Ignored for `http://` endpoints.                                                |
+
+Always source production keys from a managed secret store rather than from a checked-in `.env` file. API keys do not expire — rotate manually in the issuing system and update the secret store. Secret stores that support live reload (Kubernetes, Vault) pick up rotations without restarting the runtime.
 
 ## Resilience Controls
 
 ### Endpoint Verification
 
-On startup the connector performs a DNS + TCP reachability check against the configured `endpoint` before attempting a Flight handshake. This surfaces misconfigured endpoints as actionable startup errors rather than slow-failure query errors.
+On startup the connector performs a DNS + TCP reachability check against the resolved endpoint before attempting a Flight handshake. Misconfigured endpoints surface as actionable startup errors rather than slow-failure query errors.
 
 ### Flight Transport
 
-Data transfer uses [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html) over gRPC with TLS. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+
+For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
+
+### TLS and private CAs
+
+By default the connector trusts the system certificate store. For cluster-internal upstreams that present a private-CA-signed certificate, pin the CA explicitly:
+
+```yaml
+params:
+  spiceai_endpoint: https://upstream.cluster.svc:50051
+  spiceai_tls_ca_certificate_file: /etc/spice/upstream-ca.pem
+```
+
+The CA file is loaded once at startup; updates require a runtime restart. Mount it via Kubernetes ConfigMap or Secret in containerized deployments.
 
 ### Append Streams
 
-The connector supports long-lived append streams (`supports_changes_stream`) for real-time CDC into accelerated datasets. Stream reconnection is handled automatically; loss of connection to the Cloud Platform results in the dataset being marked `Error` if the lag exceeds the configured acceptable window (see [Data Refresh](../../../features/data-acceleration/data-refresh))..
+The connector supports long-lived append streams for real-time CDC. The upstream — whether Cloud or self-hosted — must expose a dataset with append-stream support. The sidecar subscribes over Flight `DoExchange` and receives each new batch as soon as it's emitted. Stream reconnection is automatic; persistent loss of connection causes the dataset to enter `Error` state if the lag exceeds the acceptable window. See [Data Refresh](../../../features/data-acceleration/data-refresh).
+
+Append streams are append-only — deletes and updates from the upstream are **not** propagated. Use `refresh_mode: full` for datasets that mutate.
 
 ## Capacity & Sizing
 
 ### Message Sizing
 
-Arrow Flight record batches may exceed the default gRPC 4 MiB message limit for wide or dense schemas. Control with:
+Arrow Flight record batches may exceed the default gRPC 4 MiB message limit for wide or dense schemas:
 
-| Parameter           | Default | Description                                                                                   |
-| ------------------- | ------- | --------------------------------------------------------------------------------------------- |
-| `max_message_size`  | `4MB`   | Maximum inbound gRPC message size. Raise for wide result sets or many string columns.          |
+| Parameter           | Default | Description                                                                                  |
+| ------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `max_message_size`  | `4MB`   | Maximum inbound gRPC message size. Raise for wide result sets or many string columns.        |
 
-Set via Spice configuration or via environment at runtime startup. Accepted units: `B`, `KB`, `MB`, `GB`.
+Set in spicepod parameters or via environment at runtime startup. Accepted units: `B`, `KB`, `MB`, `GB`. The same limit applies to the upstream's Flight server — raising it on the client without raising it on the server still fails.
 
 ### Network
 
-- The Spice.ai Cloud Platform is a managed service; place Spice runtime in a region geographically close to your Cloud Platform region to minimize round-trip latency.
-- Expect typical query round-trip latency in the tens of milliseconds + result streaming time; for interactive dashboards, accelerate (`acceleration: enabled`) to cache into a local engine.
+#### Cloud topology
 
-### Authentication Token Lifetime
+- Place the Spice runtime in a region geographically close to the Cloud Platform region (`spiceai_region`) to minimize round-trip latency.
+- Expect typical round-trip latency in the tens of milliseconds plus result streaming time. For interactive dashboards, accelerate (`acceleration.enabled: true`) into a local engine.
 
-API keys do not expire. Rotation is manual and must be coordinated via the secret store used by the runtime.
+#### Self-hosted / sidecar topology
+
+- Run the sidecar **in the same network namespace or cluster** as the upstream when possible — Flight is most efficient over single-digit-millisecond RTT.
+- Size sidecar memory for the local query workspace plus any in-memory acceleration. The sidecar does not need to be sized for the full dataset — only for hot data accelerated locally and the working set of in-flight queries.
+- Use a Kubernetes `Service` (with stable DNS) or a load balancer in front of multi-replica upstreams. Connection pooling is per-endpoint URL.
+
+### API key lifetime
+
+API keys do not expire. Rotation is manual; coordinate with the secret store used by the runtime.
+
+## Sidecar deployment patterns
+
+### Per-pod sidecar (Kubernetes)
+
+Co-locate a Spice sidecar with each application pod. The sidecar terminates HTTP / OpenAPI / MCP / gRPC for the app and federates queries to a central upstream Spice cluster.
+
+```yaml
+# Sidecar spicepod.yaml mounted into each app pod
+version: v1
+kind: Spicepod
+name: app-sidecar
+
+runtime:
+  http:
+    bind_address: 127.0.0.1:8090   # localhost-only, sidecar talks to the app
+
+datasets:
+  - from: spice.ai:https://upstream-spice.spiceai.svc.cluster.local:50051
+    name: orders
+    params:
+      spiceai_api_key: ${secrets:SIDECAR_API_KEY}
+      spiceai_tls_ca_certificate_file: /etc/spice/cluster-ca.pem
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_check_interval: 30s
+```
+
+The application talks to `127.0.0.1:8090`; the sidecar handles federation and caching. The upstream runs as a `Deployment` or `StatefulSet` with persistent storage for the acceleration files.
+
+### Edge → core federation
+
+Edge Spice runtimes accelerate local datasets and federate the long-tail to a core Spice in the data center. The same connector is used; the difference is that edge runtimes have their own non-federated datasets too:
+
+```yaml
+datasets:
+  - from: postgres:public.local_orders        # local, accelerated
+    name: local_orders
+    acceleration:
+      enabled: true
+
+  - from: spice.ai:https://core.example.com:50051   # federated
+    name: historical_orders
+```
 
 ## Metrics
 
@@ -65,26 +154,34 @@ Flight transport metrics are collected via the shared Flight client instrumentat
 
 - Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
-- Upstream Spice.ai Console metrics on the source dataset.
+- For Cloud: upstream Console metrics on the source dataset.
+- For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 ## Task History
 
-Queries to the Spice.ai Cloud Platform participate in [task history](../../../reference/task_history) via the Flight client spans. Each Flight request is recorded as a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
+Queries to the upstream Spice runtime participate in [task history](../../../reference/task_history) via Flight client spans. Each Flight request is recorded as a child of the enclosing `sql_query` or `accelerated_table_refresh` task. The upstream runtime records its own task history independently — correlate by request timestamps or by propagated trace IDs.
 
 ## Known Limitations
 
-- **Read-only**: The connector is read-only; writes to the Cloud Platform are done via the Spice CLI / Console, not the runtime.
-- **Single endpoint per dataset**: A dataset binds to a single `endpoint`. Multi-region failover must be handled at the load-balancer / DNS layer.
-- **API key auth only**: OIDC / SSO is not currently supported at the data-plane connector.
+- **Read-only.** The connector does not write to the upstream. Cloud writes go through the Spice CLI / Console; self-hosted writes happen on the upstream runtime directly.
+- **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
+- **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
+- **Append-only changes stream.** Updates and deletes are not propagated.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
 
-| Symptom                                             | Likely cause                                              | Resolution                                                                                                                  |
-| --------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `Failed to connect to SpiceAI endpoint`             | DNS, firewall, or TLS issue against `endpoint`.           | Verify DNS resolution and outbound 443 connectivity. Test with `grpcurl -insecure <endpoint>:443 list`.                     |
-| `UNAUTHENTICATED` on Flight handshake               | Invalid / expired / wrong-environment API key.            | Regenerate the key in the Spice.ai Console, update the secret store.                                                        |
-| `message size exceeded` / `ResourceExhausted`       | Row batch exceeds gRPC message limit.                     | Increase `max_message_size`, or narrow the query projection.                                                                |
-| Append stream stalled; acceleration lag climbing    | Network partition or upstream dataset paused.             | Check Cloud Platform status; verify the source dataset is healthy; restart the runtime to re-establish the stream.          |
-| Sudden 5xx / `UNAVAILABLE` errors                   | Transient service-side issue.                             | Flight client auto-retries; if persistent, check Spice.ai status page.                                                      |
+| Symptom                                              | Likely cause                                                  | Resolution                                                                                                                          |
+| ---------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `Failed to connect to SpiceAI endpoint`              | DNS, firewall, or TLS issue against the resolved endpoint.    | Verify DNS resolution and outbound 443/50051 connectivity. Test with `grpcurl -insecure <host>:<port> list`.                        |
+| `UnsupportedEndpointScheme`                          | Endpoint uses `grpc://` or another unsupported scheme.        | Switch to `http://`, `https://`, or `grpc+tls://`.                                                                                  |
+| `CloudEndpointRegionMismatch`                        | `spiceai_endpoint` is a Cloud regional URL but `spiceai_region` doesn't match. | Set both to the same region, or remove one and let Spice pick the other.                                                            |
+| `UNAUTHENTICATED` on Flight handshake                | Invalid / expired / wrong-environment API key.                | For Cloud: regenerate in the Console; update the secret store. For self-hosted: confirm the key is in the upstream's `runtime.auth.api-key.keys`. |
+| TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
+| `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `max_message_size` on both client and server, or narrow the query projection.                                              |
+| Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/docs/components/data-connectors/spiceai/index.md
+++ b/website/docs/components/data-connectors/spiceai/index.md
@@ -1,72 +1,248 @@
 ---
 title: 'Spice.ai Data Connector'
 sidebar_label: 'Spice.ai Data Connector'
-description: 'Spice.ai Data Connector Documentation'
+description: 'Federated SQL across Spice runtimes — Spice Cloud Platform datasets and self-hosted Spice instances (cluster-sidecar pattern).'
 pagination_next: null
 ---
 
-The [Spice.ai](https://spice.ai/) Data Connector enables federated SQL query across datasets in the [Spice.ai Cloud Platform](https://docs.spice.ai/building-blocks/datasets). Access to these datasets requires a free [Spice.ai account](https://spice.ai/login).
+The Spice.ai Data Connector federates SQL queries across **another Spice runtime** over [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html). The same connector targets two architectures:
+
+- **Spice → Spice Cloud Platform** — federate datasets hosted on the managed [Spice.ai Cloud Platform](https://docs.spice.ai/building-blocks/datasets). Requires a free [Spice.ai account](https://spice.ai/login).
+- **Spice → Spice (self-hosted)** — federate to another Spice runtime running anywhere reachable over the network. The most common pattern is a **cluster-sidecar**: a thin Spice runtime co-located with each application instance forwards queries to a heavier-weight upstream Spice (or a cluster of them) that owns the data and acceleration.
+
+Both architectures use the same `spice.ai` (or legacy `spiceai`) `from:` URI scheme; the difference is in the URI format and the `endpoint` parameter.
+
+## Quick start
+
+### Spice → Spice Cloud Platform
+
+```yaml
+datasets:
+  - from: spice.ai/spiceai/quickstart/datasets/taxi_trips
+    name: taxi_trips
+    params:
+      spiceai_api_key: ${secrets:SPICEAI_API_KEY}
+      spiceai_region: us-east-1
+```
+
+`spice login` writes the API key to `~/.spice/auth` and exposes it as `SPICEAI_API_KEY` via the [env secret store](../secret-stores/env/). The `spiceai_region` parameter selects the Spice Cloud region the API key was created in.
+
+### Spice → Spice (self-hosted, cluster-sidecar)
+
+```yaml
+datasets:
+  - from: spice.ai:http://upstream-spice.internal:50051
+    name: orders                          # table name on the upstream runtime
+    params:
+      spiceai_api_key: ${secrets:UPSTREAM_API_KEY}   # match runtime.auth.api-key on upstream
+```
+
+The local sidecar Spice now exposes `orders` as if it were a local dataset, federating every query to `upstream-spice.internal:50051`. Combine with `acceleration.enabled: true` to cache hot data at the sidecar.
 
 ## Configuration
 
-### Secrets
+### `from:` URI formats
 
-Secrets will be written to a `.env` file by using the `spice login` command and logging in with an active Spice AI account. Learn more about the [Env Secret Store](../secret-stores/env/).
+| URI                                                    | Mode       | Notes                                                                             |
+| ------------------------------------------------------ | ---------- | --------------------------------------------------------------------------------- |
+| `spice.ai/<org>/<app>/datasets/<dataset>`              | Cloud      | Path-style. Most common.                                                          |
+| `spice.ai:<org>/<app>/datasets/<dataset>`              | Cloud      | Colon-style. Equivalent to the path-style form.                                   |
+| `spice.ai://<org>/<app>/datasets/<dataset>`            | Cloud      | URL-style. Equivalent.                                                            |
+| `spice.ai/<table>`                                     | Cloud      | Short form when the dataset isn't under a 4-segment `<org>/<app>/datasets/...` path. |
+| `spice.ai:http://<host>:<port>`                        | Self-hosted| Connects without TLS. The local dataset's `name:` field is the upstream table name. |
+| `spice.ai:https://<host>:<port>`                       | Self-hosted| TLS-encrypted Flight.                                                              |
+| `spice.ai:grpc+tls://<host>:<port>`                    | Self-hosted| TLS-encrypted Flight (alias for `https://`).                                       |
 
-- `api_key`: A Spice.ai API key.
-- `token`: An active personal access token that is configured when logging in to spice via `spice login`.
+The legacy `spiceai:` prefix (without the dot) is accepted in every form above for backward compatibility.
+
+:::note `grpc://` is not supported
+Plain `grpc://` (without TLS) is rejected at startup. Use `http://` for unencrypted connections to a local sidecar, or `https://` / `grpc+tls://` for production.
+:::
 
 ### Parameters
 
-#### `from`
+| Parameter                         | Default                              | Description                                                                                                                                                       |
+| --------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spiceai_api_key`                 | None                                 | API key. **Required** for Cloud. Optional for self-hosted (omit for anonymous; supply to match the upstream's `runtime.auth.api-key.keys`). Use `${secrets:...}`. |
+| `spiceai_token`                   | None                                 | Legacy alias for `spiceai_api_key`. Prefer `spiceai_api_key` in new configurations.                                                                                |
+| `spiceai_region`                  | None                                 | Cloud region (e.g. `us-east-1`). **Required** when targeting Cloud without an explicit `spiceai_endpoint`. Used to build `https://<region>-prod-aws-flight.spiceai.io`. |
+| `spiceai_endpoint`                | Built from `spiceai_region` (Cloud)  | Override the Flight endpoint URL. Use for VPC / regional Cloud endpoints, or to point at a self-hosted Spice runtime. Schemes: `http://`, `https://`, `grpc+tls://`. |
+| `spiceai_flight_endpoint`         | None                                 | Legacy alias for `spiceai_endpoint`.                                                                                                                              |
+| `spiceai_tls_ca_certificate_file` | System cert store                    | Path to a CA certificate file (PEM) to verify a self-hosted upstream that uses a private CA. Ignored for `http://` endpoints.                                     |
 
-The Spice.ai Cloud Platform dataset URI. To query a dataset in a public Spice.ai App, use the format `spice.ai/<org>/<app>/datasets/<dataset_name>`.
+#### Endpoint resolution order
 
-#### `name`
+The connector picks a Flight endpoint in this order:
 
-The dataset name. This will be used as the table name within Spice. The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
+1. `spiceai_endpoint` (or its legacy alias `spiceai_flight_endpoint`).
+2. The URI in `from:` if it begins with `http://`, `https://`, or `grpc+tls://` (self-hosted forms).
+3. `https://<spiceai_region>-prod-aws-flight.spiceai.io` (Cloud, regional).
 
-### `params`
+The legacy `https://flight.spiceai.io` host is rewritten to the regional URL automatically. If both `spiceai_endpoint` and `spiceai_region` are set and they refer to different Cloud regions, the runtime fails fast with a region-mismatch error. For self-hosted endpoints, `spiceai_region` is not validated.
 
-The Spice.ai Cloud Platform data connector can be configured by providing the following `params`. Use the [secret replacement syntax](../secret-stores/) to load the secret from a secret store, e.g. `${secrets:SPICEAI_API_KEY}`.
+### `name`
 
-| Parameter Name    | Description                                          |
-| ----------------- | ---------------------------------------------------- |
-| `spiceai_api_key` | The Spice.ai Cloud Platform API key to connect with. |
+The dataset name as exposed on the local runtime. The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 
-## Example
+For self-hosted (`spice.ai:http://...`) `from:` URIs, the connector uses **the `name:` value as the upstream table reference** — so `name: orders` queries the `orders` table on the upstream Spice runtime. For Cloud `from:` URIs, the table reference is parsed from the path.
+
+## Spice → Spice Cloud Platform
+
+### Authentication
+
+API keys are issued in the [Spice.ai Console](https://spice.ai). The `spice login` CLI command writes the active key to a local `.env` file via the [env secret store](../secret-stores/env/), making it available as `SPICEAI_API_KEY` in spicepod parameters:
 
 ```yaml
-- from: spice.ai/spiceai/quickstart/datasets/taxi_trips
-  name: taxi_trips
+params:
+  spiceai_api_key: ${secrets:SPICEAI_API_KEY}
+```
+
+For production, prefer a managed [secret store](../secret-stores/) (Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault) over the env file. API keys do not expire — rotate manually via the Console and update the secret store.
+
+### Region & endpoint
+
+`spiceai_region` is required when targeting Cloud without an explicit endpoint. Spice builds the regional Flight URL automatically:
+
+```yaml
+params:
+  spiceai_api_key: ${secrets:SPICEAI_API_KEY}
+  spiceai_region: us-east-1
+```
+
+For VPC-peered or otherwise-routed Cloud endpoints, set `spiceai_endpoint` explicitly. The endpoint must match `spiceai_region` if it's a recognized Cloud regional URL.
+
+### Cloud example
+
+```yaml
+datasets:
+  - from: spice.ai/spiceai/tpch/datasets/customer
+    name: tpch.customer
+    params:
+      spiceai_api_key: ${secrets:SPICEAI_API_KEY}
+      spiceai_region: us-east-1
+    acceleration:
+      enabled: true
+```
+
+## Spice → Spice (self-hosted federation)
+
+The same connector federates queries to **any** Spice runtime that exposes Arrow Flight on a network endpoint. The most common pattern is a **cluster sidecar**: each application pod runs a small Spice runtime that owns no data but forwards queries to a heavier upstream Spice that owns the acceleration. The sidecar adds local caching, in-process auth, and protocol translation (HTTP / OpenAPI / MCP / gRPC) without each app needing direct access to the upstream cluster.
+
+### When to use it
+
+- **Cluster sidecar**: per-pod Spice next to each application instance, federating to a central cluster Spice. The sidecar handles in-process queries; the cluster Spice handles refresh and storage.
+- **Edge → core federation**: edge Spice runtimes accelerate local datasets and federate the long-tail to a core Spice in the data center.
+- **Multi-region read replicas**: regional Spice instances replicate hot datasets and federate cold ones to a central runtime.
+
+### Authentication
+
+If the upstream runtime has API key authentication enabled (`runtime.auth.api-key.keys`), set `spiceai_api_key` to a key listed there. The connector sends it via Flight handshake using HTTP Basic — the upstream's `BasicAuthLayer` validates the key and issues a Bearer token for subsequent calls.
+
+```yaml
+# Upstream runtime spicepod.yaml
+runtime:
+  auth:
+    api-key:
+      enabled: true
+      keys:
+        - ${secrets:SIDECAR_API_KEY}
 ```
 
 ```yaml
-- from: spice.ai/spiceai/tpch/datasets/customer
-  name: tpch.customer
+# Sidecar runtime spicepod.yaml
+datasets:
+  - from: spice.ai:https://upstream.cluster.svc:50051
+    name: events
+    params:
+      spiceai_api_key: ${secrets:SIDECAR_API_KEY}
 ```
 
-## Full Configuration Example
+If the upstream has no auth, omit `spiceai_api_key` — the connector falls back to anonymous credentials.
+
+### TLS and private CAs
+
+Production-grade self-hosted federation should use TLS (`https://` or `grpc+tls://`). By default the connector trusts the system certificate store. To pin a private CA — common in cluster-internal deployments with a self-signed or internal-PKI CA:
 
 ```yaml
-- from: spice.ai/spiceai/tpch/datasets/customer
-  name: tpch.customer
-  params:
-    spiceai_api_key: ${secrets:spiceai_api_key}
-  acceleration:
-    enabled: true
+params:
+  spiceai_tls_ca_certificate_file: /etc/spice/upstream-ca.pem
 ```
+
+For local development and trusted internal networks, `http://` (no TLS) is also supported and avoids cert configuration entirely.
+
+### Append streams (real-time CDC)
+
+The connector advertises [`supports_append_stream`](../../features/cdc/) — when the upstream Spice exposes a dataset with append-stream support, the sidecar can subscribe over Flight `DoExchange` and receive each new batch as soon as the upstream emits it. Enable on the sidecar via `refresh_mode: append` on an accelerated dataset:
+
+```yaml
+datasets:
+  - from: spice.ai:https://upstream.cluster.svc:50051
+    name: events
+    params:
+      spiceai_api_key: ${secrets:SIDECAR_API_KEY}
+    acceleration:
+      enabled: true
+      refresh_mode: append
+```
+
+Append streams are **append-only** — deletes and updates from the upstream are not propagated. Stream reconnection is automatic; persistent loss of connection causes the dataset to enter `Error` state if the lag exceeds the configured acceptable window. See [Data Refresh](../../features/data-acceleration/data-refresh) for the full append-mode reference.
+
+### Sidecar example
+
+A sidecar Spice running alongside an application, federating to a cluster Spice over TLS with API key auth and local in-memory acceleration:
+
+```yaml
+version: v1
+kind: Spicepod
+name: app-sidecar
+
+datasets:
+  - from: spice.ai:https://upstream.cluster.svc:50051
+    name: orders
+    params:
+      spiceai_api_key: ${secrets:SIDECAR_API_KEY}
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_check_interval: 30s
+
+  - from: spice.ai:https://upstream.cluster.svc:50051
+    name: customers
+    params:
+      spiceai_api_key: ${secrets:SIDECAR_API_KEY}
+    acceleration:
+      enabled: true
+      refresh_mode: full
+      refresh_check_interval: 5m
+```
+
+### Local development sidecar
+
+To run a sidecar against a local Spice without TLS:
+
+```yaml
+datasets:
+  - from: spice.ai:http://localhost:50051
+    name: events
+```
+
+`localhost` and loopback addresses are accepted with `http://` for development.
 
 ## Cookbook
 
-- A cookbook recipe to configure Spice.ai Cloud Platform as a data connector in Spice. [Spice.ai Cloud Platform Data Connector](https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme)
+- [Spice.ai Cloud Platform Data Connector](https://github.com/spiceai/cookbook/tree/trunk/spiceai#readme) — end-to-end Cloud connection.
 
 ## Limitations
 
-- The Spice.ai Data Connector is subject to a maximum limit of 1000 requests per connection, after which the connection is reset by the Spice Cloud Platform. If the error message `Connection is reset by the server. Please retry the request.` is encountered or the `spiceai-retryable` metadata appears in the response, the query should be retried.
+- **Read-only.** The connector does not support `INSERT`/`UPDATE`/`DELETE` against Cloud or self-hosted upstreams. Writes happen on the upstream runtime (or via the Spice CLI / Console for Cloud).
+- **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
+- **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
+- **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
-:::warning[Memory Considerations]
+:::warning Memory considerations
+Without `acceleration.enabled: true`, federated queries that join across multiple Spice instances perform the join in memory on the local runtime. Ensure the local runtime has enough memory for query workspace plus runtime overhead, especially for concurrent queries.
 
-When using the Spice.ai Data Connector without acceleration, part of the query execution will be in memory if federating across different Spice Cloud Platform apps. Ensure sufficient memory is available, including overhead for queries and the runtime, especially with concurrent queries.
-
-Memory limitations can be mitigated by storing acceleration data on disk, which is supported by [`duckdb`](../data-accelerators/duckdb) and [`sqlite`](../data-accelerators/sqlite) accelerators by specifying `mode: file`.
+For large workloads, accelerate hot datasets locally with a file-mode engine ([`duckdb`](../data-accelerators/duckdb) or [`sqlite`](../data-accelerators/sqlite) with `mode: file`) to spill to disk instead of RAM.
+:::


### PR DESCRIPTION
## Summary

Rewrite the Spice.ai data connector docs to cover both architectures the connector actually supports — the existing docs only covered the managed Cloud Platform path. The same connector federates queries to **any** Spice runtime over Arrow Flight, including self-hosted Spice instances in a cluster-sidecar, edge-to-core, or local-dev topology.

## What changed

### `website/docs/components/data-connectors/spiceai/index.md` (rewritten)

- **Both topologies up front**: Spice → Spice Cloud Platform vs. Spice → Spice (self-hosted / sidecar), with quick-start examples for each.
- **All five `from:` URI formats**: path-style, colon-style, and URL-style cloud forms; plus colon-prefixed `http://` / `https://` / `grpc+tls://` forms for self-hosted upstreams.
- **Full parameter table** with the actual user-facing names: `spiceai_api_key`, `spiceai_token`, `spiceai_region`, `spiceai_endpoint`, `spiceai_flight_endpoint`, `spiceai_tls_ca_certificate_file`. The previous docs incorrectly used unprefixed names like `endpoint` and were missing `spiceai_region` and `spiceai_tls_ca_certificate_file` entirely.
- **Endpoint resolution precedence** documented: explicit `spiceai_endpoint` → `from:` URI scheme → built from `spiceai_region`.
- **Spice → Spice authentication** via the upstream's `runtime.auth.api-key.keys` (not previously documented).
- **TLS with private CAs** via `spiceai_tls_ca_certificate_file` for cluster-internal certs.
- **Append-stream CDC between Spice runtimes** with `refresh_mode: append` example.
- **Worked sidecar example** including TLS, CA pinning, append streams, and a multi-dataset spicepod.

### `website/docs/components/data-connectors/spiceai/deployment.md` (rewritten)

- **Topology decision matrix** mapping each use case to its endpoint format.
- **Authentication source table** distinguishing Cloud (always required) from self-hosted (optional, must match upstream `runtime.auth.api-key.keys`).
- **Sidecar deployment pattern** for Kubernetes — co-locating a sidecar Spice with each application pod and federating to a central upstream.
- **Edge → core federation pattern** where edge runtimes accelerate local datasets and federate cold queries to a core Spice.
- **TLS / CA pinning** operations guidance.
- **Per-topology troubleshooting**: new error rows for `UnsupportedEndpointScheme`, `CloudEndpointRegionMismatch`, `MissingRequiredParameter: api_key or token`, TLS handshake failures with private CAs.

## Verification

All claims verified against the actual connector source:

- `from:` URI parsing → `spice_dataset_path` (`crates/runtime/src/dataconnector/spiceai.rs:526-553`); test cases at `:651-757`.
- Self-hosted endpoint detection → `is_flight_endpoint_path` (`:207-212`).
- Supported schemes (`http://`, `https://`, `grpc+tls://`; rejects `grpc://`) → `ensure_supported_endpoint_scheme` (`:214-223`).
- Parameter list → `PARAMETERS` array (`:176-184`).
- Endpoint resolution order → `get_endpoint` (`:252-279`).
- Authentication fallback to anonymous on self-hosted → `get_credentials` (`:293-306`); test (`:858-864`).
- Real-world parameter names confirmed in `test/spicepods/tpch/sf1/federated/spicecloud.yaml`.

## Test plan

- [ ] Verified parameter names and defaults against Rust source
- [ ] Verified URI-format parsing against connector tests
- [ ] Confirmed `runtime.auth.api-key.keys` syntax matches `runtime.md` reference
- [ ] Cross-links resolve
- [ ] Markdown renders correctly