### PR TITLE
fix: Correct Oracle catalog wallet parameter descriptions

### DIFF
--- a/website/docs/components/catalogs/oracle.md
+++ b/website/docs/components/catalogs/oracle.md
@@ -67,10 +67,10 @@ Connection can be configured using a connection string or individual parameters.
 
 ### Wallet parameters (for Oracle Cloud ADB)
 
-| Parameter Name           | Description                                                                               |
-| ------------------------ | ----------------------------------------------------------------------------------------- |
-| `oracle_wallet`          | Path to the Oracle wallet directory for mTLS connections.                                 |
-| `oracle_wallet_sso_cert` | Path to the Oracle wallet certificate file, or base64-encoded wallet certificate content. |
+| Parameter Name           | Description                                                                                                                                              |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oracle_wallet`          | Path to the Oracle wallet directory used for mTLS connections. Also used as the destination directory when `oracle_wallet_sso_cert` is set. Default: `.oracle`. |
+| `oracle_wallet_sso_cert` | Base64-encoded `cwallet.sso` (wallet auto-login certificate) content. The runtime writes the decoded certificate to `oracle_wallet`.                     |
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

The `oracle_wallet_sso_cert` parameter on the Oracle catalog connector page was documented as accepting either a file path or base64-encoded content. The runtime always base64-decodes this value before writing it to disk, so supplying a file path produces a base64 decode error rather than a successful wallet load — the behavior is identical to the Oracle data connector (which already documents this correctly as base64-encoded only).

This PR also surfaces the `.oracle` default for `oracle_wallet` (the destination directory used when `oracle_wallet_sso_cert` is set) and clarifies how the two parameters interact, matching the data connector docs and the runtime source.

## Changes

- `oracle_wallet_sso_cert`: corrected to base64-encoded `cwallet.sso` content only; added note that the runtime writes the decoded certificate to `oracle_wallet`.
- `oracle_wallet`: documented `.oracle` default and that it doubles as the destination directory when `oracle_wallet_sso_cert` is set.

Only the unversioned (trunk) catalog page is touched — the Oracle catalog connector page does not exist in any versioned-docs directory.

## Reference

Verified against spiceai/spiceai at `trunk`:

- Default wallet path constant: [`crates/runtime/src/catalogconnector/oracle.rs:39`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/oracle.rs#L39)
- Base64 decode on `wallet_sso_cert`: [`crates/runtime/src/catalogconnector/oracle.rs:144-166`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/oracle.rs#L144-L166)
- `oracle_wallet` used as the write destination: [`crates/runtime/src/catalogconnector/oracle.rs:190-202`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/oracle.rs#L190-L202)
