### PR TITLE
fix: Correct Snowflake env var prefix and secret reference syntax

### DIFF
--- a/website/docs/components/data-connectors/snowflake.md
+++ b/website/docs/components/data-connectors/snowflake.md
@@ -65,21 +65,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     `spicepod.yaml` (key-pair with private key content from secret)

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     Learn more about [Kubernetes Secret Store](../../components/secret-stores/kubernetes).

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     Learn more about [Kubernetes Secret Store](../../components/secret-stores/kubernetes).

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     Learn more about [Kubernetes Secret Store](../../components/secret-stores/kubernetes).

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     Learn more about [Kubernetes Secret Store](../../components/secret-stores/kubernetes).

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_PASSWORD=<password> \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
+    SPICE_SNOWFLAKE_USERNAME=<username> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
     spice run
     ```
 
@@ -150,9 +150,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
         params:
           snowflake_warehouse: COMPUTE_WH
           snowflake_role: accountadmin
-          snowflake_username: ${snowflake.username}
-          snowflake_password: ${snowflake.password}
-          snowflake_account: ${snowflake.account}
+          snowflake_username: ${snowflake:username}
+          snowflake_password: ${snowflake:password}
+          snowflake_account: ${snowflake:account}
     ```
 
     Learn more about [Kubernetes Secret Store](../../components/secret-stores/kubernetes).


### PR DESCRIPTION
## Summary
- Fix env var prefix in Snowflake connector docs: `SPICE_SECRET_SNOWFLAKE_*` -> `SPICE_SNOWFLAKE_*` (the env secret store uses `SPICE_` as its prefix, not `SPICE_SECRET_`; confirmed in `spiceai/spiceai crates/runtime-secrets/src/stores/env.rs` and the `spice login` CLI output)
- Fix secret reference syntax in Kubernetes spicepod YAML examples for versions 1.5.x through 1.10.x: `${snowflake.key}` (dot) -> `${snowflake:key}` (colon), matching the correct secret store reference syntax

## Files changed
- `website/docs/components/data-connectors/snowflake.md` (vNext) -- env var prefix fix
- `website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix
- `website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix
- `website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix
- `website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix
- `website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix
- `website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md` -- env var prefix + secret syntax fix

## Test plan
- [ ] Verify `SPICE_SECRET_SNOWFLAKE_*` no longer appears in any Snowflake connector doc
- [ ] Verify `${snowflake.` (dot syntax) no longer appears in any versioned Snowflake connector doc
- [ ] Confirm the corrected env vars match what `spice login snowflake` writes to `.env`
- [ ] Confirm the corrected secret syntax `${snowflake:key}` matches the secret store reference format