### PR TITLE
fix: Add missing client_timeout, versioning params and json format to ABFS

### DIFF
--- a/website/docs/components/data-connectors/abfs.md
+++ b/website/docs/components/data-connectors/abfs.md
@@ -66,7 +66,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 | Parameter name              | Description                                                                                                                                         |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `file_format`               | Specifies the data format. Required if not inferrable from `from`. Options: `parquet`, `csv`. Refer to [File Formats](./#file-formats) for details. |
+| `file_format`               | Specifies the data format. Required if not inferrable from `from`. Options: `parquet`, `csv`, `json`. Refer to [File Formats](./#file-formats) for details. |
 | `abfs_account`              | Azure storage account name                                                                                                                          |
 | `abfs_container_name`       | Azure container name                                                                                                                                |
 | `abfs_sas_string`           | SAS (Shared Access Signature) Token to use for authorization                                                                                        |
@@ -79,6 +79,8 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `abfs_proxy_excludes`       | A list of hosts to exclude from proxy connections                                                                                                   |
 | `abfs_disable_tagging`      | Disable tagging objects. Use this if your backing store doesn't support tags                                                                        |
 | `allow_http`                | Allow insecure HTTP connections                                                                                                                     |
+| `client_timeout`            | Optional. Timeout for Azure client operations.                                                                                                      |
+| `abfs_versioning`           | Enable Azure blob versioning. Default: `disabled`                                                                                                   |
 | `hive_partitioning_enabled` | Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                    |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                      |
 


### PR DESCRIPTION
## Summary
- `client_timeout` (runtime param) was undocumented — controls Azure client operation timeout
- `abfs_versioning` (component param, default: `disabled`) was undocumented — controls Azure blob versioning
- `json` was missing from the `file_format` options list (S3 docs already included it)

## Changes
- Added `client_timeout` and `abfs_versioning` to the parameter table
- Added `json` to the `file_format` options

## Reference
Verified against spiceai/spiceai at trunk — `crates/runtime/src/dataconnector/abfs.rs` lines 192-196