### PR TITLE
fix: remove deleted Cayenne catalog connector from index

### DIFF
--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -24,7 +24,6 @@ Supported Catalog Connectors include:
 
 | Name            | Description             | Status            | Protocol/Format              |
 | --------------- | ----------------------- | ----------------- | ---------------------------- |
-| `cayenne`       | Cayenne Lakehouse       | Release Candidate | Vortex                       |
 | `unity_catalog` | Unity Catalog           | Stable            | Delta Lake                   |
 | `databricks`    | Databricks              | Beta              | Spark Connect, S3/Delta Lake |
 | `iceberg`       | Apache Iceberg          | Beta              | Parquet                      |


### PR DESCRIPTION
## Summary

The Cayenne catalog connector is listed in the catalog connectors index table but is no longer available — its docs page was removed by spiceai/docs#1750, and it is not registered in the runtime's catalog connector factory.

The runtime registers these catalog connectors in `crates/runtime/src/catalogconnector/mod.rs::register_all`: `unity_catalog`, `databricks`, `iceberg`, `glue`, `spice.ai`, `ducklake`, `snowflake`, `postgres`, `mysql`, `mssql`, `oracle`, `adbc`. Cayenne is intentionally not in that list — Cayenne remains a data **accelerator** engine but is not a catalog connector.

## Changes

Remove the stale `cayenne` row from the Supported Catalog Connectors table in `website/docs/components/catalogs/index.md`.

## Reference

Verified against `spiceai/spiceai` at `trunk` — the `catalogconnector::cayenne` module exists but `CayenneCatalogConnector::new_connector` is not referenced anywhere outside the module, and the registry assembled in `register_all` has no entry for it.