### PR TITLE
docs(cosmosdb): correct inflight_operations metric as auto-registered, not opt-in

### DIFF
--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -93,13 +93,13 @@ The connector uses a single shared HTTP/2 connection pool to each account endpoi
 
 ## Metrics
 
-The Cosmos DB connector exposes one observable gauge that can be enabled per dataset:
+The Cosmos DB connector exposes one observable gauge, registered automatically for every dataset:
 
 | Metric Name           | Description                                                                                                                                                  |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `inflight_operations` | Number of Cosmos DB operations currently holding a concurrency permit. Incremented per operation and held across retry-backoff sleeps. **Per-dataset**, not per-account. |
 
-Enable in the dataset's `metrics` section:
+This metric is auto-registered — no configuration is required to export it. To disable it for a dataset, set `enabled: false` in the dataset's `metrics` section:
 
 ```yaml
 datasets:
@@ -109,7 +109,7 @@ datasets:
       cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
     metrics:
       - name: inflight_operations
-        enabled: true
+        enabled: false
 ```
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
@@ -146,6 +146,6 @@ Cosmos DB requests participate in [task history](../../../reference/task_history
 | RU consumption spikes on every restart                             | `schema_infer_max_records` × document size.                                               | Lower the sample size or pin a schema via `columns:`.                                                                            |
 | Schema doesn't include a field that exists in production           | The first `schema_infer_max_records` documents had `null` for that field.                  | Increase `schema_infer_max_records`, or pin the schema explicitly.                                                               |
 | `Invalid Azure Cosmos DB connection string`                        | Connection string was edited or trimmed.                                                   | Re-copy the full string from the Azure portal — `AccountEndpoint=...;AccountKey=...;` (note the trailing `;`).                    |
-| `Invalid dataset path` error at registration                       | `from:` does not match `cosmosdb:database.container`.                                      | Use `cosmosdb:database.container` or `cosmosdb:database/container`, or set `cosmosdb_database` and use `cosmosdb:container`.      |
+| `Could not determine Cosmos DB database from dataset path` error at registration | `from:` does not match `cosmosdb:database.container`.                            | Use `cosmosdb:database.container` or `cosmosdb:database/container`, or set `cosmosdb_database` and use `cosmosdb:container`.      |
 | Multiple datasets, one with a different `max_concurrent_requests`  | Spice keeps the **first-seen** value across datasets sharing an endpoint.                  | Set the same value on every dataset that targets the same account, or accept the warning logged at startup.                       |
 | Mid-stream scan failure leaves dataset partially loaded            | Cosmos returned an error after some rows had been emitted; mid-stream retry is not safe.   | The dataset refresh policy retries at the query boundary. For incidental failures, lower the `query` row count or accelerate.     |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
@@ -93,13 +93,13 @@ The connector uses a single shared HTTP/2 connection pool to each account endpoi
 
 ## Metrics
 
-The Cosmos DB connector exposes one observable gauge that can be enabled per dataset:
+The Cosmos DB connector exposes one observable gauge, registered automatically for every dataset:
 
 | Metric Name           | Description                                                                                                                                                  |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `inflight_operations` | Number of Cosmos DB operations currently holding a concurrency permit. Incremented per operation and held across retry-backoff sleeps. **Per-dataset**, not per-account. |
 
-Enable in the dataset's `metrics` section:
+This metric is auto-registered — no configuration is required to export it. To disable it for a dataset, set `enabled: false` in the dataset's `metrics` section:
 
 ```yaml
 datasets:
@@ -109,7 +109,7 @@ datasets:
       cosmosdb_connection_string: ${secrets:COSMOSDB_CONNECTION_STRING}
     metrics:
       - name: inflight_operations
-        enabled: true
+        enabled: false
 ```
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
@@ -146,6 +146,6 @@ Cosmos DB requests participate in [task history](../../../reference/task_history
 | RU consumption spikes on every restart                             | `schema_infer_max_records` × document size.                                               | Lower the sample size or pin a schema via `columns:`.                                                                            |
 | Schema doesn't include a field that exists in production           | The first `schema_infer_max_records` documents had `null` for that field.                  | Increase `schema_infer_max_records`, or pin the schema explicitly.                                                               |
 | `Invalid Azure Cosmos DB connection string`                        | Connection string was edited or trimmed.                                                   | Re-copy the full string from the Azure portal — `AccountEndpoint=...;AccountKey=...;` (note the trailing `;`).                    |
-| `Invalid dataset path` error at registration                       | `from:` does not match `cosmosdb:database.container`.                                      | Use `cosmosdb:database.container` or `cosmosdb:database/container`, or set `cosmosdb_database` and use `cosmosdb:container`.      |
+| `Could not determine Cosmos DB database from dataset path` error at registration | `from:` does not match `cosmosdb:database.container`.                            | Use `cosmosdb:database.container` or `cosmosdb:database/container`, or set `cosmosdb_database` and use `cosmosdb:container`.      |
 | Multiple datasets, one with a different `max_concurrent_requests`  | Spice keeps the **first-seen** value across datasets sharing an endpoint.                  | Set the same value on every dataset that targets the same account, or accept the warning logged at startup.                       |
 | Mid-stream scan failure leaves dataset partially loaded            | Cosmos returned an error after some rows had been emitted; mid-stream retry is not safe.   | The dataset refresh policy retries at the query boundary. For incidental failures, lower the `query` row count or accelerate.     |


### PR DESCRIPTION
## Summary

Two accuracy fixes on the Azure Cosmos DB connector **deployment guide**, verified against the current `spiceai/spiceai` source.

### 1. `inflight_operations` metric is auto-registered, not opt-in (wrong behavior)

The docs said the gauge "can be enabled per dataset" and showed a `metrics:` block with `enabled: true` as the way to turn it on. In reality the metric is declared with `.auto_register()`, so it is **exported by default for every dataset with no `metrics:` block at all**. The registration gate is `if explicitly_disabled || (!metric.auto_register && !user_enabled) { continue; }` — with `auto_register == true` the metric always registers; the `metrics:` block can only *disable* it (`enabled: false`).

- Source: [`crates/runtime/src/dataconnector/cosmosdb.rs:113-115`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/cosmosdb.rs#L113-L115) (`.auto_register()`) and the gate at [`crates/runtime/src/init/dataset.rs:349`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/init/dataset.rs#L349).
- Fix: reword to state the metric is auto-registered, and change the example to `enabled: false` (the only thing the block can do).

### 2. Troubleshooting error string does not match the runtime (wrong error text)

The troubleshooting table listed a `` `Invalid dataset path` `` symptom. The `InvalidDatasetPath` error variant is **declared but never constructed** — the path actually parses in `parse_database_and_container`, which on failure emits **"Could not determine Cosmos DB database from dataset path ..."**.

- Source: [`crates/runtime/src/dataconnector/cosmosdb.rs:347-349`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/cosmosdb.rs#L347-L349); variant defined-only at `crates/data_components/src/cosmosdb/mod.rs:101`.
- Fix: change the symptom cell to the real message.

## Versioning

The Cosmos DB connector only exists in v2.0.x and vNext, and `.auto_register()` has been on the metric since the connector was introduced (spiceai/spiceai#10392, present in v2.0.1). Both occurrences fixed: `website/docs/` (vNext) and `website/versioned_docs/version-2.0.x/`. Confirmed via grep that no other versioned dir carries either claim.

## Test plan
- [x] `cd website && npm run build` passes (no broken links / undefined tags)
- [x] Versioned-docs propagation: grep confirms 0 remaining occurrences of either stale claim
- [x] Files updated: 2 (vNext + version-2.0.x deployment.md)