### PR TITLE
docs: Add runtime.mcp.allowed_hosts configuration

### DIFF
--- a/website/docs/components/tools/mcp.md
+++ b/website/docs/components/tools/mcp.md
@@ -62,6 +62,20 @@ tools:
     from: mcp:http://localhost:8090/v1/mcp
 ```
 
+### Allowed Hosts
+
+By default the `/v1/mcp` endpoint only accepts requests with a `Host` header matching `localhost`, `127.0.0.1`, or `::1` to prevent DNS rebinding attacks. To allow additional hosts, configure [`runtime.mcp.allowed_hosts`](../../reference/spicepod/runtime#runtimemcp):
+
+```yaml
+runtime:
+  mcp:
+    allowed_hosts:
+      - localhost
+      - my-host.internal:8090
+```
+
+Set `allowed_hosts: ["*"]` to disable host checking entirely.
+
 ## Configuration Options
 
 ### `from`

--- a/website/docs/features/large-language-models/mcp.md
+++ b/website/docs/features/large-language-models/mcp.md
@@ -70,6 +70,20 @@ tools:
     from: mcp:http://localhost:8090/v1/mcp
 ```
 
+### Allowed Hosts
+
+By default the `/v1/mcp` endpoint only accepts requests with a `Host` header matching `localhost`, `127.0.0.1`, or `::1` to prevent DNS rebinding attacks. To allow additional hosts, configure [`runtime.mcp.allowed_hosts`](../../reference/spicepod/runtime#runtimemcp):
+
+```yaml
+runtime:
+  mcp:
+    allowed_hosts:
+      - localhost
+      - my-host.internal:8090
+```
+
+Set `allowed_hosts: ["*"]` to disable host checking entirely.
+
 ## Additional Configuration Options
 
 ### `from`

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -554,6 +554,39 @@ runtime:
 | `max_message_size`          | Yes      | -       | Maximum size of a single Arrow Flight message.                       |
 | `do_put_rate_limit_enabled` | Yes      | `true`  | Whether rate limiting is applied to `DoPut` Arrow Flight operations. |
 
+## `runtime.mcp`
+
+Configures settings for the Spice MCP server endpoint (`/v1/mcp`).
+
+### `runtime.mcp.allowed_hosts`
+
+Controls which `Host` header values are accepted on the `/v1/mcp` endpoint. This prevents [DNS rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) attacks against the MCP server.
+
+| Behavior | Configuration |
+| --- | --- |
+| **Default** (not set) | Only `localhost`, `127.0.0.1`, and `::1` are permitted. Requests with any other `Host` value receive `403 Forbidden`. |
+| **Explicit list** | Replaces the defaults entirely. Only the listed hosts are accepted. |
+| **Wildcard** (`["*"]`) | Disables host checking — all `Host` header values are accepted. |
+
+```yaml
+runtime:
+  mcp:
+    allowed_hosts:
+      - localhost
+      - my-host.internal:8090
+```
+
+To disable host checking entirely:
+
+```yaml
+runtime:
+  mcp:
+    allowed_hosts:
+      - "*"
+```
+
+Each entry can be a bare hostname (`example.com`), a host-port pair (`example.com:8090`), or a full origin URL (`https://example.com`).
+
 ## `runtime.ready_state`
 
 Controls when the runtime readiness probe (`/v1/ready`) reports the runtime as ready. This is particularly useful for Kubernetes readiness probes.


### PR DESCRIPTION
## Summary
- Document the new `runtime.mcp.allowed_hosts` setting for DNS rebinding attack prevention on the `/v1/mcp` endpoint
- Add allowed hosts section to both MCP docs pages

## Source PRs
- spiceai/spiceai#10638 — Add configurable allowed_hosts for MCP

## Changes
- `website/docs/reference/spicepod/runtime.md` — Added `runtime.mcp` and `runtime.mcp.allowed_hosts` reference section with behavior table, examples for explicit list and wildcard modes
- `website/docs/features/large-language-models/mcp.md` — Added "Allowed Hosts" section under "Spice as an MCP Server"
- `website/docs/components/tools/mcp.md` — Added "Allowed Hosts" section under "Spice as an MCP Server"

## Test plan
- [ ] Verified default behavior (localhost, 127.0.0.1, ::1) matches source code
- [ ] Verified wildcard behavior matches source code
- [ ] Links are valid
- [ ] Version references are correct (vNext only — new feature)