### PR TITLE
docs(clickhouse): remove unsupported Date32 type-mapping row

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -89,7 +89,6 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `FixedString`    | `Utf8`                      |
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
-| `Date32`         | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
 | `DateTime64`     | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |


### PR DESCRIPTION
## Summary

The ClickHouse connector docs list `Date32` → Arrow `Date32` in the Types table, but ClickHouse `Date32` columns are **not** supported by the connector.

- **What the docs said:** `| `Date32` | `Date32` |` is a supported type mapping.
- **What the code does:** the pinned `clickhouse-rs` `SqlType` enum has **no `Date32` variant** (`src/types/mod.rs:311` — only `Date` and `DateTime(DateTimeType)`), and `map_column_to_data_type` maps only `SqlType::Date => DataType::Date32`; any unmapped type falls through to `_ => unimplemented!("Unsupported column type ...")` (`crates/arrow_sql_gen/src/clickhouse.rs:525,531`). No dispatch arm produces a `Date32` mapping.

This is the same class of bug as the previously-removed ClickHouse `Date32` claim (spiceai/docs#1481 → #1592): a "type X is supported" row with no dispatch arm behind it.

`DateTime64` is **retained** — it is a real `SqlType::DateTime(DateTimeType::DateTime64(..))` value that dispatches through the `SqlType::DateTime(_)` arm to `Timestamp(Second, None)` (precision truncated to seconds, but the mapping exists).

## Source ref

- spiceai/spiceai @ `trunk` (v2.0.0-unstable)
  - `crates/arrow_sql_gen/src/clickhouse.rs:511-533` (`map_column_to_data_type`)
  - `clickhouse-rs` `SqlType` enum (`src/types/mod.rs:311-340`) — no `Date32` variant

## Scope / versioned docs

The ClickHouse Types table is a vNext-only addition — versioned docs (<=1.11.x) have no Types table, so no versioned-docs propagation is needed. Single-file change.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — N/A (table exists only in vNext `website/docs/`)
- [x] Files updated: 1
