### PR TITLE
fix: correct commited_date typo in GitHub connector docs

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -123,7 +123,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/github.md
@@ -68,7 +68,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/github.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/github.md
@@ -111,7 +111,7 @@ GitHub queries support a `github_query_mode` parameter, which can be set to eith
 - **Issues**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 - **Pull Requests**: Defaults to `auto`. Query filters are only pushed down to the GitHub API in `search` mode.
 
-Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `commited_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
+Commits only supports `auto` mode. Query with filter push down is only enabled for the `committed_date` column. `committed_date` supports exact matches, or greater/less than matches for dates provided in [ISO8601](https://www.iso.org/iso-8601-date-and-time-format.html) format, like `WHERE committed_date > '2024-09-24'`.
 
 When set to `search`, Issues and Pull Requests will use the GitHub [Search API](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests) for improved filter performance when querying against the columns:
 


### PR DESCRIPTION
## Summary

The Commits filter-pushdown paragraph on the GitHub Data Connector page referenced a non-existent `commited_date` column (missing a 't'). The actual GitHub commits column is `committed_date` — confirmed by the schema table on the same page (`| committed_date | Timestamp | YES |`) and the column name in spiceai/spiceai.

A user copying the misspelled identifier into a `WHERE` clause would query a column that does not exist.

## Changes

Corrected `` `commited_date` supports... `` to `` `committed_date` supports... `` in the Filter Push Down section. Fixed across vNext and all 7 versioned doc snapshots (the same sentence is present in each).

## Files updated

8 files (1 unversioned + 7 versioned: 1.5.x–1.11.x).

## Reference

Verified against spiceai/spiceai at trunk — `crates/runtime/src/dataconnector/github/commits.rs` (column registered as `committed_date`). Local `npm run build` passes.