### PR TITLE
docs(cayenne): separate runtime.params from acceleration.params

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -72,16 +72,17 @@ Vortex compression typically delivers 2–4× better compression than Parquet Sn
 
 ## Metrics
 
-Generic acceleration metrics are available with the `dataset_acceleration_` prefix. Cayenne also registers the following OpenTelemetry instruments for CDC ingestion and scan-path observability, all tagged by `dataset`:
+Generic acceleration metrics are available with the `dataset_acceleration_` prefix. Cayenne also registers the following OpenTelemetry instruments for CDC ingestion, write/compaction, scan-path, and segment-cache observability, all tagged by `dataset`:
 
 ### CDC Apply Metrics
 
 | Metric | Type | Unit | Description |
 | ------ | ---- | ---- | ----------- |
 | `dataset_acceleration_cdc_apply_burst_duration_ms` | Histogram | ms | Duration to apply one coalesced CDC burst. |
-| `dataset_acceleration_cdc_apply_burst_bytes` | Histogram | bytes | Arrow in-memory bytes in one coalesced CDC apply burst. |
+| `dataset_acceleration_cdc_apply_burst_bytes` | Histogram | By | Arrow in-memory bytes in one coalesced CDC apply burst. |
 | `dataset_acceleration_cdc_apply_burst_envelopes` | Histogram | envelopes | Number of source envelopes in one coalesced CDC apply burst. |
 | `dataset_acceleration_cdc_apply_fixed_cost_ms` | Histogram | ms | Duration for fixed-cost phases of CDC apply (with `phase` label: `finalize_wait`, `commit_wait`, etc.). |
