### PR TITLE
fix: Add missing mTLS parameters to FlightSQL connector docs

### DIFF
--- a/website/docs/components/data-connectors/flightsql.md
+++ b/website/docs/components/data-connectors/flightsql.md
@@ -40,6 +40,10 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `flightsql_username` | Optional. The username to use in the underlying Apache flight Handshake Request to authenticate to the server (see [reference](https://arrow.apache.org/docs/format/Flight.html#authentication)).                                                    |
 | `flightsql_password` | Optional. The password to use in the underlying Apache flight Handshake Request to authenticate to the server. Use the [secret replacement syntax](../secret-stores/) to load the password from a secret store, e.g. `${secrets:my_flightsql_pass}`. |
 | `flightsql_tls_ca_certificate_file` | Optional. Path to a CA certificate file (PEM format) to use for TLS verification instead of system certificates. |
+| `flightsql_tls_client_certificate_file` | Optional. Path to a PEM client certificate chain for mutual TLS (mTLS). Must be set together with `flightsql_tls_client_key_file`. Mutually exclusive with `flightsql_tls_client_certificate`. |
+| `flightsql_tls_client_key_file` | Optional. Path to the PEM private key matching `flightsql_tls_client_certificate_file`. Must be set together with `flightsql_tls_client_certificate_file`. Mutually exclusive with `flightsql_tls_client_key`. |
+| `flightsql_tls_client_certificate` | Optional. Inline PEM client certificate chain for mutual TLS (mTLS). Use the [secret replacement syntax](../secret-stores/) to load from a secret store, e.g. `${secrets:my_cert}`. Must be set together with `flightsql_tls_client_key`. Mutually exclusive with `flightsql_tls_client_certificate_file`. |
+| `flightsql_tls_client_key` | Optional. Inline PEM private key for mutual TLS (mTLS). Use the [secret replacement syntax](../secret-stores/) to load from a secret store, e.g. `${secrets:my_key}`. Must be set together with `flightsql_tls_client_certificate`. Mutually exclusive with `flightsql_tls_client_key_file`. |
 
 ## Secrets
 


### PR DESCRIPTION
## Summary
The FlightSQL connector supports mutual TLS (mTLS) via four parameters that are fully implemented but missing from the documentation:
- `flightsql_tls_client_certificate_file` — path to PEM client cert chain
- `flightsql_tls_client_key_file` — path to PEM private key
- `flightsql_tls_client_certificate` — inline PEM client cert (supports secret references)
- `flightsql_tls_client_key` — inline PEM private key (supports secret references)

File-based and inline variants are mutually exclusive. Each certificate param must be paired with its corresponding key param.

## Changes
Added the four mTLS parameters to the FlightSQL connector parameter table in the vNext docs. Not added to versioned docs since the feature was introduced in spiceai/spiceai#10764 which is trunk-only.

## Reference
Verified against spiceai/spiceai at `trunk` — `crates/data-connectors/connector-flightsql/src/lib.rs` lines 151-165 (PARAMETERS array) and lines 78-129 (mTLS validation logic).