### PR TITLE
docs(cdc): document apply-loop coalescing runtime.params

### DIFF
--- a/website/docs/features/cdc/index.md
+++ b/website/docs/features/cdc/index.md
@@ -29,6 +29,26 @@ It is recommended to use CDC-accelerated datasets with persistent data accelerat
 
 :::
 
+## Tuning ingestion
+
+Spice applies CDC events through a single apply loop that coalesces a contiguous run of buffered change events ("envelopes") into one accelerator write. The coalescing behavior is controlled by the following instance-wide `runtime.params` (set once under the top-level `runtime.params`, not per-dataset). Each parameter also accepts a `SPICE_`-prefixed environment variable; the `runtime.params` value takes precedence, falling back to the environment variable, then the default.
+
+| Parameter                     | Description                                                                                                                                                                                                                                                                                                                              | Default               |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `cdc_prefetch_buffer`         | Number of source change events buffered ahead of the apply loop. Range `1`–`16384`.                                                                                                                                                                                                                                                     | `128`                 |
+| `cdc_max_coalesced_envelopes` | Maximum number of change events combined into a single accelerator write. Range `1`–`16384`.                                                                                                                                                                                                                                            | `256`                 |
+| `cdc_max_coalesced_bytes`     | Maximum in-memory Arrow size (bytes) of a single coalesced write. Range `1`–`1073741824` (1 GiB).                                                                                                                                                                                                                                       | `134217728` (128 MiB) |
+| `cdc_max_coalesce_age_ms`     | Apply-loop linger window in milliseconds. When `> 0`, the loop keeps accumulating change events into one write until the envelope cap, the byte budget, or this window elapses — whichever comes first. The window is measured from the start of the previous apply. `0` disables lingering, so each buffered event is applied as soon as it arrives. | `0` (no linger)       |
+| `cdc_commit_timeout_ms`       | Maximum time to wait for the previous source-side commit before surfacing ingestion as stalled. Range `1`–`3600000` (1 hour).                                                                                                                                                                                                           | `30000` (30s)         |
+
+```yaml
+runtime:
+  params:
+    cdc_max_coalesce_age_ms: 250 # linger up to 250ms to coalesce slowly-arriving events into fewer writes
+```
+
+Out-of-range or unparseable values are rejected with a warning and fall back to the default.
+
 ## Supported Data Connectors
 
 Enabling CDC by setting `refresh_mode: changes` in the acceleration settings requires support from the data connector to provide a stream of row-level changes.


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11196](https://github.com/spiceai/spiceai/pull/11196) made `cdc_max_coalesce_age_ms` a real apply-loop linger window. This and the rest of the CDC apply-loop coalescing knobs (`cdc_prefetch_buffer`, `cdc_max_coalesced_envelopes`, `cdc_max_coalesced_bytes`, `cdc_commit_timeout_ms`) were previously undocumented.

Adds a "Tuning ingestion" section to the CDC feature page documenting the full family of instance-wide `runtime.params`.

Verified against `crates/runtime/src/accelerated_table/refresh_task/changes.rs` (`cdc_config_from_params`):
- Param names + `SPICE_`-prefixed env fallbacks read in `cdc_config_from_params`; `runtime.params` value takes precedence over env (`resolve_cdc_param` / `resolve_cdc_param_u64`)
- Defaults: `CDC_PREFETCH_BUFFER_DEFAULT=128`, `CDC_MAX_COALESCED_ENVELOPES_DEFAULT=256`, `CDC_MAX_COALESCED_BYTES_DEFAULT=128*1024*1024`, `CDC_MAX_COALESCE_AGE_MS_DEFAULT=0`, `CDC_COMMIT_TIMEOUT_MS_DEFAULT=30_000`
- Ranges: prefetch/envelopes max `16384`, bytes max `1024*1024*1024`, commit timeout max `3_600_000`; `cdc_max_coalesce_age_ms` is a `u64` with no upper bound
- `cdc_max_coalesce_age_ms` semantics (linger only when `> 0`, deadline anchored at start of previous apply, `0` = apply immediately) from the new apply-loop comments and tests

## Source PRs
- spiceai/spiceai#11196 — feat(cdc): make cdc_max_coalesce_age_ms a real apply-loop linger

## Test plan
- [x] `cd website && npm run build` passes
- [x] Addition (newly-documented params; `cdc_max_coalesce_age_ms` behavior is new) → vNext only
- [x] Files updated: 1