### PR TITLE
fix: Correct MySQL required SSL mode — it verifies certificates

### DIFF
--- a/website/docs/components/data-connectors/mysql/deployment.md
+++ b/website/docs/components/data-connectors/mysql/deployment.md
@@ -36,9 +36,9 @@ TLS is controlled via `mysql_sslmode`:
 | ------------- | ---------------------------------------------------------------- |
 | `disabled`    | No TLS.                                                          |
 | `preferred`   | Try TLS, fall back to plaintext. Not recommended for production. |
-| `required`    | Require TLS; do **not** verify the server certificate.           |
+| `required`    | Require TLS and verify the server certificate against system root CAs. |
 
-For production, use `required` with `mysql_sslrootcert` pointing to the CA bundle. The default is `required`, which encrypts the connection but does not validate the server's identity.
+For production, use `required` (the default). To verify against a specific CA rather than the system trust store, also set `mysql_sslrootcert` to the CA bundle path.
 
 ## Resilience Controls
 
@@ -96,7 +96,7 @@ MySQL operations participate in Spice [task history](../../../reference/task_his
 ## Known Limitations
 
 - Only TCP connections are supported. Unix socket connections are not exposed through Spice configuration.
-- TLS with certificate verification (`verify_ca`, `verify_identity`) is not supported; only `disabled`, `preferred`, and `required` modes are available.
+- Only `disabled`, `preferred`, and `required` SSL modes are exposed. The `required` mode verifies the server certificate and domain name (equivalent to `verify_identity`). There is no mode that encrypts without verifying.
 - Large text/blob columns are fetched in their entirety per row; consider selecting only the columns you need when federating.
 - `mysql_sslmode: preferred` silently downgrades to plaintext on TLS negotiation failure and is not recommended for production.
 


### PR DESCRIPTION
## Summary
- The `mysql_sslmode: required` mode uses `SslOpts::default()` which sets `accept_invalid_certs=false` and `skip_domain_validation=false`, meaning it verifies the server certificate against system root CAs and validates the domain name
- The docs incorrectly stated "do not verify the server certificate" and "does not validate the server's identity"
- The Known Limitations section incorrectly stated certificate verification is not supported — the `required` mode provides equivalent behavior to `verify_identity`

## Changes
- Corrected `required` mode description to reflect actual certificate verification behavior
- Updated Known Limitations to accurately describe the available SSL modes

## Reference
Verified against `datafusion-table-providers` `mysqlpool.rs` `get_ssl_opts()` function — `required` mode returns `SslOpts::default()` (verifies certs), while `preferred` mode explicitly sets `with_danger_accept_invalid_certs(true)`.

Files updated: 1