### PR TITLE
docs(snowflake): document expanded auth_type values and account identifier formats

### DIFF
--- a/website/docs/components/catalogs/snowflake.md
+++ b/website/docs/components/catalogs/snowflake.md
@@ -56,7 +56,7 @@ Use the `include` field to specify which tables to include from the catalog. The
 | `snowflake_password`               | The Snowflake password for authentication. Use the [secret replacement syntax](../secret-stores).        |
 | `snowflake_warehouse`              | The Snowflake [warehouse](https://docs.snowflake.com/en/user-guide/warehouses-tasks) to use for queries. |
 | `snowflake_role`                   | The Snowflake [role](https://docs.snowflake.com/en/user-guide/security-access-control-overview) to use.  |
-| `snowflake_auth_type`              | Authentication type: `snowflake` (default) or `keypair`.                                                 |
+| `snowflake_auth_type`              | Authentication type. Accepts `password` (or `snowflake`) and `keypair` (or `snowflake_jwt`); matched case-insensitively. Defaults to password authentication unless only key-pair credentials (`snowflake_private_key` or `snowflake_private_key_path`) are provided, in which case key-pair is selected automatically. |
 | `snowflake_private_key`            | The private key content for key pair authentication. Used when `auth_type` is `keypair`.                 |
 | `snowflake_private_key_path`       | Path to a private key file for key pair authentication. Used when `auth_type` is `keypair`.              |
 | `snowflake_private_key_passphrase` | Passphrase for the private key file, if encrypted.                                                       |

--- a/website/docs/components/data-connectors/snowflake.md
+++ b/website/docs/components/data-connectors/snowflake.md
@@ -51,10 +51,10 @@ The dataset name. This will be used as the table name within Spice. The dataset 
 | `snowflake_role`                   | Optional, specifies the role to use for accessing Snowflake data                                                |
 | `snowflake_account`                | Required, specifies the Snowflake account-identifier                                                            |
 | `snowflake_username`               | Required, specifies the Snowflake username to use for accessing Snowflake data                                  |
-| `snowflake_auth_type`              | Optional, specifies the authentication type: `snowflake` (default, password-based) or `keypair`                 |
-| `snowflake_password`               | Required when `snowflake_auth_type` is `snowflake` (default). Specifies the Snowflake password for authentication |
-| `snowflake_private_key`            | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key_path`. Specifies the private key content as a string. |
-| `snowflake_private_key_path`       | Required (one of) when `snowflake_auth_type` is `keypair`. Mutually exclusive with `snowflake_private_key`. Specifies the path to the private key file. |
+| `snowflake_auth_type`              | Optional, specifies the authentication type. Accepts `password` (or `snowflake`) and `keypair` (or `snowflake_jwt`); matched case-insensitively. Defaults to password authentication unless only key-pair credentials (`snowflake_private_key` or `snowflake_private_key_path`) are provided, in which case key-pair is selected automatically. |
+| `snowflake_password`               | Required for password authentication. Specifies the Snowflake password for authentication. |
+| `snowflake_private_key`            | Required (one of) for key-pair authentication. Mutually exclusive with `snowflake_private_key_path`. Specifies the private key content as a string. |
+| `snowflake_private_key_path`       | Required (one of) for key-pair authentication. Mutually exclusive with `snowflake_private_key`. Specifies the path to the private key file. |
 | `snowflake_private_key_passphrase` | Required when the private key is encrypted. Specifies the passphrase to decrypt the private key.                |
 
 ## Auth
@@ -259,10 +259,17 @@ datasets:
       snowflake_role: accountadmin
 ```
 
-:::warning[Limitations]
+:::info[Account Identifier Formats]
 
-1. Account identifier does not support the [Legacy account locator in a region format](https://docs.snowflake.com/en/user-guide/admin-account-identifier#format-2-legacy-account-locator-in-a-region). Use [Snowflake preferred name in organization format](https://docs.snowflake.com/en/user-guide/admin-account-identifier#format-1-preferred-account-name-in-your-organization).
-1. The connector supports password-based and [key-pair](https://docs.snowflake.com/en/user-guide/key-pair-auth) authentication.
+The `snowflake_account` parameter accepts any of the [Snowflake account identifier formats](https://docs.snowflake.com/en/user-guide/admin-account-identifier):
+
+- Preferred org/account names (`myorg-myaccount`)
+- SQL/data-sharing org-qualified names (`myorg.myaccount`)
+- Full `snowflakecomputing.com` account URLs (`https://myorg-myaccount.snowflakecomputing.com`)
+- Legacy account locators (`xy12345`, `xy12345.us-east-2.aws`)
+- SnowGov locators (`xy12345.fhplus.us-gov-west-1.aws`)
+
+Invalid identifiers fail at startup with an actionable error.
 
 :::
 


### PR DESCRIPTION
## Summary

Sync the Snowflake data connector and catalog connector docs with the auth-config and account-identifier validation rework in [spiceai/spiceai#11024](https://github.com/spiceai/spiceai/pull/11024):

- **`snowflake_auth_type` accepted values**: now `password` (or `snowflake`) and `keypair` (or `snowflake_jwt`), matched case-insensitively. Defaults to password authentication unless only key-pair credentials are provided, in which case key-pair is selected automatically. Both data and catalog connector tables were updated.
- **Account identifier formats**: the connector now accepts preferred org/account names, org-qualified names, full `snowflakecomputing.com` URLs, legacy account locators, and SnowGov locators. Replaced the now-incorrect "Legacy account locator not supported" limitation on the data connector page with an informative `Account Identifier Formats` callout listing all accepted forms.

Verified against `crates/data-connectors/connector-snowflake/src/lib.rs` (`PARAMETERS`), `crates/db_connection_pool/src/snowflakepool.rs` (`SnowflakeAuthType::from_params` + `SnowflakeAccountIdentifier::from_str`), and `crates/runtime/src/catalogconnector/snowflake.rs` (`PARAMETERS`).

## Source PRs

- [spiceai/spiceai#11024](https://github.com/spiceai/spiceai/pull/11024) — fix: validate Snowflake account identifiers and auth config

## Versioning

The new alias values, auto-detection rule, and account identifier formats are additions introduced in vNext; older versioned docs (`version-1.5.x`-`version-1.11.x`) correctly describe the prior behavior and are intentionally untouched.

## Test plan

- [x] `cd website && npm run build` passes locally (no broken links, no undefined tags)
- [x] Parameter names, accepted values, and defaults verified against Rust source
- [x] Files updated: 2 (`website/docs/components/data-connectors/snowflake.md`, `website/docs/components/catalogs/snowflake.md`)