### PR TITLE
fix: Correct Elasticsearch pagination — uses PIT + search_after

### DIFF
--- a/website/docs/components/data-connectors/elasticsearch/deployment.md
+++ b/website/docs/components/data-connectors/elasticsearch/deployment.md
@@ -57,9 +57,8 @@ Long-running search responses (very large `LIMIT`, deep pagination, or expensive
 ## Capacity & Sizing
 
 - **Throughput**: Bounded by the Elasticsearch cluster's request handling and (for kNN) HNSW search cost. Plan refresh intervals and concurrent query load to stay within the cluster's tested capacity.
-- **Result size**: Each `_search` request returns up to `size` hits, hard-capped at **10,000** (the Elasticsearch default `index.max_result_window`). The connector translates `LIMIT` to `size` but clamps the value to 10,000; queries without `LIMIT` also default to 10,000. For full-index access, accelerate the dataset into a local engine.
+- **Result size**: The connector pages through results using point-in-time (PIT) queries with `search_after`, fetching up to 10,000 hits per batch (bounded by the Elasticsearch `index.max_result_window` setting). Queries with `LIMIT` fetch only the requested number of rows. Queries without `LIMIT` page through the entire index.
 - **Mapping fetches**: At dataset registration the connector fetches the index mapping once via `GET /<index>/_mapping`. Mapping changes after registration are not picked up until the runtime restarts.
-- **Pagination**: Spice does not currently use Elasticsearch's `search_after` or scroll APIs from the data connector. For full-table scans of very large indexes, prefer accelerating into a local engine.
 
 ## Search Routing
 

--- a/website/docs/components/data-connectors/elasticsearch/index.md
+++ b/website/docs/components/data-connectors/elasticsearch/index.md
@@ -138,7 +138,7 @@ TLS is enabled automatically for `https://` endpoints.
 - Nested object fields are exposed as JSON strings rather than structured columns.
 - `date` and `date_nanos` fields are preserved as strings because Elasticsearch accepts heterogeneous date formats; cast to a timestamp in SQL when numeric comparison is required.
 - `dense_vector` fields without a declared `dims` value fall back to `Utf8` and are not usable as a vector column.
-- Queries return at most **10,000 hits** per scan. The connector translates SQL `LIMIT` to the Elasticsearch `size` parameter, capped at 10,000 (the Elasticsearch default maximum). Queries without `LIMIT` also return at most 10,000 results. For full-index access, accelerate the dataset into a local engine.
+- The connector pages through results in batches of up to 10,000 hits using point-in-time (PIT) queries with `search_after`. Queries with `LIMIT` fetch only the requested number of rows; queries without `LIMIT` page through the entire index. Individual batch size is bounded by the Elasticsearch `index.max_result_window` setting (default 10,000).
 - Pushdown of SQL predicates to Elasticsearch query DSL is limited; complex filter expressions are evaluated locally by DataFusion after fetching results.
 
 Elasticsearch can also be configured as a [Vector Engine](../vectors/elasticsearch) for datasets sourced from other connectors (storing Spice-managed embeddings in Elasticsearch rather than querying an existing index).


### PR DESCRIPTION
## Summary
- Docs incorrectly claimed a hard 10,000 hit cap and stated `search_after` is not used
- The connector uses PIT + `search_after` pagination for full-index scans in 10,000-hit batches
- Queries without `LIMIT` return all results, not just 10,000

## Changes
- **index.md**: Replaced 10,000 hit cap limitation with PIT + `search_after` pagination description
- **deployment.md**: Removed false `search_after` claim; updated result size description

## Reference
Verified against spiceai/spiceai at trunk — `crates/data_components/src/elasticsearch/query_table.rs` lines 49, 231, 273-350