### PR TITLE
docs(duckdb): document timezone-aware timestamp microsecond normalization

### DIFF
--- a/website/docs/components/data-accelerators/duckdb/index.md
+++ b/website/docs/components/data-accelerators/duckdb/index.md
@@ -70,6 +70,7 @@ Consider the following limitations when using DuckDB acceleration:
 
 - DuckDB does not support [enum and dictionary field types](https://duckdb.org/docs/sql/data_types/overview).
 - DuckDB's maximum decimal precision is 38 digits. `Decimal256` (76 digits) is unsupported.
+- Timezone-aware timestamp columns (e.g. a PostgreSQL `timestamptz` source) are stored at microsecond precision. DuckDB's `TIMESTAMP WITH TIME ZONE` type has no nanosecond variant, so a nanosecond-precision timezone-aware column is normalized to microsecond when accelerated, and sub-microsecond precision is not preserved. Timezone-naive timestamp columns are unaffected (DuckDB has a native nanosecond `TIMESTAMP_NS` type).
 - Queries using `on_zero_results: use_source` cannot filter binary columns directly (e.g., `WHERE col_blob <> ''`). Instead, cast binary columns to another type (e.g., `WHERE CAST(col_blob AS TEXT) <> ''`).
 - DuckDB indexes currently do not support spilling to disk.
 - Hot-reloading dataset configurations while the Spice Runtime is active disables DuckDB query federation until the runtime restarts.


### PR DESCRIPTION
## Summary

The DuckDB Data Accelerator stores timezone-aware timestamp columns at microsecond precision because DuckDB's `TIMESTAMP WITH TIME ZONE` type has no nanosecond variant. A source column registered as nanosecond-precision timezone-aware timestamp (e.g. a PostgreSQL `timestamptz`) is normalized to microsecond when accelerated; sub-microsecond precision is not preserved. Timezone-naive timestamps are unaffected (DuckDB has a native `TIMESTAMP_NS` type).

This behavior was not documented. Adds a line to the DuckDB accelerator **Limitations** section alongside the existing precision/type quirks (decimal precision, enum/dictionary support).

## Source PRs

- spiceai/spiceai#11145 — fix(duckdb): normalize timestamp columns to microsecond precision (fixes #10627)

## Notes

- Addition (newly-introduced behavior), so vNext only — older versioned docs predate the fix and their runtimes do not perform this normalization.
- Verified against the source PR's type-mapping rule (`TimestampTzToMicrosecond` in `DUCKDB_TYPE_REWRITE_RULES`) and DuckDB's documented type model (`TIMESTAMPTZ` = microsecond, `TIMESTAMP_NS` = nanosecond timezone-naive).

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — addition, vNext only
- [x] Files updated: 1