### PR TITLE
docs(clickhouse): remove unsupported DateTime64 type-mapping row

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -90,7 +90,6 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
-| `DateTime64`     | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 
 ## Examples

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/clickhouse.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/clickhouse.md
@@ -90,7 +90,6 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
-| `DateTime64`     | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 
 ## Examples


### PR DESCRIPTION
## Summary

The ClickHouse connector type-mapping table lists `DateTime64 → Timestamp(Second, None)`, but ClickHouse `DateTime64` columns are **not** supported and cannot be registered.

**What the code does:** Schema inference goes through `SqlTable::new` → `ClickhouseConnection::get_schema`, which queries `system.columns` and maps each type *string* via `map_clickhouse_type_to_arrow`. That function only matches the literal `"DateTime"`:

```rust
// crates/db_connection_pool/src/dbconnection/clickhouseconn.rs
"DateTime" => Ok(DataType::Timestamp(TimeUnit::Second, None)),
...
_ => Err(... format!("Unsupported Clickhouse type: {type_str}") ...),
```

A `DateTime64` column reports its type as `DateTime64(3)` / `DateTime64(3, 'UTC')` in `system.columns`, which does not equal `"DateTime"` and has no `starts_with` arm, so it falls through to the `Unsupported Clickhouse type` error. Registration of any table containing a `DateTime64` column fails before a query is ever run. (The data-path `block_to_arrow` does handle `SqlType::DateTime(_)`, but schema inference fails first, so the column is unusable end-to-end.)

This row was added in #1701 alongside the unsupported `Date32` row. #1794 removed `Date32` but missed `DateTime64`; this PR completes that cleanup.

Verified against `spiceai/spiceai` at `trunk` (and the `v2.0.0` tag for the versioned copy): `map_clickhouse_type_to_arrow` has no `DateTime64` arm in either.

## Source

- `crates/db_connection_pool/src/dbconnection/clickhouseconn.rs` — `get_schema` + `map_clickhouse_type_to_arrow`
- Prior PRs: #1701 (added Date32 + DateTime64), #1794 (removed Date32 only)

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn DateTime64 website/` returns 0 hits after the change
- [x] Cross-page grep — only `clickhouse.md` (vNext + version-2.0.x) carried the row; ClickHouse has no deployment/catalog page
- [x] Files updated: 2 (vNext + version-2.0.x)