### PR TITLE
docs(datasets): document schema_inference depth field

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -251,6 +251,23 @@ Not all connectors support specifying an `unsupported_type_action`. When specifi
 
 :::
 
+## `schema_inference`
+
+Optional. Controls the depth of source-schema inference. Applies to all refresh modes. Supported values:
+
+- `standard` - Default. Infer the base column schema (names, types, nullability) from the source, exactly as before. No primary-key, secondary-index, or sort/clustering-column detection is performed.
+- `extended` - In addition to the base column schema, auto-detect the source's primary key, secondary indexes, and sort/clustering columns and apply them to any acceleration settings left unset. Only connectors that emit inferred-schema metadata are affected — currently the [PostgreSQL](../../components/data-connectors/postgres) and [MongoDB](../../components/data-connectors/mongodb) connectors; other connectors treat `extended` as a no-op.
+
+```yaml
+datasets:
+  - from: postgres:public.events
+    name: events
+    schema_inference: extended
+    acceleration:
+      engine: cayenne
+      mode: file
+```
+
 ## `ready_state`
 
 Supports one of three values (defaults to `on_load`):


### PR DESCRIPTION
## Summary

spiceai/spiceai#11284 adds the dataset-level `schema_inference` field, which controls how deeply the runtime infers source-schema metadata. It was undocumented (only referenced indirectly from the Cayenne accelerator page, which requires `schema_inference: extended` for adaptive auto-tuning). This adds a reference section in the dataset spec.

Documents both values verified against source:

- `standard` (default) — `SchemaInference::Standard`, base column/type inference only
- `extended` — additionally auto-detects primary key, secondary indexes, and sort/clustering columns

Verified against `crates/spicepod/src/component/dataset.rs` (top-level dataset field, `#[serde(rename_all = "snake_case")]`, default `Standard`). The field's own doc-comment confirms only the PostgreSQL and MongoDB connectors emit this metadata; other connectors treat `extended` as a no-op, and it applies to all refresh modes.

Addition → vNext only (`website/docs/`).

## Source PRs
- spiceai/spiceai#11284 — feat: deepen extended schema inference and wire it into cayenne compaction sharding/sorting

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: addition, vNext only — no versioned copies
- [x] Files updated: 1 (`website/docs/reference/spicepod/datasets.md`)