### PR TITLE
fix(versions): keep v1.11.x maintained after v2.0

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -43,6 +43,11 @@ const sortedVersions = [...versions].sort((a, b) => {
 const latestVersion = sortedVersions[0] || null
 const latestVer = latestVersion ? getVersion(latestVersion) : { major: 0, minor: 0 }
 
+// Final release of the previous major stays maintained through the transition
+// (e.g. v1.11.x remains maintained after v2.0 ships as latest). sortedVersions is
+// major-desc, so the first entry below the latest major is that major's newest release.
+const prevMajorLatest = sortedVersions.find((v) => getVersion(v).major < latestVer.major) || null
+
 const docsVersionConfig = hasVersions
   ? {
       lastVersion: latestVersion!, // The stable release is the default
@@ -57,10 +62,12 @@ const docsVersionConfig = hasVersions
           versions.map((version) => {
             const ver = getVersion(version)
             const isLatest = version === latestVersion
-            // Versions within same major and latest minor - 1 are maintained (no banner)
+            // Maintained (no banner): the latest major's current + previous minor,
+            // plus the final release of the previous major (e.g. v1.11.x under v2.0).
             const isMaintained =
               ver.major > latestVer.major ||
-              (ver.major === latestVer.major && ver.minor >= latestVer.minor - 1)
+              (ver.major === latestVer.major && ver.minor >= latestVer.minor - 1) ||
+              version === prevMajorLatest
 
             return [
               version,


### PR DESCRIPTION
## What

Extends the maintenance-banner rule in `docusaurus.config.ts` so the **final release of the previous major** stays maintained alongside the latest major.

Now that **v2.0** is the latest version, the prior logic marked **all** 1.x versions `unmaintained` (it only kept the latest major's `minor >= latest.minor - 1`). This keeps **v1.11.x** maintained through the major transition; v1.10.x and earlier remain unmaintained.

## How

```ts
// Final release of the previous major stays maintained through the transition
// (e.g. v1.11.x remains maintained after v2.0 ships as latest).
const prevMajorLatest = sortedVersions.find((v) => getVersion(v).major < latestVer.major) || null
// ...
const isMaintained =
  ver.major > latestVer.major ||
  (ver.major === latestVer.major && ver.minor >= latestVer.minor - 1) ||
  version === prevMajorLatest
```

Generic — no hardcoded version. `prevMajorLatest` resolves to the newest release below the latest major (the version list is sorted major-desc), so this self-adjusts on future releases.

## Verification

`npm run build` is green. Banner check on the built output:

| Version | Banner |
|---|---|
| v2.0 (latest) | none |
| **v1.11** | **none — now maintained** |
| v1.10 | unmaintained (control — confirms scope) |
