### PR TITLE
docs(iceberg): correct catalog DELETE support and add v2-only caveat

### DIFF
--- a/website/docs/components/catalogs/iceberg.md
+++ b/website/docs/components/catalogs/iceberg.md
@@ -277,7 +277,7 @@ INSERT INTO ice.sales.transactions
 SELECT * FROM staging_transactions;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `UPDATE` and `DELETE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
 

--- a/website/docs/components/data-connectors/iceberg.md
+++ b/website/docs/components/data-connectors/iceberg.md
@@ -264,7 +264,7 @@ INSERT INTO my_table
 SELECT * FROM source_table;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files. `UPDATE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
 

--- a/website/versioned_docs/version-2.0.x/components/catalogs/iceberg.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/iceberg.md
@@ -277,7 +277,7 @@ INSERT INTO ice.sales.transactions
 SELECT * FROM staging_transactions;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `UPDATE` and `DELETE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/iceberg.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/iceberg.md
@@ -264,7 +264,7 @@ INSERT INTO my_table
 SELECT * FROM source_table;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files. `UPDATE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
 


### PR DESCRIPTION
## Summary

The Iceberg **catalog** connector page claimed `UPDATE` and `DELETE` are not supported — contradicting both the Iceberg **data-connector** page (corrected in spiceai/docs#1670) and the implementation.

**What the docs said** (`catalogs/iceberg.md`): "Inserting into partitioned Iceberg tables is supported. `UPDATE` and `DELETE` operations are not currently supported."
**What the code does:** catalog tables are wrapped in `IcebergDeletionProvider` specifically so `DELETE FROM` works via equality delete files. `DELETE` is rejected on Iceberg **v1** tables.

**What changed:** all four Iceberg pages now carry the same accurate statement — `DELETE FROM` supported via equality delete files (Iceberg v2+ only), `UPDATE` not supported:
- `components/catalogs/iceberg.md` (vNext + 2.0.x) — corrected the false "no DELETE" claim.
- `components/data-connectors/iceberg.md` (vNext + 2.0.x) — added the missing v2+ caveat for consistency.

The `IcebergDeletionProvider` catalog wrapping and the v1 rejection both exist at the **v2.0.0** tag, so the 2.0.x docs were also wrong and are corrected.

**Glue intentionally not changed:** `GlueCatalogProvider` builds tables via `GlueDataConnector.read_provider` (read-only, no deletion wrapper), so the Glue pages' "DELETE not supported" is correct.

## Source ref

`spiceai/spiceai`:
- `trunk` (7a7313b5a) and `v2.0.0` (55c0375c8):
  - `crates/data_components/src/iceberg/provider.rs:327-330` — "Wrap in IcebergDeletionProvider so that catalog tables support DELETE FROM via equality delete files."
  - `crates/data_components/src/iceberg/delete.rs:475` — "DELETE is not supported on Iceberg v1 tables. Upgrade to v2 format."
  - `crates/runtime/src/catalogconnector/glue/provider.rs:182,198` — Glue uses `GlueDataConnector` + `read_provider` (no deletion path).

Related: spiceai/docs#1670 corrected the data-connector page but left the catalog page and the v2+ caveat.

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] Cross-page/version grep: all 4 Iceberg pages now identical; 0 remaining "UPDATE` and `DELETE`...not currently supported"
- [x] Glue pages verified correct and left unchanged
- [x] Files updated: 4 (catalog + data-connector × vNext + 2.0.x)