### PR TITLE
docs(postgres): note pg_sslmode defaults to prefer on the WAL replication path

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -130,6 +130,12 @@ The following parameters configure PostgreSQL [logical replication](https://www.
 | `pg_replication_status_interval`   | Optional. How often to send StandbyStatusUpdate to Postgres (e.g. `10s`). Default: `10s`.                                                               |
 | `pg_replication_bootstrap_batch_size` | Optional. Number of rows per emitted batch during the initial replication snapshot. Default: `8192`. Maximum: `1048576`.                              |
 
+:::warning[`pg_sslmode` default differs on the WAL replication transport]
+
+The `pg_sslmode` default of `verify-full` documented above applies to the federated read/query path. On the WAL replication transport used by `refresh_mode: changes`, an unset `pg_sslmode` defaults to **`prefer`**, which negotiates a **plaintext** connection (no certificate verification). Set `pg_sslmode` to `require`, `verify-ca`, or `verify-full` to force TLS on the WAL stream — see [`pg_sslmode` for WAL streaming](../../features/cdc/postgres-replication#pg_sslmode-for-wal-streaming).
+
+:::
+
 ## Types
 
 The table below shows the PostgreSQL data types supported, along with the type mapping to Apache Arrow types in Spice.


### PR DESCRIPTION
## Summary

The PostgreSQL connector reference documents `pg_sslmode` with `verify-full` as "(default)". That is correct for the **federated read/query path**, but the **WAL replication transport** used by `refresh_mode: changes` defaults to `prefer` (plaintext, no certificate verification) when `pg_sslmode` is unset. A user setting up CDC from the connector reference page alone could reasonably believe their replication stream is verifying certificates by default when it is not.

**What the docs said vs. what the code does:**

- Connector reference `pg_sslmode` row: "`verify-full`: (default)" — unqualified.
- Replication path: `SslMode::from_str_or_default(None)` falls through to `_ => Self::Prefer` (`crates/data_components/src/postgres_replication/config.rs:91-98`). `prefer` → `requires_tls()` true but `verifies_certificate()` false, so the replication TLS builder calls `danger_accept_invalid_certs(true)` and emits a runtime warning (`config.rs:295-304`).
- The dedicated CDC page already documents this correctly — its table marks "`prefer` (default)" as plaintext (`website/docs/features/cdc/postgres-replication.md:145`). Only the connector reference page lacked the qualification.

**What changed:**

- Added a `:::warning` in the connector reference's Replication parameters section noting that the documented `verify-full` default applies to the read/query path, that the WAL replication path defaults to `prefer` (plaintext), and that operators should set `require`/`verify-ca`/`verify-full` to force TLS — cross-linking the CDC page section.

## Source verification

`spiceai/spiceai` @ `trunk`: `crates/data_components/src/postgres_replication/config.rs:91-98` (default `Prefer`) and `:295-304` (plaintext + warning for non-verifying modes).

## Test plan

- [x] `cd website && npm run build` passes (relative link + anchor resolve)
- [x] Versioned-docs propagation checked — the WAL-replication parameters and the CDC page are vNext-only (`pg_replication_slot` appears only under `website/docs/`, no `versioned_docs/` copies); this is an addition for a recent feature, so vNext only
- [x] Files updated: 1 (`website/docs/components/data-connectors/postgres/index.md`)