### PR TITLE
docs(github): correct github_include_commits columns to created_at/updated_at

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -75,7 +75,7 @@ With GitHub App Installation authentication, the connector's functionality depen
 | `github_endpoint`             | Optional. Base URL of the GitHub API. Defaults to `https://api.github.com`. Override to target a GitHub Enterprise Server instance (e.g., `https://github.example.com/api/v3`).                                                                                                                                       |
 | `github_include_comments`     | Optional. Pull-request connector only. Specifies the types of comments to fetch: `all`, `review`, `discussion`, or `none`. Defaults to `none`. See [Comments Example](#comments-example).                                                                                                                             |
 | `github_max_comments_fetched` | Optional. Pull-request connector only. Maximum number of comments to fetch per review thread (when `github_include_comments` is set to `review` or `all`) or per pull-request discussion (when set to `discussion` or `all`). Defaults to `25`, and is capped at `75` to protect against GitHub secondary rate limits. |
-| `github_include_commits`      | Optional. Files connector only. Whether to fetch commit metadata (`committed_date`, `committer_date`) for each file. Set to `true` to enable. Defaults to `false`.                                                                                                                                                    |
+| `github_include_commits`      | Optional. Files connector only. Whether to fetch commit metadata (adds the `created_at` and `updated_at` timestamp columns) for each file. Set to `true` to enable. Defaults to `false`.                                                                                                                                                    |
 | `github_workflow_logs`        | Optional. Workflow-runs connector only (`github.com/<owner>/<repo>/workflows/<workflow_file.yml>/runs`). Set to `enabled` to download and include the workflow run logs for each row. Defaults to `disabled`.                                                                                                         |
 
 ## Advanced Configuration
@@ -183,7 +183,11 @@ datasets:
 | mode         | Utf8      | YES         |
 | url          | Utf8      | YES         |
 | download_url | Utf8      | YES         |
+| created_at   | Timestamp | YES         |
+| updated_at   | Timestamp | YES         |
 | content      | Utf8      | YES         |
+
+`created_at` and `updated_at` are present only when `github_include_commits` is set to `true`.
 
 #### Example
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
@@ -75,7 +75,7 @@ With GitHub App Installation authentication, the connector's functionality depen
 | `github_endpoint`             | Optional. Base URL of the GitHub API. Defaults to `https://api.github.com`. Override to target a GitHub Enterprise Server instance (e.g., `https://github.example.com/api/v3`).                                                                                                                                       |
 | `github_include_comments`     | Optional. Pull-request connector only. Specifies the types of comments to fetch: `all`, `review`, `discussion`, or `none`. Defaults to `none`. See [Comments Example](#comments-example).                                                                                                                             |
 | `github_max_comments_fetched` | Optional. Pull-request connector only. Maximum number of comments to fetch per review thread (when `github_include_comments` is set to `review` or `all`) or per pull-request discussion (when set to `discussion` or `all`). Defaults to `25`, and is capped at `75` to protect against GitHub secondary rate limits. |
-| `github_include_commits`      | Optional. Files connector only. Whether to fetch commit metadata (`committed_date`, `committer_date`) for each file. Set to `true` to enable. Defaults to `false`.                                                                                                                                                    |
+| `github_include_commits`      | Optional. Files connector only. Whether to fetch commit metadata (adds the `created_at` and `updated_at` timestamp columns) for each file. Set to `true` to enable. Defaults to `false`.                                                                                                                                                    |
 | `github_workflow_logs`        | Optional. Workflow-runs connector only (`github.com/<owner>/<repo>/workflows/<workflow_file.yml>/runs`). Set to `enabled` to download and include the workflow run logs for each row. Defaults to `disabled`.                                                                                                         |
 
 ## Advanced Configuration
@@ -183,7 +183,11 @@ datasets:
 | mode         | Utf8      | YES         |
 | url          | Utf8      | YES         |
 | download_url | Utf8      | YES         |
+| created_at   | Timestamp | YES         |
+| updated_at   | Timestamp | YES         |
 | content      | Utf8      | YES         |
+
+`created_at` and `updated_at` are present only when `github_include_commits` is set to `true`.
 
 #### Example
 


### PR DESCRIPTION
## Summary

`github_include_commits` is a **files**-connector option. The docs described it as adding `committed_date`/`committer_date` columns — but those are columns of the **commits** connector. When `github_include_commits: true`, the files connector adds `created_at` and `updated_at` (`Timestamp`) columns.

**What the docs said:** "Whether to fetch commit metadata (`committed_date`, `committer_date`) for each file."
**What the code does:** pushes `created_at` and `updated_at` `Timestamp` fields (before the optional `content` column) when `include_commits` is set.

**What changed:**
- Corrected the `github_include_commits` parameter description.
- Added `created_at` and `updated_at` to the Files **Schema** table (in code order — after `download_url`, before `content`) with a note that they appear only when `github_include_commits` is enabled.

Applies to vNext and version-2.0.x — the `created_at`/`updated_at` fields exist identically at the `v2.0.0` tag, so the 2.0.x docs carried the same error.

## Source ref

`spiceai/spiceai` `trunk` (7a7313b5a) and `v2.0.0` (55c0375c8):
- `crates/data_components/src/github.rs:144-155` — `if include_commits { fields.push("created_at" Timestamp); fields.push("updated_at" Timestamp); }`
- `crates/data_components/src/github.rs:733-801` — `created_at_builder`/`updated_at_builder` populated only when `include_commits`.
- `committed_date`/`committer_date` are columns of the **commits** connector (`crates/data_components/src/github/commits.rs`), unrelated to the files connector.

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] Grep: 0 remaining `committed_date`/`committer_date` in the `github_include_commits` description
- [x] Column order matches source (`created_at`, `updated_at` before `content`)
- [x] Files updated: 2 (vNext + version-2.0.x)