### PR TITLE
docs(databricks): add required databricks_ prefix to catalog GCS dataset param

### DIFF
--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -224,7 +224,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.10.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.10.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.11.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.11.x/components/catalogs/databricks.md
@@ -210,7 +210,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.5.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.5.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.6.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.6.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.7.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.7.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.8.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.8.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-1.9.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-1.9.x/components/catalogs/databricks.md
@@ -206,7 +206,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 

--- a/website/versioned_docs/version-2.0.x/components/catalogs/databricks.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/databricks.md
@@ -224,7 +224,7 @@ catalogs:
 
 | Dataset Parameter Name   | Definition                                                   |
 | ------------------------ | ------------------------------------------------------------ |
-| `google_service_account` | Filesystem path to the Google service account JSON key file. |
+| `databricks_google_service_account` | Filesystem path to the Google service account JSON key file. |
 
 Example:
 


### PR DESCRIPTION
## Summary

The Databricks catalog page documents the GCS dataset parameter as `google_service_account` (without the connector prefix) in the **Google Storage (GCS)** params table, while the YAML example directly below it correctly uses `databricks_google_service_account`. The sibling S3 and Azure rows on the same page are all correctly prefixed (`databricks_aws_*`, `databricks_azure_*`) — only the GCS row was missing the prefix.

**What the code does:** the parameter is registered as `ParameterSpec::component("google_service_account")` (`crates/data-connectors/connector-databricks/src/lib.rs:1497`). `component(...)` params are prefixed with the connector name at runtime and validated against `CATALOG_PARAMETERS` with prefix `databricks` (`lib.rs:1606`). There is no bare/runtime `google_service_account`, so an unprefixed key in `dataset_params:` is filtered out and silently ignored — a reader copying the table name would hit an invalid-parameter error.

**Fix:** corrected the table row to `databricks_google_service_account`, matching the page's own example and the data-connector reference page (`data-connectors/databricks/index.md`, already correct).

## Source

- spiceai/spiceai @ `trunk` — [`connector-databricks/src/lib.rs:1497`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-databricks/src/lib.rs)

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: corrected in vNext + all 8 versioned copies (1.5.x–2.0.x); `grep -rn '| \`google_service_account\` |' website/` returns 0
- [x] Files updated: 9 (1 unversioned + 8 versioned), matching the diff