### PR TITLE
fix: Remove nonexistent turso_mvcc parameter from v1.11.x docs

### DIFF
--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/turso.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/turso.md
@@ -60,7 +60,6 @@ datasets:
 Turso acceleration supports the following optional parameters under `acceleration.params`:
 
 - `turso_file` (string, default: `.spice/data/{dataset_name}.turso`): Path to the Turso database file. Only applies if `mode` is `file`. If the file does not exist, Spice creates it automatically.
-- `turso_mvcc` (string, default: `disabled`): Enable Multi-Version Concurrency Control (MVCC) for improved concurrent read/write performance. Values: `enabled`, `disabled`.
 - `internal_timestamp_format` (string, default: `rfc3339`): Internal timestamp storage format. See [Timestamp Storage](#timestamp-storage) section. Values: `rfc3339`, `integer_millis`.
 
 ### Example Configuration
@@ -77,7 +76,6 @@ datasets:
       refresh_check_interval: 10m
       params:
         turso_file: ./orders.turso
-        turso_mvcc: enabled
 ```
 
 Refer to the [datasets configuration reference](../../reference/spicepod/datasets#acceleration) for additional supported fields.
@@ -116,16 +114,9 @@ acceleration:
 
 ### MVCC Support
 
-Multi-Version Concurrency Control (MVCC) can be enabled for improved concurrent read/write performance:
+Multi-Version Concurrency Control (MVCC) is automatically enabled for all Turso-accelerated datasets. The Turso accelerator sets `PRAGMA journal_mode = 'mvcc'` during connection pool initialization, enabling concurrent transactions via `BEGIN CONCURRENT`.
 
-```yaml
-acceleration:
-  engine: turso
-  params:
-    turso_mvcc: enabled
-```
-
-When MVCC is enabled:
+When MVCC is active:
 
 - Concurrent reads and writes perform better
 - Indexes are not yet supported (a warning is logged if indexes are configured)


### PR DESCRIPTION
## Summary

- Remove the `turso_mvcc` parameter from the v1.11.x Turso accelerator docs — this parameter does not exist in the codebase
- MVCC is unconditionally enabled: `PRAGMA journal_mode = 'mvcc'` is set during every `TursoConnectionPool::new_with_timestamp_format` call
- Update the MVCC section to match the vNext docs, which correctly state MVCC is automatically enabled

## Changes

1. Removed `turso_mvcc` from the Configuration Parameters list
2. Removed `turso_mvcc: enabled` from the Example Configuration YAML block
3. Replaced the MVCC Support section text and removed the now-unnecessary YAML example showing `turso_mvcc: enabled`

## Test plan

- [ ] Verify the v1.11.x Turso docs page renders correctly with no broken formatting
- [ ] Confirm no remaining references to `turso_mvcc` in the v1.11.x docs
- [ ] Compare the MVCC section wording with the vNext Turso docs for consistency