### PR TITLE
docs: Document source-side comment propagation in Semantic Model

### DIFF
--- a/website/docs/features/semantic-model/index.md
+++ b/website/docs/features/semantic-model/index.md
@@ -61,3 +61,17 @@ Each column in the dataset can be defined with the following attributes:
 - `embeddings`: Optional. Vector embeddings configuration for this column.
 
 For detailed `columns` configuration, see the [Dataset Reference](../reference/spicepod/datasets#columns)
+
+## Source-Side Comments
+
+When a dataset is loaded from a source that exposes table or column comments, Spice automatically imports those comments into the Arrow schema metadata under the `comment` key. This means database-native `COMMENT ON TABLE` and `COMMENT ON COLUMN` annotations show up alongside Spicepod-defined `description` values, giving the semantic model the same context that already lives in the source database.
+
+Source-side comments are imported automatically from:
+
+- **PostgreSQL** — via `obj_description` / `col_description` in `pg_catalog`.
+- **MySQL** — via `information_schema.tables.table_comment` and `information_schema.columns.column_comment`.
+- **Snowflake** — via `information_schema.tables.comment` and `information_schema.columns.comment`.
+- **Databricks SQL Warehouse** — via the table and column metadata returned by the SQL Warehouse driver.
+- **BigQuery (via ADBC catalog)** — via `INFORMATION_SCHEMA.TABLE_OPTIONS` (`description`) and the column field-path descriptions.
+
+Spicepod-defined `description` values continue to take precedence: when both a Spicepod `description` and a source-side comment are present for the same table or column, the Spicepod value wins.


### PR DESCRIPTION
## Summary

Document that table and column comments from a handful of source databases are now imported automatically into the Arrow schema metadata under the `comment` key, alongside any Spicepod-defined `description` values. The Semantic Model page didn't previously call this out.

## Source PRs

- spiceai/spiceai#10944 — Propagate source comments into schema metadata

## Changes

- `website/docs/features/semantic-model/index.md`: add a "Source-Side Comments" section listing the source databases that automatically import table/column comments (PostgreSQL, MySQL, Snowflake, Databricks SQL Warehouse, BigQuery via ADBC) and noting the Spicepod-vs-source precedence rule.

Verified from source:
- `crates/spicepod/src/component/dataset.rs` — Spicepod `description` is mapped to `comment` (not `description`) in the metadata `HashMap`.
- `crates/data_components/src/lib.rs` — Spicepod metadata is layered via `extend` over the base source schema metadata, so Spicepod values win on key collision.
- Source comment query sites:
  - `crates/data_components/src/postgres/provider.rs` — `obj_description` / `col_description`.
  - `crates/data_components/src/mysql/provider.rs` — `information_schema.tables.table_comment` / `information_schema.columns.column_comment`.
  - `crates/data_components/src/snowflake/mod.rs` — `information_schema.columns.comment` / `information_schema.tables.comment`.
  - `crates/data_components/src/databricks/sql_warehouse.rs` — SQL Warehouse table/column metadata.
  - `crates/runtime/src/dataconnector/adbc.rs` — BigQuery `INFORMATION_SCHEMA.TABLE_OPTIONS` (`description`) and `column_field_paths.description`.

## Test plan

- [x] `cd website && npm run build` passes locally
- [x] Connector list verified against the actual query sites in source
- [x] Precedence claim (Spicepod over source) verified against `extend`-based merge order