### PR TITLE
docs(secret-stores): Note hashicorp_vault is a Spice.ai Enterprise feature

### DIFF
--- a/website/docs/components/secret-stores/hashicorp-vault/index.md
+++ b/website/docs/components/secret-stores/hashicorp-vault/index.md
@@ -7,6 +7,14 @@ description: 'HashiCorp Vault Secret Store Documentation'
 
 The `hashicorp_vault` store enables Spice to read secrets from a [HashiCorp Vault](https://developer.hashicorp.com/vault) KV secrets engine (v1 or v2). The selector is the path *under the mount* — Spice automatically inserts the `data/` segment for KV v2.
 
+:::note[Build requirement]
+The official Spice Open Source prebuilt binary does not include `hashicorp_vault` in its default feature set. To use the HashiCorp Vault secret store, [build Spice from source](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `hashicorp_vault` feature enabled, for example:
+
+```bash
+cargo build --release --features release,models,hashicorp_vault -p spiced
+```
+:::
+
 ```yaml
 secrets:
   - from: hashicorp_vault:myapp/config

--- a/website/docs/components/secret-stores/hashicorp-vault/index.md
+++ b/website/docs/components/secret-stores/hashicorp-vault/index.md
@@ -7,13 +7,7 @@ description: 'HashiCorp Vault Secret Store Documentation'
 
 The `hashicorp_vault` store enables Spice to read secrets from a [HashiCorp Vault](https://developer.hashicorp.com/vault) KV secrets engine (v1 or v2). The selector is the path *under the mount* — Spice automatically inserts the `data/` segment for KV v2.
 
-:::note[Build requirement]
-The official Spice Open Source prebuilt binary does not include `hashicorp_vault` in its default feature set. To use the HashiCorp Vault secret store, [build Spice from source](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `hashicorp_vault` feature enabled, for example:
-
-```bash
-cargo build --release --features release,models,hashicorp_vault -p spiced
-```
-:::
+The HashiCorp Vault Secret Store is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions).
 
 ```yaml
 secrets:

--- a/website/docs/components/secret-stores/index.md
+++ b/website/docs/components/secret-stores/index.md
@@ -10,7 +10,7 @@ pagination_next: null
 
 A Secret Store is a secure location where secrets (such as passwords, tokens, and API keys) are stored. Spice retrieves secrets from configured stores at runtime and injects them into component parameters.
 
-Supported secret stores include: [`env`](secret-stores/env), [`kubernetes`](secret-stores/kubernetes), [`keyring`](secret-stores/keyring), [`aws_secrets_manager`](secret-stores/aws-secrets-manager), [`azure_keyvault`](secret-stores/azure-keyvault), and [`hashicorp_vault`](secret-stores/hashicorp-vault). The `env` secret store is loaded by default.
+Supported secret stores include: [`env`](secret-stores/env), [`kubernetes`](secret-stores/kubernetes), [`keyring`](secret-stores/keyring), [`aws_secrets_manager`](secret-stores/aws-secrets-manager), [`azure_keyvault`](secret-stores/azure-keyvault), and [`hashicorp_vault`](secret-stores/hashicorp-vault) (Spice.ai Enterprise). The `env` secret store is loaded by default.
 
 ### Default
 


### PR DESCRIPTION
## Summary

Flag the HashiCorp Vault Secret Store as a Spice.ai Enterprise feature, using the same admonition / index-table convention already in use for the Elasticsearch connector, PostgreSQL accelerator, and Acceleration Snapshots pages.

Triggered by [spiceai/spiceai#11037](https://github.com/spiceai/spiceai/pull/11037), which removed `hashicorp_vault` from the OSS `spiced` default feature set — clarifying that it is Enterprise-only for production use.

## Source PRs

- spiceai/spiceai#11037 — Remove default runtime features - enable explicitly in spiced

## Changes

- [`website/docs/components/secret-stores/hashicorp-vault/index.md`](website/docs/components/secret-stores/hashicorp-vault/index.md) — add a one-line "Enterprise edition" callout directly under the page intro, linking to https://docs.spice.ai/docs/enterprise/getting-started/distributions.
- [`website/docs/components/secret-stores/index.md`](website/docs/components/secret-stores/index.md) — append `(Spice.ai Enterprise)` after the `hashicorp_vault` entry in the supported-stores list.

Only the unversioned `website/docs/` pages are touched.

## Test plan

- [x] `cd website && npm run build` passes locally.
- [x] Convention matches existing Enterprise callouts on the Elasticsearch / PostgreSQL accelerator / Acceleration Snapshots pages.
- [x] No versioned docs touched.

## Follow-up

The PR is scoped to `hashicorp_vault` because that is the only OSS-default change from #11037 that affects an explicit user-visible feature. If there are additional features documented in `website/docs/` that should also be re-framed as Spice.ai Enterprise (rather than as OSS-buildable options), please flag them on this PR and they can be added in a follow-up commit on this branch.