### PR TITLE
docs(cdc/postgres): Arrow accelerator supports primary-key upserts

### DIFF
--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -153,15 +153,15 @@ All existing `pg_host`, `pg_port`, `pg_user`, `pg_pass`, `pg_db`, `pg_sslmode`, 
 
 ### Accelerator engines
 
-| Engine     | `INSERT` |      `UPDATE`      | `DELETE` | Notes                                                                             |
-|------------|:--------:|:------------------:|:--------:|-----------------------------------------------------------------------------------|
-| `duckdb`   |    ✅    | ✅ (upsert)        |    ✅    | Recommended for most workloads.                                                   |
-| `sqlite`   |    ✅    | ✅ (upsert)        |    ✅    | Great for small/medium datasets.                                                  |
-| `postgres` |    ✅    | ✅ (upsert)        |    ✅    | Use when the accelerator is another Postgres.                                     |
-| `cayenne`  |    ✅    | ✅ (upsert)        |    ✅    | S3-backed Vortex format, good for read-heavy analytics.                           |
-| `arrow`    |    ✅    | ❌ (becomes insert)|    ✅    | Arrow's in-memory engine does not support `on_conflict`; `UPDATE`s append rows.   |
+| Engine     | `INSERT` |           `UPDATE`           | `DELETE` | Notes                                                                                                                                                                                                  |
+|------------|:--------:|:----------------------------:|:--------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `duckdb`   |    ✅    | ✅ (upsert)                  |    ✅    | Recommended for most workloads.                                                                                                                                                                        |
+| `sqlite`   |    ✅    | ✅ (upsert)                  |    ✅    | Great for small/medium datasets.                                                                                                                                                                       |
+| `postgres` |    ✅    | ✅ (upsert)                  |    ✅    | Use when the accelerator is another Postgres.                                                                                                                                                          |
+| `cayenne`  |    ✅    | ✅ (upsert)                  |    ✅    | S3-backed Vortex format, good for read-heavy analytics.                                                                                                                                                |
+| `arrow`    |    ✅    | ✅ (upsert with primary key) |    ✅    | Arrow's in-memory engine uses a hash index for primary-key upserts. Without a primary key, `UPDATE`s are appended as new rows. `DELETE` and `TRUNCATE` are applied via Arrow's `DeletionTableProvider`. |
 
-For workloads that need true upsert semantics, use DuckDB, SQLite, PostgreSQL, or Cayenne.
+For Arrow workloads that need true upsert semantics (so `UPDATE`s replace existing rows instead of duplicating them), configure a `primary_key`. DuckDB, SQLite, PostgreSQL, and Cayenne also support upsert behavior.
 
 ## Multi-replica deployments
 
@@ -266,14 +266,14 @@ Core freshness signals (auto-registered):
 | Error mentioning *permission denied for database* during setup               | The role needs `CREATE` on the database, or pre-create the publication/slot yourself.                                             |
 | `pg_replication_slots.active` is `true` but the accelerator isn't updating   | Check Spice logs for schema-mismatch errors. The replication task holds the slot even after failure — restart after fixing.       |
 | `wal` on the source disk growing forever                                     | An abandoned slot. Drop it with `pg_drop_replication_slot`.                                                                       |
-| `UPDATE`s on Arrow-engine dataset don't replace rows                         | Arrow does not support `on_conflict`. Switch to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                                     |
+| `UPDATE`s on Arrow-engine dataset don't replace rows                         | Configure a `primary_key` so Arrow can use its hash index for upserts, or switch to `duckdb`, `sqlite`, `postgres`, or `cayenne`. |
 | Huge `TEXT`/`JSONB` columns show as `NULL` after `UPDATE`                    | Unchanged TOASTed columns are omitted by pgoutput. Run `ALTER TABLE ... REPLICA IDENTITY FULL;` if you need them in every event.  |
 
 ## Limitations
 
 - **One table per dataset.** Each Spice dataset replicates exactly one source table; each dataset gets its own slot and publication.
 - **No DDL replication.** Schema changes on the source are not propagated automatically. Add new columns as nullable on the source first, update the Spice dataset, then reload the Spicepod.
-- **Arrow engine** does not support `on_conflict` (upsert) semantics. `UPDATE`s therefore appear as additional inserts rather than replacing existing rows. For true upsert behavior use DuckDB, SQLite, Postgres, or Cayenne.
+- **Arrow engine** supports `on_conflict` upserts when a `primary_key` is configured. Without a primary key, `UPDATE`s appear as additional inserts rather than replacing existing rows. `DELETE` and `TRUNCATE` are applied either way.
 
 ## Comparison with Debezium + Kafka
 


### PR DESCRIPTION
## Summary
Update the PostgreSQL logical replication doc to reflect that Arrow now supports `on_conflict: upsert` when a `primary_key` is configured.

The engine matrix, troubleshooting row, and limitations bullet had all said Arrow `UPDATE`s become appends — that's only true when no primary key is set. With a primary key, Arrow uses its hash index to apply upserts in-memory.

## Source PRs
- spiceai/spiceai#10749 — Add Arrow primary key upserts (also updated the matching text in the internal `docs/features/postgres-replication.md`)

## Verification against source
- `crates/runtime/src/dataaccelerator/arrow.rs` — `enable_hash_index_for_primary_key_or_indexes` auto-enables `hash_index=enabled` when a primary key constraint is supplied; constraints are stripped only in caching mode.
- `crates/data_components/src/arrow/write.rs` — Arrow `MemTable` carries `on_conflict: Option<OnConflict>`, accepts `OnConflict::Upsert`, and validates that the `on_conflict` columns match the primary key.

## Changes
- `website/docs/features/cdc/postgres-replication.md` — engine matrix row for `arrow` flipped from "❌ (becomes insert)" to "✅ (upsert with primary key)"; troubleshooting and limitations entries updated to match.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus throws on broken links and undefined frontmatter tags)
- [x] Verified Arrow `on_conflict: upsert` against `crates/data_components/src/arrow/write.rs` and `crates/runtime/src/dataaccelerator/arrow.rs`
- [x] Internal `docs/features/postgres-replication.md` in spiceai/spiceai already uses the same wording (the public site is being brought in line)