### PR TITLE
docs(cli): correct spice run --metrics-endpoint default

### DIFF
--- a/website/docs/cli/reference/run.md
+++ b/website/docs/cli/reference/run.md
@@ -22,7 +22,7 @@ spice run [flags] -- [spiced flags]
 - `--endpoint` Configure the runtime endpoint. The URL scheme determines the endpoint type: `http://` or `https://` sets the HTTP endpoint, `grpc://` or `grpc+tls://` sets the Flight endpoint. Cannot be combined with `--http-endpoint` or `--flight-endpoint` for the same endpoint type.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 
 #### Spiced Flags
 

--- a/website/versioned_docs/version-1.10.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 

--- a/website/versioned_docs/version-1.11.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 
 #### Spiced Flags
 

--- a/website/versioned_docs/version-1.5.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.5.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 

--- a/website/versioned_docs/version-1.6.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.6.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 

--- a/website/versioned_docs/version-1.7.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.7.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 

--- a/website/versioned_docs/version-1.8.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 

--- a/website/versioned_docs/version-1.9.x/cli/reference/run.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/run.md
@@ -19,7 +19,7 @@ spice run [flags] -- [spiced flags]
 - `-h`, `--help` Print this help message.
 - `--flight-endpoint` Configure runtime Flight endpoint. Defaults to `http://127.0.0.1:50051`.
 - `--http-endpoint` Configure runtime HTTP endpoint. Defaults to `http://127.0.0.1:8090`.
-- `--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`.
+- `--metrics-endpoint` Configure the runtime Prometheus metrics endpoint (disabled by default).
 - `--open-telemetry-endpoint` Configure runtime OpenTelemetry endpoint. Defaults to `http://127.0.0.1:50052`.
 - `--captured-outputs` Configure the captured output setting for task history. Defaults to `truncated`.
 


### PR DESCRIPTION
## Summary

The `spice run --metrics-endpoint` flag was documented as defaulting to `http://127.0.0.1:9090`. There is no such default — the metrics endpoint is disabled unless the flag is set. The line also contradicted the adjacent `--metrics` entry, which already states "disabled by default".

- **What the docs said:** "`--metrics-endpoint` Configure runtime Prometheus metrics endpoint. Defaults to `http://127.0.0.1:9090`."
- **What the code does:** the flag is declared `#[arg(long)] metrics_endpoint: Option<String>` with no `default_value` (`bin/spice/src/commands/run.rs:63-65`), and `--metrics` is forwarded to spiced only when the user sets it (`run.rs:106-108` / current `:89-91`). spiced's own `--metrics` is disabled by default (`bin/spiced/src/lib.rs`). Verified identical behavior at `v1.11.6` and trunk. (The `:9090` in `bin/spice/src/context.rs` is the client's default HTTP endpoint for connecting to a running spiced — unrelated to metrics.)

Long-standing error → corrected across vNext and all versioned copies.

## Source
- spiceai/spiceai @ trunk -> `bin/spice/src/commands/run.rs:63-65,106-108`

## Test plan
- [x] `cd website && npm run build` passes
- [x] Files updated: 8 (1 vNext + 7 versioned)