### PR TITLE
docs: Add spice feedback CLI command reference

### DIFF
--- a/website/docs/cli/reference/feedback.md
+++ b/website/docs/cli/reference/feedback.md
@@ -1,0 +1,29 @@
+---
+title: "feedback"
+sidebar_label: "feedback"
+pagination_prev: null
+pagination_next: null
+---
+Open the Spice.ai community Slack in the default browser to share feedback.
+
+### Usage
+
+```shell
+spice feedback
+```
+
+#### Flags
+
+- `-h`, `--help`   Print this help message
+
+### Example
+
+```shell
+> spice feedback
+
+Opening Spice.ai community Slack in your default browser:
+
+  https://spice.ai/slack
+
+If the browser does not open, visit the URL above manually.
+```

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -27,6 +27,7 @@ spice [command] [--help]
 | [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
 | [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
+| [feedback](reference/feedback)     | Open the Spice.ai community Slack to share feedback                    |
 | help                               | Help about any command                                                 |
 | [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                     |
 | [install](reference/install)       | Install or reinstall the Spice.ai runtime                              |


### PR DESCRIPTION
## Summary
- Add new CLI reference page for the `spice feedback` command
- Add `feedback` entry to the CLI command reference table

## Source PRs
- spiceai/spiceai#10856 — feat(cli): add `spice feedback` command to open community Slack

## Changes
- `website/docs/cli/reference/feedback.md` — New reference page for the feedback command
- `website/docs/cli/reference/index.md` — Added feedback command to the command table

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Links are valid
- [x] Version references are correct