### PR TITLE
docs: SharePoint connector docs missing new auth flows, write support, and sharepoint:// URL scheme

### DIFF
--- a/website/docs/components/data-connectors/sharepoint.md
+++ b/website/docs/components/data-connectors/sharepoint.md
@@ -5,7 +5,7 @@ description: 'SharePoint Data Connector Documentation'
 pagination_prev: null
 ---
 
-The SharePoint Data Connector enables federated SQL queries on documents stored in SharePoint.
+The SharePoint Data Connector enables federated SQL queries on documents and tabular data stored in SharePoint or OneDrive.
 
 ```yaml
 datasets:
@@ -45,55 +45,66 @@ Returns
 ]
 ````
 
-:::warning[Limitations]
-The sharepoint connector does not yet support creating a dataset from a single file (e.g. an Excel spreadsheet). Datasets must be created from a folder of documents.
-:::
+The SharePoint connector supports two `from:` URL styles:
+
+- **Metadata listing** (`sharepoint:…` — single colon): one row per drive item with optional file content. Best for browsing folders of PDFs, PPTX, DOCX, etc. as document tables.
+- **Object-store** (`sharepoint://…` — double slash): tabular access via DataFusion's `ListingTable`. Enables `SELECT`, `INSERT INTO`, `COPY TO`, `COPY FROM`, and `CREATE EXTERNAL TABLE` against CSV, JSON, NDJSON, Parquet, and similar formats stored on SharePoint.
 
 ## Configuration
 
 ### Parameters
 
