### PR TITLE
fix: Remove Map from Cayenne unsupported types list

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -418,6 +418,7 @@ Cayenne (via Vortex) supports most Arrow data types with the following considera
 - Timestamps (normalized to Microsecond precision)
 - Date32 and Date64
 - Lists and FixedSizeLists
+- Maps
 - Structs
 
 ### Automatically Converted Types
@@ -433,7 +434,6 @@ The following types require the `unsupported_type_action` parameter:
 
 - `Interval` types
 - `Duration` types
-- `Map` types
 - `FixedSizeBinary`
 
 **`unsupported_type_action` options:**
@@ -504,7 +504,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 
 - **File Mode Only**: Spice Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
-- **Unsupported Data Types**: `Interval`, `Duration`, `Map`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
+- **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **No File Compaction**: Automatic file compaction to reclaim space from deleted rows is not yet available.

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
@@ -110,7 +110,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **File Mode Only**: Spice Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
 - **No Snapshot Support**: Spice Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots) for bootstrapping from object storage.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
-- **Unsupported Data Types**: `Interval`, `Duration`, `Map`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
+- **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **No File Compaction**: Automatic file compaction to reclaim space from deleted rows is not yet available.

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
@@ -420,6 +420,7 @@ Cayenne (via Vortex) supports most Arrow data types with the following considera
 - Timestamps (normalized to Microsecond precision)
 - Date32 and Date64
 - Lists and FixedSizeLists
+- Maps
 - Structs
 
 ### Automatically Converted Types
@@ -435,7 +436,6 @@ The following types require the `unsupported_type_action` parameter:
 
 - `Interval` types
 - `Duration` types
-- `Map` types
 - `FixedSizeBinary`
 
 **`unsupported_type_action` options:**
@@ -507,7 +507,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **Beta Status**: Spice Cayenne is in active development. Configuration options may change between releases.
 - **File Mode Only**: Spice Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
-- **Unsupported Data Types**: `Interval`, `Duration`, `Map`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
+- **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **No File Compaction**: Automatic file compaction to reclaim space from deleted rows is not yet available.


### PR DESCRIPTION
## Summary

- Remove `Map` from the Cayenne "Unsupported Types" list and "Limitations" section across vNext, 1.11.x, and 1.10.x docs
- Add `Maps` to the "Fully Supported Types" list in vNext and 1.11.x (1.10.x does not have this section)

The Cayenne accelerator docs incorrectly listed `Map` types as unsupported. The source code at `crates/cayenne/src/schema.rs` (lines 23-27) only lists `Interval`, `Duration`, and `FixedSizeBinary` as unsupported types. Additionally, the test `test_transform_schema_for_vortex_preserves_http_response_headers_map` at `crates/runtime/src/dataaccelerator/cayenne/mod.rs` (line 2037) explicitly verifies that Map types pass through correctly.

## Test plan

- [ ] Verify `Map` no longer appears in the "Unsupported Types" section of any Cayenne doc
- [ ] Verify `Maps` appears in the "Fully Supported Types" list in vNext and 1.11.x
- [ ] Run `grep -rn "Map" website/ | grep -i "unsupported\|cayenne"` and confirm only "Zone-Map Equivalent" and "Maps" (in supported list) remain