### PR TITLE
fix: Document missing pg_replication_bootstrap_batch_size parameter

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -124,6 +124,7 @@ The following parameters configure PostgreSQL [logical replication](https://www.
 | `pg_replication_initial_snapshot`  | Optional. Whether to take an initial snapshot of existing rows before streaming WAL changes. Default: `true`.                                            |
 | `pg_replication_temporary_slot`    | Optional. If `true`, create a temporary replication slot that is dropped when the Spice process disconnects. Default: `false` (durable slot).            |
 | `pg_replication_status_interval`   | Optional. How often to send StandbyStatusUpdate to Postgres (e.g. `10s`). Default: `10s`.                                                               |
+| `pg_replication_bootstrap_batch_size` | Optional. Number of rows per emitted batch during the initial replication snapshot. Default: `8192`. Maximum: `1048576`.                              |
 
 ## Types
 

--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -131,6 +131,7 @@ All replication-specific parameters live under `params:` on the dataset and star
 | `pg_replication_initial_snapshot`    | `true`                                           | If `true`, take an initial snapshot of the table's existing rows before streaming. Set to `false` if you are pre-seeding the accelerator yourself.                                                     |
 | `pg_replication_temporary_slot`      | `false`                                          | If `true`, the slot is dropped when Spice disconnects. Every restart re-bootstraps.                                                                                                                    |
 | `pg_replication_status_interval`     | `10s`                                            | How often `StandbyStatusUpdate` (LSN acknowledgement) is sent back to Postgres. Lower values free WAL faster; higher values reduce network chatter. Accepts any duration string (`500ms`, `30s`, `2m`). |
+| `pg_replication_bootstrap_batch_size` | `8192`                                          | Rows per emitted batch during the initial-snapshot bootstrap. Larger batches reduce per-batch overhead at the cost of more memory per batch. Maximum: `1048576`.                                       |
 
 All existing `pg_host`, `pg_port`, `pg_user`, `pg_pass`, `pg_db`, `pg_sslmode`, `pg_connection_string` parameters continue to apply — see the [PostgreSQL Data Connector](../../components/data-connectors/postgres) reference.
 


### PR DESCRIPTION
## Summary
The PostgreSQL data connector accepts `pg_replication_bootstrap_batch_size` to control rows-per-batch during the initial CDC snapshot, but it was missing from both the connector reference and the CDC feature page.

## Changes
Add `pg_replication_bootstrap_batch_size` (default `8192`, max `1048576`) to:
- `website/docs/components/data-connectors/postgres/index.md` — replication parameters table
- `website/docs/features/cdc/postgres-replication.md` — full configuration reference

## Reference
Verified against `spiceai/spiceai` trunk:
- `ParameterSpec`: [`crates/data-connectors/connector-postgres/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/lib.rs#L169-L174) (lines 169–174) declares the parameter with `default("8192")` and a 1,048,576 ceiling note.
- Consumed by [`crates/data-connectors/connector-postgres/src/replication.rs:436`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/replication.rs#L436) via `optional_usize_in_range(...)` using `DEFAULT_BOOTSTRAP_BATCH_SIZE = 8192` and `MAX_BOOTSTRAP_BATCH_SIZE = 1_048_576`, then plumbed through `ReplicationParams.bootstrap_batch_size` into the bootstrap loop at `crates/data_components/src/postgres_replication/bootstrap.rs:78`.

## Version scope
The parameter was added in source on 2026-05-12 (commit `f4a5089df`, "Improve CDC ingestion performance"). It is not yet contained in any release tag, so only the unversioned vNext docs need updating — versioned doc sets (`1.5.x` through `1.11.x`) intentionally untouched.

## Test plan
- [x] Verified parameter name, default, and maximum against the `ParameterSpec` declaration and `optional_usize_in_range` consumer call site.
- [x] Confirmed the parameter is end-to-end wired (declared in `PARAMETERS`, consumed in `replication.rs`, used in `bootstrap.rs`) — not a non-functional name.
- [ ] Local Docusaurus build skipped: host disk had ~300Mi free, insufficient for the ~600MB build output. The change is two new rows in existing tables, no new links or frontmatter tags, so broken-link / undefined-tag checks are not affected.