### PR TITLE
docs(elasticsearch): search UDTFs require Vector Engine / FTS config, not the connector alone

### DIFF
--- a/website/docs/components/data-connectors/elasticsearch/index.md
+++ b/website/docs/components/data-connectors/elasticsearch/index.md
@@ -8,7 +8,9 @@ tags:
   - search
 ---
 
-The Elasticsearch Data Connector exposes Elasticsearch indexes as SQL tables in Spice. Index mappings are translated to Arrow schemas so that documents can be queried with federated SQL alongside data from other connectors. The connector also bridges Elasticsearch's native kNN and full-text search into Spice, enabling [hybrid search](../../features/search) through the standard `vector_search`, `text_search`, and `rrf` UDTFs.
+The Elasticsearch Data Connector exposes Elasticsearch indexes as SQL tables in Spice. Index mappings are translated to Arrow schemas so that documents can be queried with federated SQL alongside data from other connectors.
+
+To run [vector, full-text, or hybrid search](../../features/search) (the `vector_search`, `text_search`, and `rrf` UDTFs) against an Elasticsearch index, the dataset must additionally be configured for search — as an [Elasticsearch Vector Engine](../vectors/elasticsearch) with an embedding model for vector search, and/or with full-text search columns for `text_search`. See [Vector and Full-Text Search](#vector-and-full-text-search) below. Registering an index through the data connector alone exposes it for federated SQL but does not make it searchable through those UDTFs.
 
 ```yaml
 datasets:
@@ -92,7 +94,12 @@ LIMIT 10;
 
 ### Vector and Full-Text Search
 
-When an index contains a `dense_vector` field, the Elasticsearch connector wires it into Spice's search pipeline. This enables:
+An Elasticsearch dataset is **not** searchable through the search UDTFs by virtue of being registered with the data connector. To enable search against an Elasticsearch index, configure the dataset for search:
+
+- For **vector** and **hybrid** search, configure the dataset as an [Elasticsearch Vector Engine](../vectors/elasticsearch) (`vectors: { engine: elasticsearch, enabled: true }`) with a column-level `embeddings` entry naming an embedding model. The embedding model is required — it is used to embed the query text at search time.
+- For **full-text** search, enable `full_text_search` on the column(s) to search.
+
+Once configured, the following UDTFs are available against the dataset:
 
 - **Vector similarity search** via [`vector_search`](../../reference/sql/search#vector-search-vector_search) — executed natively as an Elasticsearch kNN query.
 - **Full-text search** via [`text_search`](../../reference/sql/search#full-text-search-text_search) — executed using Elasticsearch's native BM25 ranking.


### PR DESCRIPTION
## Summary

The Elasticsearch **data connector** page claimed that registering an index automatically makes it searchable through the `vector_search`, `text_search`, and `rrf` UDTFs ("When an index contains a `dense_vector` field, the Elasticsearch connector wires it into Spice's search pipeline"). This is not what the code does.

**What the docs said vs. what the code does:**

- `read_provider` returns a bare `ElasticsearchQueryTable` with **no** search wiring — it is never wrapped in an `IndexedTableProvider` (`crates/data-connectors/connector-elasticsearch/src/lib.rs:181-212`).
- The search UDTFs only discover datasets wrapped in `IndexedTableProvider` / `EmbeddingTable` (`crates/runtime/src/search/util.rs` — `full_text_search_candidates` returns no candidates without an `IndexedTableProvider`; `embedding_columns_from_table` requires an `ElasticsearchIndex`/`EmbeddingTable`).
- Those wrappers are only attached when the dataset is configured for search (`crates/runtime/src/init/dataset.rs:1040-1064` — gated on `has_embeddings()` / `has_full_text_column()`). The vector `ElasticsearchIndex` constructor **requires an embedding model** and errors without one (`crates/runtime/src/embeddings/index/elasticsearch/mod.rs:229-238`).
- Net: a plain `from: elasticsearch:<index>` dataset (no `vectors:`/`embeddings:`/`full_text_search:`) is queryable via SQL but **not** searchable via the UDTFs.

**What changed:**

- Reworded the intro to state that the connector exposes indexes as SQL tables, and that search through the UDTFs additionally requires configuring the dataset as an Elasticsearch Vector Engine (with an embedding model) and/or with full-text-search columns.
- Reworded the "Vector and Full-Text Search" section to state the precondition explicitly (vector/hybrid → Vector Engine + embedding model; full-text → `full_text_search` columns), then list the UDTFs as available "once configured". The SQL examples are unchanged (they are valid once the dataset is configured).

## Source verification

`spiceai/spiceai` @ `trunk`. See file:line refs above.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — the Elasticsearch connector page exists only in vNext `website/docs/`; the incorrect claim is not present in any `versioned_docs/` snapshot
- [x] Files updated: 1 (`website/docs/components/data-connectors/elasticsearch/index.md`)