### PR TITLE
docs(abfs): remove unsupported adl:// scheme claim from connector intro

### DIFF
--- a/website/docs/components/data-connectors/abfs.md
+++ b/website/docs/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/abfs.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/abfs.md
@@ -8,7 +8,7 @@ tags:
   - blob-storage
 ---
 
-The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints.
+The Azure BlobFS (ABFS) Data Connector enables federated SQL queries on files stored in Azure Blob-compatible endpoints. This includes Azure Data Lake Storage Gen2 endpoints accessed via the `abfs://` and `abfss://` schemes.
 
 When a folder path is provided, all the contained files will be loaded.
 


### PR DESCRIPTION
## Summary

The ABFS connector intro stated it serves "Azure BlobFS (`abfss://`) and Azure Data Lake (`adl://`) endpoints." The `adl://` scheme is **not** registered by the connector — only `abfs://` and `abfss://` are. `adl://` is the deprecated Azure Data Lake Storage **Gen1** scheme, a different service from the ADLS **Gen2** this connector targets. A dataset with `from: adl://...` fails with an unknown-connector error.

The original sentence also omitted the primary `abfs://` scheme (used by every example on the page) while listing only `abfss://`.

**What changed:** reworded the intro to name the actually-registered schemes — `abfs://` and `abfss://`. Applied as a correction to all 9 doc versions (the claim predates versioning; `adl://` was never a registered scheme).

## Source ref

`spiceai/spiceai` `trunk` (7a7313b5a) and `v2.0.0` (55c0375c8):
- `crates/runtime/src/dataconnector/abfs.rs:389-401` — `register_data_connector!(... "abfs", AzureBlobFSFactory)` and `register_data_connector!(... "abfss", AzureBlobFSFactory)`. No `adl` registration anywhere in the connector (grep for `"adl"` → none).

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] `grep -rn 'adl://' website/` → 0 remaining
- [x] Versioned-docs propagation: 9 files carry the corrected sentence, 9 files changed (counts match)
- [x] Files updated: 9 (vNext + 8 versioned: 1.5.x–2.0.x)