### PR TITLE
docs(connectors): Flag ODBC and NFS as Spice.ai Enterprise features

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -58,14 +58,14 @@ Supported Data Connectors include:
 | `ducklake`                         | [DuckLake][ducklake]                  | Beta              | Parquet                      |
 | `flightsql`                        | FlightSQL                             | Beta              | Arrow Flight SQL             |
 | `mssql`                            | Microsoft SQL Server                  | Beta              | Tabular Data Stream (TDS)    |
-| `odbc`                             | ODBC                                  | Beta              | ODBC                         |
+| `odbc`                             | ODBC (Spice.ai Enterprise)            | Beta              | ODBC                         |
 | `spark`                            | Spark                                 | Beta              | [Spark Connect][spark]       |
 | `sharepoint`                       | Microsoft SharePoint                  | Beta              | Object-store listing         |
 | `oracle`                           | Oracle                                | Alpha             | [Oracle ODPI-C][ODPIC]       |
 | `abfs`                             | Azure BlobFS                          | Alpha             | Parquet, CSV                 |
 | `clickhouse`                       | ClickHouse                            | Alpha             |                              |
 | `debezium`                         | Debezium CDC                          | Alpha             | Kafka + JSON                 |
-| `elasticsearch`                    | Elasticsearch (BM25 + kNN + RRF)      | Alpha             |                              |
+| `elasticsearch`                    | Elasticsearch (BM25 + kNN + RRF) (Spice.ai Enterprise) | Alpha   |                              |
 | `gcs`, `gs`                        | [Google Cloud Storage][gcs]           | Alpha             | Parquet, CSV, JSON           |
 | `kafka`                            | Kafka                                 | Alpha             | Kafka + JSON                 |
 | `ftp`, `sftp`                      | FTP/SFTP                              | Alpha             | Parquet, CSV                 |
@@ -76,7 +76,7 @@ Supported Data Connectors include:
 | `mongodb`                          | MongoDB                               | Alpha             |                              |
 | `scylladb`                         | ScyllaDB                              | Alpha             |                              |
 | `smb`                              | SMB 3.1.1                             | Alpha             | SMB                          |
-| `nfs`                              | NFS                                   | Alpha             | Parquet, CSV, JSON           |
+| `nfs`                              | NFS (Spice.ai Enterprise)             | Alpha             | Parquet, CSV, JSON           |
 
 [databricks]: https://github.com/spiceai/cookbook/tree/trunk/databricks#readme
 [spark]: https://spark.apache.org/docs/latest/spark-connect-overview.html

--- a/website/docs/components/data-connectors/nfs.md
+++ b/website/docs/components/data-connectors/nfs.md
@@ -8,6 +8,10 @@ NFS (Network File System) is a distributed file system protocol that provides tr
 
 The NFS Data Connector enables federated SQL query across [supported file formats](./#file-formats) stored on NFS exports.
 
+:::note[Enterprise edition]
+The NFS Data Connector is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is feature-gated and not included in the default open source build; open source users can build it from source with the `nfs` feature (requires the system `libnfs` library).
+:::
+
 :::note[Platform Support]
 The NFS Data Connector is available on Linux and macOS. It is not supported on Windows.
 :::

--- a/website/docs/components/data-connectors/odbc.md
+++ b/website/docs/components/data-connectors/odbc.md
@@ -6,6 +6,10 @@ description: 'ODBC Data Connector Documentation'
 
 ODBC (Open Database Connectivity) is a standard API for connecting applications to various database management systems using a common interface. To connect to any ODBC database for federated/accelerated SQL queries, specify `odbc` as the selector in the `from` value for the dataset. The `odbc_connection_string` parameter is required.
 
+:::note[Enterprise edition]
+The ODBC Data Connector is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is feature-gated and not included in the default open source build; open source users can [build it from source](#building-spice-with-odbc).
+:::
+
 :::warning
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).


### PR DESCRIPTION
## Summary

Follow-up to [#1776](https://github.com/spiceai/docs/pull/1776) (HashiCorp Vault). Applies the same Spice.ai Enterprise framing to the other documented feature-gated capabilities, per the principle that a feature being OSS-buildable does not make it part of the open source distribution — feature gating (exclusion from the default OSS build) is the distinction.

Both the ODBC and NFS connectors are gated out of the default `spiced` build and are listed as Enterprise/local-build-only in [reference/distributions.md](website/docs/reference/distributions.md). The ODBC page previously used a "build from source" framing; this reframes it to the standard Enterprise edition callout (keeping the build path documented as a developer option, since Enterprise features remain OSS-buildable).

## Changes

- [`components/data-connectors/odbc.md`](website/docs/components/data-connectors/odbc.md) — add Enterprise edition callout; the existing "Building Spice with ODBC" section is retained and linked as the open source build path.
- [`components/data-connectors/nfs.md`](website/docs/components/data-connectors/nfs.md) — add Enterprise edition callout (notes the `nfs` feature and system `libnfs` requirement for source builds).
- [`components/data-connectors/index.md`](website/docs/components/data-connectors/index.md) — mark `odbc`, `nfs`, and `elasticsearch` rows as `(Spice.ai Enterprise)` for consistency with the existing PostgreSQL accelerator convention.

## Notes / scope

- `smb` is **not** flagged: it is in the default OSS feature set, so it ships in the open source build despite being grouped with NFS under "NAS" in `distributions.md` (a separate discrepancy worth a follow-up).
- Other feature-gated capabilities (`geo` spatial functions, `http-functions`, `wasm-functions`, `vortex`, `rate-control`) are gated but are **not** listed as Enterprise in `distributions.md`, so they are intentionally left out of this PR pending confirmation of their commercial status.

## Test plan

- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links / undefined tags).
- [x] Enterprise callout wording matches the existing Elasticsearch / PostgreSQL accelerator / HashiCorp Vault pages.
- [x] No versioned docs touched.