### PR TITLE
docs(data-refresh): document `on_schema_resolved` ready_state value

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -197,6 +197,7 @@ The ready state for an accelerated dataset can be configured using the [`ready_s
 
 - `ready_state: on_load`: Default. The dataset is considered ready after the initial load of the accelerated data. For file-based accelerated datasets that have existing data, this will be ready immediately. Queries against this dataset before the data is loaded will return an error.
 - `ready_state: on_registration`: The dataset is considered ready when the dataset is registered in Spice, even before the initial data is loaded. Queries against this dataset before the data is loaded will automatically fallback to the federated source. Once the data is loaded, queries will be served from the acceleration.
+- `ready_state: on_schema_resolved`: The dataset is considered ready once the federated source's schema has been resolved (which also verifies access to the source), without waiting for the initial data refresh. Queries fall back to the federated source until the initial load completes; subsequent refresh failures are still reported via dataset status and metrics.
 
 Example:
 
@@ -204,7 +205,7 @@ Example:
 datasets:
   - from: s3://my_bucket/my_dataset
     name: my_dataset
-    ready_state: on_load # or on_registration
+    ready_state: on_load # or on_registration, on_schema_resolved
     acceleration:
       enabled: true
 ```

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
@@ -197,6 +197,7 @@ The ready state for an accelerated dataset can be configured using the [`ready_s
 
 - `ready_state: on_load`: Default. The dataset is considered ready after the initial load of the accelerated data. For file-based accelerated datasets that have existing data, this will be ready immediately. Queries against this dataset before the data is loaded will return an error.
 - `ready_state: on_registration`: The dataset is considered ready when the dataset is registered in Spice, even before the initial data is loaded. Queries against this dataset before the data is loaded will automatically fallback to the federated source. Once the data is loaded, queries will be served from the acceleration.
+- `ready_state: on_schema_resolved`: The dataset is considered ready once the federated source's schema has been resolved (which also verifies access to the source), without waiting for the initial data refresh. Queries fall back to the federated source until the initial load completes; subsequent refresh failures are still reported via dataset status and metrics.
 
 Example:
 
@@ -204,7 +205,7 @@ Example:
 datasets:
   - from: s3://my_bucket/my_dataset
     name: my_dataset
-    ready_state: on_load # or on_registration
+    ready_state: on_load # or on_registration, on_schema_resolved
     acceleration:
       enabled: true
 ```


### PR DESCRIPTION
## Summary

The **Ready State** section of the data-refresh feature page lists only two `ready_state` values (`on_load`, `on_registration`), but the runtime supports a third: **`on_schema_resolved`**.

The `ReadyState` enum has three variants — `crates/spicepod/src/component/dataset.rs:125-135` (`OnLoad` / `OnRegistration` / `OnSchemaResolved`, `rename_all = "snake_case"`). `on_schema_resolved` was added in **v2.0.0** (spiceai/spiceai#10368).

#1831 documented `on_schema_resolved` on the [datasets reference page](https://docs.spiceai.org/docs/reference/spicepod/datasets#ready_state) but did not propagate it to this feature page, leaving the enumeration incomplete.

## What changed
- Add the `on_schema_resolved` bullet (reusing the description already on `datasets.md`) and include it in the example comment.

## Version scope
`on_schema_resolved` landed in v2.0.0 (commit `c968e90`, `v2.0.0`+). Fixed in **vNext + version-2.0.x**; v1.11.x and earlier do not have the value and are left unchanged.

## Source
- spiceai/spiceai @ trunk — `crates/spicepod/src/component/dataset.rs:125-135`
- Prior reference-page addition: spiceai/docs#1831

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext + version-2.0.x (value added in v2.0.0)
- [x] Files updated: 2