### PR TITLE
docs: update spicepod examples from v1beta1 to v1 for v2.0

### DIFF
--- a/website/docs/components/data-connectors/redshift.md
+++ b/website/docs/components/data-connectors/redshift.md
@@ -16,7 +16,7 @@ Use the format `postgres:schema.table` to reference a Redshift table. The connec
 ### Example Spicepod
 
 ```yaml
-version: v1beta1
+version: v1
 kind: Spicepod
 name: tpch-read
 datasets:

--- a/website/docs/deployment/aws/integrations.md
+++ b/website/docs/deployment/aws/integrations.md
@@ -367,7 +367,7 @@ aws configure
 
 ```yaml
 # spicepod.yaml
-version: v1beta1
+version: v1
 kind: Spicepod
 name: aws_quickstart
 


### PR DESCRIPTION
## Summary

Two Spicepod examples in the vNext docs declare `version: v1beta1`. Per the v2.0.0 release notes, the `v1beta1` Spicepod version is **removed / no longer accepted** in v2.0 — these examples fail to load on a v2.0 runtime. Updated both to `version: v1` (the convention used by every other connector doc; `v1` remains supported with auto-migration in v2.0).

- `website/docs/components/data-connectors/redshift.md` — `version: v1beta1` → `version: v1`
- `website/docs/deployment/aws/integrations.md` — `version: v1beta1` → `version: v1`

## Source

- v2.0.0 release notes, Breaking Changes / Spicepod v2: "`v1beta1` | Removed. No longer accepted." (spiceai/spiceai `docs/release_notes/v2.0.0.md`)

## Scope / propagation

- **Version-specific** → vNext only. Versioned 1.x docs (where `v1beta1` was still accepted) are intentionally untouched.
- Excluded `deployment/kubernetes/flux/index.md`, whose `v1beta1` is a Kubernetes `kustomize.config.k8s.io/v1beta1` apiVersion — unrelated to Spicepod.
- Cross-grep confirms no remaining `^version: v1beta1` Spicepod examples in vNext.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext only
- [x] Files updated: 2