### PR TITLE
docs(postgres): remove unsupported pg_sslmode=allow value

### DIFF
--- a/website/docs/components/data-connectors/postgres/deployment.md
+++ b/website/docs/components/data-connectors/postgres/deployment.md
@@ -35,11 +35,10 @@ TLS is controlled via `pg_sslmode`:
 | Value         | Behavior                                                    |
 | ------------- | ----------------------------------------------------------- |
 | `disable`     | No TLS.                                                     |
-| `allow`       | Try non-TLS first, retry with TLS if the server requires it. |
 | `prefer`      | Try TLS, fall back to plaintext. Not recommended for production. |
 | `require`     | Require TLS; no server certificate verification.            |
 | `verify-ca`   | Require TLS and verify the CA chain.                        |
-| `verify-full` | Require TLS, verify CA chain, and verify server hostname.   |
+| `verify-full` | (default) Require TLS, verify CA chain, and verify server hostname. |
 
 For production, use `verify-full` with `pg_sslrootcert` pointing to the CA bundle file path.
 


### PR DESCRIPTION
## Summary

The PostgreSQL connector deployment guide's `pg_sslmode` table listed `allow` as a valid value, but the runtime's Postgres connection pool only accepts `disable | require | prefer | verify-ca | verify-full`. Any other input — including `allow` — is rejected with `InvalidParameterValue` at connect time, so users who followed the deployment guide and configured `pg_sslmode: allow` would get a connect-time failure with no obvious cause.

This PR removes the `allow` row and annotates `verify-full` as the default to match the existing `index.md` description and the runtime default hardcoded in the pool.

## What the docs said vs. what the code does

- **Docs (deployment.md):** `allow` — "Try non-TLS first, retry with TLS if the server requires it."
- **Code:** the connection pool matches `disable | require | prefer | verify-ca | verify-full` and falls through to an `InvalidParameterValue` error on any other value. The replication path's `SslMode::from_str_or_default` also doesn't accept `allow` (it silently falls back to `Prefer`).

The reference page (`index.md`) already correctly lists only the five supported values and notes `verify-full` as the default — only `deployment.md` had the stale row.

## Source

- datafusion-table-providers @ pinned rev `466acff6af701872ba41de99c1783df2a288ddf8`, `core/src/sql/db_connection_pool/postgrespool.rs`:
  - L235: `let mut ssl_mode = "verify-full".to_string();` (read-path default)
  - L278-289: accepted-value match arm

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: not applicable — `deployment.md` only exists in unversioned `website/docs/`; no versioned copies to update
- [x] Files updated: 1 (matches the diff)
