### PR TITLE
docs(sqlite): document storage-profile-conditional busy_timeout default

### DIFF
--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -31,7 +31,7 @@ Use `mode: file` for any dataset larger than a few hundred MB or where restart s
 
 | Parameter         | Default  | Description                                                                                 |
 | ----------------- | -------- | ------------------------------------------------------------------------------------------- |
-| `busy_timeout` | `5000`   | Milliseconds SQLite will wait for a table lock before returning `SQLITE_BUSY`.              |
+| `busy_timeout` | `5000`   | Milliseconds SQLite will wait for a table lock before returning `SQLITE_BUSY`. Defaults to `15000` when the acceleration `storage_profile` resolves to EBS-class network storage. |
 
 Raise this when you observe `database is locked` errors under sustained concurrent refresh + read load.
 

--- a/website/docs/components/data-accelerators/sqlite/index.md
+++ b/website/docs/components/data-accelerators/sqlite/index.md
@@ -21,7 +21,7 @@ datasets:
 The connection to SQLite can be configured by providing the following `params`:
 
 - `sqlite_file`: The filename for the file to back the SQLite database. Only applies if `mode` is `file`.
-- `busy_timeout`: Optional. Specifies the duration for the SQLite [busy timeout](https://www.sqlite.org/c3ref/busy_timeout.html) when connecting to the database file. Default: 5000 ms.
+- `busy_timeout`: Optional. Specifies the duration for the SQLite [busy timeout](https://www.sqlite.org/c3ref/busy_timeout.html) when connecting to the database file. Default: 5000 ms, or 15000 ms when the acceleration `storage_profile` resolves to EBS-class network storage (where fsync latency spikes are more frequent).
 
 Configuration `params` are provided in the `acceleration` section of a dataset. Other common `acceleration` fields can be configured for sqlite, see see [datasets](../../reference/spicepod/datasets).
 


### PR DESCRIPTION
## Summary

The SQLite accelerator `busy_timeout` default was documented as `5000` ms unconditionally. The runtime applies a storage-profile-aware default: `5000` ms normally, but `15000` ms when the acceleration `storage_profile` resolves to EBS-class network storage (where fsync latency spikes are more frequent).

- **What the docs said:** "Default: 5000 ms." (unconditional)
- **What the code does:** `effective_busy_timeout` returns `Duration::from_millis(15_000)` for `ResolvedAccelerationStorage::Ebs` and the general `5000` ms otherwise, when the user has not explicitly set `busy_timeout` — `crates/runtime/src/dataaccelerator/sqlite.rs:166-196` (general default at `:155-163`).

This storage-profile tuning shipped in commit `9f6cfd14` ("Tune accelerators by storage profile", #10913), which is present only on trunk / `v2.0.0-rc.5` and **not** in any 1.x release (`v1.11.6` and earlier do not have it). The versioned 1.x docs correctly document the unconditional `5000` ms, so this is a vNext-only change.

## Source
- spiceai/spiceai @ trunk -> `crates/runtime/src/dataaccelerator/sqlite.rs:166-196`

## Test plan
- [x] `cd website && npm run build` passes
- [x] Files updated: 2 (vNext index.md + deployment.md; versioned docs intentionally untouched — feature not in 1.x)