### PR TITLE
docs(redshift): remove unsupported pg_sslmode=allow value

### DIFF
--- a/website/docs/components/data-connectors/redshift.md
+++ b/website/docs/components/data-connectors/redshift.md
@@ -127,7 +127,7 @@ datasets:
 | `pg_db`                     | Database name                                                                                                     |
 | `pg_user`                   | Username for authentication                                                                                       |
 | `pg_pass`                   | Password for authentication (use secret reference)                                                                |
-| `pg_sslmode`                | SSL mode (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`)                                    |
+| `pg_sslmode`                | SSL mode. Default `verify-full`. Supported values: `disable`, `prefer`, `require`, `verify-ca`, `verify-full`.    |
 | `pg_sslrootcert`            | Optional. Path to a custom root certificate for SSL verification                                                  |
 | `pg_connection_pool_min_idle` | Optional. The minimum number of idle connections to keep open in the pool. Default is `1`.                       |
 | `connection_pool_size`      | Optional. The maximum number of connections in the connection pool. Default is `5`.                               |


### PR DESCRIPTION
## Summary

The Redshift connector reference's `pg_sslmode` row listed `allow` as a valid value, but the underlying PostgreSQL connection pool only accepts `disable | prefer | require | verify-ca | verify-full`. Any other input — including `allow` — is rejected with `InvalidParameterValue` at connect time, so users who followed this doc and configured `pg_sslmode: allow` got a connect-time failure with no obvious cause.

This PR removes the `allow` row and annotates `verify-full` as the default to match the existing PostgreSQL connector `index.md` description and the runtime default hardcoded in the connection pool.

This is the same bug PR #1788 fixed in the PostgreSQL connector deployment guide; the unversioned Redshift reference still carried the stale row.

## What the docs said vs. what the code does

- **Docs (`redshift.md`):** `pg_sslmode` — `(disable, allow, prefer, require, verify-ca, verify-full)`
- **Code:** the connection pool matches `disable | require | prefer | verify-ca | verify-full` and falls through to an `InvalidParameterValue` error on any other value.

## Source

- spiceai/spiceai @ `trunk`, `crates/data-connectors/connector-postgres/src/lib.rs` — `PARAMETERS` `sslmode` spec lists `allow` in `one_of`, but the upstream `postgrespool` rejects it
- Read-path default `verify-full` is hardcoded in the upstream `postgrespool.rs` (`let mut ssl_mode = "verify-full".to_string()`)

## Versioned-docs propagation

Not applicable. The full sslmode value list only appears in the unversioned `website/docs/components/data-connectors/redshift.md`. All versioned `redshift.md` snapshots already use a shortened description (`SSL mode (e.g., \`prefer\`)`) that doesn't enumerate values.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: not applicable — versioned `redshift.md` snapshots don't enumerate sslmode values
- [x] Files updated: 1 (matches the diff)