### PR TITLE
docs(dremio): correct false Flight client auto-retry claim in deployment guide

### DIFF
--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -29,7 +29,7 @@ Use TLS endpoints (`grpc+tls://`) in production. Credentials must be sourced fro
 
 ### Flight SQL Transport
 
-Data transfer uses gRPC. Transient `UNAVAILABLE` / `DEADLINE_EXCEEDED` errors surface to the caller and rely on the Flight client's default retry policy. Per-operation retry parameters are not exposed at the Spice layer.
+Data transfer uses gRPC. Transient `UNAVAILABLE` / `DEADLINE_EXCEEDED` errors surface to the caller; the connector does not perform automatic retries, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or rely on Spice acceleration to reduce direct coordinator queries.
 
 ### Query Pushdown
 
@@ -64,7 +64,7 @@ Dremio queries participate in [task history](../../../reference/task_history) vi
 | Symptom                                     | Likely cause                                         | Resolution                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `UNAUTHENTICATED` on handshake              | Wrong or expired username/password credentials.      | Verify `dremio_username` and `dremio_password`; reset the credentials via the Dremio UI if needed. |
-| `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Flight client auto-retries; if persistent, check coordinator health.                              |
+| `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Errors surface to the caller; retry the request from the application and check coordinator health if persistent. |
 | `PERMISSION_DENIED` on a specific dataset   | Dremio role lacks SELECT on the underlying source.   | Grant access in Dremio via the user/role management UI.                                           |
 | Slow queries for repeated dashboards        | Coordinator overloaded by repeat queries.            | Enable Spice acceleration for the dataset to cache results locally.                               |
 | TLS handshake failures                      | Self-signed cert or missing CA.                      | Configure TLS at the Flight client; ensure the CA bundle is trusted by the Spice runtime.         |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
@@ -29,7 +29,7 @@ Use TLS endpoints (`grpc+tls://`) in production. Credentials must be sourced fro
 
 ### Flight SQL Transport
 
-Data transfer uses gRPC. Transient `UNAVAILABLE` / `DEADLINE_EXCEEDED` errors surface to the caller and rely on the Flight client's default retry policy. Per-operation retry parameters are not exposed at the Spice layer.
+Data transfer uses gRPC. Transient `UNAVAILABLE` / `DEADLINE_EXCEEDED` errors surface to the caller; the connector does not perform automatic retries, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or rely on Spice acceleration to reduce direct coordinator queries.
 
 ### Query Pushdown
 
@@ -64,7 +64,7 @@ Dremio queries participate in [task history](../../../reference/task_history) vi
 | Symptom                                     | Likely cause                                         | Resolution                                                                                        |
 | ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `UNAUTHENTICATED` on handshake              | Wrong or expired username/password credentials.      | Verify `dremio_username` and `dremio_password`; reset the credentials via the Dremio UI if needed. |
-| `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Flight client auto-retries; if persistent, check coordinator health.                              |
+| `UNAVAILABLE` intermittent errors           | Network partition or coordinator restart.            | Errors surface to the caller; retry the request from the application and check coordinator health if persistent. |
 | `PERMISSION_DENIED` on a specific dataset   | Dremio role lacks SELECT on the underlying source.   | Grant access in Dremio via the user/role management UI.                                           |
 | Slow queries for repeated dashboards        | Coordinator overloaded by repeat queries.            | Enable Spice acceleration for the dataset to cache results locally.                               |
 | TLS handshake failures                      | Self-signed cert or missing CA.                      | Configure TLS at the Flight client; ensure the CA bundle is trusted by the Spice runtime.         |


### PR DESCRIPTION
## Summary

The Dremio deployment guide claimed automatic retry behavior that the connector does not implement:

- **Resilience Controls / Flight SQL Transport**: "Transient `UNAVAILABLE` / `DEADLINE_EXCEEDED` errors surface to the caller and **rely on the Flight client's default retry policy**."
- **Troubleshooting table** (`UNAVAILABLE` row): "**Flight client auto-retries**; if persistent, check coordinator health."

### What the code does

The Dremio connector uses the shared `flight_client` crate, which has **no** retry/backoff/reconnect logic:

- On a connection reset, `flight_client` returns `Error::ConnectionReset` whose message instructs the **caller** to retry — it does not retry itself: `"Connection is reset by the server. Please retry the request."` (`crates/flight_client/src/lib.rs:177-178`).
- The gRPC channel is built with a plain `tonic` `.connect()` (`crates/flight_client/src/arrow_flight_factory.rs`) — no `tower` retry layer, no backoff loop. A repo-wide search for `retry`/`backoff`/`reconnect` in `crates/flight_client/src/` finds only the error-message string above.
- The Dremio connector (`crates/data-connectors/connector-dremio/src/lib.rs`) adds no retry wrapper of its own.

Transient errors therefore surface to the caller; there is no connector-level auto-retry and no per-operation retry parameter.

### Change

Corrected both surfaces to state that errors surface to the caller and that retry/backoff must be handled by the calling application (or mitigated via Spice acceleration). Applied to vNext and the `version-2.0.x` snapshot (the only two versions that carry this deployment guide — confirmed by grep).

## Source ref
- spiceai/spiceai @ `trunk` (`d9ad5df96`)
- `crates/flight_client/src/lib.rs:177-178`, `crates/flight_client/src/arrow_flight_factory.rs`

## Test plan
- [ ] `cd website && npm run build` — **could not complete locally**: the full versioned Docusaurus build is OOM-killed (exit 137) on this 8 GB-RAM environment before reaching link/tag validation. The diff is **prose-only** (no link, frontmatter, or tag changes), so it cannot affect `onBrokenLinks`/`onInlineTags`. Relying on the CI `Deploy` check for full validation.
- [x] Versioned-docs propagation checked: `grep -rln "default retry policy\|auto-retr"` over Dremio docs returns 0 hits after the fix.
- [x] Files updated: 2 (vNext + version-2.0.x)

## Related observation (not in this PR)
The same templated "Flight client's default retry policy" / "auto-retries" wording also appears in the **spiceai** connector deployment guide (`spiceai/deployment.md:59,199,213`). That connector uses the same `flight_client`, but the guide also references a `spiceai-retryable` metadata flag and a 1000-requests-per-connection cap — the flag exists only as a **server-side** signal (`crates/runtime/src/flight/mod.rs:483`), and the cloud connection-cap reconnect behavior needs separate verification. Left out of this PR to keep one fix per PR; flagged for a follow-up audit.