### PR TITLE
docs: fix "REPL inferface" typo across versioned getting-started pages

### DIFF
--- a/website/docs/getting-started/index.mdx
+++ b/website/docs/getting-started/index.mdx
@@ -132,7 +132,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.10.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.10.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.11.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.11.x/getting-started/index.mdx
@@ -132,7 +132,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.5.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.5.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.6.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.6.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.7.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.7.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.8.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.8.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.

--- a/website/versioned_docs/version-1.9.x/getting-started/index.mdx
+++ b/website/versioned_docs/version-1.9.x/getting-started/index.mdx
@@ -128,7 +128,7 @@ The OpenAI model was automatically provided with the `taxi_trips` dataset and wa
 spice sql
 ```
 
-The SQL REPL inferface will be shown:
+The SQL REPL interface will be shown:
 
 ```
 Welcome to the Spice.ai SQL REPL! Type 'help' for help.


### PR DESCRIPTION
## Summary
Fixes a long-standing typo — `REPL inferface` → `REPL interface` — in the SQL REPL section of the getting-started page. The same typo existed in every versioned copy of the page, so the fix propagates to all eight versions.

## Source PRs
- spiceai/spiceai#11042 — chore: fix two typos (fixed the matching typo in the project README and one in `modelsource/spiceai.rs`)

## Changes
- `website/docs/getting-started/index.mdx` (vNext) — fix typo
- `website/versioned_docs/version-1.5.x/getting-started/index.mdx` through `version-1.11.x` (7 versioned files) — same fix carried into each release's docs

This is a propagating correction (per the docs-update skill guidance for typo fixes), not a feature addition, so every shipped version of the page is updated.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Verified the only occurrence of `REPL inferface` in `website/` is now gone (`grep -r 'REPL inferface' website/` returns no matches)