### PR TITLE
docs: remove -models image tags for v2.0 (AI in default image)

### DIFF
--- a/website/docs/deployment/azure/index.md
+++ b/website/docs/deployment/azure/index.md
@@ -201,7 +201,7 @@ az containerapp create \
   --name spiceai \
   --resource-group $RG \
   --environment $ENV \
-  --image spiceai/spiceai:1.11.5-models \
+  --image spiceai/spiceai:2.0.0 \
   --target-port 8090 \
   --ingress external \
   --transport http \

--- a/website/docs/deployment/docker/index.md
+++ b/website/docs/deployment/docker/index.md
@@ -30,13 +30,7 @@ Spice listens on three ports:
 - `9090` — Prometheus metrics (optional)
 - `50051` — Arrow Flight (gRPC) for high-throughput query results
 
-To use AI features (embeddings, models, search), substitute the `latest-models` tag:
-
-```bash
-docker run --rm -it -p 8090:8090 -p 50051:50051 \
-  -v "$(pwd)":/app \
-  spiceai/spiceai:latest-models
-```
+As of Spice v2.0, AI features (embeddings, local model inference, search) are included in the default image — no separate tag is required. The data-only image, without AI/ML dependencies, is published only in nightly builds for open source and is available as a production-ready distribution through [Spice Cloud and Spice.ai Enterprise](https://spice.ai/pricing).
 
 Browse all published tags at [hub.docker.com/r/spiceai/spiceai/tags](https://hub.docker.com/r/spiceai/spiceai/tags).
 
@@ -48,17 +42,19 @@ Browse all published tags at [hub.docker.com/r/spiceai/spiceai/tags](https://hub
 
 ## Image Tags
 
-| Tag                | Description                                                                                        |
-| ------------------ | -------------------------------------------------------------------------------------------------- |
-| `latest`           | Latest stable release. Excludes large model dependencies for a smaller image.                      |
-| `latest-models`    | Latest stable release including AI features (embeddings, local model inference, vector search).    |
-| `<version>`        | A specific stable release, e.g. `1.11.5`. Recommended for production for reproducible deployments. |
-| `<version>-models` | A specific stable release with AI features included.                                               |
+| Tag         | Description                                                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `latest`    | Latest stable release. Includes AI features (embeddings, local model inference, vector search) by default.                 |
+| `<version>` | A specific stable release, e.g. `2.0.0`. Recommended for production for reproducible deployments.                          |
+
+:::note
+The `-models` image tags were removed in Spice v2.0 — AI/ML support is now part of the default image. The data-only image (without AI/ML dependencies) is published only in nightly builds for open source.
+:::
 
 Pin to a specific version in production to avoid unexpected upgrades:
 
 ```bash
-docker run -p 8090:8090 spiceai/spiceai:1.11.5
+docker run -p 8090:8090 spiceai/spiceai:2.0.0
 ```
 
 ## Run with Docker Compose
@@ -98,9 +94,9 @@ docker compose up
 For deployments that ship a Spicepod and data with the runtime, build a custom image that copies them in:
 
 ```dockerfile
-# Use spiceai/spiceai:latest-models for AI features.
+# AI features are included in the default image as of Spice v2.0.
 # See https://hub.docker.com/r/spiceai/spiceai/tags for all tags.
-FROM spiceai/spiceai:1.11.5
+FROM spiceai/spiceai:2.0.0
 
 WORKDIR /app
 

--- a/website/docs/deployment/gcp/index.md
+++ b/website/docs/deployment/gcp/index.md
@@ -170,7 +170,7 @@ Cloud Run pulls the [Spice.ai container image](https://hub.docker.com/r/spiceai/
 gcloud run deploy spiceai \
   --project $PROJECT \
   --region $REGION \
-  --image spiceai/spiceai:1.11.5-models \
+  --image spiceai/spiceai:2.0.0 \
   --port 8090 \
   --service-account spiceai-runtime@${PROJECT}.iam.gserviceaccount.com \
   --min-instances 1 --max-instances 5 \

--- a/website/docs/deployment/kubernetes/argocd/index.md
+++ b/website/docs/deployment/kubernetes/argocd/index.md
@@ -92,7 +92,7 @@ spec:
         replicaCount: 1
         image:
           repository: spiceai/spiceai
-          tag: latest-models
+          tag: latest
         spicepod:
           name: app
           version: v1

--- a/website/docs/deployment/kubernetes/flux/index.md
+++ b/website/docs/deployment/kubernetes/flux/index.md
@@ -125,7 +125,7 @@ spec:
     replicaCount: 1
     image:
       repository: spiceai/spiceai
-      tag: latest-models
+      tag: latest
     spicepod:
       name: app
       version: v1

--- a/website/docs/deployment/kubernetes/helm/index.md
+++ b/website/docs/deployment/kubernetes/helm/index.md
@@ -173,7 +173,7 @@ The Helm convention is to use a file called `values.yaml`, but any file name can
 | `additionalLabels`              | Additional labels to add to all resources.                                                                                                                                                | `{}`              |
 | `image.pullSecrets`             | Specify Docker registry secret names as an array.                                                                                                                                         | `[]`              |
 | `image.repository`              | The repository of the Docker image.                                                                                                                                                       | `spiceai/spiceai` |
-| `image.tag`                     | Replace with a specific version of Spice.ai to run.                                                                                                                                       | `latest-models`   |
+| `image.tag`                     | Replace with a specific version of Spice.ai to run.                                                                                                                                       | `latest`          |
 | `monitoring.podMonitor.enabled` | Enable Prometheus metrics collection for the Spice pods. Requires the [Prometheus Operator](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.PodMonitor) CRDs. | `false`           |
 | `replicaCount`                  | Number of Spice.ai replicas to run.                                                                                                                                                       | `1`               |
 | `resources`                     | Resource requests and limits for the Spice.ai container. See [Container resource examples](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#example-1).     | `{}`              |
@@ -393,7 +393,7 @@ additionalLabels:
 
 image:
   repository: spiceai/spiceai
-  tag: latest-models
+  tag: latest
 replicaCount: 1
 
 service:

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -350,7 +350,7 @@ metadata:
 spec:
   containers:
     - name: spice
-      image: spiceai/spiceai:latest-models
+      image: spiceai/spiceai:latest
       resources:
         requests:
           memory: '8Gi'

--- a/website/docs/reference/system_requirements.md
+++ b/website/docs/reference/system_requirements.md
@@ -63,7 +63,7 @@ metadata:
 spec:
   containers:
     - name: spice-ai-container
-      image: spiceai/spiceai:latest-models
+      image: spiceai/spiceai:latest
       resources:
         requests:
           memory: '8Gi'


### PR DESCRIPTION
## Summary

Spice v2.0 removed the separate `models` build variant — AI/ML support (embeddings, local model inference, search) is now included in the **default** image and build. The `-models` Docker image tags (`latest-models`, `<version>-models`) are no longer published. The vNext deployment and reference docs still instruct users to use these removed tags and still describe the default `latest` image as excluding models.

This corrects every vNext page that references a `-models` tag or the old "default excludes models" model:

- `deployment/docker/index.md` — rewrote the "use `latest-models` for AI" instructions, the **Image Tags** table (removed the two `-models` rows; `latest` now documented as including AI; added a v2.0 note), and the custom-image example.
- `deployment/azure/index.md`, `deployment/gcp/index.md` — `spiceai/spiceai:1.11.5-models` → `spiceai/spiceai:2.0.0`.
- `deployment/kubernetes/{flux,argocd}/index.md` — `tag: latest-models` → `tag: latest`.
- `deployment/kubernetes/helm/index.md` — `image.tag` default and example `latest-models` → `latest`.
- `reference/memory.md`, `reference/system_requirements.md` — pod-spec examples `spiceai/spiceai:latest-models` → `latest`.

## Source

- v2.0.0 release notes, **Distribution Changes** / **Breaking Changes**: "The separate `models` build variant has been removed… AI/ML support… is now included in the default Spice build and image." (spiceai/spiceai `docs/release_notes/v2.0.0.md`)
- Released chart `deploy/chart/values.yaml` @ `v2.0.0` defaults to `repository: spiceai/spiceai`, `tag: 2.0.0` (no `-models`) — confirms the `-models` tag is gone for the release.

## Scope / propagation

- **Version-specific (v2.0)** → vNext only. Versioned 1.x docs correctly keep `-models` (those releases published the variant) and are left untouched.
- Final grep confirms no `-models` tag references remain anywhere in `website/docs/`.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext only
- [x] Files updated: 8 (cross-page sweep, no follow-up needed)