### PR TITLE
fix: Update hash index docs for auto-enable behavior

### DIFF
--- a/website/docs/features/data-acceleration/hash-index.md
+++ b/website/docs/features/data-acceleration/hash-index.md
@@ -22,7 +22,7 @@ The hash index is an optional, high-performance indexing feature for Arrow-accel
 
 ## Configuration
 
-To use the hash index, explicitly enable it and specify a primary key:
+Hash indexing activates automatically on Arrow-accelerated datasets when a `primary_key` or [secondary index](./indexes) is configured. No additional parameter is required.
 
 ```yaml
 datasets:
@@ -31,9 +31,13 @@ datasets:
     acceleration:
       engine: arrow
       primary_key: order_id
-      params:
-        hash_index: enabled
 ```
+
+The hash index activates whenever:
+
+- `engine` is `arrow` or `partitioned_arrow`,
+- `acceleration.enabled` is `true`,
+- and either `indexes` is set, or `primary_key` is set with a non-`caching` `refresh_mode`.
 
 ### Secondary Indexes
 
@@ -50,8 +54,6 @@ datasets:
         email: unique
         status: enabled
         '(region, category)': unique
-      params:
-        hash_index: enabled
 ```
 
 Index types:
@@ -67,11 +69,14 @@ Only single-column `unique` secondary indexes currently accelerate queries. Non-
 
 ### Configuration Options
 
-| Parameter     | Type                 | Required                    | Default    | Description                                  |
-| ------------- | -------------------- | --------------------------- | ---------- | -------------------------------------------- |
-| `hash_index`  | `enabled`/`disabled` | No                          | `disabled` | Enable hash indexing                         |
-| `primary_key` | string or list       | Yes (if hash_index enabled) | None       | Column(s) for the primary key index          |
-| `indexes`     | YAML map             | No                          | None       | Secondary indexes (see [indexes](./indexes)) |
+| Parameter     | Type           | Required                                 | Default | Description                                  |
+| ------------- | -------------- | ---------------------------------------- | ------- | -------------------------------------------- |
+| `primary_key` | string or list | Yes (unless `indexes` is set)            | None    | Column(s) for the primary key index          |
+| `indexes`     | YAML map       | No                                       | None    | Secondary indexes (see [indexes](./indexes)) |
+
+:::note `hash_index` parameter is ignored
+The legacy `hash_index: enabled` parameter is accepted but no longer activates indexing on its own. When set, the runtime logs a warning and falls back to the automatic rules above. Remove `hash_index` from `params` to clear the warning.
+:::
 
 ## Supported Data Types
 
@@ -239,16 +244,17 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 **Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
 
-### Warning: "Add 'hash_index: enabled' to use primary_key for fast lookups"
+### Warning: "The hash_index acceleration parameter is ignored for Arrow acceleration"
 
-**Cause**: `primary_key` is specified but `hash_index` is not enabled.
+**Cause**: `hash_index: enabled` is set in `params` but no longer activates indexing on its own.
 
-**Solution**: Add `hash_index: enabled` to `params`:
+**Solution**: Remove `hash_index` from `params`. Hash indexing activates automatically when `primary_key` or `indexes` is configured on an Arrow-accelerated dataset (see [Configuration](#configuration)).
 
-```yaml
-params:
-  hash_index: enabled
-```
+### Hash index not active despite `primary_key` being set
+
+**Cause**: `refresh_mode: caching` disables hash indexing even when `primary_key` is set; the caching path uses its own lookup strategy.
+
+**Solution**: Use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) for datasets that need point-lookup acceleration via the hash index.
 
 ### High Memory Usage
 
@@ -256,5 +262,5 @@ params:
 
 **Solution**:
 
-- Disable hash_index for datasets where point lookups are rare
+- Remove `primary_key` for datasets where point lookups are rare (hash indexing stops being applied)
 - Consider using a different acceleration engine for very large datasets


### PR DESCRIPTION
## Summary
[spiceai/spiceai#10749](https://github.com/spiceai/spiceai/pull/10749) (Arrow primary key upserts) removed the explicit `hash_index: enabled` parameter from the spicepod schema and changed Arrow acceleration to enable hash indexing automatically when `primary_key` or `indexes` is configured. The runtime now logs a warning if `hash_index` is still set, but the docs at `website/docs/features/data-acceleration/hash-index.md` continued to instruct users to set `hash_index: enabled` — which produces a warning and has no effect.

## Changes
- **Configuration section** — rewrote the intro to describe automatic activation, removed `hash_index: enabled` from both YAML examples, and listed the exact runtime activation conditions.
- **Configuration Options table** — removed the `hash_index` row, and added a `:::note` admonition explaining the deprecation and recommending removal from `params`.
- **Troubleshooting** — replaced the obsolete "Add `hash_index: enabled` to use primary_key" entry with the new "ignored" warning, plus an entry covering the `refresh_mode: caching` exception that the new runtime logic enforces.

vNext-only: the source change ([spiceai/spiceai#10749](https://github.com/spiceai/spiceai/pull/10749)) is only in `trunk` / `nightly`. `website/versioned_docs/version-1.11.x/features/data-acceleration/hash-index.md` was deliberately left untouched because v1.11.x still requires the explicit `hash_index: enabled` parameter.

The related references in `arrow/index.md`, `arrow/deployment.md`, and `partitioning.md` are intentionally **out of scope for this PR** — they'll be addressed in a follow-up. Keeping this PR scoped to the canonical hash-index page makes the review tractable.

## Reference
Verified against `spiceai/spiceai` `trunk`:
- `crates/runtime/src/component/dataset/acceleration.rs` lines 357-365 — new `is_hash_index_enabled()` logic
- `crates/runtime/src/component/dataset/acceleration.rs` lines 437-441 — ignored-parameter warning text
- `crates/runtime/src/component/dataset/acceleration.rs` line 745 — `test_hash_index_param_is_ignored` unit test confirms the runtime behavior

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] No broken links, no undefined tags
- [x] Versioned docs (v1.11.x and earlier) intentionally untouched