### PR TITLE
docs(ducklake): bump bundled DuckDB version to 1.5.3

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -198,7 +198,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.2, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -201,7 +201,7 @@ datasets:
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.2, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.


### PR DESCRIPTION
## Summary

The DuckLake connector and catalog limitations notes state "Spice uses DuckDB 1.5.2". [spiceai/spiceai#11107](https://github.com/spiceai/spiceai/pull/11107) upgraded the bundled DuckDB to **v1.5.3** (`duckdb = "1.10503" # 1.10503.x corresponds to DuckDB v1.5.3`), so this updates both pages to match the shipping version. DuckLake 1.0 compatibility is unchanged.

## Source PRs

- [spiceai/spiceai#11107](https://github.com/spiceai/spiceai/pull/11107) — Upgrade to DuckDB 1.5.3 + statically link the VSS (HNSW) extension

Note: the VSS static-linking half of that PR needs no doc change — `website/docs/components/vectors/duckdb.md` already states the VSS extension is "installed and loaded automatically by the runtime; no manual setup is required," which the static link makes reliably true.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — the "DuckDB 1.5.2" string is a version-specific constant present only in the two unversioned `website/docs/` pages; no `versioned_docs/` snapshot carries it, so no back-propagation is needed.
- [x] Files updated: 2 (data-connectors/ducklake.md, catalogs/ducklake.md)