### PR TITLE
docs: Promote DuckLake data connector and catalog to Beta

### DIFF
--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -29,7 +29,7 @@ Supported Catalog Connectors include:
 | `databricks`    | Databricks              | Beta   | Spark Connect, S3/Delta Lake |
 | `iceberg`       | Apache Iceberg          | Beta   | Parquet                      |
 | `spice.ai`      | Spice.ai Cloud Platform | Beta   | Arrow Flight                 |
-| `ducklake`      | DuckLake                | Alpha  | Parquet                      |
+| `ducklake`      | DuckLake                | Beta   | Parquet                      |
 | `glue`          | AWS Glue                | Alpha  | Parquet, Iceberg             |
 | `snowflake`     | Snowflake               | Alpha  | Snowflake SQL                |
 | `pg`            | PostgreSQL / Redshift   | Alpha  | PostgreSQL Wire Protocol     |

--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -70,7 +70,7 @@ Supported Data Connectors include:
 | `debezium`                         | Debezium CDC                          | Alpha             | Kafka + JSON                 |
 | `kafka`                            | Kafka                                 | Alpha             | Kafka + JSON                 |
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
-| `ducklake`                         | DuckLake                              | Alpha             | Parquet                      |
+| `ducklake`                         | DuckLake                              | Beta              | Parquet                      |
 | `scylladb`                         | ScyllaDB                              | Alpha             | CQL, Alternator (DynamoDB)   |
 | `adbc`                             | [ADBC][adbc]                          | Alpha             | Arrow (ADBC)                 |
 | `elasticsearch`                    | [Elasticsearch][elasticsearch]        | Alpha             | Elasticsearch REST           |


### PR DESCRIPTION
## Summary
- Update DuckLake data connector status from Alpha to Beta in the connectors index
- Update DuckLake catalog connector status from Alpha to Beta in the catalogs index

## Source PRs
- spiceai/spiceai#10743 — Promote DuckLake Catalog and Data Connector to Beta quality

## Changes
- `website/docs/components/data-connectors/index.md` — DuckLake row Alpha → Beta
- `website/docs/components/catalogs/index.md` — DuckLake row Alpha → Beta

## Test plan
- [ ] Links are valid
- [ ] Version references are correct