### PR TITLE
fix: Correct Redshift pg_port default and add missing sslmode values

### DIFF
--- a/website/docs/components/data-connectors/redshift.md
+++ b/website/docs/components/data-connectors/redshift.md
@@ -123,11 +123,11 @@ datasets:
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `pg_connection_string`      | Optional. A [PostgreSQL connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). Overrides individual connection parameters when provided. |
 | `pg_host`                   | Hostname or IP address of the Redshift cluster                                                                    |
-| `pg_port`                   | Port for Redshift (default: 5439)                                                                                 |
+| `pg_port`                   | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly.                              |
 | `pg_db`                     | Database name                                                                                                     |
 | `pg_user`                   | Username for authentication                                                                                       |
 | `pg_pass`                   | Password for authentication (use secret reference)                                                                |
-| `pg_sslmode`                | SSL mode (e.g., `prefer`, `require`, `verify-ca`, `verify-full`)                                                  |
+| `pg_sslmode`                | SSL mode (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`)                                    |
 | `pg_sslrootcert`            | Optional. Path to a custom root certificate for SSL verification                                                  |
 | `pg_connection_pool_min_idle` | Optional. The minimum number of idle connections to keep open in the pool. Default is `1`.                       |
 | `connection_pool_size`      | Optional. The maximum number of connections in the connection pool. Default is `5`.                               |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/redshift.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/redshift.md
@@ -122,7 +122,7 @@ datasets:
 | Parameter Name | Description                                        |
 | -------------- | -------------------------------------------------- |
 | `pg_host`      | Hostname or IP address of the Redshift cluster     |
-| `pg_port`      | Port for Redshift (default: 5439)                  |
+| `pg_port`      | The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly. |
 | `pg_sslmode`   | SSL mode (e.g., `prefer`)                          |
 | `pg_db`        | Database name                                      |
 | `pg_user`      | Username for authentication                        |


### PR DESCRIPTION
## Summary
- **`pg_port` description corrected across all doc versions (vNext + 1.6.x through 1.11.x):** The docs previously stated `pg_port` defaults to `5439`. The Postgres connector code (`connector-postgres/src/lib.rs`) has no `.default()` call on the port parameter — the underlying `tokio-postgres` default is `5432`, not `5439`. Port `5439` is Redshift's standard port but is not a Spice-level default. Updated the description to: *"The PostgreSQL TCP port. Redshift uses port `5439` by default — set this explicitly."*
- **`pg_sslmode` values completed in vNext docs:** The vNext parameter table listed only `prefer`, `require`, `verify-ca`, `verify-full`. The code's `one_of` constraint also includes `disable` and `allow`. Added these two missing values. Older versioned docs use a vaguer description (`e.g., prefer`) and were left as-is.

## Test plan
- [ ] Verify no remaining `(default: 5439)` text in any Redshift connector doc parameter table
- [ ] Verify vNext `pg_sslmode` row lists all six modes: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`
- [ ] Confirm YAML examples still show `pg_port: 5439` (correct — examples demonstrate the recommended explicit value)