### PR TITLE
docs(arrow): hash index auto-enables via primary_key/indexes, not `hash_index: enabled`

### DIFF
--- a/website/docs/components/data-accelerators/arrow/deployment.md
+++ b/website/docs/components/data-accelerators/arrow/deployment.md
@@ -28,7 +28,7 @@ The Arrow accelerator is **not durable**. Data is held in RAM and is lost on pro
 ## Capacity & Sizing
 
 - **Memory**: Plan for 1.0–1.5× the raw row-oriented size of the source data, plus overhead for string dictionaries. Use the source connector's schema and row count to estimate.
-- **Hash index**: Optional, disabled by default. When enabled via `hash_index: enabled`, a hash map is built over the primary-key columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
+- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
 - **Startup cost**: Full-dataset materialization happens on startup. For tables larger than ~1 GB, consider a durable accelerator to avoid repeated full refresh on every restart.
 
 ## Metrics
@@ -65,5 +65,5 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
 | `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
-| Query slow for point lookups                     | Hash index disabled or wrong key column.                | Enable `hash_index: enabled`; ensure the query filter matches the primary-key columns.          |
+| Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/docs/components/data-accelerators/arrow/index.md
+++ b/website/docs/components/data-accelerators/arrow/index.md
@@ -38,7 +38,7 @@ datasets:
 Hash index is an experimental feature available in Spice v1.11.0-rc.2 and later.
 :::
 
-The In-Memory Arrow Data Accelerator supports an optional [hash index](../../features/data-acceleration/hash-index) for O(1) point lookups on primary key columns. To enable, set `hash_index: enabled` in the dataset params:
+The In-Memory Arrow Data Accelerator supports an optional [hash index](../../features/data-acceleration/hash-index) for O(1) point lookups on primary key columns. Hash indexing activates automatically when a `primary_key` (or a secondary [`indexes`](../../features/data-acceleration/indexes) entry) is configured — no additional parameter is required:
 
 ```yaml
 datasets:
@@ -47,9 +47,9 @@ datasets:
     acceleration:
       engine: arrow
       primary_key: order_id
-      params:
-        hash_index: enabled
 ```
+
+The legacy `hash_index: enabled` parameter is accepted but no longer activates indexing on its own; when set, the runtime logs a warning and falls back to the automatic rules above.
 
 See [Hash Index](../../features/data-acceleration/hash-index) for configuration details, supported data types, and performance characteristics.
 

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -27,7 +27,7 @@ Choose the appropriate [Data Accelerator](../components/data-accelerators) based
 | Large datasets (100 GB - 1+ TB)          | `cayenne`                  | Tune cache parameters                                                 |
 | Write-heavy workloads                    | `cayenne` with `zstd`      | Set `cayenne_compression_strategy: zstd`                              |
 | Point lookups, large datasets            | `cayenne`                  | Vortex provides [100x faster random access](https://bench.vortex.dev) |
-| Point lookups, small-medium datasets     | `arrow` with hash index    | Set `hash_index: enabled` (experimental, v1.11.0-rc.2+)               |
+| Point lookups, small-medium datasets     | `arrow` with hash index    | Set a `primary_key` to auto-enable the hash index (experimental, v1.11.0-rc.2+) |
 | Point lookups with explicit indexes      | `duckdb` or `sqlite`       | Configure indexes                                                     |
 
 ## Spice Cayenne Performance Optimization

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
@@ -28,7 +28,7 @@ The Arrow accelerator is **not durable**. Data is held in RAM and is lost on pro
 ## Capacity & Sizing
 
 - **Memory**: Plan for 1.0–1.5× the raw row-oriented size of the source data, plus overhead for string dictionaries. Use the source connector's schema and row count to estimate.
-- **Hash index**: Optional, disabled by default. When enabled via `hash_index: enabled`, a hash map is built over the primary-key columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
+- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
 - **Startup cost**: Full-dataset materialization happens on startup. For tables larger than ~1 GB, consider a durable accelerator to avoid repeated full refresh on every restart.
 
 ## Metrics
@@ -65,5 +65,5 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
 | `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
-| Query slow for point lookups                     | Hash index disabled or wrong key column.                | Enable `hash_index: enabled`; ensure the query filter matches the primary-key columns.          |
+| Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/index.md
@@ -38,7 +38,7 @@ datasets:
 Hash index is an experimental feature available in Spice v1.11.0-rc.2 and later.
 :::
 
