### PR TITLE
docs(smb): correct supported SMB dialect to 3.1.1 only

### DIFF
--- a/website/docs/components/data-connectors/smb.md
+++ b/website/docs/components/data-connectors/smb.md
@@ -6,7 +6,7 @@ description: 'SMB Data Connector Documentation'
 
 SMB (Server Message Block) is a network file sharing protocol that provides shared access to files, printers, and serial ports. It is commonly used in Windows environments for network shares but is also supported on Linux (via Samba) and macOS.
 
-The SMB Data Connector enables federated SQL query across [supported file formats](../data-connectors#file-formats) stored on SMB/CIFS network shares. It supports SMB 2.0, 2.1, 3.0, and 3.1.1 protocols, compatible with Windows Server file shares, Samba servers, NAS devices (Synology, QNAP, etc.), and Azure Files.
+The SMB Data Connector enables federated SQL query across [supported file formats](../data-connectors#file-formats) stored on SMB/CIFS network shares. It requires the SMB 3.1.1 dialect — the only protocol version the connector negotiates — and is compatible with Windows Server 2016+ and Samba 4.x file shares, NAS devices (Synology, QNAP, etc.) configured for SMB 3.1.1, and Azure Files.
 
 ## Quickstart
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/smb.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/smb.md
@@ -6,7 +6,7 @@ description: 'SMB Data Connector Documentation'
 
 SMB (Server Message Block) is a network file sharing protocol that provides shared access to files, printers, and serial ports. It is commonly used in Windows environments for network shares but is also supported on Linux (via Samba) and macOS.
 
-The SMB Data Connector enables federated SQL query across [supported file formats](../data-connectors#file-formats) stored on SMB/CIFS network shares. It supports SMB 2.0, 2.1, 3.0, and 3.1.1 protocols, compatible with Windows Server file shares, Samba servers, NAS devices (Synology, QNAP, etc.), and Azure Files.
+The SMB Data Connector enables federated SQL query across [supported file formats](../data-connectors#file-formats) stored on SMB/CIFS network shares. It requires the SMB 3.1.1 dialect — the only protocol version the connector negotiates — and is compatible with Windows Server 2016+ and Samba 4.x file shares, NAS devices (Synology, QNAP, etc.) configured for SMB 3.1.1, and Azure Files.
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

The SMB connector intro claimed it "supports SMB 2.0, 2.1, 3.0, and 3.1.1 protocols." The connector's pure-Rust `smb` crate negotiates **only SMB 3.1.1** and rejects any server that selects a different dialect — a server limited to SMB 2.x or 3.0 fails the negotiation handshake.

**What the docs said:** supports SMB 2.0, 2.1, 3.0, and 3.1.1.
**What the code does:** offers a single dialect (3.1.1) and errors otherwise.

**What changed:** the intro now states SMB 3.1.1 is required (the only dialect negotiated) and tempers the compatibility list to servers that support 3.1.1.

Scoped to **vNext + version-2.0.x** — the `smb` crate with the 3.1.1-only negotiation is present at the `v2.0.0` tag. **version-1.11.x predates the `smb` crate** (the connector used a different implementation there), so its docs are intentionally left unchanged.

## Source ref

`spiceai/spiceai` `trunk` (7a7313b5a) and `v2.0.0` (55c0375c8):
- `crates/smb/src/protocol.rs:213,219` — `pub const DIALECT_SMB3_1_1: u16 = 0x0311;` and `const DIALECTS: [u16; 1] = [DIALECT_SMB3_1_1];`
- `crates/smb/src/client.rs:289,295` — rejects any other selected dialect: `"server selected unsupported dialect 0x{:04X}; only 3.1.1 is supported"`.

## Test plan

- [x] `cd website && npm run build` passes (Generated static files; no broken links/tags)
- [x] `grep -rn 'SMB 2.0, 2.1, 3.0' website/docs website/versioned_docs/version-2.0.x` → 0 remaining (1.11.x intentionally retained)
- [x] Files updated: 2 (vNext + version-2.0.x)