### PR TITLE
fix: Correct ScyllaDB host required status and ssl default

### DIFF
--- a/website/docs/components/data-connectors/scylladb.md
+++ b/website/docs/components/data-connectors/scylladb.md
@@ -67,14 +67,14 @@ The ScyllaDB data connector can be configured by providing the following `params
 
 | Parameter Name        | Description                                                        | Required | Default |
 | --------------------- | ------------------------------------------------------------------ | -------- | ------- |
-| `scylladb_host`       | Hostname(s) of ScyllaDB nodes. Comma-separated for multiple nodes. | Yes      | -       |
-| `scylladb_hosts`      | Alternative to `scylladb_host`. Comma-separated list of hostnames. | No       | -       |
+| `scylladb_host`       | Hostname(s) of ScyllaDB nodes. Comma-separated for multiple nodes. Either `scylladb_host` or `scylladb_hosts` must be provided. | Yes*     | -       |
+| `scylladb_hosts`      | Alternative to `scylladb_host`. Comma-separated list of hostnames. Either `scylladb_host` or `scylladb_hosts` must be provided. | Yes*     | -       |
 | `scylladb_port`       | ScyllaDB CQL native transport port.                                | No       | `9042`  |
 | `scylladb_keyspace`   | The keyspace to use for queries.                                   | Yes      | -       |
 | `scylladb_user`       | Username for authentication.                                       | No       | -       |
 | `scylladb_pass`       | Password for authentication.                                       | No       | -       |
 | `scylladb_datacenter` | Preferred datacenter for connection routing.                       | No       | -       |
-| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | `false` |
+| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | -       |
 | `connection_timeout`  | Connection timeout in milliseconds.                                | No       | `10000` |
 
 ## Types

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/scylladb.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/scylladb.md
@@ -67,14 +67,14 @@ The ScyllaDB data connector can be configured by providing the following `params
 
 | Parameter Name        | Description                                                        | Required | Default |
 | --------------------- | ------------------------------------------------------------------ | -------- | ------- |
-| `scylladb_host`       | Hostname(s) of ScyllaDB nodes. Comma-separated for multiple nodes. | Yes      | -       |
-| `scylladb_hosts`      | Alternative to `scylladb_host`. Comma-separated list of hostnames. | No       | -       |
+| `scylladb_host`       | Hostname(s) of ScyllaDB nodes. Comma-separated for multiple nodes. Either `scylladb_host` or `scylladb_hosts` must be provided. | Yes*     | -       |
+| `scylladb_hosts`      | Alternative to `scylladb_host`. Comma-separated list of hostnames. Either `scylladb_host` or `scylladb_hosts` must be provided. | Yes*     | -       |
 | `scylladb_port`       | ScyllaDB CQL native transport port.                                | No       | `9042`  |
 | `scylladb_keyspace`   | The keyspace to use for queries.                                   | Yes      | -       |
 | `scylladb_user`       | Username for authentication.                                       | No       | -       |
 | `scylladb_pass`       | Password for authentication.                                       | No       | -       |
 | `scylladb_datacenter` | Preferred datacenter for connection routing.                       | No       | -       |
-| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | `false` |
+| `scylladb_ssl`        | Enable SSL/TLS for connections. Not yet implemented — the parameter is accepted but has no effect. | No       | -       |
 | `connection_timeout`  | Connection timeout in milliseconds.                                | No       | `10000` |
 
 ## Types


### PR DESCRIPTION
## Summary
Two accuracy issues in the ScyllaDB connector parameter table:

1. `scylladb_host` was marked Required=Yes and `scylladb_hosts` was marked Required=No, but the runtime accepts either — it checks `scylladb_hosts` first then falls back to `scylladb_host` (lib.rs lines 326-333). A user providing only `scylladb_hosts` succeeds, contradicting the table.

2. `scylladb_ssl` had Default=`false`, but the parameter is never read by the connector (no `params.get("ssl")` call exists). Documenting a default for an unimplemented parameter is misleading.

## Changes
- Changed both `scylladb_host` and `scylladb_hosts` to Required=Yes* with descriptions clarifying either must be provided
- Changed `scylladb_ssl` default from `false` to `-` (no effective default since the parameter has no effect)
- Fixed in both vNext and v1.11.x docs (2 files)

## Reference
Verified against spiceai/spiceai at `trunk` — `crates/data-connectors/connector-scylladb/src/lib.rs` lines 126-131 (PARAMETERS), 326-333 (host resolution).