### PR TITLE
fix(catalogs/glue): document glue catalog id via from field, not params

### DIFF
--- a/website/docs/components/catalogs/glue.md
+++ b/website/docs/components/catalogs/glue.md
@@ -30,7 +30,21 @@ catalogs:
 
 ### `from`
 
-The `from` field is used to specify the catalog provider. For Glue, you need only specify `glue`. The catalog is unique for each AWS account and AWS region.
+The `from` field is used to specify the catalog provider. For Glue, use either `glue` (which targets the default Glue catalog for the AWS account and region) or `glue:<catalog_id>` to target a specific Glue catalog.
+
+The catalog id appears after the first `:` in the `from` value. For [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html), use the format `glue:<account_id>:s3tablescatalog/<table_bucket_name>`. The catalog id is otherwise the AWS account id when overriding the default catalog explicitly.
+
+Examples:
+
+```yaml
+catalogs:
+  # Default Glue catalog for the configured AWS account and region.
+  - from: glue
+    name: glue_default
+  # Specific S3 Tables-backed Glue catalog.
+  - from: glue:123456789012:s3tablescatalog/my_table_bucket
+    name: glue_s3_tables
+```
 
 ### `name`
 
@@ -47,11 +61,12 @@ The following parameters are supported for configuring the connection to the Glu
 | Parameter Name       | Definition                                                                                                                                                                  |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `glue_region`        | The AWS region for the Glue Data Catalog. E.g. `us-west-2`.                                                                                                                 |
-| `glue_catalog_id`    | The Glue catalog ID. For Amazon S3 Tables, use the format `<account_id>:s3tablescatalog/<table_bucket_name>`. If not provided, the default catalog for the account is used. |
 | `glue_key`           | Access key (e.g. AWS_ACCESS_KEY_ID for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                           |
 | `glue_secret`        | Secret key (e.g. AWS_SECRET_ACCESS_KEY for AWS). If not provided, credentials will be loaded from environment variables or IAM roles.                                       |
 | `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                    |
 | `glue_iam_role_source` | Optional. IAM role credential source. `auto` (default) uses the default AWS credential chain, `metadata` uses only instance/container metadata (IMDS, ECS, EKS/IRSA), `env` uses only environment variables. |
+
+To target a non-default Glue catalog (for example, an S3 Tables catalog), specify the catalog id in the `from` field as `glue:<catalog_id>` — see [`from`](#from) above.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

The Glue catalog connector does not register a `glue_catalog_id` parameter. The catalog id is extracted from the `from` field — the second segment after `glue:` becomes `catalog.catalog_id` and is forwarded into the Glue SDK calls. A `glue_catalog_id` key inside `params` is silently dropped because no `ParameterSpec` for it is declared on the catalog connector.

This is distinct from the Glue *data* connector, which does accept `glue_catalog_id` as a component param.

## Changes

- `website/docs/components/catalogs/glue.md`:
  - Remove the misleading `glue_catalog_id` row from the params table.
  - Expand the `from` section to document the `glue` (default catalog) and `glue:<catalog_id>` forms, with an explicit example for the Amazon S3 Tables format `glue:<account_id>:s3tablescatalog/<bucket>`.
  - Add a short pointer back to the `from` section from the params section.

## Reference

Verified against `crates/runtime/src/catalogconnector/glue.rs` and `glue/provider.rs` on spiceai/spiceai `trunk` — `catalog_id` is sourced from `catalog.catalog_id`, which is populated by `Catalog::catalog_id` in `crates/runtime/src/component/catalog.rs` from the segment after the first delimiter in `from`.