### PR TITLE
docs(datasets): document on_schema_resolved ready_state value and default

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -253,10 +253,11 @@ Not all connectors support specifying an `unsupported_type_action`. When specifi
 
 ## `ready_state`
 
-Supports one of two values:
+Supports one of three values (defaults to `on_load`):
 
 - `on_registration`: Mark the dataset as ready immediately, and queries on this table will fall back to the underlying source directly until the initial acceleration is complete. When combined with fully declared [`columns[].type`](#columnstype) entries, enables [deferred dataset initialization](#deferred-dataset-initialization) — the source connector is not created until the first query.
-- `on_load`: Mark the dataset as ready only after the initial acceleration. Queries against the dataset will return an error before the load has been completed.
+- `on_load`: (default) Mark the dataset as ready only after the initial acceleration. Queries against the dataset will return an error before the load has been completed.
+- `on_schema_resolved`: Mark the dataset as ready once the federated source's schema has been resolved (which also verifies access to the source), without waiting for the initial data refresh. Queries fall back to the federated source until the initial load completes; subsequent refresh failures are still reported via dataset status and metrics.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
@@ -253,10 +253,11 @@ Not all connectors support specifying an `unsupported_type_action`. When specifi
 
 ## `ready_state`
 
-Supports one of two values:
+Supports one of three values (defaults to `on_load`):
 
 - `on_registration`: Mark the dataset as ready immediately, and queries on this table will fall back to the underlying source directly until the initial acceleration is complete. When combined with fully declared [`columns[].type`](#columnstype) entries, enables [deferred dataset initialization](#deferred-dataset-initialization) — the source connector is not created until the first query.
-- `on_load`: Mark the dataset as ready only after the initial acceleration. Queries against the dataset will return an error before the load has been completed.
+- `on_load`: (default) Mark the dataset as ready only after the initial acceleration. Queries against the dataset will return an error before the load has been completed.
+- `on_schema_resolved`: Mark the dataset as ready once the federated source's schema has been resolved (which also verifies access to the source), without waiting for the initial data refresh. Queries fall back to the federated source until the initial load completes; subsequent refresh failures are still reported via dataset status and metrics.
 
 ```yaml
 datasets:


### PR DESCRIPTION
## Summary

The `ready_state` reference said **"Supports one of two values"** and listed only `on_registration` and `on_load`. The `ReadyState` enum actually has **three** variants, and the doc also never stated the default.

**What the docs said:** two values — `on_registration`, `on_load`.
**What the code does:** `ReadyState` = `OnLoad` (`#[default]`), `OnRegistration`, **`OnSchemaResolved`**. `on_schema_resolved` marks the dataset ready once the federated source's schema is resolved (which also verifies source access), without waiting for the initial data refresh — queries fall back to the federated source until the load completes.

**What changed:** added the `on_schema_resolved` value, stated the default (`on_load`), and marked which bullet is the default.

Scoped to **vNext + version-2.0.x** — `OnSchemaResolved` is present in the v2.0.0 enum. Older 1.x docs predate the variant and use a different `ready_state` framing, so they are intentionally left unchanged (would require per-version verification).

## Source ref

`spiceai/spiceai` `trunk` (7a7313b5a) and `v2.0.0` (55c0375c8):
- `crates/spicepod/src/component/dataset.rs:125-136` — `enum ReadyState { #[default] OnLoad, OnRegistration, OnSchemaResolved }` with the `OnSchemaResolved` doc-comment.

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] `on_schema_resolved` now present in both edited files
- [x] Files updated: 2 (vNext + version-2.0.x)