### PR TITLE
docs(distributed-query): link to Enterprise Distributed Accelerations

### DIFF
--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -136,9 +136,14 @@ EXPLAIN SELECT count(id) FROM my_dataset;
 
 :::warning[Limitations]
 
-- Accelerated datasets are not yet supported; distributed query currently targets partitioned data lake sources.
+- In open source, distributed query targets partitioned data lake sources (e.g. Parquet, Delta Lake, Iceberg). Distributing **accelerated** datasets across executors is a Spice.ai Enterprise feature (see below).
 - As a preview feature, clusters may encounter stability or performance issues.
-- Accelerator support is planned for future releases; follow release notes for updates.
+
+:::
+
+:::tip[Spice.ai Enterprise]
+
+[**Distributed Accelerations**](https://docs.spice.ai/docs/enterprise/features/distributed-accelerations) partition-shard accelerated datasets across executors — each executor materializes and serves only the partitions it owns, with partition-aware read routing and write-through semantics. This is available in [Spice.ai Enterprise](https://spice.ai) and requires a [`SpicepodCluster`](https://docs.spice.ai/docs/enterprise/kubernetes-operator/spicepodcluster).
 
 :::
 


### PR DESCRIPTION
## Summary

The distributed-query feature page's **Limitations** section claimed accelerated datasets were "not yet supported" in cluster mode, with accelerator support "planned for future releases." Distributed accelerations now ship in **Spice.ai Enterprise**, so that framing is stale and misleading.

This updates the OSS note to:
- Accurately state that open-source distributed query targets partitioned data-lake sources (Parquet, Delta Lake, Iceberg).
- Add a `:::tip[Spice.ai Enterprise]` admonition pointing to the [Distributed Accelerations](https://docs.spice.ai/docs/enterprise/features/distributed-accelerations) Enterprise docs, with a cross-link to `SpicepodCluster`.

Matches the existing Enterprise-pointer convention used in the Kubernetes / Helm / ArgoCD deployment docs (same admonition style and `docs.spice.ai/docs/enterprise/...` link pattern).

## Changes
- `website/docs/features/distributed-query/index.md` — reframed the Limitations bullets and added the Enterprise tip.

## Notes
Scanned all current OSS docs for other statements implying accelerations are unsupported in distributed/cluster mode — this was the only spot. The general "preview feature" stability note is left unchanged.