### PR TITLE
docs(tools): Note SQL tool writes require ReadWrite API key

### DIFF
--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -15,7 +15,7 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | Name                      | Description                                                       | Default Group |
 | ------------------------- | ----------------------------------------------------------------- | ------------- |
 | `list_datasets`           | List all available datasets in the runtime.                       | `auto`        |
-| `sql`                     | Execute SQL queries on the runtime.                               | `auto`        |
+| `sql`                     | Execute SQL queries on the runtime. Write statements (`INSERT`/`UPDATE`/`DELETE`/DDL) are accepted only when the request is authenticated with a ReadWrite API key and the target dataset is configured `access: read_write`; otherwise the tool runs as read-only. | `auto`        |
 | `table_schema`            | Get the schema of a specific SQL table.                           | `auto`        |
 | `search`                  | Searches a configured dataset based on an input query.            | `auto`        |
 | `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `auto`        |


### PR DESCRIPTION
## Summary
Update the built-in LLM tool catalog entry for `sql` to reflect that the tool no longer hardcodes read-only behavior. Writes (`INSERT`/`UPDATE`/`DELETE`/DDL) are accepted only when the request is authenticated with a ReadWrite API key and the target dataset is configured `access: read_write`, matching the principal-based gate already used by `/v1/sql`, Flight, and function tools.

## Source PRs
- spiceai/spiceai#11040 — fix(sql-tool): allow writes for ReadWrite API keys

## Changes
- `website/docs/components/tools/index.md` — Expand the `sql` tool description in the Available Tools table to describe the principal-based write gate.

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] Behavior verified against `crates/runtime/src/tools/builtin/sql.rs` (`DEFAULT_DESCRIPTION` constant and the `current_principal_requires_read_only` gate)