### PR TITLE
fix: Add cayenne_ prefix to upload_concurrency in deployment guide

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -58,7 +58,7 @@ For point-lookup-heavy workloads, size `cayenne_segment_cache_mb` generously —
 
 | Parameter             | Description                                               |
 | --------------------- | --------------------------------------------------------- |
-| `upload_concurrency`  | Parallel segment uploads during refresh / append commits. |
+| `cayenne_upload_concurrency` | Parallel segment uploads during refresh / append commits. |
 
 For S3 Express One Zone, 8–16 parallel uploads typically maximize throughput. For standard S3 across regions, higher concurrency helps hide per-request latency.
 


### PR DESCRIPTION
## Summary
- The Cayenne deployment guide shows `upload_concurrency` without the required `cayenne_` prefix
- Since the parameter is defined as `ParameterSpec::component("upload_concurrency")` with prefix "cayenne", the user-facing name is `cayenne_upload_concurrency`
- Using the unprefixed name causes the setting to be silently ignored

## Changes
- Fixed parameter name from `upload_concurrency` to `cayenne_upload_concurrency` in `cayenne/deployment.md`

## Reference
Verified against spiceai/spiceai at trunk — `crates/runtime/src/dataaccelerator/cayenne/mod.rs:767-769`