### PR TITLE
docs: Document spice cloud login subcommands

### DIFF
--- a/website/docs/cli/reference/login.md
+++ b/website/docs/cli/reference/login.md
@@ -45,3 +45,62 @@ spice login
 ```shell
 spice login --key <API_KEY>
 ```
+
+## `spice cloud login`
+
+Authenticate with the Spice Cloud Platform. Running `spice cloud login` without a subcommand opens an interactive method chooser when stdin is a TTY. Non-interactive callers must specify a method explicitly.
+
+### Methods
+
+#### `spice cloud login subscription`
+
+Browser-based OAuth login flow. Automatically opens a browser for authentication.
+
+```shell
+spice cloud login subscription
+```
+
+Use `--device` to print the URL and one-time code without opening a browser (useful for SSH/headless environments):
+
+```shell
+spice cloud login subscription --device
+```
+
+#### `spice cloud login pat`
+
+Authenticate with a personal access token.
+
+```shell
+spice cloud login pat --token <TOKEN>
+```
+
+The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
+
+```shell
+export SPICE_CLOUD_PAT=<TOKEN>
+spice cloud login pat
+```
+
+#### `spice cloud login api`
+
+Authenticate using OAuth2 client credentials for CI/automation workflows.
+
+```shell
+spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+```
+
+Credentials can also be provided via environment variables:
+
+```shell
+export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
+export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+spice cloud login api
+```
+
+### Environment Variables
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `SPICE_CLOUD_PAT` | `login pat` | Personal access token |
+| `SPICE_CLOUD_CLIENT_ID` | `login api` | OAuth2 client ID |
+| `SPICE_CLOUD_CLIENT_SECRET` | `login api` | OAuth2 client secret |


### PR DESCRIPTION
## Summary
- Document the restructured `spice cloud login` command with its three authentication methods: subscription (browser-based), pat (personal access token), and api (OAuth2 client credentials)

## Source PRs
- spiceai/spiceai#10586 — Support OAuth2 client credentials in 'spice cloud login'

## Changes
- `website/docs/cli/reference/login.md` — Added `spice cloud login` section with documentation for `subscription`, `pat`, and `api` subcommands, including flags, environment variables, and usage examples

## Test plan
- [ ] Verified subcommand names and flags match source code
- [ ] Verified environment variable names match source code
- [ ] Links are valid
- [ ] Version references are correct (vNext only — new feature)