### PR TITLE
docs(dynamodb): correct write-path IAM permissions and DELETE API

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/index.md
+++ b/website/docs/components/data-connectors/dynamodb/index.md
@@ -205,10 +205,12 @@ The IAM role or user needs the following permissions to access DynamoDB tables:
 | `dynamodb:Scan`          | Required. Allows reading all items from the table                        |
 | `dynamodb:Query`         | Required. Allows reading items from the table using partition key        |
 | `dynamodb:DescribeTable` | Required. Allows fetching table metadata and schema information          |
-| `dynamodb:PutItem`       | Required for INSERT. Allows writing new items to the table               |
+| `dynamodb:BatchWriteItem`| Required for INSERT and DELETE. Both write paths issue `BatchWriteItem` requests |
 | `dynamodb:UpdateItem`    | Required for UPDATE. Allows modifying existing items in the table        |
-| `dynamodb:DeleteItem`    | Required for DELETE. Allows removing items from the table                |
-| `dynamodb:BatchWriteItem`| Required for batch INSERT/DELETE. Allows batch write operations           |
+
+:::note[Streams / CDC permissions]
+When using `refresh_mode: changes` (DynamoDB Streams), the IAM role or user additionally needs `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, and `dynamodb:GetRecords`, scoped to the table's stream ARN (`arn:aws:dynamodb:*:*:table/YOUR_TABLE_NAME/stream/*`).
+:::
 
 ### Example IAM Policies
 
@@ -491,7 +493,7 @@ DELETE FROM users WHERE id = 42;
 Write operations use the table's primary key (partition key and optional sort key) to identify items. The `write_parallelism` parameter controls how many DynamoDB API calls are issued concurrently for batch operations (default: `10`).
 
 :::note
-INSERT uses `BatchWriteItem` for efficiency. UPDATE and DELETE use per-item API calls (`UpdateItem` / `DeleteItem`) issued in parallel chunks sized by `write_parallelism`.
+INSERT and DELETE both use `BatchWriteItem` (with `PutRequest` and `DeleteRequest` items respectively) for efficiency. UPDATE uses per-item `UpdateItem` calls. All write operations are issued in parallel chunks sized by `write_parallelism`.
 :::
 
 ## Examples


### PR DESCRIPTION
## Summary

The DynamoDB connector docs misdescribe the write-path AWS API calls, which would cause `INSERT`/`DELETE` to fail with `AccessDenied` for users who scope their IAM policy to the documented "Permission Details" table.

**What the docs said vs. what the code does:**

- The IAM "Permission Details" table listed `dynamodb:PutItem` ("Required for INSERT") and `dynamodb:DeleteItem` ("Required for DELETE"). **Neither API is ever called.** INSERT and DELETE both issue `BatchWriteItem` (with `PutRequest` / `DeleteRequest` items respectively); UPDATE uses `UpdateItem`.
- The write-mechanism note said "UPDATE and DELETE use per-item API calls (`UpdateItem` / `DeleteItem`)" — wrong for DELETE.
- The Streams/CDC IAM permissions were entirely missing.

**What changed:**

- Replaced the `PutItem` / `DeleteItem` rows with a corrected `BatchWriteItem` row ("Required for INSERT and DELETE"); kept `UpdateItem` for UPDATE.
- Corrected the write-mechanism note: INSERT and DELETE use `BatchWriteItem`; UPDATE uses `UpdateItem`.
- Added a note documenting the Streams permissions (`DescribeStream`, `GetShardIterator`, `GetRecords`) required for `refresh_mode: changes`.

## Source verification

`spiceai/spiceai` @ `trunk`. The only DynamoDB write/stream API calls in the connector:

- `crates/data_components/src/dynamodb/dml/mod.rs:56` — `batch_write_item()` (sole write path; INSERT via `dml/insert.rs` `PutRequest`, DELETE via `dml/delete.rs` `DeleteRequest`)
- `crates/data_components/src/dynamodb/dml/update.rs:189` — `update_item()` (UPDATE)
- `crates/dynamodb-streams/src/client_sdk.rs` — `describe_stream()` (:67), `get_shard_iterator()` (:106), `get_records()` (:126)
- No `put_item()` / `delete_item()` calls exist anywhere in the connector.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `dynamodb:DeleteItem` and the per-item sentence exist only in vNext `website/docs/` (DynamoDB DML is a recent feature; no versioned copies carry these rows)
- [x] Files updated: 1 (`website/docs/components/data-connectors/dynamodb/index.md`)