### PR TITLE
docs: Document UDTF filter pushdown via args in WHERE clauses

### DIFF
--- a/website/docs/features/functions/index.md
+++ b/website/docs/features/functions/index.md
@@ -223,6 +223,31 @@ body: |
 
 The query's output columns must match the declared `returns` schema.
 
+### Filter pushdown with args
+
+Scalar args are inlined as literals before logical planning, so they participate in filter pushdown. This makes it possible to parameterize a table function against connectors that require concrete filter values — for example, the HTTP connector's `request_path`:
+
+```yaml
+functions:
+  - name: hn_user
+    from: sql
+    kind: table
+    signature:
+      args:
+        - { name: username, type: utf8 }
+      returns:
+        - { name: username, type: utf8 }
+        - { name: karma, type: utf8 }
+    body: |
+      SELECT
+        json_get_str(content, 'username') AS username,
+        json_get_str(content, 'karma')    AS karma
+      FROM raw_users
+      WHERE request_path = concat('/users/', (SELECT username FROM args))
+```
+
+Calling `SELECT * FROM hn_user('pg')` resolves the `(SELECT username FROM args)` subquery to the literal `'pg'` before planning, so the resulting `WHERE request_path = '/users/pg'` predicate is pushed down to the HTTP connector.
+
 ## Volatility
 
 Volatility tells the optimizer how the function behaves across calls. Pick the strongest level that's actually true — the default (`volatile`) is the safest but disables constant folding, query-level caching, and pushdown.


### PR DESCRIPTION
## Summary

Adds a "Filter pushdown with args" subsection to the Table Functions reference at [features/functions/index.md](https://docs.spiceai.org/docs/features/functions), explaining that scalar args are inlined as literals before logical planning. This enables filter pushdown when args are referenced in `WHERE` clauses — e.g. parameterizing the HTTP connector's `request_path` with a table function argument.

## Source PRs

- spiceai/spiceai#11004 — Enable filter pushdown in spicepod defined UDTFs

## Changes

- `website/docs/features/functions/index.md` — new "Filter pushdown with args" subsection with an HTTP-connector example.

## Test plan

- [x] `cd website && npm run build` passes locally
- [x] Example mirrors the runtime behavior from spiceai/spiceai#11004
- [x] Links and version references unchanged