### PR TITLE
fix: use correct WAL replication parameter names in postgres example

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -227,8 +227,8 @@ datasets:
       pg_user: spice_writer
       pg_pass: ${secrets:PG_PASSWORD}
       # Replication-mode parameters (see Configuration above)
-      pg_replication_publication: spice_pub
-      pg_replication_slot_name: spice_slot
+      pg_publication: spice_pub
+      pg_replication_slot: spice_slot
     acceleration:
       engine: duckdb
       mode: file


### PR DESCRIPTION
## Summary

The PostgreSQL connector docs include a `read_write` + `refresh_mode: changes` example that uses parameter names the connector does not accept. Users copying the example get silently-dropped config (or a parameter-validation error).

| Doc said | Actual parameter name |
| --- | --- |
| `pg_replication_publication` | `pg_publication` |
| `pg_replication_slot_name` | `pg_replication_slot` |

## Changes

- `website/docs/components/data-connectors/postgres/index.md` — replace the two parameter names in the WAL replication example block.

vNext-only fix. Native Postgres WAL CDC was introduced in [spiceai#10364](https://github.com/spiceai/spiceai/pull/10364), which is not in any 1.x release tag — so versioned docs (`version-1.5.x` through `version-1.11.x`) are not affected.

## Reference

Verified against spiceai/spiceai trunk:
- [`crates/data-connectors/connector-postgres/src/lib.rs:143-148`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/lib.rs#L143-L148) — `ParameterSpec::component("replication_slot")` and `ParameterSpec::component("publication")` (auto-prefixed `pg_`).
- [`crates/data-connectors/connector-postgres/src/replication.rs:425-427`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-postgres/src/replication.rs#L425-L427) — `optional_string(params, "replication_slot")` and `optional_string(params, "publication")`.