### PR TITLE
docs(datasets): document on_schema_change schema-evolution policy

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -227,9 +227,38 @@ Spice emits a warning if the `time_column` from the data source is incompatible 
 
 ## Schema Inference and Evolution
 
-Spice infers the dataset schema from the data source at startup. The inferred schema defines the column names, data types, and nullability used for the lifetime of that runtime process. Schema changes at the source are not applied at runtime — data refreshes will fail if the source schema drifts. Restart the runtime to re-infer the schema.
+Spice infers the dataset schema from the data source at startup. The inferred schema defines the column names, data types, and nullability used for the lifetime of that runtime process. By default, schema changes at the source are not applied at runtime — data refreshes will fail if the source schema drifts, and you must restart the runtime to re-infer the schema.
+
+Accelerated datasets can opt into automatic, in-place schema evolution with the [`on_schema_change`](#on_schema_change) policy, which adopts lossless, widening-compatible source changes without a restart.
 
 For connector-specific inference parameters, runtime schema change behavior, and recommendations, see [Schema Inference](../../components/data-connectors#schema-inference).
+
+## `on_schema_change`
+
+Optional. Controls how the runtime reacts when the source schema changes after the dataset is registered. Applies to **accelerated datasets only** — federated (non-accelerated) queries always reflect the live source schema, so the policy is inert for them (a non-default value logs a warning and otherwise has no effect).
+
+The following values are supported:
+
+- `block` - Default. Schema changes are not applied automatically. The dataset stays healthy and continues serving queries using the registered schema; this preserves the historical behavior.
+- `fail` - Set the dataset to an error status with an actionable message when the projected source schema diverges from the registered schema. Self-heals if the source reverts.
+- `append_new_columns` - Adopt new nullable source columns in place; type changes and relaxed/tightened nullability are treated as `block` (the dataset keeps serving on the old schema) and a warning is logged.
+- `sync_all_columns` - Adopt the full set of lossless, widening changes in place: new nullable columns, widened column types (for example `Int32`→`Int64`, an increase in decimal precision, or `Utf8`→`LargeUtf8`), and relaxed nullability. Non-widening changes (column removals, narrowing type changes) remain `block`-equivalent and are warned.
+
+```yaml
+datasets:
+  - from: postgres:public.events
+    name: events
+    on_schema_change: sync_all_columns
+    acceleration:
+      engine: duckdb
+      mode: file
+```
+
+:::note
+
+In-place evolution (no restart) is supported for the `duckdb`, `sqlite`, `turso`, and Spice Cayenne (`cayenne`) acceleration engines, including for PostgreSQL CDC (`refresh_mode: changes`). Other engines (for example `arrow` and the PostgreSQL accelerator) log a clear unsupported message and degrade safely, applying additive changes on restart. Constraint and primary-key columns cannot be widened in place. For destructive schema changes (column removals or narrowing), use [`mode: file_update`](#accelerationmode), which recreates the acceleration file.
+
+:::
 
 ## `unsupported_type_action`
 


### PR DESCRIPTION
## Summary

spiceai/spiceai#11261 wires up the dataset-level `on_schema_change` policy (the config was added in #10908 but previously unwired). Accelerated datasets can now evolve their schema in place for lossless, widening-compatible source changes instead of failing the refresh. This adds a reference section for the field in the dataset spec — it was undocumented (only mentioned in release notes).

Documents the four policy values verified against source:

- `block` (default) — `OnSchemaChange::Block`, preserves historical behavior
- `fail`
- `append_new_columns`
- `sync_all_columns`

Verified against `crates/spicepod/src/component/dataset.rs` (top-level dataset field, `#[serde(rename_all = "snake_case")]`, default `Block`) and `crates/runtime/src/init/dataset.rs` (accelerated-datasets-only; non-accelerated datasets warn and treat it as inert). Engine support (DuckDB/SQLite/Turso/Cayenne in place; others degrade on restart) and the `mode: file_update` escape hatch are documented per the PR's implementation notes.

Addition → vNext only (`website/docs/`); older versions don't have the wired feature.

## Source PRs
- spiceai/spiceai#11261 — feat(acceleration): widening-only schema evolution via on_schema_change

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: addition, vNext only — no versioned copies
- [x] Files updated: 1 (`website/docs/reference/spicepod/datasets.md`)