### PR TITLE
docs(s3_vectors): document 10,000 topK search limit via pagination

### DIFF
--- a/website/docs/components/vectors/s3_vectors.md
+++ b/website/docs/components/vectors/s3_vectors.md
@@ -51,6 +51,7 @@ embeddings:
 
 - `s3_vectors_index` and `s3_vectors_arn` specify a single index for the dataset and therefore should not be used with a dataset containing more than one embedding column.
 - S3 Vectors uses approximate nearest neighbor (ANN) algorithms for performance, providing probabilistically closest results.
+- A single vector search can retrieve up to **10,000** results. Spice paginates the underlying `QueryVectors` calls (100 results per page) to reach this limit. When no `LIMIT` is specified, the search returns one page (100 results); a `LIMIT` larger than 10,000 is clamped to 10,000.
 
   :::
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11405](https://github.com/spiceai/spiceai/pull/11405) raised the S3 Vectors `QueryVectors` cap from 100 to 10,000 results via transparent pagination (100 results per page). Previously vector searches were silently truncated at 100 rows. This documents the new limit on the S3 Vectors engine page.

Verified against source: `QUERY_VECTORS_MAX_TOPK = 10_000`, `QUERY_VECTORS_PAGE_SIZE = 100`; no `LIMIT` defaults to one page (`S3_VECTOR_PAGE_SIZE`), an oversized `LIMIT` clamps to `S3_VECTOR_MAX_TOPK`.

## Source PRs
- spiceai/spiceai#11405 — feat(s3_vectors): paginate QueryVectors for topK up to 10,000

## Test plan
- [x] `cd website && npm run build` passes
- [x] Addition (new behavior in this release) → vNext only; older versioned docs correctly reflect the prior 100 cap
- [x] Files updated: 1