### PR TITLE
docs(datasets): correct snapshots_trigger for refresh_mode caching

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -454,10 +454,14 @@ Snapshots are written beneath the configured snapshot location using Hive-style 
 
 Optional. Controls when Spice creates new snapshots. The available triggers depend on the dataset's refresh mode.
 
-**For batch-based datasets** (`refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with `time_column`):
+**For batch-based datasets** (`refresh_mode: full`, or `refresh_mode: append` with `time_column`):
 
 - `refresh_complete` (default) – Create a snapshot after each data refresh completes.
 - `time_interval` – Create snapshots at a fixed time interval specified by `snapshots_trigger_threshold`.
+
+**For caching datasets** (`refresh_mode: caching`):
+
+- `time_interval` (default) – The only supported trigger. Create snapshots at a fixed time interval, defaulting to `10m` if `snapshots_trigger_threshold` is not specified. `refresh_complete` and `stream_batches` are not supported in caching mode and cause a configuration error.
 
 **For stream-based datasets** (`refresh_mode: changes`, or `refresh_mode: append` without `time_column`):
 

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -328,10 +328,14 @@ Snapshots are written beneath the configured snapshot location using Hive-style 
 
 Optional. Controls when Spice creates new snapshots. The available triggers depend on the dataset's refresh mode.
 
-**For batch-based datasets** (`refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with `time_column`):
+**For batch-based datasets** (`refresh_mode: full`, or `refresh_mode: append` with `time_column`):
 
 - `refresh_complete` (default) – Create a snapshot after each data refresh completes.
 - `time_interval` – Create snapshots at a fixed time interval specified by `snapshots_trigger_threshold`.
+
+**For caching datasets** (`refresh_mode: caching`):
+
+- `time_interval` (default) – The only supported trigger. Create snapshots at a fixed time interval, defaulting to `10m` if `snapshots_trigger_threshold` is not specified. `refresh_complete` and `stream_batches` are not supported in caching mode and cause a configuration error.
 
 **For stream-based datasets** (`refresh_mode: changes`, or `refresh_mode: append` without `time_column`):
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
@@ -408,10 +408,14 @@ Snapshots are written beneath the configured snapshot location using Hive-style 
 
 Optional. Controls when Spice creates new snapshots. The available triggers depend on the dataset's refresh mode.
 
-**For batch-based datasets** (`refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with `time_column`):
+**For batch-based datasets** (`refresh_mode: full`, or `refresh_mode: append` with `time_column`):
 
 - `refresh_complete` (default) – Create a snapshot after each data refresh completes.
 - `time_interval` – Create snapshots at a fixed time interval specified by `snapshots_trigger_threshold`.
+
+**For caching datasets** (`refresh_mode: caching`):
+
+- `time_interval` (default) – The only supported trigger. Create snapshots at a fixed time interval, defaulting to `10m` if `snapshots_trigger_threshold` is not specified. `refresh_complete` and `stream_batches` are not supported in caching mode and cause a configuration error.
 
 **For stream-based datasets** (`refresh_mode: changes`, or `refresh_mode: append` without `time_column`):
 


### PR DESCRIPTION
## Summary

The `acceleration.snapshots_trigger` reference grouped `refresh_mode: caching` together with batch-based datasets (`full`, `append` + `time_column`) and stated that `refresh_complete` is the default. That is wrong for caching mode.

In the runtime, caching is handled on its **own** branch:

```rust
let is_caching = matches!(refresh_mode, RefreshMode::Caching);
let snapshot_creation_trigger = if is_caching {
    match snapshot_trigger {
        None | Some(SnapshotsTrigger::TimeInterval) => SnapshotCreateTrigger::Interval(parse_interval(&snapshot_threshold)?),
        Some(SnapshotsTrigger::RefreshComplete | SnapshotsTrigger::StreamBatches) =>
            return Err(Error::UnsupportedSnapshotTriggerForCaching),
    }
} else if is_streaming_refresh { ... } else { ... }
```

So for `refresh_mode: caching`:
- The default (and only supported) trigger is `time_interval` (defaults to `10m`).
- `refresh_complete` and `stream_batches` are **not** supported — they return `UnsupportedSnapshotTriggerForCaching`.

This PR splits caching into its own subsection with the correct supported value and default.

## What the docs said vs. what the code does

- **Said:** caching is batch-based; `refresh_complete` (default), `time_interval`.
- **Code:** caching is its own branch; `time_interval` (default, only supported); `refresh_complete`/`stream_batches` error out.

## Source

- spiceai/spiceai @ `trunk` — `crates/runtime/src/datafusion/mod.rs` (`is_caching` branch, `Error::UnsupportedSnapshotTriggerForCaching`).
- Verified the same branch exists at `v1.11.6` and `v2.0.1`, so the correction is propagated to both versioned doc sets.

## Test plan
- [x] `cd website && npm run build` passes (`[SUCCESS] Generated static files`)
- [x] Versioned-docs propagation: 0 occurrences of the wrong grouping remain (`grep -rln`); fixed in vNext + 1.11.x + 2.0.x
- [x] Files updated: 3