### PR TITLE
fix: Correct DuckDB path description and Dremio parameter status

### DIFF
--- a/website/docs/components/data-connectors/dremio/index.md
+++ b/website/docs/components/data-connectors/dremio/index.md
@@ -64,9 +64,9 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 | Parameter Name    | Description                                                                                                                                                                    |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `dremio_endpoint` | The endpoint used to connect to the Dremio server.                                                                                                                             |
-| `dremio_username` | The username used to connect to the Dremio endpoint.                                                                                                                           |
-| `dremio_password` | The password used to connect to the Dremio endpoint. Use the [secret replacement syntax](#secrets) to load the password from a secret store, e.g. `${secrets:my_dremio_pass}`. |
+| `dremio_endpoint` | Required. The endpoint used to connect to the Dremio server.                                                                                                                             |
+| `dremio_username` | Optional. The username used to connect to the Dremio endpoint.                                                                                                                           |
+| `dremio_password` | Optional. The password used to connect to the Dremio endpoint. Use the [secret replacement syntax](#secrets) to load the password from a secret store, e.g. `${secrets:my_dremio_pass}`. |
 
 ## Examples
 
@@ -134,8 +134,6 @@ WHERE ws_item_sk NOT IN (
     SELECT DISTINCT ss_item_sk FROM store_sales
 );
 ```
-
-:::
 
 ## Cookbook
 

--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -19,7 +19,7 @@ DuckDB is an embedded engine; the connector reads a local DuckDB database file. 
 
 | Parameter          | Description                                                            |
 | ------------------ | ---------------------------------------------------------------------- |
-| `duckdb_open`      | Absolute path to the DuckDB database file. If omitted, uses in-memory mode. |
+| `duckdb_open`      | Path to the DuckDB database file. If omitted, uses in-memory mode. |
 
 Protect the DuckDB file with filesystem permissions. Store it on encrypted storage (LUKS/dm-crypt, EBS encryption, etc.) for data-at-rest protection. For data loaded from cloud object stores inside DuckDB, configure AWS/Azure/GCS credentials via DuckDB extensions rather than Spice parameters.
 

--- a/website/docs/components/data-connectors/duckdb/index.md
+++ b/website/docs/components/data-connectors/duckdb/index.md
@@ -64,7 +64,7 @@ The DuckDB data connector can be configured by providing the following `params`:
 
 | Parameter Name | Description                              |
 | -------------- | ---------------------------------------- |
-| `duckdb_open`  | The name of the DuckDB database to open. |
+| `duckdb_open`  | Path to the DuckDB database file to open. |
 
 Configuration `params` are provided either in the top level `dataset` for a dataset source, or in the `acceleration` section for a data store.
 


### PR DESCRIPTION
## Summary
- DuckDB deployment.md said "Absolute path" but code accepts relative paths
- DuckDB index.md described `duckdb_open` as "name" instead of "path"
- Dremio parameter table lacked Required/Optional indicators
- Dremio index.md had an orphaned `:::` admonition closing tag

## Changes
- DuckDB: Changed "Absolute path" to "Path"; changed "name" to "Path to the DuckDB database file"
- Dremio: Added Required/Optional to parameter descriptions; removed stray `:::`

## Reference
Verified against spiceai/spiceai at trunk — `crates/data-connectors/connector-duckdb/src/lib.rs`, `crates/data-connectors/connector-dremio/src/lib.rs`