### PR TITLE
docs(imap): remove orphaned Outlook OAuth cookbook link

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/imap.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/imap.md
@@ -124,4 +124,3 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 ## Cookbook
 
 - A cookbook recipe to configure IMAP as a data connector in Spice. [IMAP Data Connector](https://github.com/spiceai/cookbook/tree/trunk/imap/#readme)
-- A cookbook recipe to configure IMAP with Outlook using OAuth authentication as a data connector in Spice. [Connecting to an Outlook mailbox](https://github.com/spiceai/cookbook/tree/trunk/imap#readme)


### PR DESCRIPTION
## Summary

The IMAP connector page lists a Cookbook recipe **"Connecting to an Outlook mailbox"** described as configuring *IMAP with Outlook using OAuth authentication*. This entry is stale and incorrect on three counts:

1. **OAuth is not supported by the IMAP connector.** `parse_authentication` unconditionally builds `ImapAuthModeParameter::Plain` ([connector-imap/src/lib.rs:188](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-imap/src/lib.rs#L188)). There is no parameter to select an OAuth/XOAUTH2 auth mode. IMAP OAuth documentation was already removed in spiceai/docs#948.
2. **The linked recipe does not exist.** The link target `.../cookbook/tree/trunk/imap#readme` is the *same* URL as the basic "IMAP Data Connector" recipe directly above it — the cookbook contains only the single `imap` recipe, with no Outlook/OAuth variant.
3. It was therefore a duplicate link with a misleading label.

## What changed

Removed the orphaned bullet from the Cookbook section. The valid "IMAP Data Connector" recipe link is retained.

## Source ref

- Code: spiceai/spiceai @ `trunk` (`9c71a3ac2`), `crates/data-connectors/connector-imap/src/lib.rs:188` (Plain auth hardcoded)
- Prior cleanup: spiceai/docs#948 — "docs: Remove IMAP OAuth"

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: removed in vNext + all 8 versioned copies (9 files, 9 deletions) — grep for `Outlook using OAuth` now returns 0 hits
- [x] Basic IMAP recipe link retained in all 9 files