### PR TITLE
docs(runtime): document runtime.query.max_concurrent_queries

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -456,6 +456,23 @@ Specify the value as a size, for example `4GiB` or `1024MiB`.
 
 For detailed memory information, see [Memory](../memory).
 
+## `runtime.query.max_concurrent_queries`
+
+The `max_concurrent_queries` parameter bounds how many query-executing plans may run concurrently. Excess queries wait (admission control) rather than oversubscribing the shared query runtime and memory pool, which can otherwise cause queries to starve each other under load — for example, analytical queries running alongside CDC ingestion and compaction.
+
+```yaml
+runtime:
+  query:
+    max_concurrent_queries: 8
+```
+
+Behavior:
+
+- Applies to ordinary queries, DDL/DML, and `EXECUTE`. Lightweight session-state statements (`PREPARE`, `DEALLOCATE`, `SET`) are not gated.
+- A permit is held for the plan's full execution and result-streaming lifetime. A results-cache hit is never gated.
+- If not set, the number of concurrent queries is **unbounded** (the default behavior).
+- A configured value is clamped to a minimum of `1`, so `max_concurrent_queries: 0` allows one concurrent query (not unbounded).
+
 ## `runtime.query.spill_compression`
 
 The `spill_compression` parameter configures compression for spill files generated during large query execution in the Spice runtime.


### PR DESCRIPTION
## Summary
Documents the new `runtime.query.max_concurrent_queries` parameter (query admission control) shipped in spiceai/spiceai#11332. Bounds how many query-executing plans run concurrently so a burst cannot oversubscribe the shared query runtime and memory pool and starve queries under load (e.g. analytical queries alongside CDC ingestion and compaction).

Verified against source (`pub struct Query` in spiceai/spiceai): field is `max_concurrent_queries: Option<usize>` under `runtime.query`; unset = unbounded; a configured value is clamped to a minimum of 1; permit held for the full execution/result-streaming lifetime; results-cache hits are never gated; `PREPARE`/`DEALLOCATE`/`SET` are not gated.

## Source PRs
- spiceai/spiceai#11332 — perf(cayenne): in-RAM scan parallelism, query admission control, ...

## Doc pages changed
- `website/docs/reference/spicepod/runtime.md` — new `## runtime.query.max_concurrent_queries` section

## Classification
New feature → vNext (`website/docs/`) only; older versions do not have the parameter.

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (addition → vNext only)
- [x] Files updated: 1