### PR TITLE
fix: Mark spark_remote parameter as Required in Spark connector docs

### DIFF
--- a/website/docs/components/data-connectors/spark.md
+++ b/website/docs/components/data-connectors/spark.md
@@ -24,7 +24,7 @@ Unquoted identifiers are normalized to lowercase. To reference a table with mixe
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords.md).
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/spark.md
@@ -20,7 +20,7 @@ datasets:
 
 ## Configuration
 
-- `spark_remote`: A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
+- `spark_remote`: Required. A [spark remote](https://spark.apache.org/docs/latest/spark-connect-overview.html#set-sparkremote-environment-variable) connection URI. Refer to [spark connect client connection string](https://github.com/apache/spark/blob/master/connector/connect/docs/client-connection-string.md) for parameters in URI.
 
 The dataset name cannot be a [reserved keyword](../../reference/spicepod/keywords).
 


### PR DESCRIPTION
## Summary
- The `spark_remote` parameter is declared as `.required()` in the Spark connector code (`crates/data-connectors/connector-spark/src/lib.rs` line 109), but the docs did not label it as Required.
- Added "Required." to the `spark_remote` parameter description in the Configuration section across vNext and all versioned docs (1.5.x through 1.11.x).

## Test plan
- [ ] Verify `spark_remote` shows "Required." in the Configuration section on vNext docs
- [ ] Verify all versioned docs (1.5.x-1.11.x) consistently show "Required." for `spark_remote`