### PR TITLE
docs(dynamodb): remove unused dynamodb:ListStreams IAM permission

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/deployment.md
+++ b/website/docs/components/data-connectors/dynamodb/deployment.md
@@ -24,7 +24,7 @@ DynamoDB authentication uses the standard AWS credential chain. Configure via th
 | `dynamodb_aws_secret_access_key` | Explicit secret key (optional).                                                                   |
 | `dynamodb_aws_session_token` | Session token for temporary credentials (optional).                                                  |
 
-For production on EKS/ECS, leave access-key parameters unset and rely on instance-profile, IRSA, or ECS task-role credentials. Grant the role `dynamodb:Scan`, `dynamodb:Query`, and `dynamodb:DescribeTable` on the table; for streams, additionally grant `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, `dynamodb:GetRecords`, and `dynamodb:ListStreams`.
+For production on EKS/ECS, leave access-key parameters unset and rely on instance-profile, IRSA, or ECS task-role credentials. Grant the role `dynamodb:Scan`, `dynamodb:Query`, and `dynamodb:DescribeTable` on the table; for streams, additionally grant `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, and `dynamodb:GetRecords`.
 
 Secrets should be sourced from a [secret store](../../secret-stores/) when not using IAM role auth.
 
@@ -90,5 +90,5 @@ Stream polling and bootstrap operations emit spans that participate in [task his
 | Dataset stuck in `Error` after restart with stream enabled | Checkpoint older than 18h or exceeded 24h retention.              | Set `lag_exceeds_shard_retention_behavior: ready_after_load` to auto-recover, or trigger a manual refresh.   |
 | `ProvisionedThroughputExceededException`         | RCU exhausted during initial scan.                                     | Switch to on-demand billing, raise RCU for the refresh window, or slow the refresh via acceleration settings.    |
 | `TrimmedDataAccessException`                     | Records trimmed from the stream before they could be processed.        | Same recovery path as `ShardNotFound` — re-bootstrap. Reduce bootstrap duration via parallel segments if supported. |
-| `AccessDeniedException` on `DescribeStream`      | IAM role lacks stream permissions.                                     | Add `dynamodb:DescribeStream`, `GetShardIterator`, `GetRecords`, `ListStreams` to the role.                     |
+| `AccessDeniedException` on `DescribeStream`      | IAM role lacks stream permissions.                                     | Add `dynamodb:DescribeStream`, `GetShardIterator`, `GetRecords` to the role.                     |
 | `ResourceNotFoundException` on stream start      | Stream not enabled on the table.                                       | Enable streams on the DynamoDB table (`NEW_AND_OLD_IMAGES` recommended).                                         |

--- a/website/docs/features/cdc/dynamodb-streams.md
+++ b/website/docs/features/cdc/dynamodb-streams.md
@@ -60,8 +60,7 @@ The credentials Spice uses need both table and stream actions:
         "dynamodb:Scan",
         "dynamodb:DescribeStream",
         "dynamodb:GetShardIterator",
-        "dynamodb:GetRecords",
-        "dynamodb:ListStreams"
+        "dynamodb:GetRecords"
       ],
       "Resource": [
         "arn:aws:dynamodb:*:*:table/orders",

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dynamodb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dynamodb/deployment.md
@@ -24,7 +24,7 @@ DynamoDB authentication uses the standard AWS credential chain. Configure via th
 | `dynamodb_aws_secret_access_key` | Explicit secret key (optional).                                                                   |
 | `dynamodb_aws_session_token` | Session token for temporary credentials (optional).                                                  |
 
-For production on EKS/ECS, leave access-key parameters unset and rely on instance-profile, IRSA, or ECS task-role credentials. Grant the role `dynamodb:Scan`, `dynamodb:Query`, and `dynamodb:DescribeTable` on the table; for streams, additionally grant `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, `dynamodb:GetRecords`, and `dynamodb:ListStreams`.
+For production on EKS/ECS, leave access-key parameters unset and rely on instance-profile, IRSA, or ECS task-role credentials. Grant the role `dynamodb:Scan`, `dynamodb:Query`, and `dynamodb:DescribeTable` on the table; for streams, additionally grant `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, and `dynamodb:GetRecords`.
 
 Secrets should be sourced from a [secret store](../../secret-stores/) when not using IAM role auth.
 
@@ -90,5 +90,5 @@ Stream polling and bootstrap operations emit spans that participate in [task his
 | Dataset stuck in `Error` after restart with stream enabled | Checkpoint older than 18h or exceeded 24h retention.              | Set `lag_exceeds_shard_retention_behavior: ready_after_load` to auto-recover, or trigger a manual refresh.   |
 | `ProvisionedThroughputExceededException`         | RCU exhausted during initial scan.                                     | Switch to on-demand billing, raise RCU for the refresh window, or slow the refresh via acceleration settings.    |
 | `TrimmedDataAccessException`                     | Records trimmed from the stream before they could be processed.        | Same recovery path as `ShardNotFound` — re-bootstrap. Reduce bootstrap duration via parallel segments if supported. |
-| `AccessDeniedException` on `DescribeStream`      | IAM role lacks stream permissions.                                     | Add `dynamodb:DescribeStream`, `GetShardIterator`, `GetRecords`, `ListStreams` to the role.                     |
+| `AccessDeniedException` on `DescribeStream`      | IAM role lacks stream permissions.                                     | Add `dynamodb:DescribeStream`, `GetShardIterator`, `GetRecords` to the role.                     |
 | `ResourceNotFoundException` on stream start      | Stream not enabled on the table.                                       | Enable streams on the DynamoDB table (`NEW_AND_OLD_IMAGES` recommended).                                         |

--- a/website/versioned_docs/version-2.0.x/features/cdc/dynamodb-streams.md
+++ b/website/versioned_docs/version-2.0.x/features/cdc/dynamodb-streams.md
@@ -60,8 +60,7 @@ The credentials Spice uses need both table and stream actions:
         "dynamodb:Scan",
         "dynamodb:DescribeStream",
         "dynamodb:GetShardIterator",
-        "dynamodb:GetRecords",
-        "dynamodb:ListStreams"
+        "dynamodb:GetRecords"
       ],
       "Resource": [
         "arn:aws:dynamodb:*:*:table/orders",


### PR DESCRIPTION
## Summary

The DynamoDB CDC docs instruct users to grant `dynamodb:ListStreams`, but the connector never calls the DynamoDB Streams `ListStreams` API. It discovers the stream ARN via `DescribeTable` (`table.latest_stream_arn`) and then reads with `DescribeStream` / `GetShardIterator` / `GetRecords`. Granting `ListStreams` is unnecessary and over-broad.

This also reconciles an internal contradiction: the connector reference page (`dynamodb/index.md`) already lists only `DescribeStream`, `GetShardIterator`, `GetRecords` for streams — it never included `ListStreams`. Only the deployment guide and the CDC feature page did.

**What the docs said:** stream access requires `dynamodb:DescribeStream`, `dynamodb:GetShardIterator`, `dynamodb:GetRecords`, **and `dynamodb:ListStreams`**.
**What the code does:** no `ListStreams`/`list_streams` call exists anywhere in the connector or the `dynamodb-streams` crate. SDK operations used: `describe_table`, `describe_stream`, `get_shard_iterator`, `get_records`, `scan`, `query`.

**What changed:** removed `dynamodb:ListStreams` from the CDC IAM policy JSON, the deployment-guide prose, and the deployment-guide troubleshooting row — in vNext and the version-2.0.x copies (DynamoDB docs exist only in 2.0.x + vNext).

## Source ref

`spiceai/spiceai` @ `trunk` (7a7313b5a):
- `crates/dynamodb-streams/src/client_sdk.rs:49-57` — stream ARN via `describe_table().latest_stream_arn`
- `crates/data_components/src/dynamodb/provider.rs:304,348,366` — `describe_table` / `latest_stream_arn`
- repo-wide grep for `list_streams`/`ListStreams` (DynamoDB Streams API) → no call sites

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] Versioned-docs propagation checked — `grep -rn ListStreams website/docs website/versioned_docs` returns 0 hits
- [x] Files updated: 4 (2 vNext + 2 version-2.0.x)