### PR TITLE
docs(views): document view-level params.file_format for embedding chunking

### DIFF
--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -43,6 +43,26 @@ The name of the view. Used to reference the view in the pod manifest, as well as
 
 The description of the view. Used as part of the [Semantic Data Model](../../features/semantic-model).
 
+## `params`
+
+Optional. A map of view-level parameters, mirroring the `params` map available on [datasets](./datasets).
+
+Currently the only supported key is `file_format`, which selects the [file format](../file_format) used when chunking the view's columns for [embeddings](../../components/embeddings). It accepts the same values as the dataset `file_format` parameter (for example `parquet`, `csv`, `json`, `md`).
+
+```yaml
+views:
+  - name: my_view
+    sql_ref: ./my_view.sql
+    params:
+      file_format: md
+    columns:
+      - name: body
+        embeddings:
+          - from: my_embedding_model
+            chunking:
+              enabled: true
+```
+
 ## `ready_state`
 
 Supports one of two values:


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11424](https://github.com/spiceai/spiceai/pull/11424) added a generic `params` map to views (mirroring datasets) and wired `params.file_format` through to embedding chunking. Previously views had no `params` field, so the chunking file format could not be set.

This documents the new `params` section on the views Spicepod reference, with `file_format` as the currently-supported key (verified in source: `prepare_view` reads `view.params.get("file_format")` and passes it into both the vector-engine and plain-embedding chunking paths).

## Source PRs
- spiceai/spiceai#11424 — feat(views): support params.file_format for embedding chunking

## Test plan
- [x] `cd website && npm run build` passes
- [x] Addition (new feature) → vNext only (`website/docs/`); not propagated to versioned docs
- [x] Files updated: 1