### PR TITLE
docs: Document MCP Streamable HTTP auth parameters

### DIFF
--- a/website/docs/components/tools/mcp.md
+++ b/website/docs/components/tools/mcp.md
@@ -38,6 +38,34 @@ tools:
     from: mcp:http://example.com/v1/mcp
 ```
 
+### Example: Connecting to an Auth-Enabled MCP Server (Streamable HTTP)
+
+Streamable HTTP MCP tools support sending an `Authorization: Bearer` token via `mcp_auth_token`, or arbitrary HTTP headers via `mcp_headers`. Both parameters resolve [secret references](../secret-stores/) before the MCP client is constructed.
+
+Sending a bearer token:
+
+```yaml
+tools:
+  - name: remote_spice
+    from: mcp:https://my-spice.example.com/v1/mcp
+    params:
+      # Sends: Authorization: Bearer <expanded secret value>
+      mcp_auth_token: ${ secrets:MCP_SERVER_API_KEY }
+```
+
+Sending a custom header (e.g., API key):
+
+```yaml
+tools:
+  - name: remote_spice
+    from: mcp:https://my-spice.example.com/v1/mcp
+    params:
+      # Sends: X-API-Key: <expanded secret value>
+      mcp_headers: 'X-API-Key: ${ secrets:MCP_SERVER_API_KEY }'
+```
+
+If both `mcp_auth_token` and a custom `Authorization` header in `mcp_headers` are set, `mcp_auth_token` wins and a warning is logged.
+
 ## Using MCP Tools with Models
 
 Once configured, MCP tools can be assigned to models via the `tools` parameter. For example:
@@ -87,7 +115,9 @@ The `from` field specifies the transport mechanism for the MCP tool:
 
 ### `params`
 
-The `params` field provides additional configuration for MCP tools. For stdio-based tools, use `mcp_args` to specify command-line arguments.
+The `params` field provides additional configuration for MCP tools.
+
+For stdio-based tools, use `mcp_args` to specify command-line arguments:
 
 ```yaml
 tools:
@@ -96,6 +126,13 @@ tools:
     params:
       mcp_args: -y @custom/tool
 ```
+
+For Streamable HTTP tools, the following auth parameters are supported:
+
+- `mcp_auth_token` — Sends `Authorization: Bearer <token>` on every request to the MCP server.
+- `mcp_headers` — Sends additional HTTP headers using the same `Header: Value` comma- or semicolon-delimited format as the [HTTP data connector's `http_headers`](../data-connectors/https). Header values are marked sensitive.
+
+Both parameters support [secret expansion](../secret-stores/). When `mcp_auth_token` is set, an `Authorization` header in `mcp_headers` is ignored and a warning is logged to avoid duplicate auth headers.
 
 ### `env`
 


### PR DESCRIPTION
## Summary

Documents the new `mcp_auth_token` and `mcp_headers` MCP tool parameters introduced in spiceai/spiceai#10927.

## Source PRs
- spiceai/spiceai#10927 — feat(mcp): support auth for streamable HTTP tools

## Changes
- `website/docs/components/tools/mcp.md`
  - Added a new auth example section showing `mcp_auth_token` (bearer) and `mcp_headers` (custom header) usage with secret expansion.
  - Extended the `params` configuration reference to enumerate both parameters and the precedence rule (when both set, `mcp_auth_token` wins and a warning is logged).

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Links resolve: `../secret-stores/` and `../data-connectors/https` both exist
- [x] Verified parameter names and behavior against `crates/runtime/src/tools/mcp/mod.rs` (`MCP_AUTH_TOKEN_PARAM`, `MCP_HEADERS_PARAM`, `parse_custom_headers`)