### PR TITLE
docs(sql-reference): Link rerank and rrf in the Search table of contents

### DIFF
--- a/website/docs/reference/sql/index.md
+++ b/website/docs/reference/sql/index.md
@@ -113,6 +113,8 @@ FROM employees;
 
 - [Vector Search (`vector_search`)](sql/search#vector-search-vector_search)
 - [Full-Text Search (`text_search`)](sql/search#full-text-search-text_search)
+- [Reciprocal Rank Fusion (`rrf`)](sql/search#reciprocal-rank-fusion-rrf)
+- [Reranking (`rerank`)](sql/search#reranking-rerank)
 - [Lexical Search: LIKE, =, and Regex](sql/search#lexical-search-like--and-regex)
 
 ### [Prepared Statements](sql/prepared_statements)


### PR DESCRIPTION
## Summary
The Search section's `rrf` and `rerank` UDTFs are documented in `sql/search.md`, but the parent SQL Reference table-of-contents at `reference/sql/index.md` only listed `vector_search`, `text_search`, and Lexical Search — so the rerank function appeared to be missing from the Reference index.

## Changes
- `website/docs/reference/sql/index.md` — Add two TOC entries under **Search**: Reciprocal Rank Fusion (`rrf`) and Reranking (`rerank`), each pointing at the existing anchors in `sql/search.md`.

## Test plan
- [x] `cd website && npm run build` passes locally
- [x] Anchor slugs verified against `sql/search.md` headings (`#reciprocal-rank-fusion-rrf`, `#reranking-rerank`)