### PR TITLE
docs(cdc): document per-dataset cdc_* overrides on Cayenne datasets

### DIFF
--- a/website/docs/features/cdc/index.md
+++ b/website/docs/features/cdc/index.md
@@ -31,7 +31,7 @@ It is recommended to use CDC-accelerated datasets with persistent data accelerat
 
 ## Tuning ingestion
 
-Spice applies CDC events through a single apply loop that coalesces a contiguous run of buffered change events ("envelopes") into one accelerator write. The coalescing behavior is controlled by the following instance-wide `runtime.params` (set once under the top-level `runtime.params`, not per-dataset). Each parameter also accepts a `SPICE_`-prefixed environment variable; the `runtime.params` value takes precedence, falling back to the environment variable, then the default.
+Spice applies CDC events through a single apply loop that coalesces a contiguous run of buffered change events ("envelopes") into one accelerator write. The coalescing behavior is controlled by the following `runtime.params`, set once under the top-level `runtime.params` and applied to every CDC-accelerated dataset in the instance. Each parameter also accepts a `SPICE_`-prefixed environment variable; the `runtime.params` value takes precedence, falling back to the environment variable, then the default. Cayenne-accelerated datasets can additionally override any of these values per-dataset — see [Per-dataset overrides](#per-dataset-overrides) below.
 
 | Parameter                     | Description                                                                                                                                                                                                                                                                                                                              | Default               |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
@@ -48,6 +48,26 @@ runtime:
 ```
 
 Out-of-range or unparseable values are rejected with a warning and fall back to the default.
+
+### Per-dataset overrides
+
+For [Cayenne](../../components/data-accelerators/cayenne/index.md)-accelerated datasets, any of the five parameters above can also be set per-dataset under the dataset's `acceleration.params` to override the instance-wide value for that dataset only. A per-dataset value layers on top of the resolved global configuration (`runtime.params` → environment variable → default): a dataset overrides only the parameters it sets and inherits the global value for the rest. Out-of-range or unparseable per-dataset values are rejected with a warning and keep the global value.
+
+```yaml
+runtime:
+  params:
+    cdc_max_coalesce_age_ms: 250 # global default for every CDC-accelerated dataset
+
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    acceleration:
+      engine: cayenne
+      refresh_mode: changes
+      params:
+        cdc_max_coalesce_age_ms: 1000 # this dataset lingers longer than the global 250ms
+        cdc_prefetch_buffer: 1024 # ...and buffers more aggressively
+```
 
 ## Supported Data Connectors
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11295](https://github.com/spiceai/spiceai/pull/11295) adds per-dataset overrides for the five CDC ingestion-tuning parameters. Previously the **Tuning ingestion** section stated these were instance-wide `runtime.params` and "not per-dataset". The PR registers `cdc_prefetch_buffer`, `cdc_max_coalesced_envelopes`, `cdc_max_coalesced_bytes`, `cdc_max_coalesce_age_ms`, and `cdc_commit_timeout_ms` as `ParameterSpec`s on the **Cayenne** accelerator and layers any per-dataset values on top of the resolved global config (`cdc_config_overlay` in `refresh_task/changes.rs`).

Verified against source:
- The five overridable keys are exactly the five `runtime.params` already in the table (`cdc_config_overlay` covers `prefetch_buffer`, `max_coalesced_envelopes`, `max_coalesced_bytes`, `max_coalesce_age_ms`, `commit_timeout`).
- Acceptance is wired on the Cayenne accelerator (`ParameterSpec::runtime("cdc_*")` in `dataaccelerator/cayenne/mod.rs`); overrides are extracted from `acceleration.params` and layered in the refresh task.
- Out-of-range / unparseable per-dataset values keep the global value with a warning (`overlay_usize` / `overlay_u64`), matching the existing global-param fallback wording.

This is an addition (new capability post-v2.0.0), so it lands in vNext (`website/docs/`) only — older versioned docs do not have the feature.

## Source PRs
- spiceai/spiceai#11295 — Support per-dataset CDC tunable overrides

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: throw`; the new `../../components/data-accelerators/cayenne/index.md` link and `#per-dataset-overrides` anchor resolve)
- [x] Versioned-docs propagation: N/A — addition, vNext only
- [x] Files updated: 1 (`website/docs/features/cdc/index.md`)