### PR TITLE
docs: Document Authorization: Bearer for HTTP API auth

### DIFF
--- a/website/docs/api/auth/index.md
+++ b/website/docs/api/auth/index.md
@@ -36,7 +36,7 @@ The API key authentication is applied on startup and changes will not take effec
 
 ## HTTP
 
-For HTTP routes, the API key is expected to be included in the `X-API-Key` header.
+For HTTP routes, the API key can be supplied in either the `X-API-Key` header or the `Authorization: Bearer ${ api_key }` header. The `Bearer` scheme is matched case-insensitively. If both headers are present, `X-API-Key` takes precedence.
 
 ```bash
 > curl -i "http://localhost:8090/v1/sql" -H "X-API-Key: 1234567890" -d 'SELECT 1'
@@ -48,6 +48,12 @@ content-length: 16
 date: Fri, 08 Nov 2024 07:14:24 GMT
 
 [{"Int64(1)":1}]
+```
+
+Or using `Authorization: Bearer`:
+
+```bash
+> curl -i "http://localhost:8090/v1/sql" -H "Authorization: Bearer 1234567890" -d 'SELECT 1'
 ```
 
 The `/health` and `/v1/ready` endpoints are not protected and can be accessed without an API key.


### PR DESCRIPTION
## Summary

Documents the new `Authorization: Bearer ${api_key}` header support for HTTP API authentication added in spiceai/spiceai#10911. Previously the docs only mentioned the `X-API-Key` header for HTTP routes.

## Source PRs

- spiceai/spiceai#10911 — Adds `Authorization: Bearer` to the API key auth path for HTTP routes alongside the existing `X-API-Key`. Bearer scheme matching is case-insensitive; `X-API-Key` takes precedence when both headers are present.

## Changes

- `website/docs/api/auth/index.md` — extend the HTTP section to note that either `X-API-Key` or `Authorization: Bearer ${api_key}` is accepted, with a `curl` example for the Bearer form.

## Test plan

- [ ] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [ ] Verified examples work locally
- [ ] Links are valid
- [ ] Version references are correct