### PR TITLE
fix: Remove non-functional rate control params from GitHub connector docs

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -108,17 +108,13 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector also supports the shared HTTP rate control parameters for per-dataset concurrency and request rate limits:
+The GitHub connector supports the following HTTP concurrency parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
-| `requests_per_second_limit` | Maximum number of HTTP requests per second to the same upstream origin. Overrides `runtime.params.http_requests_per_second_limit`. If both are unset, no per-second rate limit is applied.    |
-| `requests_per_minute_limit` | Maximum number of HTTP requests per minute to the same upstream origin. Overrides `runtime.params.http_requests_per_minute_limit`. If both are unset, no per-minute rate limit is applied.    |
-| `rate_control_jitter_min`   | Minimum random delay added before HTTP requests when rate control is active. Defaults to `5ms` when a request-rate limit is configured.                                                      |
-| `rate_control_jitter_max`   | Maximum random delay added before HTTP requests when rate control is active. Defaults to `10ms` when a request-rate limit is configured.                                                     |
 
-Multiple datasets targeting the same GitHub endpoint share the same rate controller.
+The GitHub connector uses its own rate limiter based on GitHub API `X-RateLimit-*` response headers. Multiple datasets targeting the same GitHub endpoint share this rate limiter.
 
 ## Filter Push Down
 


### PR DESCRIPTION
The GitHub connector docs list 4 HTTP rate control parameters that are not in the connector PARAMETERS array and are silently ignored. The GitHub connector uses its own rate limiter based on X-RateLimit-* headers, not the generic HTTP rate control mechanism. Removed the 4 non-functional parameters while keeping max_concurrent_requests which IS wired in. Verified against spiceai/spiceai trunk.