### PR TITLE
fix: Add missing Variant type to Delta Lake type mapping table

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/index.md
+++ b/website/docs/components/data-connectors/delta-lake/index.md
@@ -181,6 +181,7 @@ The table below shows the Delta Lake data types supported, along with the type m
 | `Decimal`       | `Decimal128`                          |
 | `Array`         | `List`                                |
 | `Struct`        | `Struct`                              |
+| `Variant`       | `Struct`                              |
 | `Map`           | `Map`                                 |
 
 ## Limitations

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -179,6 +179,7 @@ The table below shows the Delta Lake data types supported, along with the type m
 | `Decimal`       | `Decimal128`                          |
 | `Array`         | `List`                                |
 | `Struct`        | `Struct`                              |
+| `Variant`       | `Struct`                              |
 | `Map`           | `Map`                                 |
 
 ## Limitations

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -179,6 +179,7 @@ The table below shows the Delta Lake data types supported, along with the type m
 | `Decimal`       | `Decimal128`                          |
 | `Array`         | `List`                                |
 | `Struct`        | `Struct`                              |
+| `Variant`       | `Struct`                              |
 | `Map`           | `Map`                                 |
 
 ## Limitations


### PR DESCRIPTION
## Summary
- Delta Lake `Variant` type is mapped to Arrow `Struct` in the code but was missing from the type mapping table in the docs

## Changes
- Added `Variant` → `Struct` row to the type mapping table in vNext, v1.11.x, and v1.10.x docs

## Reference
Verified against spiceai/spiceai at trunk — `crates/data_components/src/delta_lake.rs` `map_delta_data_type_to_arrow_data_type`:
```rust
delta_kernel::schema::DataType::Struct(struct_type)
| delta_kernel::schema::DataType::Variant(struct_type) => { ... }
```
Variant support confirmed in v1.10.4 and v1.11.6 tags as well.

Files updated: 3