### PR TITLE
docs: Add Cayenne CDC and scan-path observability metrics

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -72,7 +72,24 @@ Vortex compression typically delivers 2–4× better compression than Parquet Sn
 
 ## Metrics
 
-Generic acceleration metrics are available with the `dataset_acceleration_` prefix. Cayenne-specific OpenTelemetry instruments are not currently registered at the runtime layer; use Cayenne's footer/segment cache hit rates surfaced via query plan explain and the generic acceleration counters.
+Generic acceleration metrics are available with the `dataset_acceleration_` prefix. Cayenne also registers the following OpenTelemetry instruments for CDC ingestion and scan-path observability, all tagged by `dataset`:
+
+### CDC Apply Metrics
+
+| Metric | Type | Unit | Description |
+| ------ | ---- | ---- | ----------- |
+| `dataset_acceleration_cdc_apply_burst_duration_ms` | Histogram | ms | Duration to apply one coalesced CDC burst. |
+| `dataset_acceleration_cdc_apply_burst_bytes` | Histogram | bytes | Arrow in-memory bytes in one coalesced CDC apply burst. |
+| `dataset_acceleration_cdc_apply_burst_envelopes` | Histogram | envelopes | Number of source envelopes in one coalesced CDC apply burst. |
+| `dataset_acceleration_cdc_apply_fixed_cost_ms` | Histogram | ms | Duration for fixed-cost phases of CDC apply (with `phase` label: `finalize_wait`, `commit_wait`, etc.). |
+
+### Scan-Path Metrics
+
+| Metric | Type | Unit | Description |
+| ------ | ---- | ---- | ----------- |
+| `cayenne_scan_listing_table_cache_entries` | Gauge | entries | Number of entries in the scan `ListingTable` cache. Cleared on snapshot change (compaction/sort/overwrite). |
+| `cayenne_listing_fence_wait_duration_ms` | Histogram | ms | Time spent waiting on listing-fence reads during scans. |
+| `cayenne_listing_scan_duration_ms` | Histogram | ms | Duration of listing-table scans. |
 
 See [Component Metrics](../../../features/observability/component_metrics) for enabling and exporting metrics.
 


### PR DESCRIPTION
## Summary
- Update the Cayenne deployment guide Metrics section to document new OpenTelemetry instruments for CDC ingestion and scan-path observability
- Replaces the previous statement that no Cayenne-specific instruments are registered

## Source PRs
- spiceai/spiceai#10852 — feat(cayenne): CDC throughput, compaction, scan caching, and benchmarks

## Changes
- `website/docs/components/data-accelerators/cayenne/deployment.md` — Added CDC Apply Metrics table (4 histograms: burst duration, bytes, envelopes, fixed-cost phases) and Scan-Path Metrics table (1 gauge + 2 histograms: listing table cache entries, fence wait duration, listing scan duration)

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] All metric names verified against source code (`crates/runtime/src/accelerated_table/metrics.rs` and `crates/telemetry/src/lib.rs`)
- [x] Links are valid