-| Name                       | Required? | Description                                                                                                                                      |
-| -------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sharepoint_client_id`     | **Yes**   | The client ID of the Azure AD (Entra) application                                                                                                |
-| `sharepoint_tenant_id`     | **Yes**   | The tenant ID of the Azure AD (Entra) application.                                                                                               |
-| `sharepoint_client_secret` | Optional  | For service principal authentication. The client secret of the Azure AD (Entra) application.                                                     |
-| `sharepoint_bearer_token`  | Optional  | For user authentication. The bearer access token obtained from the OAuth2 flow (see `spice login sharepoint` [docs](../../cli/reference/login)). |
+| Name                            | Required?      | Description                                                                                                                                                                                                                                                       |
+| ------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sharepoint_client_id`          | Conditional    | The client ID of the Azure AD (Entra) application. Required for every flow except `sharepoint_bearer_token`.                                                                                                                                                      |
+| `sharepoint_tenant_id`          | Conditional    | The tenant ID of the Azure AD (Entra) application. Required for every flow except `sharepoint_bearer_token`.                                                                                                                                                      |
+| `sharepoint_client_secret`      | Conditional    | The client secret of the Azure AD (Entra) application. Required for client-credentials, authorization-code, and refresh-token flows.                                                                                                                              |
+| `sharepoint_bearer_token`       | Conditional    | A pre-acquired bearer access token. Generally obtained via `spice login sharepoint` (see [docs](../../cli/reference/login)).                                                                                                                                      |
+| `sharepoint_auth_code`          | Conditional    | OAuth2 authorization code (`auth_code` flow). Requires `sharepoint_client_secret` and `sharepoint_redirect_uri`.                                                                                                                                                  |
+| `sharepoint_refresh_token`      | Conditional    | OAuth2 refresh token. Requires `sharepoint_client_secret`.                                                                                                                                                                                                        |
+| `sharepoint_device_code`        | Conditional    | A pre-acquired OAuth2 device code (`device_code` flow).                                                                                                                                                                                                           |
+| `sharepoint_saml_assertion`     | Conditional    | SAML 2.0 bearer assertion ([RFC 7522](https://datatracker.ietf.org/doc/html/rfc7522)) — exchanges a federated IdP assertion for an Azure AD token.                                                                                                                |
+| `sharepoint_redirect_uri`       | Conditional    | OAuth2 redirect URI. Required when using `sharepoint_auth_code`.                                                                                                                                                                                                  |
+| `sharepoint_scope`              | Optional       | OAuth2 scope. Defaults to `https://graph.microsoft.com/.default`.                                                                                                                                                                                                 |
+| `sharepoint_conflict_behavior`  | Optional       | How writes to an existing path are handled. One of `replace` (default; SharePoint stores a new version), `fail` (reject), or `rename` (write under a unique name). Only `replace` is compatible with `INSERT INTO` / `COPY TO`. Applies only to `sharepoint://`. |
+| `sharepoint_max_put_bytes`      | Optional       | Hard cap, in bytes, on a single `put`/multipart upload. Writes above this size are rejected rather than silently buffered. Default: `1073741824` (1 GiB). Applies only to `sharepoint://`.                                                                       |
 
 :::note
-Only one of `sharepoint_client_secret` or `sharepoint_bearer_token` is allowed.
+Exactly one of `sharepoint_client_secret` (alone, for client-credentials), `sharepoint_bearer_token`, `sharepoint_auth_code` (with `sharepoint_client_secret` + `sharepoint_redirect_uri`), `sharepoint_refresh_token` (with `sharepoint_client_secret`), `sharepoint_device_code`, or `sharepoint_saml_assertion` must be supplied. Combining unrelated auth credentials is rejected at startup.
 :::
+
+When using the `sharepoint://` URL scheme, the standard listing-table parameters (`file_format`, `csv_has_header`, `csv_delimiter`, `json_pointer`, `hive_partitioning_enabled`, etc.) all apply — see [File Formats](./#file-formats) and the [Object Store File Formats](./#object-store-file-formats) reference for the full list.
 
 ### `from` formats
 
-The `from` field in a SharePoint dataset takes the following format:
+The SharePoint connector accepts two `from:` URL styles.
+
+#### Metadata listing — `sharepoint:` (single colon)
+
+Returns one row per drive item, optionally with the parsed `content` column. Use for document workflows over folders of PDF, PPTX, DOCX, XLSX, etc.
 
 ```yaml
 from: 'sharepoint:<drive_type>:<drive_id>/<subpath_type>:<subpath_value>'
 ```
 
-#### Drives
+`drive_type` supports the following types:
 
-`drive_type` in a SharePoint Connector `from` field supports the following types:
-
-| Drive Type | Description                 | Example                                               |
-| ---------- | --------------------------- | ----------------------------------------------------- |
-| `drive`    | The SharePoint drive's name | `from: sharepoint:drive:Documents/...`                |
-| `driveId`  | The SharePoint drive's ID   | `from: sharepoint:driveId:b!Mh8opUGD80ec7zGXgX9r/...` |
-| `site`     | A SharePoint site's name    | `from: sharepoint:site:MySite/...`                    |
-| `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`  |
-| `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                  |
-| `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...` |
+| Drive Type | Description                 | Example                                                          |
+| ---------- | --------------------------- | ---------------------------------------------------------------- |
+| `drive`    | The SharePoint drive's name | `from: sharepoint:drive:Documents/...`                           |
+| `driveId`  | The SharePoint drive's ID   | `from: sharepoint:driveId:b!Mh8opUGD80ec7zGXgX9r/...`            |
+| `site`     | A SharePoint site's name    | `from: sharepoint:site:MySite/...`                               |
+| `siteId`   | A SharePoint site's ID      | `from: sharepoint:siteId:b!Mh8opUGD80ec7zGXgX9r/...`             |
+| `group`    | A SharePoint group's name   | `from: sharepoint:group:MyGroup/...`                             |
+| `groupId`  | A SharePoint group's ID     | `from: sharepoint:groupId:b!Mh8opUGD80ec7zGXgX9r/...`            |
 | `user`     | A user's drive by user ID   | `from: sharepoint:user:48d31887-5fad-4d73-a9f5-3c356e68a038/...` |
-| `me`       | A user's OneDrive           | `from: sharepoint:me/...`                             |
+| `me`       | A user's OneDrive           | `from: sharepoint:me/...`                                        |
 
 :::note
-For the `me` drive type the user is identified based on `sharepoint_bearer_token` and cannot be used with `sharepoint_client_secret`
+For the `me` drive type the user is identified based on `sharepoint_bearer_token` and cannot be used with `sharepoint_client_secret`.
 :::
 
 For a name-based `drive_id`, the connector will attempt to resolve the name to an ID at startup.
-
-#### Subpaths
 
 Within a drive, the SharePoint connector can load documents from:
 
@@ -103,24 +114,60 @@ Within a drive, the SharePoint connector can load documents from:
 | A specific path within the drive | `from: sharepoint:drive:Documents/path:/top_secrets`                   |
 | A specific folder ID             | `from: sharepoint:group:MyGroup/id:01QM2NJSNHBISUGQ52P5AJQ3CBNOXDMVNT` |
 
+#### Object-store — `sharepoint://` (double slash)
+
+Routes through an `ObjectStore` plus DataFusion's `ListingTable`. Enables `SELECT`, `INSERT INTO`, `COPY TO`, `COPY FROM`, and `CREATE EXTERNAL TABLE` for CSV, JSON, NDJSON, Parquet, and other tabular formats — and binary round-trips for blobs (PDF, etc.) via `(FORMAT binary)`.
+
+| URL form                                       | Description                       |
+| ---------------------------------------------- | --------------------------------- |
+| `sharepoint://me/{item-path}`                  | The authenticated user's OneDrive |
+| `sharepoint://drives/{drive-id}/{item-path}`   | A specific drive by ID            |
+| `sharepoint://sites/{site-id}/{item-path}`     | A site's default document library |
+| `sharepoint://users/{user-id}/{item-path}`     | A user's default drive            |
+| `sharepoint://groups/{group-id}/{item-path}`   | A group's default drive           |
+
+Path segments are percent-decoded, so site IDs containing `,` (e.g. `contoso.sharepoint.com,abc-def,ghi-jkl`) and file paths containing spaces work without extra escaping beyond standard URL encoding.
+
+`file_format` is auto-inferred from the URL extension when omitted, so `from: sharepoint://me/Documents/Q4.xlsx` resolves without specifying `file_format: xlsx`.
+
 ## Authentication
 
-As outlined in the [connector parameters](#parameters), the SharePoint connector supports two types of authentication:
+The SharePoint connector supports six authentication flows. Configure exactly one — the connector picks the flow based on which auth parameter is set. See the [Required Microsoft Graph permissions](#required-microsoft-graph-permissions) section below for the API permissions each flow requires.
 
-1. Service principal authentication, by setting the `sharepoint_client_secret` parameter.
-2. User authentication, by setting the `sharepoint_bearer_token` parameter. Generally this is obtained by running `spice login sharepoint` and following the OAuth2 flow.
+| Flow                            | Parameters                                                                                          | Notes                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Client credentials              | `sharepoint_client_secret`                                                                          | Service principal / daemon workloads.                                                       |
+| Bearer token (passthrough)      | `sharepoint_bearer_token`                                                                           | Short-lived broker-minted token. Typically obtained via `spice login sharepoint`.           |
+| Authorization code              | `sharepoint_auth_code` + `sharepoint_client_secret` + `sharepoint_redirect_uri`                     | Caller has already completed the user-agent redirect and captured the `auth_code`.          |
+| Refresh token                   | `sharepoint_refresh_token` + `sharepoint_client_secret`                                             | Renewal from a prior grant.                                                                 |
+| Device code                     | `sharepoint_device_code`                                                                            | Caller has already obtained a device code.                                                  |
+| SAML 2.0 bearer ([RFC 7522](https://datatracker.ietf.org/doc/html/rfc7522)) | `sharepoint_saml_assertion`                                                                         | Federated IdP (Okta, Ping, ADFS, …) assertion → Azure AD token.                             |
 
 ### Creating an Enterprise Application
 
-To use the SharePoint connector with service principal authentication, you will need to create an Azure AD application and grant it the necessary permissions. This will also support OAuth2 authentication for users within the tenant (i.e. `sharepoint_bearer_token`).
+To use the SharePoint connector with service principal authentication, create an Azure AD application and grant it the necessary permissions. This same app registration also supports the OAuth2 user flows above.
 
 1. Create a new Azure AD application in the [Azure portal](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Overview).
-2. Under the application's `API permissions`, add the following permissions: `Sites.Read.All`, `Files.Read.All`, `User.Read`, `GroupMember.Read.All`
+2. Under the application's `API permissions`, add the permissions listed in [Required Microsoft Graph permissions](#required-microsoft-graph-permissions).
    - For service principal authentication, Application permissions are required.
    - For user authentication, only delegated permissions are required.
-3. (For user authentication): Under the applications's `Authentication`, add `http://localhost` as Mobile and desktop applications redirect URI.
+3. (For user authentication): Under the application's `Authentication`, add `http://localhost` as a Mobile and desktop applications redirect URI.
 4. Add `sharepoint_client_id` (from the `Application (Client) ID` field) and `sharepoint_tenant_id` to the connector configuration.
 5. (For service principal authentication): Under the application's `Certificates & secrets`, create a new client secret. Use this for the `sharepoint_client_secret` parameter.
+
+### Required Microsoft Graph permissions
+
+Read-only workflows require:
+
+- `Sites.Read.All`
+- `Files.Read.All`
+- `User.Read`
+- `GroupMember.Read.All`
+
+Write workflows (`INSERT INTO`, `COPY TO`, `CREATE EXTERNAL TABLE` over `sharepoint://`) additionally require:
+
+- `Files.ReadWrite` (for personal drive / specific drive writes), and
+- `Sites.ReadWrite.All` (for site-scoped writes).
 
 ### Default Spice Application
 
@@ -141,6 +188,57 @@ And set the `SPICE_SHAREPOINT_BEARER_TOKEN` secret via:
 ```shell
 spice login sharepoint --tenant-id $TENANT_ID --client-id f2b3116e-b4c4-464f-80ec-73cd9d9886b4
 ```
+
+## Read/write examples (`sharepoint://`)
+
+Reading a CSV from a site library:
+
+```yaml
+datasets:
+  - from: sharepoint://sites/contoso.sharepoint.com,11111111-2222-3333-4444-555555555555,66666666-7777-8888-9999-aaaaaaaaaaaa/Shared%20Documents/reports/sales.csv
+    name: sales
+    params:
+      sharepoint_client_id: ${secrets:SPICE_SHAREPOINT_CLIENT_ID}
+      sharepoint_tenant_id: ${secrets:SPICE_SHAREPOINT_TENANT_ID}
+      sharepoint_client_secret: ${secrets:SPICE_SHAREPOINT_CLIENT_SECRET}
+      file_format: csv
+      csv_has_header: 'true'
+```
+
+Inserting rows:
+
+```sql
+INSERT INTO sales VALUES ('Q2', 123456.78);
+```
+
+Copying a query result out as Parquet:
+
+```sql
+COPY (SELECT * FROM orders WHERE year = 2026)
+TO 'sharepoint://me/Documents/exports/orders-2026.parquet'
+(FORMAT parquet);
+```
+
+Creating an external table over a folder of Parquet files:
+
+```sql
+CREATE EXTERNAL TABLE reports
+STORED AS PARQUET
+LOCATION 'sharepoint://sites/{site-id}/Shared%20Documents/reports/';
+```
+
+Round-tripping a binary blob (e.g. a PDF):
+
+```sql
+COPY (SELECT content FROM cache WHERE name = 'Q2-report.pdf')
+TO 'sharepoint://me/Documents/Q2-report.pdf'
+(FORMAT binary);
+```
+
+:::warning[Limitations]
+- The `sharepoint:` (metadata-listing) syntax cannot create a dataset from a single file (e.g. an Excel spreadsheet) — datasets must be created from a folder of documents. Use the `sharepoint://` object-store syntax for single-file workflows.
+- For `INSERT INTO` and `COPY TO`, only `sharepoint_conflict_behavior=replace` is supported. `fail` and `rename` cause writes to be rejected with a clear error.
+:::
 
 ## Secrets
 


### PR DESCRIPTION
## Summary
Fixes #1660

Updates the SharePoint connector documentation to reflect the object-store listing connector revamp shipped in spiceai/spiceai#10473 — documenting the four new auth flows, the new `sharepoint://` URL scheme, and the new write-side parameters.

## Changes
- `website/docs/components/data-connectors/sharepoint.md`
  - **Auth flows**: Added authorization code, refresh token, device code, and SAML 2.0 bearer ([RFC 7522](https://datatracker.ietf.org/doc/html/rfc7522)) flows — six total — alongside the existing client_secret and bearer_token flows. Documented `sharepoint_redirect_uri` (required with `auth_code`) and `sharepoint_scope` (defaults to `https://graph.microsoft.com/.default`).
  - **Write support**: Documented `sharepoint_conflict_behavior` (`replace` (default) / `fail` / `rename`) and `sharepoint_max_put_bytes` (default `1073741824`, i.e. 1 GiB), with a limitation note that only `replace` is compatible with `INSERT INTO` / `COPY TO`.
  - **`sharepoint://` URL scheme**: New section documenting the five drive forms (`me` / `drives` / `sites` / `users` / `groups`), routing through DataFusion's `ListingTable`, and pointing readers to the standard listing-table parameters.
  - **Required Microsoft Graph permissions**: Split into read-only baseline (`Sites.Read.All`, `Files.Read.All`, `User.Read`, `GroupMember.Read.All`) and the additional `Files.ReadWrite` / `Sites.ReadWrite.All` needed for write workflows.
  - **Parameter accuracy**: Reclassified `sharepoint_client_id` and `sharepoint_tenant_id` from "Required" to "Conditional" — they're not required for the `bearer_token` flow. Updated the auth-exclusivity note to list all six flows.
  - **Examples**: Added end-to-end examples for `SELECT` from a SharePoint site library, `INSERT INTO`, `COPY TO Parquet`, `CREATE EXTERNAL TABLE`, and binary blob round-trip via `COPY TO (FORMAT binary)`.

## Reference
Verified against `spiceai/spiceai` at `origin/trunk`:
- `crates/data-connectors/connector-sharepoint/src/lib.rs` — `PARAMETERS` registers all eight new auth/write parameters; `build_auth_from_params` enforces "exactly one auth flow"; `parse_conflict_behavior` and `parse_max_put_bytes` provide the write defaults.
- `crates/data_components/src/sharepoint/auth/mod.rs` — `DEFAULT_SCOPE = "https://graph.microsoft.com/.default"`; the `SharepointAuth` enum dispatches the six flows.
- `crates/data_components/src/sharepoint/url.rs` — `SharepointUrl::from_url` parses the five drive kinds.
- `crates/data_components/src/sharepoint/object_store.rs` — `DEFAULT_MAX_PUT_BYTES = 1024 * 1024 * 1024` (1 GiB); only `Replace` is honored by `put` / `put_multipart`.
- `crates/data-connectors/connector-sharepoint/README.md` — confirms the Microsoft Graph scopes for read-only vs write workflows.

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] No broken-link-checker failures
- [x] Addition is in the unversioned `website/docs/` only (per skill rule for new content)
- [x] Existing examples preserved; no behavior changes implied beyond what shipped on `trunk`