### PR TITLE
docs: Document acceleration.storage_profile config

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -365,6 +365,31 @@ Optional. The mode of acceleration. The following values are supported:
 - `file_create` - Always create a new acceleration file on startup, removing any existing file. When [snapshots](../../features/data-acceleration/snapshots) are enabled, the existing file is snapshotted before deletion. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.
 - `file_update` - Open an existing acceleration file if it exists, then check schema compatibility on refresh. If the source schema change is additive (new columns only), the existing file is kept. If the schema change is incompatible (columns removed, renamed, or type changed), the file is snapshotted (if [snapshots](../../features/data-acceleration/snapshots) are enabled) and recreated from scratch. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.
 
+## `acceleration.storage_profile`
+
+Optional. The storage profile for file-backed acceleration. The runtime uses this hint to tune connection-pool sizing, checkpoint thresholds, and file-size defaults for the underlying medium. Only applies to file-mode accelerators (`duckdb`, `sqlite`, `turso`, and Spice Cayenne); memory-mode accelerators ignore this setting.
+
+Supported values:
+
+- `auto` (default) – Detect the storage profile from the resolved acceleration file path. On Linux, detection reads `/proc/self/mountinfo` and inspects block-device metadata to recognize Amazon EBS, Azure Managed Disks, Amazon EC2 NVMe instance storage, `tmpfs`/`ramfs`, and generic NVMe/SSD. On other platforms, detection returns unknown and the engine defaults apply.
+- `local_ssd` (aliases: `ssd`, `nvme`) – Treat the acceleration file location as local SSD/NVMe (for example, EC2 instance store or Azure temporary/NVMe local storage). Uses the engine defaults for connection pool size and checkpoint thresholds.
+- `ebs` (aliases: `azure_disk`, `managed_disk`, `network_disk`) – Treat the acceleration file location as network-attached block storage (for example, Amazon EBS or Azure Managed Disks). Reduces connection-pool size and raises DuckDB's checkpoint threshold so per-IO latency is amortized across larger flushes. Spice Cayenne uses smaller per-file targets to reduce write amplification.
+- `tmpfs` (aliases: `ram`, `ramdisk`, `ramfs`, `memory`) – Treat the acceleration file location as RAM-backed storage. Raises DuckDB's checkpoint threshold so steady-state workloads don't pay checkpoint cost on small amounts of dirty data; Spice Cayenne uses larger per-file targets to improve scan throughput.
+
+Example:
+
+```yaml
+datasets:
+  - from: s3://bucket/data/
+    name: analytics
+    acceleration:
+      engine: duckdb
+      mode: file
+      storage_profile: ebs
+      params:
+        duckdb_file: /mnt/ebs/analytics.db
+```
+
 ## `acceleration.snapshots`
 
 Optional. Controls how this dataset participates in managed acceleration snapshots. Requires the Spicepod to configure the top-level [`snapshots` block](.#snapshots), the acceleration engine to be `duckdb`, `sqlite`, `cayenne`, or `turso`, and `mode: file` with a dataset-specific file path (for example `acceleration.params.duckdb_file: /nvme/my_dataset.db`).


### PR DESCRIPTION
## Summary

Adds a new reference section in `datasets.md` for the `acceleration.storage_profile` config option introduced in spiceai/spiceai#10913. The field tunes connection pool sizing, checkpoint thresholds, and per-file size defaults across DuckDB, SQLite, Turso, and Spice Cayenne file-mode accelerators based on the underlying storage medium.

## Source PRs

- spiceai/spiceai#10913 — Tune accelerators by storage profile

## Changes

- `website/docs/reference/spicepod/datasets.md` — new `acceleration.storage_profile` section documenting `auto` (default), `local_ssd` (aliases: `ssd`, `nvme`), `ebs` (aliases: `azure_disk`, `managed_disk`, `network_disk`), and `tmpfs` (aliases: `ram`, `ramdisk`, `ramfs`, `memory`). Notes that detection is Linux-only and that memory-mode accelerators ignore the setting.

## Test plan

- [ ] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [ ] Verified examples work locally
- [ ] Links are valid
- [ ] Version references are correct