### PR TITLE
fix: Add missing query_federation parameter to ADBC connector docs

### DIFF
--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -112,6 +112,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `adbc_schema`              | Optional. Sets the default schema for the connection.                                                                                |
 | `connection_pool_size`     | Optional. Maximum number of connections in the connection pool. Default: `5`.                                                        |
 | `connection_pool_min_idle` | Optional. Minimum number of idle connections in the pool. Default: `1`.                                                              |
+| `query_federation`         | Optional. Controls whether queries are federated to the ADBC source. Values: `enabled`, `disabled`. Default: `enabled`.              |
 
 :::warning[In-memory databases]
 In-memory database URIs (e.g., `:memory:` or URIs containing `mode=memory`) are not supported.


### PR DESCRIPTION
## Summary
- The `query_federation` runtime parameter exists in the ADBC connector code but was missing from the docs
- Values: `enabled` (default), `disabled`
- Users who want to disable query federation for ADBC datasets had no way to discover this parameter

## Changes
- Added `query_federation` row to the ADBC parameter table

## Reference
Verified against spiceai/spiceai at trunk — `crates/runtime/src/dataconnector/adbc.rs:325-327`