### PR TITLE
docs(glue): document inherited S3 parameters

### DIFF
--- a/website/docs/components/catalogs/glue.md
+++ b/website/docs/components/catalogs/glue.md
@@ -53,6 +53,16 @@ The following parameters are supported for configuring the connection to the Glu
 | `glue_session_token` | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                    |
 | `glue_iam_role_source` | Optional. IAM role credential source. `auto` (default) uses the default AWS credential chain, `metadata` uses only instance/container metadata (IMDS, ECS, EKS/IRSA), `env` uses only environment variables. |
 
+The following parameters control how the embedded S3 reader fetches Parquet/CSV data files referenced by Glue table metadata. They are inherited from the [S3 data connector](../data-connectors/s3/) and do not apply to Iceberg-format tables, whose object I/O is handled by the Iceberg client.
+
+| Parameter Name    | Definition                                                                                                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `glue_endpoint`   | Optional. Custom S3-compatible endpoint URL used when reading Parquet/CSV data files (e.g. `https://s3.us-east-1.amazonaws.com`, `http://minio.local:9000`). Leave unset for AWS S3.                                             |
+| `glue_url_style`  | Optional. S3 URL addressing style for Parquet/CSV data files. One of `vhost` or `path`. Auto-detected from the endpoint when unset.                                                                                              |
+| `glue_versioning` | Optional. Enables S3 object versioning support for Parquet/CSV data files when set to `enabled`. Defaults to `enabled`.                                                                                                          |
+| `client_timeout`  | Optional. Timeout for the underlying S3 client used to fetch Parquet/CSV data files. E.g. `30s`.                                                                                                                                 |
+| `allow_http`      | Optional. Set to `true` to allow insecure HTTP for the S3 endpoint used to read Parquet/CSV data files. Defaults to `false`. Required when `glue_endpoint` uses an `http://` scheme.                                             |
+
 ## Authentication
 
 If AWS credentials are not explicitly provided in the configuration, the connector will automatically load credentials from the following sources in order. These credentials will be used to connect to the S3 bucket as well as the Glue catalog.

--- a/website/docs/components/data-connectors/glue.md
+++ b/website/docs/components/data-connectors/glue.md
@@ -59,6 +59,16 @@ The following parameters are supported for configuring the connection to the Glu
 | `glue_session_token`   | Session token (e.g. AWS_SESSION_TOKEN for AWS) for temporary credentials                                                                                                                                     |
 | `glue_iam_role_source` | Optional. IAM role credential source. `auto` (default) uses the default AWS credential chain, `metadata` uses only instance/container metadata (IMDS, ECS, EKS/IRSA), `env` uses only environment variables. |
 
+The following parameters control how the embedded S3 reader fetches Parquet/CSV data files referenced by Glue table metadata. They are inherited from the [S3 data connector](./s3/) and do not apply to Iceberg-format tables, whose object I/O is handled by the Iceberg client.
+
+| Parameter Name    | Definition                                                                                                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `glue_endpoint`   | Optional. Custom S3-compatible endpoint URL used when reading Parquet/CSV data files (e.g. `https://s3.us-east-1.amazonaws.com`, `http://minio.local:9000`). Leave unset for AWS S3.                                             |
+| `glue_url_style`  | Optional. S3 URL addressing style for Parquet/CSV data files. One of `vhost` or `path`. Auto-detected from the endpoint when unset.                                                                                              |
+| `glue_versioning` | Optional. Enables S3 object versioning support for Parquet/CSV data files when set to `enabled`. Defaults to `enabled`.                                                                                                          |
+| `client_timeout`  | Optional. Timeout for the underlying S3 client used to fetch Parquet/CSV data files. E.g. `30s`.                                                                                                                                 |
+| `allow_http`      | Optional. Set to `true` to allow insecure HTTP for the S3 endpoint used to read Parquet/CSV data files. Defaults to `false`. Required when `glue_endpoint` uses an `http://` scheme.                                             |
+
 ## Examples
 
 ### Basic Glue Table


### PR DESCRIPTION
## Summary

The Glue data connector and Glue catalog connector both inherit the full set of S3 parameters from the S3 connector — `glue_endpoint`, `glue_url_style`, `glue_versioning`, `client_timeout`, and `allow_http` — because Parquet/CSV table data is read through an embedded S3 reader. Only the AWS credential parameters were previously documented, so users hitting S3-compatible endpoints (MinIO, custom URL styles, HTTP endpoints) had no documented way to configure them.

## Changes

Added a second parameter table to both `website/docs/components/data-connectors/glue.md` and `website/docs/components/catalogs/glue.md` covering the inherited S3-reader parameters. The table notes the applicability scope (Parquet/CSV data files only — Iceberg uses a separate I/O path).

## Reference

Verified against `spiceai/spiceai` `trunk`:

- `crates/runtime/src/dataconnector/glue.rs` — `PARAMETERS` extends `crate::dataconnector::s3::PARAMETERS` (line 244), so the connector's parameter validation accepts every S3 parameter under the `glue_` prefix.
- `crates/runtime/src/dataconnector/glue.rs::create_s3_provider` — constructs an inner `S3` connector with those parameters when reading Parquet/CSV files.
- `crates/runtime/src/catalogconnector/glue/provider.rs` — instantiates a `GlueDataConnector` per discovered table with the same parameter map, so the catalog inherits the same surface area.