### PR TITLE
docs: Document DuckLake INSERT write support

### DIFF
--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -5,6 +5,7 @@ description: 'DuckLake Data Connector Documentation'
 tags:
   - data-connectors
   - ducklake
+  - write
 ---
 
 [DuckLake](https://ducklake.select/) is an open lakehouse format that stores metadata in a SQLite-compatible database (or PostgreSQL) and data in Parquet files. This connector enables querying individual DuckLake tables as datasets in Spice.
@@ -106,6 +107,25 @@ datasets:
       ducklake_aws_allow_http: true
 ```
 
+## Write Support
+
+This connector supports writing data to DuckLake tables using SQL [`INSERT INTO`](../../reference/sql/dml#insert) statements when `access` is set to `read_write`:
+
+```yaml
+datasets:
+  - from: ducklake:customer
+    name: customer
+    access: read_write
+    params:
+      ducklake_connection_string: s3://my-bucket/metadata.ducklake
+```
+
+```sql
+INSERT INTO customer (c_custkey, c_name) VALUES (1, 'Acme Corp');
+```
+
+`UPDATE` and `DELETE FROM` are not supported. For DDL operations (`CREATE TABLE`, `DROP TABLE`), use the [DuckLake Catalog Connector](../catalogs/ducklake) with `access: read_write_create`.
+
 ## Examples
 
 ### Reading from a local DuckLake catalog
@@ -185,5 +205,6 @@ datasets:
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.
+- Writes are limited to `INSERT INTO`. `UPDATE`, `DELETE FROM`, and DDL (`CREATE TABLE`, `DROP TABLE`) are not supported on the data connector — use the [DuckLake Catalog Connector](../catalogs/ducklake) for schema operations.
 
 :::


### PR DESCRIPTION
## Summary
The DuckLake data connector gained `INSERT INTO` write support via [spiceai/spiceai#10744](https://github.com/spiceai/spiceai/pull/10744) but the data connector docs still implied read-only. The DuckLake **catalog** connector docs already cover `access: read_write` (and `read_write_create` for DDL); this PR brings the **data** connector docs in line.

## Changes
- Added a `Write Support` section to `website/docs/components/data-connectors/ducklake.md` showing `access: read_write` and an `INSERT INTO` example.
- Added `write` to the page's `tags:` frontmatter (already declared in `tags.yml`).
- Clarified in `Limitations` that `UPDATE`, `DELETE FROM`, and DDL are not supported on the data connector — users needing DDL should use the catalog connector with `access: read_write_create`.

vNext-only: feature shipped post-v1.11.6 so no versioned docs need updating.

## Reference
Verified against `spiceai/spiceai` `trunk`:
- `crates/runtime/src/dataconnector/ducklake.rs` lines 363-385 — `read_write_provider` method
- `crates/data_components/src/ducklake/writer.rs` lines 174-194 — `insert_into` implementation (only `Append` and `Overwrite` ops; no `delete_from` or `update`)

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] No broken links, no undefined tags