### PR TITLE
fix: Add missing Date32 and DateTime64 to ClickHouse type support table

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -89,7 +89,9 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `FixedString`    | `Utf8`                      |
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
+| `Date32`         | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
+| `DateTime64`     | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 
 ## Examples


### PR DESCRIPTION
## Summary
- The ClickHouse type support table was missing `Date32` and `DateTime64`, both of which are supported by the connector
- `Date32` maps to Arrow `Date32` (same as `Date` but with wider date range: 1900-2299 vs 1970-2149)
- `DateTime64` maps to Arrow `Timestamp(Second, None)` — sub-second precision is silently lost

## Changes
- Added `Date32` and `DateTime64` rows to the type mapping table in `clickhouse.md`

## Reference
Verified against spiceai/spiceai at trunk — `crates/arrow_sql_gen/src/clickhouse.rs:525-526`