### PR TITLE
docs(semantic-model): Expand description / metadata coverage and AI-tool exposure

### DIFF
--- a/website/docs/features/semantic-model/index.md
+++ b/website/docs/features/semantic-model/index.md
@@ -1,27 +1,24 @@
 ---
 title: 'Semantic Model'
 sidebar_label: 'Semantic Model'
-description: 'Learn how to define and use semantic data models with Spice.'
+description: 'Attach descriptions and metadata to datasets, views, and columns in Spice so LLMs, SQL functions, and humans share the same understanding of your data.'
 sidebar_position: 12
 pagination_prev: null
 pagination_next: null
 ---
 
-Semantic data models in Spice are defined using the `datasets[*].columns` configuration. These models provide structured and meaningful data representations, which are beneficial for both AI large language models (LLMs) and traditional data analysis.
+The semantic model is the layer that gives every dataset, view, and column a human-readable description plus structured metadata, and exposes that context uniformly to SQL queries, LLM tools, and language models.
 
-## Use-Cases
+Every description ends up in two places at once:
 
-### Large Language Models (LLMs)
-
-The semantic model is automatically used by [Spice Models](../reference/spicepod/models) as context to produce more accurate and context-aware AI responses.
+- on the dataset's Arrow schema as `description` metadata — readable from SQL via [`obj_description`](../../reference/sql/scalar_functions.md#obj_description) and [`col_description`](../../reference/sql/scalar_functions.md#col_description); and
+- in the LLM tool context — surfaced by the built-in [`list_datasets`](../../components/tools/index.md#available-tools) and [`table_schema`](../../components/tools/index.md#available-tools) tools, so models see your descriptions automatically.
 
 ## Defining a Semantic Model
 
-Semantic data models are defined within the `spicepod.yaml` file, specifically under the `datasets` section. Each dataset supports `description`, `metadata`, and a `columns` field where individual columns are described with metadata and features for utility and clarity.
+Semantic data models are defined within the `spicepod.yaml` file under the `datasets` section. Each dataset supports `description`, `metadata`, and a `columns` field where individual columns are described with metadata and features for utility and clarity.
 
 ### Example Configuration
-
-Example `spicepod.yaml`:
 
 ```yaml
 datasets:
@@ -51,27 +48,103 @@ Datasets can be defined with the following metadata:
 - `instructions`: Optional. Instructions to provide to a language model when using this dataset.
 - `reference_url_template`: Optional. A URL template for citation links.
 
-For detailed `metadata` configuration, see the [Dataset Reference](../reference/spicepod/datasets#metadata)
+Arbitrary additional keys may be added under `metadata:` and are passed through to the Arrow schema unchanged, so anything an LLM tool or downstream consumer expects to find there (e.g. governance labels, owning team, source-of-truth links) can be attached without code changes.
+
+For detailed `metadata` configuration, see the [Dataset Reference](../../reference/spicepod/datasets.md#metadata).
 
 ## Column Definitions
 
-Each column in the dataset can be defined with the following attributes:
+Each column can be defined with the following attributes:
 
 - `description`: Optional. A description of the column's contents and purpose.
+- `type` (alias `data_type`): Optional. Declared column type (Postgres-style or Arrow display form).
+- `nullable`: Optional. Override column nullability.
 - `embeddings`: Optional. Vector embeddings configuration for this column.
+- `full_text_search`: Optional. Full-text-search configuration.
+- `metadata`: Optional. Arbitrary key/value metadata attached to the column.
 
-For detailed `columns` configuration, see the [Dataset Reference](../reference/spicepod/datasets#columns)
+For detailed `columns` configuration, see the [Dataset Reference](../../reference/spicepod/datasets.md#columns).
 
 ## Source-Side Comments
 
-When a dataset is loaded from a source that exposes table or column comments, Spice automatically imports those comments into the Arrow schema metadata under the `comment` key. This means database-native `COMMENT ON TABLE` and `COMMENT ON COLUMN` annotations show up alongside Spicepod-defined `description` values, giving the semantic model the same context that already lives in the source database.
+When a dataset is loaded from a source that exposes table or column comments, Spice automatically imports those comments into the Arrow schema metadata under the `description` key. This means database-native `COMMENT ON TABLE` and `COMMENT ON COLUMN` annotations show up alongside Spicepod-defined `description` values, giving the semantic model the same context that already lives in the source database.
 
 Source-side comments are imported automatically from:
 
-- **PostgreSQL** — via `obj_description` / `col_description` in `pg_catalog`.
-- **MySQL** — via `information_schema.tables.table_comment` and `information_schema.columns.column_comment`.
-- **Snowflake** — via `information_schema.tables.comment` and `information_schema.columns.comment`.
-- **Databricks SQL Warehouse** — via the table and column metadata returned by the SQL Warehouse driver.
-- **BigQuery (via ADBC catalog)** — via `INFORMATION_SCHEMA.TABLE_OPTIONS` (`description`) and the column field-path descriptions.
+| Source                          | What is imported                                                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PostgreSQL**                  | Table and column comments via `obj_description` / `col_description` in `pg_catalog`.                                                                          |
+| **MySQL**                       | `information_schema.tables.table_comment` and `information_schema.columns.column_comment`.                                                                    |
+| **Snowflake**                   | `information_schema.tables.comment` and `information_schema.columns.comment`.                                                                                  |
+| **Databricks SQL Warehouse**    | Table and column comments returned by the SQL Warehouse driver's metadata API.                                                                                |
+| **BigQuery** (via ADBC catalog) | `INFORMATION_SCHEMA.TABLE_OPTIONS` (`description`) for the table and `INFORMATION_SCHEMA.COLUMN_FIELD_PATHS.description` for top-level columns.               |
 
-Spicepod-defined `description` values continue to take precedence: when both a Spicepod `description` and a source-side comment are present for the same table or column, the Spicepod value wins.
+Connectors not listed above (object stores, file formats, HTTP, etc.) do not have a comment concept on the source side; for those datasets, attach descriptions in the Spicepod.
+
+### Precedence
+
+When both a Spicepod `description` and a source-side comment exist for the same table or column, **the Spicepod value wins**. This lets you override unhelpful or out-of-date source comments without round-tripping a DDL change through the upstream database.
+
+If the Spicepod does not set a `description`, the source-side comment passes through unchanged.
+
+## Reading descriptions from SQL
+
+Two PostgreSQL-compatible scalar UDFs read the `description` metadata at query time:
+
+```sql
+-- Table-level description
+SELECT obj_description('public.taxi_trips');
+
+-- Column-level description (by name or 1-based ordinal)
+SELECT col_description('public.taxi_trips', 'fare_amount');
+SELECT col_description('public.taxi_trips', 3);
+```
+
+Full signatures, including PostgreSQL-shaped `(oid, 'pg_class')` variants and four-part `(catalog, schema, table, column)` forms, are documented in [`obj_description`](../../reference/sql/scalar_functions.md#obj_description) and [`col_description`](../../reference/sql/scalar_functions.md#col_description).
+
+Because these UDFs read the same metadata that source-side comment extraction populates, queries against PostgreSQL or Snowflake datasets that were authored with `COMMENT ON …` will return those comments without any additional configuration.
+
+## How LLMs see the semantic model
+
+The built-in [LLM tools](../../components/tools/index.md) surface descriptions and metadata into the model's context automatically.
+
+### `list_datasets`
+
+Returns every dataset, view, and catalog table visible to the runtime as JSON, with each entry's fully-qualified `table` name, `description`, `metadata`, columns, and capability flags (e.g. `can_search_documents`). Descriptions come from the Spicepod, falling back to source-side comments when no Spicepod description is set.
+
+### `table_schema`
+
+Returns one or more tables' columns as a markdown table. When called with `output: full` (the default), the rendered schema includes a `Metadata:` block at the top with the table-level `description` and any other dataset metadata keys, and a per-column `Metadata` cell containing the column's `description` and any column metadata. With `output: minimal`, only column names, types, and nullability are returned.
+
+```text
+**Table: spice.public.taxi_trips**
+Metadata:
+description: NYC taxi trip rides
+instructions: Always provide citations with reference URLs.
+
+| Column           | Sql Type  | Arrow Type             | Nullable | Metadata                                            |
+| ---------------- | --------- | ---------------------- | -------- | --------------------------------------------------- |
+| tpep_pickup_time | TIMESTAMP | Timestamp(Microsecond) | true     | description: The time the passenger was picked up   |
+| notes            | VARCHAR   | Utf8                   | true     | description: Optional notes about the trip          |
+```
+
+Because both `list_datasets` and `table_schema` are part of the [`auto` and `all` tool groups](../../components/tools/index.md#tool-groups), no extra configuration is required — every model declared with `tools: auto` (or any explicit list that includes `table_schema` / `list_datasets`) gets the semantic model in its context.
+
+When the [Tool Registry](../tool-registry/index.md) is active, dataset descriptions also feed the hybrid search index used by `tool_search` to match user questions to relevant dataset-bound tools, so well-described datasets are easier for the model to discover at scale.
+
+## End-to-end flow
+
+```text
+spicepod.yaml description          source COMMENT ON TABLE / COLUMN
+        |                                |
+        |    (Spicepod wins on overlap)  |
+        +---------------+----------------+
+                        v
+            Arrow schema metadata (`description` key)
+                        |
+        +---------------+-----------------+
+        v               v                 v
+  obj_description    table_schema     list_datasets
+  col_description    (LLM context)    (LLM context)
+  (SQL)
+```


### PR DESCRIPTION
## Summary
Rewrite the Semantic Model page so it covers the full lifecycle of table and column descriptions in Spice:

1. How to attach descriptions (in `spicepod.yaml`).
2. Which data connectors auto-import source-side comments (and via which system catalog).
3. How Spicepod overrides source comments.
4. How to read descriptions back from SQL (`obj_description` / `col_description`).
5. How the built-in LLM tools (`list_datasets`, `table_schema`) surface descriptions into the model's context automatically.

It also fixes a stale reference to the `comment` Arrow metadata key — renamed to `description` upstream in [spiceai/spiceai#11032](https://github.com/spiceai/spiceai/pull/11032).

## Changes
- `website/docs/features/semantic-model/index.md` — substantial rewrite. Highlights:
  - Lead paragraph now names the two consumer surfaces (Arrow schema → SQL UDFs, LLM tools) so the rest of the page maps cleanly.
  - Existing **Source-Side Comments** list promoted to a table listing the exact source-side mechanism per connector (PostgreSQL `pg_catalog`, MySQL `information_schema`, Snowflake `information_schema`, Databricks SQL Warehouse driver, BigQuery via ADBC). Note added that file-format / object-store / HTTP connectors have no source comments and rely on the Spicepod.
  - New **Precedence** subsection: Spicepod values win over source comments; missing Spicepod values fall through to the source comment.
  - New **Reading descriptions from SQL** section linking the `obj_description` / `col_description` UDF docs.
  - New **How LLMs see the semantic model** section showing what `list_datasets` and `table_schema` (output: full) emit, including a sample rendered markdown table.
  - End-to-end flow diagram from `spicepod.yaml` and source `COMMENT ON …` statements through Arrow metadata to the SQL UDFs and LLM tools.

## Source verification
- Source-comment connectors verified against `crates/data_components/src/{postgres,mysql,snowflake,databricks}/...` and `crates/runtime/src/dataconnector/adbc.rs` (`enrich_with_bigquery_metadata`).
- Spicepod-over-source precedence verified against `data_components::MetadataEnrichedTableProvider::new_with_field_metadata` (`metadata.extend(extra_metadata)`).
- LLM tool output shapes verified against `crates/runtime/src/tools/builtin/{list_datasets,table_schema}.rs` and `arrow_tools::format::table_schemas_to_markdown_table`.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links + anchors + undefined tags)
- [x] All cross-page anchor links verified against current heading slugs (`scalar_functions#obj_description`, `scalar_functions#col_description`, `components/tools#available-tools`, `components/tools#tool-groups`, `reference/spicepod/datasets#metadata`, `reference/spicepod/datasets#columns`, `features/tool-registry`)