### PR TITLE
docs: Add Elasticsearch unsigned_long → UInt64 type mapping

### DIFF
--- a/website/docs/components/data-connectors/elasticsearch/index.md
+++ b/website/docs/components/data-connectors/elasticsearch/index.md
@@ -60,6 +60,7 @@ The connector derives an Arrow schema from each index's mapping via `GET /<index
 | ---------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------- |
 | `text`, `keyword`, `wildcard`, `constant_keyword`, `match_only_text` | `Utf8`                            |                                                             |
 | `long`                                                           | `Int64`                              |                                                             |
+| `unsigned_long`                                                  | `UInt64`                             | Accepts both numeric values and digit strings (JS clients commonly serialize values > 2<sup>53</sup>-1 as strings). |
 | `integer`                                                        | `Int32`                              |                                                             |
 | `short`                                                          | `Int16`                              |                                                             |
 | `byte`                                                           | `Int8`                               |                                                             |


### PR DESCRIPTION
## Summary
Add the `unsigned_long` row to the Elasticsearch type-mapping table now that the connector decodes it explicitly to Arrow `UInt64`.

## Source PRs
- spiceai/spiceai#10825 — Expand Arrow type handling in formatting and Elasticsearch

## Changes
- `website/docs/components/data-connectors/elasticsearch/index.md`
  - Add `unsigned_long → UInt64` to the type-mapping table, with a note that the decoder accepts both numeric values and digit-string representations (since JS clients commonly serialize values > 2^53-1 as strings).

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] Type-mapping arm verified in source diff (`Some("unsigned_long") => DataType::UInt64`)