### PR TITLE
docs: update community Slack URL to spice.ai/slack

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -145,7 +145,7 @@ Spice enables developers to build data-grounded AI applications and agents by co
 
 ### Connect with Us
 
-- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spiceai.org/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
+- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spice.ai/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
 - [File an issue](https://github.com/spiceai/spiceai/issues/new) for bugs or issues.
 - Join our team ([We're hiring!](https://spice.ai/careers)).
 - Contribute code or documentation ([CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING)).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -269,7 +269,7 @@ const config: Config = {
         },
         {
           label: 'Slack',
-          href: 'https://spiceai.org/slack',
+          href: 'https://spice.ai/slack',
           position: 'right'
         },
         {
@@ -318,7 +318,7 @@ const config: Config = {
             },
             {
               label: 'Slack',
-              href: 'https://spiceai.org/slack'
+              href: 'https://spice.ai/slack'
             },
             {
               label: 'X',

--- a/website/src/components/docs/intro.mdx
+++ b/website/src/components/docs/intro.mdx
@@ -5,7 +5,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks'
 # Spice.ai OSS
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Slack](https://img.shields.io/badge/slack-orange?logo=slack)](https://spiceai.org/slack)
+[![Slack](https://img.shields.io/badge/slack-orange?logo=slack)](https://spice.ai/slack)
 [![Follow on X](https://img.shields.io/twitter/follow/spice_ai.svg?style=social&logo=x)](https://x.com/intent/follow?screen_name=spice_ai)
 
 ### What is Spice?

--- a/website/src/components/molecules/social/social.tsx
+++ b/website/src/components/molecules/social/social.tsx
@@ -29,7 +29,7 @@ export const Social = () => {
           <Icon iconName='twitter' className='h-7 w-7 hover:text-primary' />
         </Link>
         <Link
-          href='https://spiceai.org/slack'
+          href='https://spice.ai/slack'
           target='_blank'
           rel='noreferrer'
           aria-label='Spice.ai Slack Community'

--- a/website/versioned_docs/version-1.10.x/index.mdx
+++ b/website/versioned_docs/version-1.10.x/index.mdx
@@ -153,7 +153,7 @@ Spice enables developers to build data-grounded AI applications and agents by co
 
 ### Connect with Us
 
-- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spiceai.org/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
+- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spice.ai/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
 - [File an issue](https://github.com/spiceai/spiceai/issues/new) for bugs or issues.
 - Join our team ([We're hiring!](https://spice.ai/careers)).
 - Contribute code or documentation ([CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING)).

--- a/website/versioned_docs/version-1.11.x/index.mdx
+++ b/website/versioned_docs/version-1.11.x/index.mdx
@@ -179,7 +179,7 @@ Spice enables developers to build data-grounded AI applications and agents by co
 
 ### Connect with Us
 
-- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spiceai.org/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
+- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spice.ai/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
 - [File an issue](https://github.com/spiceai/spiceai/issues/new) for bugs or issues.
 - Join our team ([We're hiring!](https://spice.ai/careers)).
 - Contribute code or documentation ([CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING)).

--- a/website/versioned_docs/version-1.9.x/index.mdx
+++ b/website/versioned_docs/version-1.9.x/index.mdx
@@ -153,7 +153,7 @@ Spice enables developers to build data-grounded AI applications and agents by co
 
 ### Connect with Us
 
-- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spiceai.org/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
+- Build with Spice and share feedback at [hey@spice.ai](mailto:hey@spice.ai), [Slack](https://spice.ai/slack), [X](https://twitter.com/spice_ai), or [LinkedIn](https://www.linkedin.com/company/74148478).
 - [File an issue](https://github.com/spiceai/spiceai/issues/new) for bugs or issues.
 - Join our team ([We're hiring!](https://spice.ai/careers)).
 - Contribute code or documentation ([CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md)).


### PR DESCRIPTION
## Summary
- Replace `https://spiceai.org/slack` with `https://spice.ai/slack` across the docs site (navbar, footer, intro/index pages, social component, and currently-served versioned docs).
- Historical release notes under `website/releases/` are left untouched.

## Test plan
- [ ] `npm run build` (or equivalent) succeeds in `website/`
- [ ] Spot-check the Slack link in the navbar, footer, and `/docs` landing page renders as `https://spice.ai/slack`