### PR TITLE
docs(catalogs/unity-catalog): Document unity_catalog_aws_allow_http parameter

### DIFF
--- a/website/docs/components/catalogs/unity-catalog/index.md
+++ b/website/docs/components/catalogs/unity-catalog/index.md
@@ -59,6 +59,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 - `unity_catalog_aws_access_key_id`: The access key ID for the S3 object store.
 - `unity_catalog_aws_secret_access_key`: The secret access key for the S3 object store.
 - `unity_catalog_aws_endpoint`: The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.
+- `unity_catalog_aws_allow_http`: Enables insecure HTTP connections to the AWS endpoint, useful for S3-compatible servers (e.g. MinIO). Defaults to `false`.
 
 #### Azure Blob
 


### PR DESCRIPTION
## Summary
Add the new `unity_catalog_aws_allow_http` dataset parameter to the Unity Catalog catalog connector documentation. The parameter enables insecure HTTP connections to S3-compatible endpoints (e.g. MinIO) for Delta Lake table storage.

## Source PRs
- spiceai/spiceai#11026 — Fix Unity Catalog connector deserialization failure with OSS Unity Catalog

## Changes
- `website/docs/components/catalogs/unity-catalog/index.md` — Add `unity_catalog_aws_allow_http` to the AWS S3 dataset params list.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Parameter name verified against `crates/runtime/src/catalogconnector/unity_catalog.rs` (`ParameterSpec::component("aws_allow_http")` with `unity_catalog` factory prefix → `unity_catalog_aws_allow_http`)
- [x] Default `false` verified against the source description