### PR TITLE
docs(http): document mTLS client-identity params

### DIFF
--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -33,6 +33,15 @@ For OAuth2-protected APIs, prefer refresh-token flow over storing long-lived bea
 
 Use HTTPS endpoints in production. `auth_token_url` must use HTTPS (loopback addresses are allowed for local testing only). Self-signed certificates require a trusted CA bundle in the container or host OS trust store.
 
+For upstream servers that require mutual TLS (mTLS), the connector can present a client certificate during the TLS handshake. Supply the certificate and key as file paths or inline PEM — the two forms are mutually exclusive, and the certificate and key must be set together. mTLS client identity applies to dynamic JSON API endpoints only.
+
+| Parameter                          | Description                                                                                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `http_tls_client_certificate_file` | Path to a PEM client certificate chain. Pair with `http_tls_client_key_file`.                |
+| `http_tls_client_key_file`         | Path to the PEM private key matching the client certificate file.                            |
+| `http_tls_client_certificate`      | Inline PEM client certificate chain. Use `${secrets:...}`. Pair with `http_tls_client_key`.  |
+| `http_tls_client_key`              | Inline PEM private key matching the inline certificate. Use `${secrets:...}`.                |
+
 ## Resilience Controls
 
 ### Rate Control

--- a/website/docs/components/data-connectors/https/index.md
+++ b/website/docs/components/data-connectors/https/index.md
@@ -171,6 +171,17 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `auth_scopes`              | Optional. Space-separated OAuth2 scopes to request when refreshing (e.g. `read:data offline_access`). Omit to inherit the scopes bound to the refresh token.                                                                                                                                                                                                                                                                              |
 | `auth_client_auth`         | Optional. How client credentials are sent to the token endpoint: `basic` (HTTP Basic header, default per RFC 6749 §2.3.1) or `body` (`client_id`/`client_secret` in the form body). Default: `basic`.                                                                                                                                                                                                                                     |
 
+#### Mutual TLS (mTLS) Client Authentication
+
+For upstream servers that require mutual TLS, the connector can present a client certificate during the TLS handshake. Provide the certificate and key either as file paths or inline PEM — the file-path and inline forms are mutually exclusive, and the certificate and key must always be set together. mTLS client identity applies to dynamic JSON API endpoints only; structured HTTP file datasets reject these parameters.
+
+| Parameter Name                     | Description                                                                                                                                                                              |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http_tls_client_certificate_file` | Optional. Path to a PEM client certificate chain to present during the TLS handshake. Must be set together with `http_tls_client_key_file`. Mutually exclusive with the inline forms.   |
+| `http_tls_client_key_file`         | Optional. Path to the PEM private key matching `http_tls_client_certificate_file`. Must be set together with it. Mutually exclusive with the inline forms.                              |
+| `http_tls_client_certificate`      | Optional. Inline PEM client certificate chain (or `${secrets:...}` reference). Must be set together with `http_tls_client_key`. Mutually exclusive with the file-path forms.            |
+| `http_tls_client_key`              | Optional. Inline PEM private key (or `${secrets:...}` reference) matching `http_tls_client_certificate`. Must be set together with it. Mutually exclusive with the file-path forms.     |
+
 #### Rate Control Parameters
 
 HTTP-based connectors share a rate control system that limits concurrency and request rate per upstream origin. These parameters can be set per-dataset (in `params`) or globally (in `runtime.params`). Dataset-level settings override the global defaults.


### PR DESCRIPTION
## Summary

The HTTP(s) data connector gained mutual-TLS (mTLS) client authentication in spiceai/spiceai#11127, but the four client-identity parameters were never documented. This PR adds them to both the connector reference and the deployment guide.

**What the docs said vs. what the code does:** the `params` table on the HTTPS connector page listed basic-auth and OAuth2 params but no mTLS client-certificate params; the deployment guide's TLS section covered only server-trust (CA bundle) concerns. The connector accepts four `ParameterSpec::component` params (auto-prefixed `http_`):

- `http_tls_client_certificate_file`
- `http_tls_client_key_file`
- `http_tls_client_certificate` (`.secret()`)
- `http_tls_client_key` (`.secret()`)

The file-path and inline forms are mutually exclusive, the certificate and key must be set together, and mTLS client identity applies to dynamic JSON API endpoints only (structured HTTP file datasets reject these params).

## Verified source ref

spiceai/spiceai @ `trunk` (post-v2.0.0; commit `08b480684`):
- `crates/runtime/src/dataconnector/client_identity.rs:19-22` — param-name constants
- `crates/runtime/src/dataconnector/https.rs:1483-1490` — `ParameterSpec::component(...)` declarations + descriptions (pairing / mutual-exclusivity / JSON-only constraints)

This is a vNext-only addition (the feature is not in any released tag — `git merge-base --is-ancestor 08b480684 v2.0.0` → false), so no versioned-docs propagation is needed.

## Source PRs

- spiceai/spiceai#11127 — Add HTTP connector mTLS support

## Test plan

- [x] `cd website && npm run build` passes (3271 docs processed, no broken-link / undefined-tag errors)
- [x] Versioned-docs propagation: N/A — feature is trunk-only, not in any release tag
- [x] Files updated: 2 (`https/index.md`, `https/deployment.md`)