### PR TITLE
docs: Document PostgreSQL catalog FK discovery

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -100,6 +100,15 @@ catalogs:
       pg_connection_string: postgresql://${secrets:REDSHIFT_USER}:${secrets:REDSHIFT_PASS}@my-cluster.abc123.us-east-1.redshift.amazonaws.com:5439/my_database?sslmode=require
 ```
 
+## Foreign Key Discovery
+
+The PostgreSQL Catalog Connector automatically discovers foreign key relationships by querying `information_schema.referential_constraints` and `key_column_usage` during catalog refresh. Discovered FK metadata is attached to each table's Arrow schema and surfaces through:
+
+- The `table_schema` tool — agents can use FK relationships to infer join paths between tables
+- FlightSQL `GetTables` — programmatic clients receive FK metadata in the schema response
+
+No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).


### PR DESCRIPTION
## Summary
- Document automatic foreign key relationship discovery in the PostgreSQL Catalog Connector
- FK metadata surfaces through the `table_schema` tool (for agents) and FlightSQL `GetTables` (for programmatic clients)

## Source PRs
- spiceai/spiceai#10849 — Add foreign key metadata discovery to PostgreSQL Catalog

## Changes
- `website/docs/components/catalogs/postgres.md` — Added "Foreign Key Discovery" section describing automatic FK metadata discovery, how it surfaces, and graceful degradation when permissions are insufficient

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Verified behavior against source code in `crates/data_components/src/postgres/provider.rs`
- [x] Links are valid