+| `dataset_acceleration_cdc_source_recv_wait_ms` | Histogram | ms | Duration the CDC apply loop waited to receive the next batch from the source-reader channel. High values indicate the apply loop is source-bound (slot read / WAL decode can't keep up); near-zero indicates it is apply-bound. |
 
 ### Scan-Path Metrics
 
@@ -90,6 +91,27 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 | `cayenne_scan_listing_table_cache_entries` | Gauge | entries | Number of entries in the scan `ListingTable` cache. Cleared on snapshot change (compaction/sort/overwrite). |
 | `cayenne_listing_fence_wait_duration_ms` | Histogram | ms | Time spent waiting on listing-fence reads during scans. |
 | `cayenne_listing_scan_duration_ms` | Histogram | ms | Duration of listing-table scans. |
+
+### Write & Compaction Metrics
+
+| Metric | Type | Unit | Description |
+| ------ | ---- | ---- | ----------- |
+| `cayenne_write_phase_duration_ms` | Histogram | ms | Time spent in Cayenne write-path phases. |
+| `cayenne_compaction_duration_ms` | Histogram | ms | Wall-clock time of Cayenne background compaction passes. The histogram's count doubles as the compaction-pass counter. |
+| `cayenne_compaction_memory_pool_bytes` | Gauge | By | Size of the dedicated compaction memory pool carved from the query memory limit (see `cayenne_compaction_memory_fraction`). |
+| `cayenne_compaction_memory_exhausted_total` | Counter | passes | Compaction passes that hit `ResourcesExhausted` on the dedicated compaction memory pool. |
+
+### Segment Cache Metrics
+
+The segment cache is the per-dataset Vortex decompressed-segment cache (`cayenne_segment_cache_mb`). The `accesses` and `hits` instruments are cumulative.
+
+| Metric | Type | Unit | Description |
+| ------ | ---- | ---- | ----------- |
+| `cayenne_segment_cache_accesses` | Gauge | accesses | Cumulative Vortex segment cache `get()` calls. |
+| `cayenne_segment_cache_hits` | Gauge | hits | Cumulative Vortex segment cache hits. (Hit rate = `hits / accesses`.) |
+| `cayenne_segment_cache_entries` | Gauge | entries | Live Vortex segment cache entry count. |
+| `cayenne_segment_cache_weighted_bytes` | Gauge | By | Live Vortex segment cache size in bytes. |
+| `cayenne_segment_cache_capacity_bytes` | Gauge | By | Configured Vortex segment cache capacity in bytes. |
 
 See [Component Metrics](../../../features/observability/component_metrics) for enabling and exporting metrics.
 

--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -47,10 +47,10 @@ Cayenne enforces single-writer-per-table concurrency via the metastore. Multiple
 
 Two in-memory caches tune the random-read vs memory tradeoff:
 
-| Parameter                    | Description                                                                       |
-| ---------------------------- | --------------------------------------------------------------------------------- |
-| `cayenne_footer_cache_mb`    | Footer cache (Vortex file footers). Low memory cost; enables fast plan-time decisions. |
-| `cayenne_segment_cache_mb`   | Segment (data page) cache. Set proportional to your hot working set.              |
+| Parameter                    | Scope                 | Description                                                                       |
+| ---------------------------- | --------------------- | --------------------------------------------------------------------------------- |
+| `cayenne_footer_cache_mb`    | `runtime.params`      | Engine-global footer cache (Vortex file footers), shared by all Cayenne datasets. Low memory cost; enables fast plan-time decisions. |
+| `cayenne_segment_cache_mb`   | `acceleration.params` | Per-dataset segment (data page) cache. Set proportional to your hot working set.  |
 
 For point-lookup-heavy workloads, size `cayenne_segment_cache_mb` generously — Vortex random-access reads are ~100× faster for cached segments than cold S3 reads.
 

--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -59,13 +59,23 @@ datasets:
       mode: file
 ```
 
-### `params`
+### Parameters
+
+Spice Cayenne is configured through two distinct parameter scopes:
+
+- **Acceleration parameters** are set per dataset under `acceleration.params` and control how that dataset's accelerated data is stored, compressed, written, and compacted.
+- **Runtime parameters** are set once per instance under `runtime.params` and control engine-global behavior — caches, optimizer rules, and dedicated memory pools — shared by every Cayenne-accelerated dataset.
+
+The two scopes are not interchangeable: setting a runtime parameter under `acceleration.params` (or a per-dataset parameter under `runtime.params`) has no effect — the value is ignored.
+
+#### Acceleration parameters (`acceleration.params`)
+
+Set under a dataset's `acceleration.params`:
 
 | Parameter                         | Description                                                                                                                                                                                   |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cayenne_compression_strategy`    | Compression algorithm for accelerated data. Defaults to `btrblocks`. Supports `btrblocks` or `zstd`.                                                                                          |
 | `cayenne_unsupported_type_action` | Action when an unsupported data type is encountered. Defaults to `error`. See [Data Type Support](#data-type-support).                                                                        |
-| `cayenne_footer_cache_mb`         | Size of the in-memory Vortex footer cache in megabytes. Larger values improve query performance for repeated scans. Defaults to `128`.                                                        |
 | `cayenne_segment_cache_mb`        | Size of the in-memory Vortex segment cache in megabytes, caching decompressed data segments for improved query performance. Defaults to `256`.                                                |
 | `cayenne_file_path`               | Custom path for storing Cayenne data files. Supports local paths or S3 Express One Zone URLs (e.g., `s3://bucket--usw2-az1--x-s3/prefix/`).                                                   |
 | `cayenne_target_file_size_mb`     | Target size for individual Vortex files in MB. When writes exceed this size, a new Vortex file is created. Defaults to `256`. Smaller files enable better parallelism and predicate pushdown. |
@@ -78,7 +88,9 @@ datasets:
 | `sort_columns`                    | Comma-separated list of columns to sort data by on refresh operations. Improves segment pruning for frequently filtered columns.                                                              |
 | `unsupported_type_action`         | Action when encountering unsupported data types. Options: `error` (default), `string`, `warn`, `ignore`.                                                                                      |
 
-### S3 Express One Zone Parameters
+##### S3 Express One Zone parameters
+
+These are acceleration parameters (set under `acceleration.params`) used when storing Cayenne data files in S3 Express One Zone:
 
 | Parameter                   | Description                                                                                                                                     |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -93,6 +105,37 @@ datasets:
 | `cayenne_s3_unsigned_payload` | Use unsigned payload for S3 Express One Zone requests. Defaults to `true`.                                                                    |
 | `cayenne_s3_allow_http`     | Set to `true` for testing with local S3-compatible storage. Defaults to `false`.                                                                |
 
+#### Runtime parameters (`runtime.params`)
+
+Set once under the top-level `runtime.params` and applied to every Cayenne-accelerated dataset in the instance. These are **not** valid under a dataset's `acceleration.params`:
+
+| Parameter                                  | Description                                                                                                                                                                                                                                                            |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cayenne_footer_cache_mb`                  | Size of the engine-wide in-memory Vortex footer cache in megabytes. The footer cache stores Vortex file metadata (schemas, statistics, encoding information) and is shared across all Cayenne datasets. Larger values improve query performance for repeated scans. Defaults to `128`. |
+| `cayenne_filter_propagation`               | Enables Cayenne's filter-propagation optimizer rules. Accepts `enabled` or `disabled`; defaults to `disabled`.                                                                                                                                                         |
+| `cayenne_optimizer_rules`                  | Selects which Cayenne optimizer rules run. Accepts `auto` (default — enables the recommended set, gated by `cayenne_filter_propagation`), `all`, `none` / `disabled`, or a comma-separated list of individual rule names.                                               |
+| `cayenne_compaction_memory_fraction`       | Fraction of the query memory pool carved out for a dedicated Cayenne compaction memory pool. Defaults to `0.2` and is clamped to a supported range. Only applied when at least one Cayenne-accelerated dataset is enabled and dedicated thread pools are not disabled. |
+| `cayenne_sort_merge_min_rows`              | Advanced anti-join tuning: row-count threshold above which the filter-propagation optimizer switches to a sort-merge strategy. Defaults to an internally tuned value; override only when profiling indicates a need.                                                    |
+| `cayenne_sort_merge_memory_pool_fraction`  | Advanced anti-join tuning: fraction of the memory pool the sort-merge anti-join strategy may use. Defaults to an internally tuned value.                                                                                                                                |
+
+```yaml
+runtime:
+  params:
+    # Engine-global Cayenne tuning, shared by every Cayenne-accelerated dataset
+    cayenne_footer_cache_mb: 512
+    cayenne_filter_propagation: enabled
+
+datasets:
+  - from: s3://analytics-bucket/events/
+    name: events
+    acceleration:
+      engine: cayenne
+      mode: file
+      params:
+        # Per-dataset Cayenne tuning
+        cayenne_segment_cache_mb: 1024
+```
+
 ## Performance Tuning
 
 Spice Cayenne performance can be optimized through cache configuration, compression strategy selection, and resource allocation.
@@ -101,17 +144,17 @@ Spice Cayenne performance can be optimized through cache configuration, compress
 
 Spice Cayenne uses two in-memory caches to accelerate query performance:
 
-**Footer Cache (`cayenne_footer_cache_mb`):**
+**Footer Cache (`cayenne_footer_cache_mb`) — runtime parameter:**
 
-The footer cache stores Vortex file metadata, including schemas, statistics, and encoding information. Larger cache sizes benefit workloads with many files.
+The footer cache stores Vortex file metadata, including schemas, statistics, and encoding information. It is engine-global and shared across every Cayenne-accelerated dataset, so it is set under `runtime.params`, not per dataset. Larger cache sizes benefit workloads with many files.
 
 - Default: 128 MB
 - Increase for datasets with many small files
 - Each file requires approximately 1-10 KB of footer cache
 
-**Segment Cache (`cayenne_segment_cache_mb`):**
+**Segment Cache (`cayenne_segment_cache_mb`) — acceleration parameter:**
 
-The segment cache stores decompressed data segments. Larger cache sizes benefit workloads with repeated queries on the same data.
+The segment cache stores decompressed data segments. It is configured per dataset under `acceleration.params`. Larger cache sizes benefit workloads with repeated queries on the same data.
 
 - Default: 256 MB
 - Increase for workloads with hot data patterns
@@ -120,6 +163,11 @@ The segment cache stores decompressed data segments. Larger cache sizes benefit 
 **Example - High-throughput configuration:**
 
 ```yaml
+runtime:
+  params:
+    # Engine-global footer cache, shared by all Cayenne datasets
+    cayenne_footer_cache_mb: 512
+
 datasets:
   - from: s3://analytics-bucket/events/
     name: events
@@ -127,7 +175,7 @@ datasets:
       engine: cayenne
       mode: file
       params:
-        cayenne_footer_cache_mb: 512
+        # Per-dataset segment cache
         cayenne_segment_cache_mb: 1024
 ```
 
@@ -490,6 +538,10 @@ Spice Cayenne manages memory efficiently through columnar storage and selective 
 **Example - Memory-constrained environment:**
 
 ```yaml
+runtime:
+  params:
+    cayenne_footer_cache_mb: 64
+
 datasets:
   - from: s3://my-bucket/data/
     name: constrained_data
@@ -497,7 +549,6 @@ datasets:
       engine: cayenne
       mode: file
       params:
-        cayenne_footer_cache_mb: 64
         cayenne_segment_cache_mb: 128
 ```
 
@@ -541,6 +592,9 @@ runtime:
   query:
     memory_limit: 4GiB
     temp_directory: /tmp/spice
+  params:
+    # Engine-global Cayenne runtime tuning (shared by all Cayenne datasets)
+    cayenne_footer_cache_mb: 256
 
 datasets:
   # Local file storage example with upsert
@@ -560,7 +614,6 @@ datasets:
       refresh_check_interval: 1h
       params:
         cayenne_compression_strategy: btrblocks
-        cayenne_footer_cache_mb: 256
         cayenne_segment_cache_mb: 512
         cayenne_target_file_size_mb: 64
         sort_columns: created_at,id

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -61,10 +61,10 @@ Spice Cayenne is DataFusion query-native, meaning all query execution adheres to
 
 **Memory Configuration Parameters:**
 
-| Parameter                  | Default | Description                                                                                                                                  |
-| -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cayenne_footer_cache_mb`  | `128`   | Size of the in-memory Vortex footer cache in megabytes. Larger values improve query performance for repeated scans by caching file metadata. |
-| `cayenne_segment_cache_mb` | `256`   | Size of the in-memory Vortex segment cache in megabytes. Caches decompressed data segments for improved query performance.                   |
+| Parameter                  | Scope                  | Default | Description                                                                                                                                  |
+| -------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cayenne_footer_cache_mb`  | `runtime.params`       | `128`   | Size of the engine-global in-memory Vortex footer cache in megabytes, shared by all Cayenne datasets. Larger values improve query performance for repeated scans by caching file metadata. |
+| `cayenne_segment_cache_mb` | `acceleration.params`  | `256`   | Per-dataset size of the in-memory Vortex segment cache in megabytes. Caches decompressed data segments for improved query performance.        |
 
 **Memory Usage Guidelines:**
 
@@ -76,6 +76,11 @@ Spice Cayenne is DataFusion query-native, meaning all query execution adheres to
 **Example Configuration:**
 
 ```yaml
+runtime:
+  params:
+    # Engine-global footer cache (shared by all Cayenne datasets)
+    cayenne_footer_cache_mb: 256
+
 datasets:
   - from: s3://my-bucket/large-dataset/
     name: large_dataset
@@ -83,7 +88,7 @@ datasets:
       engine: cayenne
       mode: file
       params:
-        cayenne_footer_cache_mb: 256
+        # Per-dataset segment cache
         cayenne_segment_cache_mb: 512
 ```
 

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -47,9 +47,13 @@ For point lookups on large datasets, Spice Cayenne often matches or exceeds the 
 
 ### Cache Configuration
 
-Spice Cayenne maintains two in-memory caches that significantly impact query performance:
+Spice Cayenne maintains two in-memory caches that significantly impact query performance. The footer cache is engine-global and set under `runtime.params`; the segment cache is configured per dataset under `acceleration.params`:
 
 ```yaml
+runtime:
+  params:
+    cayenne_footer_cache_mb: 256   # Engine-global; increase for many files
+
 datasets:
   - from: s3://bucket/data/
     name: analytics
@@ -57,8 +61,7 @@ datasets:
       engine: cayenne
       mode: file
       params:
-        cayenne_footer_cache_mb: 256   # Increase for many files
-        cayenne_segment_cache_mb: 512  # Increase for hot data patterns
+        cayenne_segment_cache_mb: 512  # Per-dataset; increase for hot data patterns
 ```
 
 **Footer Cache Sizing:**

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -170,6 +170,26 @@ SELECT ST_AsText(ST_Point(0.0, 0.0)) AS geom;
 -- POINT(0 0)
 ```
 
+### Spice Cayenne (engine-global)
+
+Engine-global tuning for the [Spice Cayenne](../../components/data-accelerators/cayenne) data accelerator. These apply to every Cayenne-accelerated dataset in the instance and are **not** valid under a dataset's `acceleration.params` (per-dataset Cayenne parameters are documented on the [Cayenne accelerator page](../../components/data-accelerators/cayenne#acceleration-parameters-accelerationparams)).
+
+| Parameter Name                            | Description                                                                                                                                                                                                              |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cayenne_footer_cache_mb`                 | Size of the engine-wide in-memory Vortex footer cache in megabytes, shared across all Cayenne datasets. Defaults to `128`.                                                                                              |
+| `cayenne_filter_propagation`              | Enables Cayenne's filter-propagation optimizer rules. Accepts `enabled` or `disabled`; defaults to `disabled`.                                                                                                          |
+| `cayenne_optimizer_rules`                 | Selects which Cayenne optimizer rules run. Accepts `auto` (default), `all`, `none` / `disabled`, or a comma-separated list of rule names.                                                                               |
+| `cayenne_compaction_memory_fraction`      | Fraction of the query memory pool reserved for the dedicated Cayenne compaction pool. Defaults to `0.2` (clamped to a supported range). Applied only when a Cayenne dataset is enabled and dedicated thread pools are not disabled. |
+| `cayenne_sort_merge_min_rows`             | Advanced anti-join tuning: row-count threshold above which filter propagation switches to a sort-merge strategy. Internally tuned default.                                                                              |
+| `cayenne_sort_merge_memory_pool_fraction` | Advanced anti-join tuning: fraction of the memory pool the sort-merge anti-join strategy may use. Internally tuned default.                                                                                             |
+
+```yaml
+runtime:
+  params:
+    cayenne_footer_cache_mb: 512
+    cayenne_filter_propagation: enabled
+```
+
 ## `runtime.source_rate_control`
 
 Optional. Configures how Spice limits outbound requests to upstream data sources, and optionally enables cluster-wide coordination through persisted state in object storage.


### PR DESCRIPTION
## Summary

The Cayenne docs conflated **runtime parameters** (engine-global, set under `runtime.params`) with **dataset/acceleration parameters** (per-dataset, set under `acceleration.params`). Most visibly, `cayenne_footer_cache_mb` was documented as an acceleration parameter and shown inside `acceleration.params:` in every example — but the runtime reads it **only** from `runtime.params` (`crates/runtime/src/builder.rs`; the catalog code literally logs `runtime.params.cayenne_footer_cache_mb`). Setting it under `acceleration.params` is silently ignored. Conversely, `cayenne_segment_cache_mb` genuinely *is* per-acceleration, so the two were wrongly lumped together.

## Authoritative split (verified against the implementation)

**Runtime parameters (`runtime.params`, engine-global):**
`cayenne_footer_cache_mb`, `cayenne_filter_propagation`, `cayenne_optimizer_rules`, `cayenne_compaction_memory_fraction`, `cayenne_sort_merge_min_rows`, `cayenne_sort_merge_memory_pool_fraction`

**Acceleration parameters (`acceleration.params`, per-dataset):**
`cayenne_segment_cache_mb`, `cayenne_compression_strategy`, `cayenne_file_path`, `cayenne_target_file_size_mb`, `cayenne_metadata_dir`, `cayenne_metastore`, `cayenne_upload_concurrency`, `cayenne_write_concurrency`, `cayenne_deletion_mode`, `cayenne_pk_conflict_detection`, `sort_columns`, `unsupported_type_action`, and all `cayenne_s3_*` parameters.

## Changes

- **`components/data-accelerators/cayenne/index.md`** — split the `params` section into **Acceleration parameters (`acceleration.params`)** and a new **Runtime parameters (`runtime.params`)** table; moved `cayenne_footer_cache_mb` to the runtime table; documented the previously-undocumented runtime knobs; nested the S3 params under acceleration; fixed every YAML example that placed footer cache under `acceleration.params`.
- **`reference/spicepod/runtime.md`** — added a **Spice Cayenne (engine-global)** subsection under `runtime.params` (previously had zero Cayenne entries), cross-linked to the accelerator page.
- **`reference/memory.md`**, **`reference/performance-tuning.md`**, **`components/data-accelerators/cayenne/deployment.md`** — added a Scope column / fixed the same footer-cache misplacement so every page agrees.

## Notes

- No new parameters or behavior — documentation accuracy only.
- Related runtime: the unknown-`runtime.params` startup validation in spiceai/spiceai PR #11133 makes mis-scoped Cayenne params surface as warnings, which this doc cleanup complements.
