### PR TITLE
docs(cli): fix login subcommand name delta_lake -> delta-lake

### DIFF
--- a/website/docs/cli/reference/login.md
+++ b/website/docs/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.10.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.11.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.5.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.5.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.6.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.6.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.7.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.7.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.8.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage

--- a/website/versioned_docs/version-1.9.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/login.md
@@ -26,7 +26,7 @@ spice login [command] [flags]
 
 - `abfs` Login to a Azure Storage Account
 - `databricks` Login to a Databricks instance
-- `delta_lake` Configure credentials to access a Delta Lake table
+- `delta-lake` Configure credentials to access a Delta Lake table
 - `dremio` Login to a Dremio instance
 - `postgres` Login to a Postgres instance
 - `s3` Login to an s3 storage


### PR DESCRIPTION
## Summary

The `spice login` reference listed the Delta Lake subcommand as `delta_lake` (underscore). The actual subcommand is `delta-lake` (kebab-case).

- **What the docs said:** "- `delta_lake` Configure credentials to access a Delta Lake table"
- **What the code does:** the subcommand variant is `DeltaLake(...)` (`bin/spice/src/commands/login/mod.rs:106`), which clap v4 renders as `delta-lake`. The crate's own help text already lists it as `delta-lake` (`mod.rs:63`). `spice login delta_lake` does not match the subcommand.

This is a long-standing naming error (clap has always rendered the variant kebab-case), so it is corrected across vNext and all versioned copies.

## Source
- spiceai/spiceai @ trunk -> `bin/spice/src/commands/login/mod.rs:63,106`

## Test plan
- [x] `cd website && npm run build` passes
- [x] Files updated: 8 (1 vNext + 7 versioned). The legitimate `delta_lake` data-connector/mode references elsewhere are unchanged.