### PR TITLE
docs(duckdb): correct duckdb_open in-memory-mode claim in deployment guide

### DIFF
--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -19,7 +19,7 @@ DuckDB is an embedded engine; the connector reads a local DuckDB database file. 
 
 | Parameter          | Description                                                            |
 | ------------------ | ---------------------------------------------------------------------- |
-| `duckdb_open`      | Path to the DuckDB database file. If omitted, uses in-memory mode. |
+| `duckdb_open`      | Path to the DuckDB database file. Required when reading from a table reference (`from: duckdb:database.schema.table`); it may be omitted only when the dataset's `from:` uses a DuckDB table function (e.g. `duckdb:read_csv(...)`), which runs against an in-memory database. Omitting it for a table-reference dataset fails with a `MissingDuckDBFile` error. |
 
 Protect the DuckDB file with filesystem permissions. Store it on encrypted storage (LUKS/dm-crypt, EBS encryption, etc.) for data-at-rest protection. For data loaded from cloud object stores inside DuckDB, configure AWS/Azure/GCS credentials via DuckDB extensions rather than Spice parameters.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
@@ -19,7 +19,7 @@ DuckDB is an embedded engine; the connector reads a local DuckDB database file. 
 
 | Parameter          | Description                                                            |
 | ------------------ | ---------------------------------------------------------------------- |
-| `duckdb_open`      | Path to the DuckDB database file. If omitted, uses in-memory mode. |
+| `duckdb_open`      | Path to the DuckDB database file. Required when reading from a table reference (`from: duckdb:database.schema.table`); it may be omitted only when the dataset's `from:` uses a DuckDB table function (e.g. `duckdb:read_csv(...)`), which runs against an in-memory database. Omitting it for a table-reference dataset fails with a `MissingDuckDBFile` error. |
 
 Protect the DuckDB file with filesystem permissions. Store it on encrypted storage (LUKS/dm-crypt, EBS encryption, etc.) for data-at-rest protection. For data loaded from cloud object stores inside DuckDB, configure AWS/Azure/GCS credentials via DuckDB extensions rather than Spice parameters.
 


### PR DESCRIPTION
## Summary

The DuckDB data connector deployment guide described `duckdb_open` as: *"Path to the DuckDB database file. If omitted, uses in-memory mode."*

That claim is misleading. Omitting `duckdb_open` only falls back to an in-memory database when the dataset's `from:` is a **DuckDB table function** (e.g. `duckdb:read_csv(...)`). For a **table-reference** dataset (`from: duckdb:database.schema.table`), omitting `duckdb_open` does not silently start in-memory mode — `read_provider` rejects the dataset with a `MissingDuckDBFile` error.

### What the code does

`read_provider` gates on the path being a table function OR `duckdb_open` being present, otherwise it errors:

```rust
// crates/data-connectors/connector-duckdb/src/lib.rs
if !(is_table_function(&path) || dataset.params.contains_key("duckdb_open")) {
    return Err(DataConnectorError::UnableToGetReadProvider {
        dataconnector: "duckdb".to_string(),
        source: Box::new(Error::MissingDuckDBFile {}),
        ...
    });
}
```

The in-memory pool (`create_in_memory`) is only reached when `duckdb_open` is absent, which is usable solely with a table-function `from:`.

### Change

Rewrote the `duckdb_open` description to state it is required for table-reference datasets, may be omitted only for DuckDB table-function `from:` forms (in-memory), and that omitting it for a table reference fails with `MissingDuckDBFile`.

## Source

- spiceai/spiceai @ `origin/trunk` (verified identical in `v2.0.0-rc.5`) — `crates/data-connectors/connector-duckdb/src/lib.rs` (`read_provider` gate, `create_in_memory` / `create_file` routing)

## Versioned-docs propagation

This `deployment.md` page exists only in vNext and `version-2.0.x` (older versions ship the single `duckdb.md` without a deployment guide). Both copies fixed. `grep -rln "If omitted, uses in-memory" website/` now returns 0.

## Test plan

- [x] `cd website && npm run build` passes (exit 0, static files generated)
- [x] Versioned-docs propagation checked (0 remaining stale occurrences)
- [x] Files updated: 2 (vNext + version-2.0.x deployment.md)