### PR TITLE
docs(ingestion/cdc): Cover acceleration as ingestion path; add CDC subpages for DynamoDB Streams, MongoDB Change Streams, Debezium

### DIFF
--- a/website/docs/features/cdc/debezium.md
+++ b/website/docs/features/cdc/debezium.md
@@ -1,0 +1,136 @@
+---
+title: 'Debezium (CDC over Kafka)'
+sidebar_label: 'Debezium'
+description: 'Consume Debezium change events from Kafka into a Spice-accelerated dataset for sources without a native Spice CDC path.'
+sidebar_position: 5
+pagination_prev: null
+pagination_next: null
+---
+
+Consume [Debezium](https://debezium.io/) change events from a Kafka topic and apply them to a Spice-accelerated dataset.
+
+Use Debezium when:
+
+- You already operate Debezium + Kafka for change data capture; or
+- The source database does not have a native Spice CDC path (e.g. MySQL, SQL Server, Oracle).
+
+For sources with a native CDC path, prefer the dedicated connector — [PostgreSQL Logical Replication](./postgres-replication.md), [DynamoDB Streams](./dynamodb-streams.md), or [MongoDB Change Streams](./mongodb-streams.md) — to avoid the extra Kafka + Debezium hop.
+
+## How it works
+
+```
+┌────────────────┐  Debezium connector   ┌───────────┐    Spice consumes      ┌───────────────────┐    ChangeBatch     ┌───────────────┐
+│   Source DB    │ ────────────────────▶│   Kafka   │ ────────────────────▶│   Spice runtime   │──────────────────▶│  Accelerator  │
+│   (MySQL,      │  WAL → JSON events    │   topic   │   one consumer group   │  (debezium        │  (INSERT/         │  DuckDB /     │
+│    SQL Server, │                       │           │   per Spice replica    │   connector)      │   UPDATE /        │  SQLite /     │
+│    Oracle, …)  │                       │           │                        │                   │   DELETE)         │  Postgres     │
+└────────────────┘                       └───────────┘                        └───────────────────┘                   └───────────────┘
+```
+
+On startup, Spice subscribes to the configured Debezium-managed Kafka topic using either a uniquely generated consumer group or one specified via `kafka_consumer_group_id`. With a persistent acceleration engine (`mode: file`), data is fetched starting from the **last committed offset**, so restarts resume without reprocessing historical events.
+
+## Prerequisites
+
+- A running **Debezium connector** publishing change events to a **Kafka topic** for the source table.
+- A reachable Kafka cluster (one or more `bootstrap.servers`).
+- A Spice acceleration engine that supports CDC: `duckdb`, `sqlite`, or `postgres`.
+
+## Minimal configuration
+
+```yaml
+datasets:
+  - from: debezium:my_kafka_topic_with_debezium_changes
+    name: customer_addresses
+    params:
+      debezium_transport: kafka         # Optional. Only `kafka` is currently supported.
+      debezium_message_format: json     # Optional. Only `json` is currently supported.
+      kafka_bootstrap_servers: localhost:9092
+      kafka_security_protocol: PLAINTEXT
+    acceleration:
+      enabled: true                     # Required.
+      engine: duckdb                    # duckdb / sqlite / postgres
+      mode: file                        # Persist Kafka offsets so restarts resume.
+      refresh_mode: changes             # Required.
+```
+
+The `from` field takes the form `debezium:<kafka_topic>`. The topic must contain Debezium-formatted change events for a single source table.
+
+## SASL/SSL authentication
+
+For Kafka clusters with SASL/SSL enabled:
+
+```yaml
+datasets:
+  - from: debezium:my_kafka_topic_with_debezium_changes
+    name: orders
+    params:
+      kafka_bootstrap_servers: broker1:9092,broker2:9092,broker3:9092
+      kafka_security_protocol: sasl_ssl          # Default
+      kafka_sasl_mechanism: SCRAM-SHA-512        # PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512
+      kafka_sasl_username: kafka_user
+      kafka_sasl_password: ${secrets:kafka_sasl_password}
+      kafka_ssl_ca_location: ./certs/kafka_ca_cert.pem
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
+```
+
+The full set of `kafka_*` parameters is documented in the [Debezium connector reference](../../components/data-connectors/debezium.md#params).
+
+## Consumer-group management
+
+The connector manages Kafka consumer groups so offsets persist across restarts:
+
+- **Default** — Spice auto-generates a unique consumer group ID, stores it in the acceleration metadata, and reuses it on subsequent restarts.
+- **Custom** — Pass `kafka_consumer_group_id` to use your own group ID. The same ID must be used on every restart; if Spice detects a mismatch against the stored ID, it returns an error to prevent data inconsistency.
+
+To recover from a deliberate consumer-group change, reset the acceleration data so Spice starts fresh.
+
+See the full description in the [Debezium connector reference](../../components/data-connectors/debezium.md#consumer-group-management).
+
+## Schema evolution
+
+Debezium emits change events whose schema may evolve as the upstream table is altered. Set `schema_evolution: true` to have Spice peek at the latest Kafka message on reload and detect schema changes:
+
+```yaml
+params:
+  schema_evolution: true   # Default: false
+```
+
+## Batching
+
+Two parameters control how many events Spice groups into a single CDC batch before applying it to the accelerator:
+
+| Parameter            | Default  | Description                                                       |
+| -------------------- | -------- | ----------------------------------------------------------------- |
+| `batch_max_size`     | `10000`  | Max number of change events to batch together before processing.  |
+| `batch_max_duration` | `1s`     | Max time to wait for a batch to fill before processing.           |
+
+Larger batches improve throughput at the cost of higher per-batch latency.
+
+## Metrics
+
+The connector exposes the following [component metrics](../observability/component_metrics.md):
+
+| Metric Name              | Type    | Description                                                                          |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------ |
+| `bytes_consumed_total`   | Counter | Total number of bytes consumed from the Kafka topic                                  |
+| `records_consumed_total` | Counter | Total number of records (messages) consumed from Kafka topics                        |
+| `records_lag`            | Gauge   | Total consumer lag across all topic partitions (number of messages not yet consumed) |
+
+These metrics are opt-in; see the [Debezium connector reference](../../components/data-connectors/debezium.md#metrics) for an example `metrics:` block.
+
+## Limitations
+
+- Only `kafka` is supported as the Debezium transport.
+- Only `json` is supported as the message format.
+- Acceleration is required — Debezium cannot be used as a federated, non-accelerated dataset.
+
+## See also
+
+- [Debezium Data Connector](../../components/data-connectors/debezium.md) — complete parameter reference.
+- [Streaming changes in real-time with Debezium CDC](https://github.com/spiceai/cookbook/tree/trunk/cdc-debezium#readme) — cookbook recipe.
+- [Streaming changes with Debezium and SASL/SCRAM authentication](https://github.com/spiceai/cookbook/tree/trunk/cdc-debezium/sasl-scram#readme) — authenticated-Kafka recipe.
+- [`refresh_mode: changes`](../data-acceleration/refresh-modes/changes.md) — refresh-mode reference.

--- a/website/docs/features/cdc/dynamodb-streams.md
+++ b/website/docs/features/cdc/dynamodb-streams.md
@@ -1,0 +1,144 @@
+---
+title: 'DynamoDB Streams (Native CDC)'
+sidebar_label: 'DynamoDB Streams'
+description: 'Stream INSERT, UPDATE, and DELETE events from Amazon DynamoDB directly into a Spice-accelerated dataset using DynamoDB Streams.'
+sidebar_position: 3
+pagination_prev: null
+pagination_next: null
+---
+
+Stream every `INSERT`, `UPDATE`, and `DELETE` from an Amazon DynamoDB table directly into a Spice-accelerated dataset using [DynamoDB Streams](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html).
+
+This is the recommended way to keep a Spice accelerator ([DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [PostgreSQL](../../components/data-accelerators/postgres), Cayenne) continuously in sync with a DynamoDB source — no Kafka, no Debezium, no Lambda required.
+
+## How it works
+
+```
+┌──────────────────┐    DynamoDB Streams    ┌───────────────────┐    ChangeBatch     ┌───────────────┐
+│   DynamoDB       │──────────────────────▶│   Spice runtime   │──────────────────▶│  Accelerator  │
+│   table          │   shard iterators      │  (dynamodb        │   (INSERT/        │  DuckDB /     │
+│   + stream       │                        │   connector)      │    UPDATE /       │  SQLite /     │
+│                  │                        │                   │    DELETE)        │  Postgres /   │
+└──────────────────┘                        └───────────────────┘                   │  Cayenne      │
+                                                                                    └───────────────┘
+```
+
+On first start the connector:
+
+1. Bootstraps the accelerator with a full `Scan` of the source table so initial state is captured.
+2. Subscribes to each open **stream shard** and begins polling for records.
+3. Applies each `INSERT` / `MODIFY` / `REMOVE` event as a row-level change to the accelerator.
+
+The dataset reports `Ready` once stream lag drops below `ready_lag` (default `2s`).
+
+On subsequent restarts, file-backed accelerators resume from the persisted shard checkpoint instead of re-scanning the source table.
+
+## Prerequisites
+
+### 1. Enable Streams on the source table
+
+Streams must be enabled with view type **`NEW_AND_OLD_IMAGES`** so Spice receives both the old and new image of every modified item.
+
+```bash
+aws dynamodb update-table \
+  --table-name orders \
+  --stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES
+```
+
+### 2. IAM permissions
+
+The credentials Spice uses need both table and stream actions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:Scan",
+        "dynamodb:DescribeStream",
+        "dynamodb:GetShardIterator",
+        "dynamodb:GetRecords",
+        "dynamodb:ListStreams"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/orders",
+        "arn:aws:dynamodb:*:*:table/orders/stream/*"
+      ]
+    }
+  ]
+}
+```
+
+### 3. Acceleration must be enabled with `refresh_mode: changes`
+
+Using DynamoDB Streams **requires** acceleration with `refresh_mode: changes`. Supported engines are `duckdb`, `sqlite`, `postgres`, and `cayenne`.
+
+## Minimal configuration
+
+```yaml
+datasets:
+  - from: dynamodb:orders
+    name: orders_stream
+    params:
+      dynamodb_aws_region: us-east-1
+      dynamodb_aws_access_key_id: ${secrets:aws_access_key_id}
+      dynamodb_aws_secret_access_key: ${secrets:aws_secret_access_key}
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file              # Persistence is recommended so restarts skip the initial Scan
+      refresh_mode: changes
+```
+
+## Tuning
+
+```yaml
+datasets:
+  - from: dynamodb:orders
+    name: orders_stream
+    params:
+      scan_interval: 100ms    # Poll DynamoDB Streams every 100 ms (default 0s)
+      ready_lag: 1s           # Report Ready when stream lag drops below 1s (default 2s)
+      lag_exceeds_shard_retention_behavior: ready_before_load   # Behavior on > 24h lag
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      refresh_mode: changes
+      snapshots: enabled
+      snapshots_trigger: stream_batches
+      snapshots_trigger_threshold: 5     # Snapshot every 5 batch updates
+```
+
+- `scan_interval` — Polling frequency for new records. Lower values give lower latency at the cost of more `GetRecords` API calls.
+- `ready_lag` — Maximum stream lag before the dataset is reported `Ready` for queries. Defaults to `2s`.
+- `lag_exceeds_shard_retention_behavior` — What to do when stream lag exceeds the DynamoDB shard retention window (24h). One of `error` (default), `ready_before_load`, or `ready_after_load`. See the [connector parameter reference](../../components/data-connectors/dynamodb/index.md#params) for the full description.
+- `snapshots_trigger: stream_batches` and `snapshots_trigger_threshold` let you trigger acceleration snapshots based on stream-batch counts rather than wall time. See [Acceleration Snapshots](../data-acceleration/snapshots.md).
+
+## Metrics
+
+The connector exposes the following [component metrics](../observability/component_metrics.md) for monitoring streaming health:
+
+| Metric                                                   | Type    | Description                                                                |
+| -------------------------------------------------------- | ------- | -------------------------------------------------------------------------- |
+| `shards_active`                                          | Gauge   | Current number of active shards in the stream                              |
+| `records_consumed_total`                                 | Counter | Total number of records consumed from the stream                           |
+| `lag_ms`                                                 | Gauge   | Current lag in milliseconds between stream watermark and now               |
+| `errors_transient_total`                                 | Counter | Total number of transient errors encountered while polling from the stream |
+| `reinitializations_on_lag_exceeds_shard_retention_total` | Counter | Total rebootstrap operations triggered due to expired shards               |
+
+These metrics are opt-in. See the [DynamoDB Streams Metrics](../../components/data-connectors/dynamodb/index.md#metrics) section of the connector docs for an example `metrics:` block and a sample Grafana dashboard.
+
+## Limitations
+
+- DynamoDB Streams shards are retained for 24 hours. If Spice falls behind by more than that, the connector follows `lag_exceeds_shard_retention_behavior` (default: `error`).
+- `refresh_sql` is not supported with DynamoDB Streams.
+
+## See also
+
+- [DynamoDB Data Connector](../../components/data-connectors/dynamodb/index.md) — complete parameter reference, deployment guide, and supported AWS regions.
+- [DynamoDB Streams cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/dynamodb/streams#readme).
+- [`refresh_mode: changes`](../data-acceleration/refresh-modes/changes.md) — refresh-mode reference.

--- a/website/docs/features/cdc/index.md
+++ b/website/docs/features/cdc/index.md
@@ -36,9 +36,10 @@ Enabling CDC by setting `refresh_mode: changes` in the acceleration settings req
 Spice currently supports streaming ingestion via:
 
 - **[PostgreSQL Logical Replication](./postgres-replication.md)** — **recommended** for PostgreSQL sources. Spice connects directly to the source using Postgres' native logical replication protocol (`wal_level=logical` + pgoutput) and streams `INSERT`/`UPDATE`/`DELETE` events into the accelerator. No Kafka, no Debezium, no external services.
-- **[DynamoDB Streams](../../components/data-connectors/dynamodb#streams)** — for Amazon DynamoDB sources. Spice consumes the table's DynamoDB Streams directly and applies `INSERT`/`UPDATE`/`DELETE` events to the accelerator.
-- **[Apache Kafka](../../components/data-connectors/kafka)** — for event-streaming topics. Spice consumes records directly with `refresh_mode: append` for real-time, append-only acceleration (no separate CDC connector required).
-- **[Debezium](../../components/data-connectors/debezium)** (over Kafka) — for sources where Debezium + Kafka is already deployed, or for databases without a native Spice CDC path (MySQL, SQL Server, etc.).
+- **[DynamoDB Streams](./dynamodb-streams.md)** — for Amazon DynamoDB sources. Spice consumes the table's DynamoDB Streams directly and applies `INSERT`/`UPDATE`/`DELETE` events to the accelerator.
+- **[MongoDB Change Streams](./mongodb-streams.md)** — for MongoDB replica sets and sharded clusters. Spice opens a native Change Stream on the source collection and applies inserts, updates, replaces, and deletes to the accelerator.
+- **[Apache Kafka](../../components/data-connectors/kafka.md)** — for event-streaming topics. Spice consumes records directly with `refresh_mode: append` for real-time, append-only acceleration (no separate CDC connector required).
+- **[Debezium](./debezium.md)** (over Kafka) — for sources where Debezium + Kafka is already deployed, or for databases without a native Spice CDC path (MySQL, SQL Server, etc.).
 
 ## Example
 

--- a/website/docs/features/cdc/mongodb-streams.md
+++ b/website/docs/features/cdc/mongodb-streams.md
@@ -1,0 +1,113 @@
+---
+title: 'MongoDB Change Streams (Native CDC)'
+sidebar_label: 'MongoDB Change Streams'
+description: 'Stream insert, update, replace, and delete events from MongoDB directly into a Spice-accelerated dataset using MongoDB Change Streams.'
+sidebar_position: 4
+pagination_prev: null
+pagination_next: null
+---
+
+Stream every insert, update, replace, and delete from a MongoDB collection directly into a Spice-accelerated dataset using native [MongoDB Change Streams](https://www.mongodb.com/docs/manual/changeStreams/).
+
+This is the recommended way to keep a Spice accelerator ([DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [PostgreSQL](../../components/data-accelerators/postgres), [Turso](../../components/data-accelerators/turso), Cayenne) continuously in sync with a MongoDB source — no Kafka, no Debezium, no external services.
+
+## How it works
+
+```
+┌──────────────────┐     Change Streams       ┌───────────────────┐    ChangeBatch     ┌───────────────┐
+│   MongoDB        │ ───────────────────────▶│   Spice runtime   │──────────────────▶│  Accelerator  │
+│   replica set /  │  fullDocument=           │  (mongodb         │   (INSERT/        │  DuckDB /     │
+│   sharded        │    updateLookup          │   connector)      │    UPDATE /       │  SQLite /     │
+│   cluster        │  + resume tokens         │                   │    DELETE)        │  Postgres /   │
+└──────────────────┘                          └───────────────────┘                   │  Turso /      │
+                                                                                      │  Cayenne      │
+                                                                                      └───────────────┘
+```
+
+On first start the connector:
+
+1. Opens a Change Stream on the source collection with `fullDocument=updateLookup`.
+2. Emits a CDC `TRUNCATE` and applies a full snapshot of the collection as upsert rows.
+3. Signals readiness, then processes Change Stream events in batches.
+
+Opening the Change Stream **before** the snapshot prevents gaps between the snapshot and the live stream.
+
+For file-backed accelerators (acceleration `mode: file` / `file_create` / `file_update`, or `engine: postgres`), Spice persists the most recent Change Stream resume token in a sidecar table named `spice_sys_mongodb` alongside the accelerator data. The token is committed only after the downstream accelerator write succeeds (at-least-once semantics). On restart, Spice resumes from the persisted token and skips the snapshot.
+
+In-memory accelerators do not persist a resume token; restarts re-bootstrap from a fresh snapshot.
+
+## Prerequisites
+
+- **MongoDB 4.0+** with Change Streams enabled. MongoDB requires a **replica set** or **sharded cluster** — single-node `mongod` deployments do not support Change Streams.
+- The MongoDB user must have the `changeStream` privilege on the source collection.
+- The accelerator must support upsert behavior — use `duckdb`, `sqlite`, `postgres`, `turso`, or `cayenne`.
+- `acceleration.primary_key: _id` is required. Delete events only include the document key, so Spice needs `_id` to route deletes.
+- `acceleration.on_conflict` must specify `upsert` on `_id` so update and replace events overwrite existing rows.
+
+## Minimal configuration
+
+```yaml
+datasets:
+  - from: mongodb:users
+    name: users
+    params:
+      mongodb_host: localhost
+      mongodb_port: '27017'
+      mongodb_db: my_database
+      mongodb_user: my_user
+      mongodb_pass: ${secrets:mongodb_pass}
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file              # Persist resume tokens so restarts skip the snapshot
+      refresh_mode: changes
+      primary_key: _id
+      on_conflict:
+        _id: upsert
+```
+
+## Tuning
+
+These optional runtime parameters live under dataset `params:`. Defaults are reasonable; tune only when you have a specific batching or oplog-window concern.
+
+| Parameter Name                            | Default | Description                                                                                                                          |
+| ----------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `change_stream_batch_max_size`            | `1000`  | Max number of Change Stream events to group into one CDC batch before applying it.                                                   |
+| `change_stream_batch_max_duration`        | `1s`    | Max time to wait for a Change Stream batch to fill before applying it. Accepts [fundu](https://docs.rs/fundu) duration strings.       |
+| `change_stream_max_await_time`            | `1s`    | Max time MongoDB waits for new events before returning an empty server batch. Accepts fundu duration strings.                        |
+| `change_stream_batch_size`                | `1000`  | Number of Change Stream events MongoDB should request from the server per batch.                                                     |
+| `mongodb_resume_token_invalid_behavior`   | `error` | Behavior when a persisted resume token is rejected (e.g. past the oplog window). `error` surfaces the failure; `rebootstrap` drops the token and re-snapshots. |
+
+The existing `mongodb_unnest_depth` parameter applies to Change Stream documents too, so nested BSON is flattened the same way as normal MongoDB reads.
+
+## Event mapping
+
+| MongoDB event   | Applied as              | Notes                                                                                       |
+| --------------- | ----------------------- | ------------------------------------------------------------------------------------------- |
+| `insert`        | create / upsert         | Uses `fullDocument`.                                                                        |
+| `update`        | update / upsert         | Uses `fullDocument` from `fullDocument=updateLookup`.                                       |
+| `replace`       | update / upsert         | Uses `fullDocument`.                                                                        |
+| `delete`        | delete                  | Uses `documentKey`; non-key columns are `null`.                                             |
+| `drop`, `rename`, `dropDatabase`, `invalidate` | truncate | Collection continuity is no longer guaranteed; the accelerator is reset and re-bootstrapped. |
+
+If MongoDB does not include `fullDocument` for an update or replace event, Spice fails the stream with a clear error instead of applying a partial row.
+
+## Resumability across restarts
+
+For file-accelerated datasets, the persisted resume token lets Spice resume from where it left off without re-snapshotting. When MongoDB rejects the token (typical codes `ChangeStreamHistoryLost` 286 or `ChangeStreamFatalError` 280 — usually when the oplog window has rolled past the token's position), the behavior is governed by `mongodb_resume_token_invalid_behavior`:
+
+- `error` (default) — Spice surfaces a clear error and stops; the operator decides what to do.
+- `rebootstrap` — Spice drops the persisted token and re-snapshots the collection.
+
+Re-snapshotting a large collection is opt-in by default to prevent silent expensive rebootstraps.
+
+## Limitations
+
+- Change Streams require a replica set or sharded cluster — they do not work against a single-node `mongod`.
+- `refresh_sql` is not supported with Change Streams.
+- In-memory accelerators do not persist resume tokens; every restart re-snapshots.
+
+## See also
+
+- [MongoDB Data Connector](../../components/data-connectors/mongodb.md) — complete parameter reference and connection options.
+- [`refresh_mode: changes`](../data-acceleration/refresh-modes/changes.md) — refresh-mode reference.

--- a/website/docs/features/data-ingestion/index.md
+++ b/website/docs/features/data-ingestion/index.md
@@ -12,10 +12,46 @@ tags:
 
 Data can be ingested into the Spice runtime using the following methods:
 
-1. **SQL Statements** – Write data directly to [write-capable connectors](../tags/write) using standard SQL syntax.
-2. **OpenTelemetry (OTEL) Ingestion** – Stream OTEL metrics for real-time processing and acceleration.
+1. **Acceleration Refresh Modes** – Pull data from a source connector into a local accelerator using one of the standard [refresh modes](../data-acceleration/refresh-modes/index.md) (`full`, `append`, `changes`, `snapshot`, `caching`). This is the most common ingestion path for keeping a local accelerator in sync with an upstream system.
+2. **SQL Statements** – Write data directly to [write-capable connectors](../tags/write) using standard SQL `INSERT` (and, where supported, `UPDATE`/`DELETE`) syntax.
+3. **OpenTelemetry (OTEL) Ingestion** – Stream OTEL metrics for real-time processing and acceleration.
 
-Data ingestion is useful for scenarios such as collecting metrics from edge devices, writing application events for later analysis, or populating datasets from external sources.
+Data ingestion is useful for scenarios such as keeping a local accelerator continuously in sync with an upstream database, collecting metrics from edge devices, writing application events for later analysis, or populating datasets from external sources.
+
+## Ingestion via Acceleration Refresh Modes
+
+When a dataset is configured with `acceleration.enabled: true`, Spice ingests rows from the source connector into a local engine (Arrow, DuckDB, SQLite, PostgreSQL, or Cayenne). The `refresh_mode` controls how that ingestion happens.
+
+| Refresh Mode                                                            | What it ingests                                                                                                                                                                              | Typical source                                                                                |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [`full`](../data-acceleration/refresh-modes/full.md)                    | Replaces the accelerator's contents with a fresh read of the source on every refresh.                                                                                                        | Slowly-changing reference tables; small lookup datasets.                                      |
+| [`append`](../data-acceleration/refresh-modes/append.md)                | Inserts only rows newer than the highest seen `time_column` value on each refresh.                                                                                                           | Time-series, event/log data, append-only tables.                                              |
+| [`changes`](../data-acceleration/refresh-modes/changes.md)              | Streams row-level inserts, updates, and deletes from a source [CDC feed](../cdc/index.md) (PostgreSQL logical replication, DynamoDB Streams, MongoDB Change Streams, Debezium, Kafka, etc.). | Operational databases where you need near real-time mirror of the source.                     |
+| [`snapshot`](../data-acceleration/refresh-modes/snapshot.md)            | Loads exclusively from an external snapshot store; no source reads.                                                                                                                          | Read-only replicas bootstrapped from a centralized snapshot, e.g. for fan-out reader fleets.  |
+| [`caching`](../data-acceleration/refresh-modes/caching.md)              | Read-through caches per-request HTTP/HTTPS responses with a TTL.                                                                                                                             | API search results or other request-keyed content fetched lazily.                             |
+
+For cross-cutting refresh behavior — refresh intervals, on-demand refresh, retries, retention, and zero-results handling — see [Data Refresh](../data-acceleration/data-refresh.md).
+
+### Example: continuous CDC ingestion into an accelerator
+
+```yaml
+datasets:
+  - from: postgres:public.users
+    name: users
+    params:
+      pg_host: pg.internal
+      pg_port: '5432'
+      pg_user: spice
+      pg_pass: ${secrets:pg_pass}
+      pg_db: myapp
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file        # Persistence so resume across restarts is cheap
+      refresh_mode: changes
+```
+
+This uses [PostgreSQL Logical Replication](../cdc/postgres-replication.md) to ingest every `INSERT`, `UPDATE`, and `DELETE` from `public.users` into a local DuckDB accelerator with low latency.
 
 ## SQL Statements
 


### PR DESCRIPTION
## Summary
1. Expand **Data Ingestion** to call out that pulling data from a source connector into a local accelerator via an [acceleration refresh mode](https://spiceai.org/docs/features/data-acceleration/refresh-modes) is itself an ingestion path. Previously the page only documented SQL `INSERT` and OTEL.
2. Under **Change Data Capture**, add three dedicated subpages — mirroring the existing PostgreSQL Logical Replication page — for DynamoDB Streams, MongoDB Change Streams, and Debezium. The CDC index now links to those feature pages instead of dropping users straight into the connector reference.

## Changes
- `features/data-ingestion/index.md` — Lead list now starts with **Acceleration Refresh Modes**. New "Ingestion via Acceleration Refresh Modes" section with a table that maps each mode (`full`, `append`, `changes`, `snapshot`, `caching`) to what it ingests and the typical source shape, plus an end-to-end Postgres-CDC example.
- `features/cdc/dynamodb-streams.md` (new) — Streaming model overview, IAM/stream-view prerequisites, minimal config, tuning (`scan_interval`, `ready_lag`, `lag_exceeds_shard_retention_behavior`, snapshot triggers), metrics, limitations.
- `features/cdc/mongodb-streams.md` (new) — Change Stream model with the `fullDocument=updateLookup` flow, prerequisites (replica set or sharded cluster, `changeStream` privilege, `_id` primary key with upsert), tuning knobs, event mapping table (insert/update/replace/delete/drop), resume-token semantics across restarts, limitations.
- `features/cdc/debezium.md` (new) — When to use Debezium vs a native path, Kafka topic / consumer-group model, SASL/SSL example, schema-evolution toggle, batching parameters, metrics, limitations.
- `features/cdc/index.md` — Supported-sources list links the new feature pages; adds **MongoDB Change Streams** to the list (previously absent).

## Source verification
- DynamoDB Streams behavior and parameters verified against the existing connector reference and `crates/runtime/src/dataconnector/dynamodb*`.
- MongoDB Change Streams behavior verified against `crates/data_components/src/mongodb/stream.rs` (operation-type dispatch, resume tokens, `spice_sys_mongodb` sidecar) and the existing connector reference.
- Debezium behavior verified against the existing connector reference (consumer-group management, batching, SASL parameters).

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links + anchors + undefined tags)
- [x] All cross-page links verified against the current source headings and `tags.yml`