### PR TITLE
docs(cosmosdb): remove inaccurate _search task-history reference

### DIFF
--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -122,7 +122,7 @@ For broader observability, also monitor:
 
 ## Task History
 
-Cosmos DB requests participate in [task history](../../../reference/task_history) through the connector span. Each `_search` and `query` call is a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
+Cosmos DB requests participate in [task history](../../../reference/task_history) through the connector span. Each query is captured as a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
 
 ## Known Limitations
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
@@ -122,7 +122,7 @@ For broader observability, also monitor:
 
 ## Task History
 
-Cosmos DB requests participate in [task history](../../../reference/task_history) through the connector span. Each `_search` and `query` call is a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
+Cosmos DB requests participate in [task history](../../../reference/task_history) through the connector span. Each query is captured as a child of the enclosing `sql_query` or `accelerated_table_refresh` task.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

The CosmosDB connector **deployment guide**'s _Task History_ section claimed:

> Each `_search` and `query` call is a child of the enclosing `sql_query` or `accelerated_table_refresh` task.

**What the code does:** the CosmosDB connector is a **read-only document scan** connector — no filter/projection/limit pushdown, no write path, and **no search operation**. The `_search` task type is a runtime full-text/vector-search UDTF (`text_search` / `vector_search`), which lives in the search/vector engine and is unrelated to any data connector. There is no `_search` instrumentation anywhere in the cosmos module (`crates/data_components/src/cosmosdb/*`) or its runtime connector layer.

The sibling SQL/HTTP connector deployment guides (Dremio, GitHub, GraphQL) describe their operations as child spans of `sql_query` / `accelerated_table_refresh` **without** referencing `_search`. This change aligns the CosmosDB wording with that established template.

**Change:** ``Each `_search` and `query` call is a child...`` -> ``Each query is captured as a child...``

## Source ref

- `spiceai/spiceai` @ `trunk` (2.0.0-unstable): no `_search`/span instrumentation in `crates/data_components/src/cosmosdb/`; `_search` originates from `crates/runtime/src/cluster/datafusion/codec/udtf_args.rs` (`text_search`/`vector_search` UDTFs).

## Test plan

- [x] `cd website && npm run build` passes (no broken links / undefined tags)
- [x] Versioned-docs propagation checked: claim existed only in vNext + `version-2.0.x` (CosmosDB is a 2.0 feature; older versions have no cosmosdb page). Both fixed; grep for the bad string returns 0.
- [x] Files updated: 2 (vNext + version-2.0.x)