### PR TITLE
fix: Remove incorrect SSH key authentication claim from SFTP docs

### DIFF
--- a/website/docs/components/data-connectors/ftp.md
+++ b/website/docs/components/data-connectors/ftp.md
@@ -34,7 +34,7 @@ SELECT * FROM sales LIMIT 10;
 | --------------- | ------------------------- | ------------------------------ |
 | Default Port    | 21                        | 22                             |
 | Encryption      | None (plain text)         | SSH encryption                 |
-| Authentication  | Username/password         | Username/password or SSH keys  |
+| Authentication  | Username/password         | Username/password              |
 | Recommended Use | Internal/trusted networks | Production and public networks |
 
 :::tip[Security Recommendation]

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/ftp.md
@@ -34,7 +34,7 @@ SELECT * FROM sales LIMIT 10;
 | --------------- | ------------------------- | ------------------------------ |
 | Default Port    | 21                        | 22                             |
 | Encryption      | None (plain text)         | SSH encryption                 |
-| Authentication  | Username/password         | Username/password or SSH keys  |
+| Authentication  | Username/password         | Username/password              |
 | Recommended Use | Internal/trusted networks | Production and public networks |
 
 :::tip[Security Recommendation]


### PR DESCRIPTION
## Summary
The FTP/SFTP comparison table claimed SFTP supports "Username/password or SSH keys" for authentication. The SFTP connector (`connector-sftp/src/lib.rs`) only defines `component("user")` and `component("pass")` parameters — no SSH key file or passphrase parameters exist in the code.

## Changes
Changed SFTP authentication column from "Username/password or SSH keys" to "Username/password" in both vNext and v1.11.x docs (2 files).

## Reference
Verified against spiceai/spiceai at `trunk` — `crates/data-connectors/connector-sftp/src/lib.rs` PARAMETERS array (lines 62-70). Confirmed no SSH-related parameters via `grep -rn 'ssh\|SSH\|identity_file\|private_key' crates/data-connectors/connector-sftp/src/` (no results).