### PR TITLE
fix: Add missing acceleration engine modes and Turso snapshot support

### DIFF
--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -31,10 +31,10 @@ By default, datasets are locally materialized using in-memory Arrow records.
 | ---------- | ------------------------------- | ----------------- | ---------------- |
 | `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `file`, `file_create`, `file_update` |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
-| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file` |
+| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file`, `file_create`, `file_update` |
 | `postgres` | Attached [PostgreSQL][postgres] (Spice.ai Enterprise) | Release Candidate | N/A              |
-| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |
-| `turso`    | Embedded [Turso][turso]         | Beta              | `memory`, `file` |
+| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file`, `file_create`, `file_update` |
+| `turso`    | Embedded [Turso][turso]         | Beta              | `memory`, `file`, `file_create`, `file_update` |
 
 [cayenne]: ./cayenne/index.md
 [duckdb]: ./duckdb/index.md

--- a/website/docs/features/data-acceleration/index.md
+++ b/website/docs/features/data-acceleration/index.md
@@ -40,7 +40,7 @@ Consider a high-volume e-trading frontend application backed by an AWS RDS datab
 | ---------- | -------------------------------------------------- | ------------------------------------------------- |
 | `arrow`    | Read-heavy analytics, in-memory speed              | `memory`                                          |
 | `duckdb`   | Complex analytical queries, file-based persistence | `memory`, `file`, `file_create`, or `file_update` |
-| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `file`, `file_create`, or `file_update`           |
+| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `memory`, `file`, `file_create`, or `file_update` |
 | `postgres` | When a full SQL database is needed as accelerator  | External                                          |
 | `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file`, `file_create`, or `file_update`           |
 

--- a/website/docs/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/docs/features/data-acceleration/refresh-modes/snapshot.md
@@ -41,7 +41,7 @@ datasets:
 ## Requirements
 
 - `acceleration.snapshots` must be `enabled` or `bootstrap_only`.
-- The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, or **Cayenne**.
+- The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**.
 
 ## Behavior
 

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/index.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/index.md
@@ -33,9 +33,9 @@ Supported Data Accelerators include:
 | ---------- | ------------------------------- | -------------------- | ---------------- |
 | `arrow`    | In-Memory Arrow Records         | Stable               | `memory`         |
 | `cayenne`  | [Cayenne][cayenne]              | Alpha (v1.9.0-rc.1+) | `file`, `file_create`, `file_update` |
-| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable               | `memory`, `file` |
+| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable               | `memory`, `file`, `file_create` |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate    | N/A              |
-| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate    | `memory`, `file` |
+| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate    | `memory`, `file`, `file_create` |
 
 [cayenne]: /docs/components/data-accelerators/cayenne
 [duckdb]: /docs/components/data-accelerators/duckdb

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/index.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/index.md
@@ -31,10 +31,10 @@ By default, datasets are locally materialized using in-memory Arrow records.
 | ---------- | ------------------------------- | ----------------- | ---------------- |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
 | `cayenne`  | [Spice Cayenne][cayenne]        | Beta              | `file`, `file_create`, `file_update` |
-| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file` |
+| `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file`, `file_create` |
 | `postgres` | Attached [PostgreSQL][postgres] | Release Candidate | N/A              |
-| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file` |
-| `turso`    | Embedded [Turso][turso]         | Beta              | `memory`, `file` |
+| `sqlite`   | Embedded [SQLite][sqlite]       | Release Candidate | `memory`, `file`, `file_create` |
+| `turso`    | Embedded [Turso][turso]         | Beta              | `memory`, `file`, `file_create` |
 
 [cayenne]: ./cayenne.md
 [duckdb]: ./duckdb.md

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/index.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/index.md
@@ -37,10 +37,10 @@ Consider a high-volume e-trading frontend application backed by an AWS RDS datab
 | Engine     | Best For                                           | Mode               |
 | ---------- | -------------------------------------------------- | ------------------ |
 | `arrow`    | Read-heavy analytics, in-memory speed              | `memory`           |
-| `duckdb`   | Complex analytical queries, file-based persistence | `memory` or `file` |
-| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `file`             |
+| `duckdb`   | Complex analytical queries, file-based persistence | `memory`, `file`, or `file_create` |
+| `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `memory`, `file`, or `file_create` |
 | `postgres` | When a full SQL database is needed as accelerator  | External           |
-| `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file`             |
+| `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file` or `file_create`            |
 
 ## Example
 


### PR DESCRIPTION
## Summary

- DuckDB, SQLite, and Turso accelerator tables were missing `file_create` and `file_update` modes (vNext) and `file_create` (v1.10.x, v1.11.x)
- SQLite was missing `memory` mode in the engine selection table
- Snapshot refresh mode page omitted Turso from snapshot-capable engines despite `supports_snapshot_reload()` returning `true`

## Changes

- **vNext accelerators index**: Added `file_create`, `file_update` to DuckDB, SQLite, Turso engine modes
- **vNext feature page**: Added `memory` to SQLite engine selection table
- **vNext snapshot mode page**: Added Turso to snapshot-capable engines list
- **v1.11.x accelerators index**: Added `file_create` to DuckDB, SQLite, Turso (not `file_update` — introduced in vNext only)
- **v1.11.x feature page**: Added `memory` and `file_create` to SQLite/DuckDB/Cayenne engine table
- **v1.10.x accelerators index**: Added `file_create` to DuckDB, SQLite (not `file_update` — introduced in vNext only)

## Reference

Verified against spiceai/spiceai at trunk:
- `file_create`: `crates/spicepod/src/acceleration/mod.rs` — introduced in commit `9b07efea3` (first tag: `v1.10.0`)
- `file_update`: `crates/spicepod/src/acceleration/mod.rs` — introduced in commit `d26f07647` (first tag: `v2.0.0-rc.2`, vNext only)
- DuckDB supports all file modes: `crates/runtime/src/dataaccelerator/duckdb.rs` line 163
- SQLite supports all file modes: `crates/runtime/src/dataaccelerator/sqlite.rs` line 177
- Turso supports all file modes: `crates/runtime/src/dataaccelerator/turso.rs` line 461
- Turso `supports_snapshot_reload()`: `crates/runtime/src/dataaccelerator/turso.rs` line 697
- v1.5.x–v1.9.x docs correctly show only `memory`, `file` (no change needed)