### PR TITLE
docs(structure): Move Views and Workers from Components to Features; resolve sidebar collisions

### DIFF
--- a/website/docs/clients/powerbi/index.md
+++ b/website/docs/clients/powerbi/index.md
@@ -88,7 +88,7 @@ The following Apache Arrow / DataFusion SQL types are supported. Other types wil
 
 ### LargeUtf8 Data Type Is Not Supported
 
-To work around this limitation, use [views](https://spiceai.org/docs/components/views) to manually convert `LargeUtf8` columns to `Utf8` by casting them with `::TEXT`.
+To work around this limitation, use [views](../../features/views/index.md) to manually convert `LargeUtf8` columns to `Utf8` by casting them with `::TEXT`.
 
 **Example:**
 

--- a/website/docs/components/index.md
+++ b/website/docs/components/index.md
@@ -23,11 +23,9 @@ Spice runtime components are the building blocks for configuring data access, ac
 
 **[Tools](./components/tools)** define callable functions that LLMs can invoke during inference, including MCP (Model Context Protocol) integrations for connecting to external services.
 
-**[Views](./components/views)** create virtual tables from SQL queries over other datasets, similar to database views.
+**[Vector Engines](./components/vectors)** index dataset embedding columns and serve nearest-neighbour search backed by DuckDB, Elasticsearch, or Amazon S3 Vectors.
 
 **[Secret Stores](./components/secret-stores)** manage credentials and sensitive configuration values using environment variables, files, or external secret managers like AWS Secrets Manager and Azure Key Vault.
-
-**[Workers](./components/workers)** coordinate interactions between models and tools, supporting load balancing strategies like round-robin and fallback across multiple LLM providers.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -3,6 +3,7 @@ title: 'Model Providers'
 sidebar_label: 'Model Providers'
 description: 'Overview of supported model providers for ML and LLMs in Spice.'
 image: /img/og/models.png
+sidebar_position: 5
 ---
 
 Spice supports various model providers for traditional machine learning (ML) models and large language models (LLMs).

--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -2,6 +2,7 @@
 title: 'LLM Tools (Function Calling)'
 sidebar_label: 'LLM Tools'
 description: 'Overview of supported LLM tools (function calling) and how to define new tools'
+sidebar_position: 7
 ---
 
 A tool is a function or operation that can be called directly or by a [language model](../features/large-language-models) (LLMs). The Spice runtime has several tools available by default, giving LLMs access to various parts of the runtime. Tools can also be added or configured by the user by declaring them in the `tools` section of `spicepod.yaml`.

--- a/website/docs/components/vectors/index.md
+++ b/website/docs/components/vectors/index.md
@@ -2,7 +2,7 @@
 title: 'Vector Engines'
 sidebar_label: 'Vector Engines'
 description: 'Configure vector engines for efficient embedding storage and similarity search in Spice.'
-sidebar_position: 7
+sidebar_position: 8
 pagination_prev: null
 pagination_next: null
 ---

--- a/website/docs/faq/index.md
+++ b/website/docs/faq/index.md
@@ -65,7 +65,7 @@ Yes. Spice natively supports federated queries across disparate data sources wit
 
 ## 9. Can Spice federate joins across many tables and data sources?
 
-Yes, but performance degrades as the number of sources and tables grows because the slowest source bounds end-to-end latency. For workloads that join across many tables or many heterogeneous sources, the recommended pattern is to **materialize the join into an accelerated dataset or [accelerated view](../components/views)**. This converts a multi-source federated join into a single local scan, making latency predictable and decoupling query performance from any one source's availability.
+Yes, but performance degrades as the number of sources and tables grows because the slowest source bounds end-to-end latency. For workloads that join across many tables or many heterogeneous sources, the recommended pattern is to **materialize the join into an accelerated dataset or [accelerated view](../features/views/index.md)**. This converts a multi-source federated join into a single local scan, making latency predictable and decoupling query performance from any one source's availability.
 
 Plan acceleration of hot joins proactively rather than waiting to discover them under load. See [Query Federation](../features/query-federation), [Data Acceleration](../features/data-acceleration), and [Performance Tuning](../reference/performance-tuning) for tradeoffs and configuration. The [Multi-Tenancy for AI Agents without the Pipelines](https://spice.ai/blog/multi-tenancy-for-ai-agents-without-pipelines) blog post walks through a concrete federation + acceleration example.
 

--- a/website/docs/features/index.md
+++ b/website/docs/features/index.md
@@ -21,9 +21,13 @@ Spice provides a set of features for building data-driven applications and AI ag
 
 [Data Acceleration](./data-acceleration/index.md) materializes remote datasets locally in memory or on disk using engines like Arrow, DuckDB, SQLite, or PostgreSQL. Accelerated datasets stay current through scheduled refreshes, append mode, or [Change Data Capture (CDC)](./cdc/index.md). [Caching](./caching/index.md) stores query and search results in memory with configurable TTLs and eviction policies to avoid redundant computation.
 
+### Views
+
+[Views](./views/index.md) create virtual tables from SQL queries over other datasets, similar to database views — useful for encapsulating query logic and (when accelerated) materializing precomputed joins or aggregates.
+
 ### AI and Language Models
 
-[Large Language Models](./large-language-models/index.md) provides an OpenAI-compatible API gateway for hosted models (OpenAI, Anthropic, xAI) and locally served models (Llama, Phi) with CUDA and Metal acceleration. Models can call tools to query datasets, run SQL, and retrieve schemas. [Embeddings](./embeddings/index.md) generates vector representations of text for semantic search and RAG workflows.
+[Large Language Models](./large-language-models/index.md) provides an OpenAI-compatible API gateway for hosted models (OpenAI, Anthropic, xAI) and locally served models (Llama, Phi) with CUDA and Metal acceleration. Models can call tools to query datasets, run SQL, and retrieve schemas. [Embeddings](./embeddings/index.md) generates vector representations of text for semantic search and RAG workflows. [Workers](./workers/index.md) coordinate interactions between models and tools, supporting load-balancing strategies such as round-robin and fallback across multiple LLM providers.
 
 ### Search
 

--- a/website/docs/features/observability/index.md
+++ b/website/docs/features/observability/index.md
@@ -2,7 +2,7 @@
 title: 'Observability & Monitoring'
 sidebar_label: 'Observability'
 description: 'Monitor Spice with Prometheus metrics, OpenTelemetry, and distributed tracing.'
-sidebar_position: 12
+sidebar_position: 14
 pagination_prev: null
 pagination_next: null
 ---

--- a/website/docs/features/semantic-model/index.md
+++ b/website/docs/features/semantic-model/index.md
@@ -2,7 +2,7 @@
 title: 'Semantic Model'
 sidebar_label: 'Semantic Model'
 description: 'Learn how to define and use semantic data models with Spice.'
-sidebar_position: 11
+sidebar_position: 12
 pagination_prev: null
 pagination_next: null
 ---

--- a/website/docs/features/tool-registry/index.md
+++ b/website/docs/features/tool-registry/index.md
@@ -2,7 +2,7 @@
 title: 'Tool Registry'
 sidebar_label: 'Tool Registry'
 description: 'Reduce per-turn token cost and improve LLM tool selection accuracy by replacing individual tool definitions with searchable tool_search and tool_invoke meta-tools backed by hybrid full-text, keyword, schema, and vector search.'
-sidebar_position: 12
+sidebar_position: 13
 pagination_prev: null
 pagination_next: null
 tags:

--- a/website/docs/features/views/index.md
+++ b/website/docs/features/views/index.md
@@ -3,7 +3,7 @@ title: 'Views'
 sidebar_label: 'Views'
 description: 'Documentation for defining Views in Spice'
 image: /img/og/views.png
-sidebar_position: 7
+sidebar_position: 16
 ---
 
 Views in Spice are virtual tables defined by SQL queries. They help simplify complex queries and promote reuse across different applications by encapsulating query logic in a single, reusable entity.
@@ -37,7 +37,7 @@ views:
 
 - `name`: The view's identifier, used for referencing in queries.
 - `sql`: The SQL query defining the view, supporting joins, subqueries, and aggregations.
-- `acceleration`: Views can be [locally accelerated](../features/data-acceleration).
+- `acceleration`: Views can be [locally accelerated](../data-acceleration/index.md).
 
 ## Limitations and Considerations
 
@@ -51,4 +51,4 @@ Views derive their schema from the SQL query that defines them. When a view is a
 
 If the underlying dataset schemas change while the runtime is running, the accelerated view will fail to refresh because the materialized schema no longer matches the source data. Restart the runtime to re-derive the view schema from the updated datasets.
 
-For more detail on schema inference and runtime schema changes, see the [Data Connectors schema inference](data-connectors#schema-inference) documentation.
+For more detail on schema inference and runtime schema changes, see the [Data Connectors schema inference](../../components/data-connectors/index.md#schema-inference) documentation.

--- a/website/docs/features/web-search/index.md
+++ b/website/docs/features/web-search/index.md
@@ -2,7 +2,7 @@
 title: 'Web Search'
 sidebar_label: 'Web Search'
 description: 'Learn how Spice can perform web search'
-sidebar_position: 13
+sidebar_position: 15
 tags:
   - search
   - models

--- a/website/docs/features/workers/index.md
+++ b/website/docs/features/workers/index.md
@@ -1,11 +1,11 @@
 ---
-title: 'Workers Overview'
-description: 'Detailed documentation for workers in the Spice runtime.'
-sidebar_label: 'Workers Overview'
-sidebar_position: 8
+title: 'Workers'
+description: 'Configure workers in the Spice runtime to coordinate interactions between LLMs and tools, with load-balancing, round-robin, and fallback strategies.'
+sidebar_label: 'Workers'
+sidebar_position: 17
 ---
 
-Workers in the Spice runtime represent configurable units of compute that help coordinate and manage interactions between models and tools. Each worker is defined as a component in the `spicepod.yaml` file, specifying its behavior and interaction logic.
+Workers in the Spice runtime coordinate and manage interactions between models and tools — providing load-balancing strategies such as round-robin and fallback across multiple LLM providers. Each worker is defined in the `workers` section of the `spicepod.yaml` file, specifying its behavior and interaction logic.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
Views (virtual SQL tables) and Workers (load-balancing across LLM providers/tools) are runtime *behaviours* configured in `spicepod.yaml`, not plug-in component types like data-connectors, models, embeddings, secret-stores, etc. They are now grouped with the other top-level Spicepod sections (Functions, Search, Caching) under **Features** instead of being mixed into **Components**.

This PR also cleans up sidebar collisions inside `features/` and adds explicit `sidebar_position` values to the two `components/` entries that didn't have any.

## Changes
- Move `website/docs/components/views/` → `website/docs/features/views/`.
- Move `website/docs/components/workers/` → `website/docs/features/workers/`.
- Update inbound links in `faq/index.md`, `clients/powerbi/index.md`, the Components index, and the Features index.
- Rewrite the moved pages' internal links to use file-relative paths (so they resolve correctly inside the new directory across versions).
- **Sidebar — `features/`:** Resolve `sidebar_position` collisions where Functions/Semantic Model both used 11, Tool Registry/Observability both used 12, etc. New order: …Tool Registry 13, Observability 14, Web Search 15, Views 16, Workers 17.
- **Sidebar — `components/`:** Add `sidebar_position: 5` to **Model Providers** and `sidebar_position: 7` to **LLM Tools** (both were unset and falling to alphabetical order); bump **Vector Engines** to position 8 to make room.

## Versioning
Versioned docs (`v1.5.x` – `v1.11.x`) are deliberately not touched. Existing URLs under `/docs/components/views` and `/docs/components/workers` continue to resolve against the frozen released versions where the pages still live in `components/`.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links + undefined tags)
- [x] All inbound references to the moved pages updated (verified with `grep -rn 'components/views\|components/workers' website/docs website/src`)
- [x] Per-section sidebar ordering reviewed for collisions
