### PR TITLE
fix: Correct Elasticsearch deployment guide pagination claim

### DIFF
--- a/website/docs/components/data-connectors/elasticsearch/deployment.md
+++ b/website/docs/components/data-connectors/elasticsearch/deployment.md
@@ -57,7 +57,7 @@ Long-running search responses (very large `LIMIT`, deep pagination, or expensive
 ## Capacity & Sizing
 
 - **Throughput**: Bounded by the Elasticsearch cluster's request handling and (for kNN) HNSW search cost. Plan refresh intervals and concurrent query load to stay within the cluster's tested capacity.
-- **Result size**: The connector issues a single `_search` request per query, returning at most 10,000 hits (bounded by the Elasticsearch `index.max_result_window` setting). Queries with `LIMIT N` fetch `min(N, 10000)` rows. For result sets larger than 10,000, accelerate the dataset.
+- **Result size**: For queries with `LIMIT N` where N ≤ 10,000, the connector issues a single `_search` request. For larger result sets or queries without `LIMIT`, the connector automatically paginates using Point-In-Time (PIT) + `search_after`, fetching all matching documents in 10,000-hit batches (bounded by the Elasticsearch `index.max_result_window` setting per batch).
 - **Mapping fetches**: At dataset registration the connector fetches the index mapping once via `GET /<index>/_mapping`. Mapping changes after registration are not picked up until the runtime restarts.
 
 ## Search Routing


### PR DESCRIPTION
## Summary
- The deployment guide's Capacity & Sizing section incorrectly stated the connector issues a single `_search` request per query, returning at most 10,000 hits, and advised accelerating for larger result sets
- The connector actually uses PIT + `search_after` pagination for queries without `LIMIT` or with `LIMIT > 10,000`, fetching all matching documents in 10,000-hit batches
- The connector index.md already documents this correctly (fixed in PR #1712), but the deployment guide was missed

## Changes
- Updated the "Result size" bullet in `website/docs/components/data-connectors/elasticsearch/deployment.md` to match the index.md description and actual code behavior

## Reference
Verified against spiceai/spiceai at trunk — [query_table.rs:231](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/elasticsearch/query_table.rs#L231): `use_point_in_time: limit.is_none_or(|limit| limit > ELASTICSEARCH_PAGE_SIZE)`