### PR TITLE
docs(unity-catalog): document unity_catalog_credential_vending param

### DIFF
--- a/website/docs/components/catalogs/unity-catalog/index.md
+++ b/website/docs/components/catalogs/unity-catalog/index.md
@@ -46,6 +46,18 @@ Use the `include` field to specify which tables to include from the catalog. The
 The `params` field is used to configure the connection to the Unity Catalog. The following parameters are supported:
 
 - `unity_catalog_token`: The [personal access token](https://docs.unitycatalog.io/server/auth/#use-admin-token-to-verify-admin-user-is-in-local-database) used to authenticate against the Unity Catalog API.
+- `unity_catalog_credential_vending`: When set to `enabled`, short-lived storage credentials for each table are fetched from the Unity Catalog [credential vending](https://docs.databricks.com/api/workspace/temporarytablecredentials) API instead of using the static storage credentials in `dataset_params`. Defaults to `disabled`. Works with both Databricks Unity Catalog and OSS Unity Catalog.
+
+When credential vending is enabled, the static object-store credentials below (`unity_catalog_aws_*`, `unity_catalog_azure_*`, `unity_catalog_google_*`) are not required:
+
+```yaml
+catalogs:
+  - from: unity_catalog:https://<host>/api/2.1/unity-catalog/catalogs/my_catalog
+    name: uc
+    params:
+      unity_catalog_token: ${secrets:UC_TOKEN}
+      unity_catalog_credential_vending: enabled
+```
 
 ## `dataset_params`
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11180](https://github.com/spiceai/spiceai/pull/11180) added Unity Catalog credential vending. The merged docs PR #1818 documented the `databricks` side (`databricks_credential_vending`) but left the `unity_catalog` catalog page untouched, so `unity_catalog_credential_vending` was undocumented.

This adds the `unity_catalog_credential_vending` parameter under the catalog's `params`. When `enabled`, short-lived per-table storage credentials are fetched from the Unity Catalog `temporary-table-credentials` API instead of using the static `unity_catalog_aws_*` / `unity_catalog_azure_*` / `unity_catalog_google_*` credentials in `dataset_params`.

Verified against source:
- `unity_catalog.rs`: `ParameterSpec::component("credential_vending")` → auto-prefixed to `unity_catalog_credential_vending`
- Accepts `enabled` / `disabled`; `None | Some("disabled") => false`, so default is `disabled`
- Unlike the databricks connector, the unity_catalog connector's ParameterSpec has no `mode: delta_lake` requirement in its description
- PR description confirms it works with both Databricks Unity Catalog and OSS Unity Catalog

## Source PRs
- spiceai/spiceai#11180 — feat(unity_catalog): support Unity Catalog credential vending for Delta Lake tables

## Test plan
- [x] `cd website && npm run build` passes
- [x] Addition (new feature) → vNext only (older versions lack the param)
- [x] Files updated: 1