### PR TITLE
fix(catalogs/ducklake): prefix params in YAML example with ducklake_

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -24,8 +24,8 @@ catalogs:
     name: my_lakehouse
     # access: read_write  # Optional. Enable write operations.
     params:
-      name: ducklake # Optional. Name to attach the catalog as in DuckDB. Defaults to 'ducklake'.
-      open: /path/to/local.duckdb # Optional. Path to a DuckDB file for persistent storage.
+      ducklake_name: ducklake # Optional. Name to attach the catalog as in DuckDB. Defaults to 'ducklake'.
+      ducklake_open: /path/to/local.duckdb # Optional. Path to a DuckDB file for persistent storage.
 ```
 
 ## `from`


### PR DESCRIPTION
## Summary

The DuckLake catalog connector example used the unprefixed keys `name:` and `open:` inside `params:`. Component params are prefixed with the catalog name at runtime, so the correct user-facing keys are `ducklake_name` and `ducklake_open` — which is what the params table on the same page already shows.

Unprefixed keys are filtered out and only logged as a warning, so the example silently no-ops for the user.

## Changes

- `website/docs/components/catalogs/ducklake.md`: prefix `name`/`open` with `ducklake_` in the configuration example.

## Reference

Verified against the `PARAMETERS` array in `crates/runtime/src/catalogconnector/ducklake.rs` on spiceai/spiceai `trunk` — both keys are declared via `ParameterSpec::component(...)`, which is prefixed by the connector's `PREFIX = "ducklake"`.