### PR TITLE
docs(delta-lake): clarify Databricks UC credential vending is opt-in

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/deployment.md
+++ b/website/docs/components/data-connectors/delta-lake/deployment.md
@@ -28,7 +28,7 @@ Credentials must be sourced from a [secret store](../../secret-stores/) in produ
 
 ### Databricks Unity Catalog
 
-To access Delta tables registered in Unity Catalog, use the [Databricks connector](../databricks) in `mode: delta_lake`. It handles UC metadata resolution and credential vending automatically — see the [Databricks Deployment Guide](../databricks/deployment) for details.
+To access Delta tables registered in Unity Catalog, use the [Databricks connector](../databricks) in `mode: delta_lake`. It handles UC metadata resolution automatically, and can optionally fetch short-lived storage credentials via Unity Catalog credential vending when `databricks_credential_vending: enabled` is set (defaults to `disabled`) — see the [Databricks Deployment Guide](../databricks/deployment) for details.
 
 ## Resilience Controls
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
@@ -28,7 +28,7 @@ Credentials must be sourced from a [secret store](../../secret-stores/) in produ
 
 ### Databricks Unity Catalog
 
-To access Delta tables registered in Unity Catalog, use the [Databricks connector](../databricks) in `mode: delta_lake`. It handles UC metadata resolution and credential vending automatically — see the [Databricks Deployment Guide](../databricks/deployment) for details.
+To access Delta tables registered in Unity Catalog, use the [Databricks connector](../databricks) in `mode: delta_lake`. It handles UC metadata resolution automatically — see the [Databricks Deployment Guide](../databricks/deployment) for details.
 
 ## Resilience Controls
 


### PR DESCRIPTION
## Summary

The Delta Lake deployment guide's "Databricks Unity Catalog" section said the Databricks connector in `mode: delta_lake` "handles UC metadata resolution and credential vending **automatically**." That overstates credential vending.

**What the docs said:** UC metadata resolution and credential vending are handled automatically.
**What the code does:** Credential vending is **opt-in** via `databricks_credential_vending: enabled` (default `disabled`). When disabled — the default — the connector uses static object-store credentials, not vended ones. This matches the Databricks connector reference (`databricks/index.md`), which documents the param as default-`disabled`.

**What changed (version-aware):**
- **vNext** (`website/docs/...`): reworded to state UC metadata resolution is automatic, and credential vending is available when `databricks_credential_vending: enabled` is set (default `disabled`).
- **version-2.0.x**: credential vending did **not exist** in the v2.0.0 Databricks connector at all (`credential_vending`/`vending` appears nowhere in the v2.0.0 source tree), so the claim is removed for that release — the connector handles UC metadata resolution only.

## Source ref

`spiceai/spiceai`:
- `trunk` (7a7313b5a) — `crates/data-connectors/connector-databricks/src/lib.rs:148-149` (param `databricks_credential_vending`, default `disabled`, requires `mode: delta_lake`), consumed at `:291`/`:303`/`:428`.
- `v2.0.0` (55c0375c8) — no `credential_vending`/`vending` symbol anywhere in `connector-databricks` / `data_components` (feature not present).

Related: the param itself was documented in spiceai/docs#1818; this PR reconciles the cross-referencing sentence that PR left untouched.

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] Cross-page/version grep: `grep -rn "credential vending automatically" website/` → 0 remaining
- [x] Files updated: 2 (vNext + version-2.0.x)