### PR TITLE
docs(evals): Deprecate evals in vNext (v2.x) docs

### DIFF
--- a/website/docs/comparison.md
+++ b/website/docs/comparison.md
@@ -50,7 +50,6 @@ Spice combines SQL query, search, and LLM inference in a single runtime. This pa
 | **Accelerated Data Access**   | ✅                                   | ❌                  | ❌                  | ❌                             |
 | **Tools/Functions**           | ✅ (MCP HTTP+SSE)                    | ✅                  | ✅                  | ✅                             |
 | **LLM Memory**                | ✅                                   | ✅                  | ✅                  | ❌                             |
-| **Evaluations (Evals)**       | ✅                                   | Limited            | Limited            | ❌                             |
 | **Search**                    | ✅ (Keyword, Vector, Full-Text)      | ✅                  | ✅                  | Limited                       |
 | **Caching**                   | ✅ (Query and results caching)       | Limited            | ❌                  | ❌                             |
 | **Embeddings**                | ✅ (Built-in & pluggable models/DBs) | ✅                  | ✅                  | ✅                             |

--- a/website/docs/features/large-language-models/evals.md
+++ b/website/docs/features/large-language-models/evals.md
@@ -1,0 +1,12 @@
+---
+title: 'Evaluating Language Models (Deprecated)'
+description: 'Language model evals are no longer supported in Spice.'
+sidebar_label: 'Evals (Deprecated)'
+sidebar_position: 4
+pagination_prev: null
+pagination_next: null
+---
+
+:::warning Deprecated
+Language model evals — the `evals` Spicepod component and the `/v1/evals` API endpoint — are no longer supported and were removed in Spice v2.0 ([spiceai/spiceai#9420](https://github.com/spiceai/spiceai/pull/9420)). For documentation on evals in the last version that supported them, see the [v1.11.x Evals documentation](https://docs.spiceai.org/docs/1.11.x/features/large-language-models/evals).
+:::

--- a/website/docs/reference/spicepod/evals.md
+++ b/website/docs/reference/spicepod/evals.md
@@ -1,0 +1,9 @@
+---
+title: 'Evals (Deprecated)'
+sidebar_label: 'Evals (Deprecated)'
+description: 'The evals Spicepod component is no longer supported in Spice.'
+---
+
+:::warning Deprecated
+The `evals` Spicepod component is no longer supported and was removed in Spice v2.0 ([spiceai/spiceai#9420](https://github.com/spiceai/spiceai/pull/9420)). For the evals YAML reference in the last version that supported it, see the [v1.11.x Evals reference](https://docs.spiceai.org/docs/1.11.x/reference/spicepod/evals).
+:::


### PR DESCRIPTION
## Summary

Evals — the `evals` Spicepod component and the `/v1/evals` API endpoint — were removed in Spice v2.0 ([spiceai/spiceai#9420](https://github.com/spiceai/spiceai/pull/9420), first shipped in `v2.0.0-rc.2`). The vNext docs pages for evals were hard-deleted in an earlier commit, so old links (e.g. `/docs/next/features/large-language-models/evals`) now 404 with no explanation.

This restores those pages as **deprecation stubs** (keeping the URLs alive and pointing users to the v1.11.x docs), following the existing [Perplexity deprecation pattern](https://github.com/spiceai/docs/blob/trunk/website/docs/components/models/perplexity.md). Per docs convention, deprecated entries are removed from summary tables rather than struck through.

## Source

- spiceai/spiceai#9420 — refactor: Remove `v1/evals` functionality

## Changes (vNext / `website/docs/` only)

- **`features/large-language-models/evals.md`** (new stub) — `:::warning Deprecated` notice citing #9420, linking to the [v1.11.x Evals docs](https://docs.spiceai.org/docs/1.11.x/features/large-language-models/evals). Restored at its original sidebar slot (position 4) with a `(Deprecated)` label.
- **`reference/spicepod/evals.md`** (new stub) — same pattern, linking to the [v1.11.x Evals reference](https://docs.spiceai.org/docs/1.11.x/reference/spicepod/evals).
- **`comparison.md`** — removed the `Evaluations (Evals)` row from the AI Apps & Agents comparison table (Spice v2.x no longer supports evals).

## Scope notes

- **Versioned docs (1.5.x–1.11.x) are intentionally untouched** — those releases shipped evals, so their docs remain correct. This is an addition/version-specific change, not a correction.
- Cross-version links use the absolute `https://docs.spiceai.org/docs/1.11.x/...` form, matching the Perplexity precedent and the docs link convention.

## Test plan

- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links / undefined tags).
- [x] Both stubs render at `/docs/next/...` with the deprecation notice and working external v1.11.x links.
- [x] Evals row no longer present in the vNext comparison table.