### PR TITLE
docs(dremio): correct PAT terminology in deployment troubleshooting

### DIFF
--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -63,7 +63,7 @@ Dremio queries participate in [task history](../../../reference/task_history) vi
 
 | Symptom                                     | Likely cause                                         | Resolution                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `UNAUTHENTICATED` on handshake              | Wrong credentials or expired PAT.                    | Verify credentials; regenerate the PAT via Dremio UI.                                             |
+| `UNAUTHENTICATED` on handshake              | Wrong or expired username/password credentials.      | Verify `dremio_username` and `dremio_password`; reset the credentials via the Dremio UI if needed. |
 | `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Flight client auto-retries; if persistent, check coordinator health.                              |
 | `PERMISSION_DENIED` on a specific dataset   | Dremio role lacks SELECT on the underlying source.   | Grant access in Dremio via the user/role management UI.                                           |
 | Slow queries for repeated dashboards        | Coordinator overloaded by repeat queries.            | Enable Spice acceleration for the dataset to cache results locally.                               |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
@@ -63,7 +63,7 @@ Dremio queries participate in [task history](../../../reference/task_history) vi
 
 | Symptom                                     | Likely cause                                         | Resolution                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `UNAUTHENTICATED` on handshake              | Wrong credentials or expired PAT.                    | Verify credentials; regenerate the PAT via Dremio UI.                                             |
+| `UNAUTHENTICATED` on handshake              | Wrong or expired username/password credentials.      | Verify `dremio_username` and `dremio_password`; reset the credentials via the Dremio UI if needed. |
 | `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Flight client auto-retries; if persistent, check coordinator health.                              |
 | `PERMISSION_DENIED` on a specific dataset   | Dremio role lacks SELECT on the underlying source.   | Grant access in Dremio via the user/role management UI.                                           |
 | Slow queries for repeated dashboards        | Coordinator overloaded by repeat queries.            | Enable Spice acceleration for the dataset to cache results locally.                               |


### PR DESCRIPTION
## Summary

The Dremio data connector authenticates with **username/password only** — `Credentials::new(username, password)` ([connector-dremio/src/lib.rs](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-dremio/src/lib.rs)), and its `PARAMETERS` array exposes exactly `dremio_endpoint`, `dremio_username`, `dremio_password`. There is no personal-access-token (PAT) parameter.

The `UNAUTHENTICATED` troubleshooting row in the Dremio deployment guide referenced an "expired PAT" and told users to "regenerate the PAT via Dremio UI." This contradicted the page's own Authentication section (which correctly documents username/password) and pointed users at a credential type the connector doesn't use.

**What the docs said:**
> `UNAUTHENTICATED` on handshake | Wrong credentials or expired PAT. | Verify credentials; regenerate the PAT via Dremio UI.

**What the code does:** username/password via Flight SQL `Credentials::new(...)`; no PAT handling.

**Fix:** reworded the row to reference the actual `dremio_username` / `dremio_password` credentials.

## Source ref

- spiceai/spiceai @ `trunk` — `crates/data-connectors/connector-dremio/src/lib.rs` (`PARAMETERS` = username/password/endpoint; `create()` builds `Credentials::new(username, password)`)

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus build succeeded — `Generated static files in "build"`)
- [x] Versioned-docs propagation checked — `PAT` for Dremio appeared only in vNext + `version-2.0.x` deployment.md (the page doesn't exist in older versions); both fixed
- [x] Files updated: 2 (vNext + version-2.0.x)