### PR TITLE
docs(file-formats): document vortex as a supported file_format

### DIFF
--- a/website/docs/reference/file_format.md
+++ b/website/docs/reference/file_format.md
@@ -27,6 +27,7 @@ The `file_format` parameter accepts these values:
 | Value     | Reader              | Default Extension | Notes                                       |
 | --------- | ------------------- | ----------------- | ------------------------------------------- |
 | `parquet` | Apache Parquet      | `.parquet`        |                                             |
+| `vortex`  | Vortex              | `.vortex`         | Columnar format. Not available on Windows.  |
 | `csv`     | CSV                 | `.csv`            | Uses `csv_*` parameters.                    |
 | `tsv`     | TSV (tab-delimited) | `.tsv`            | Uses `tsv_*` parameters. Delimiter is tab.  |
 | `json`    | JSON                | `.json`           | Auto-detects format. Uses `json_format` to control parsing mode. |
@@ -90,6 +91,12 @@ Supported data encodings:
 - [`DELTA_LENGTH_BYTE_ARRAY`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#delta-length-byte-array-delta_length_byte_array--6)
 - [`DELTA_BYTE_ARRAY`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#delta-strings-delta_byte_array--7)
 - [`BYTE_STREAM_SPLIT`](https://parquet.apache.org/docs/file-format/data-pages/encodings/#byte-stream-split-byte_stream_split--9)
+
+## Vortex
+
+[Vortex](https://github.com/vortex-data/vortex) is a columnar file format read everywhere Parquet is, including the S3, ABFS, GCS, file, and HTTPS connectors. Set `file_format: vortex` or use a `.vortex` file extension (auto-detection also resolves `.vortex` files when `file_format` is omitted or set to `auto`).
+
+Vortex has no format-specific parameters. It is not available on Windows builds.
 
 ## CSV
 


### PR DESCRIPTION
## Summary

`vortex` is now a fully-supported `file_format` value across every file/object data connector that supports `parquet` (S3, ABFS, GCS, file, HTTPS), but it was undocumented in the File Formats reference. spiceai/spiceai#11282 closed the last gaps (`file_format: auto` + `.vortex` files, and HTTPS routing), so vortex now works everywhere parquet does.

This adds:
- A `vortex` row to the **Supported Formats** table (extension `.vortex`, columnar, not available on Windows).
- A short **Vortex** section noting it has no format-specific parameters and is read everywhere Parquet is.

Verified against source: the `Some("vortex")` arm in `get_file_format_and_extension` dispatches to `VortexFormatFactory` with extension `.vortex`, gated `#[cfg(not(windows))]`. No `vortex_*` parameters exist.

## Source PRs
- spiceai/spiceai#11282 — feat(connectors): support `format: vortex` everywhere `format: parquet` is supported

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: addition → vNext only (vortex absent from versioned_docs; not back-propagated)
- [x] Files updated: 1