-The In-Memory Arrow Data Accelerator supports an optional [hash index](../../features/data-acceleration/hash-index) for O(1) point lookups on primary key columns. To enable, set `hash_index: enabled` in the dataset params:
+The In-Memory Arrow Data Accelerator supports an optional [hash index](../../features/data-acceleration/hash-index) for O(1) point lookups on primary key columns. Hash indexing activates automatically when a `primary_key` (or a secondary [`indexes`](../../features/data-acceleration/indexes) entry) is configured — no additional parameter is required:
 
 ```yaml
 datasets:
@@ -47,9 +47,9 @@ datasets:
     acceleration:
       engine: arrow
       primary_key: order_id
-      params:
-        hash_index: enabled
 ```
+
+The legacy `hash_index: enabled` parameter is accepted but no longer activates indexing on its own; when set, the runtime logs a warning and falls back to the automatic rules above.
 
 See [Hash Index](../../features/data-acceleration/hash-index) for configuration details, supported data types, and performance characteristics.
 

--- a/website/versioned_docs/version-2.0.x/reference/performance-tuning.md
+++ b/website/versioned_docs/version-2.0.x/reference/performance-tuning.md
@@ -27,7 +27,7 @@ Choose the appropriate [Data Accelerator](../components/data-accelerators) based
 | Large datasets (100 GB - 1+ TB)          | `cayenne`                  | Tune cache parameters                                                 |
 | Write-heavy workloads                    | `cayenne` with `zstd`      | Set `cayenne_compression_strategy: zstd`                              |
 | Point lookups, large datasets            | `cayenne`                  | Vortex provides [100x faster random access](https://bench.vortex.dev) |
-| Point lookups, small-medium datasets     | `arrow` with hash index    | Set `hash_index: enabled` (experimental, v1.11.0-rc.2+)               |
+| Point lookups, small-medium datasets     | `arrow` with hash index    | Set a `primary_key` to auto-enable the hash index (experimental, v1.11.0-rc.2+) |
 | Point lookups with explicit indexes      | `duckdb` or `sqlite`       | Configure indexes                                                     |
 
 ## Spice Cayenne Performance Optimization


### PR DESCRIPTION
## Summary

The Arrow accelerator pages and the performance-tuning reference still tell users to set `hash_index: enabled` in `params` to activate the hash index. **That is no longer how it works.**

As of **v2.0.0** (spiceai/spiceai#10749), the runtime:
- strips and ignores the `hash_index` param for Arrow/PartitionedArrow, logging a warning that "hash_index alone no longer enables indexing" — `crates/runtime/src/component/dataset/acceleration.rs:470-477`
- auto-enables the hash index **only** when a `primary_key` (or a secondary `indexes` entry) is configured — `crates/runtime/src/dataaccelerator/arrow.rs:62-86` (`enable_hash_index_for_primary_key_or_indexes`)

The canonical [hash index feature page](https://docs.spiceai.org/docs/features/data-acceleration/hash-index) was already corrected for this in #1730, but that PR only touched `hash-index.md` — it left the Arrow accelerator reference + deployment pages and the performance-tuning table instructing the old (now no-op) mechanism. The Arrow `deployment.md` even contradicted itself (one troubleshooting row already said "hash index activates automatically", the next said "Enable `hash_index: enabled`").

## What changed
- `index.md` / `deployment.md` / `performance-tuning.md`: replace "set `hash_index: enabled`" guidance with "set a `primary_key` (or `indexes`) — the hash index auto-enables", and note that the legacy `hash_index: enabled` param is accepted but no longer activates indexing.

## Version scope
The behavior changed in v2.0.0 (commit `5a99cd3`, in `v2.0.0`+ only). Fixed in **vNext + version-2.0.x** only — v1.11.x / v1.10.x correctly document the legacy `hash_index: enabled` activation for their releases, so they are intentionally left untouched.

## Source
- spiceai/spiceai @ trunk — `crates/runtime/src/dataaccelerator/arrow.rs:62-86`, `crates/runtime/src/component/dataset/acceleration.rs:470-477`
- Prior partial fix: spiceai/docs#1730 (hash-index.md only)

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'`)
- [x] Versioned-docs propagation checked — vNext + version-2.0.x only (version-specific behavior change in v2.0.0)
- [x] Files updated: 6 (3 vNext + 3 version-2.0.x)