### PR TITLE
docs(graphql): correct false metrics claim — connector does register rate-control instruments

### DIFF
--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -54,13 +54,32 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 ## Metrics
 
-The GraphQL connector does not register connector-specific instruments. Monitor via:
+When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset:
+
+| Metric Name                                 | Type    | Description                                                                                              |
+| ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `inflight_operations`                       | Gauge   | Current number of HTTP requests holding a rate-control permit.                                           |
+| `rate_control_max_concurrent_requests`      | Gauge   | Configured maximum concurrent HTTP requests for this upstream origin; `0` means disabled.                |
+| `rate_control_requests_per_second_limit`    | Gauge   | Configured HTTP request-per-second limit for this upstream origin; `0` means disabled.                   |
+| `rate_control_requests_per_minute_limit`    | Gauge   | Configured HTTP request-per-minute limit for this upstream origin; `0` means disabled.                   |
+| `rate_control_jitter_min_ms`                | Gauge   | Configured minimum rate-control jitter (ms) before HTTP requests.                                        |
+| `rate_control_jitter_max_ms`                | Gauge   | Configured maximum rate-control jitter (ms) before HTTP requests.                                        |
+| `rate_control_available_permits`            | Gauge   | Current available permits in the HTTP request concurrency semaphore; `0` when concurrency is disabled.   |
+| `rate_control_acquisitions_total`           | Counter | Total HTTP request rate-control permits acquired.                                                        |
+| `rate_control_acquire_errors_total`         | Counter | Total HTTP request rate-control permit acquisition errors.                                               |
+| `rate_control_wait_duration_ms`             | Counter | Cumulative time (ms) spent waiting for HTTP rate-control permits, quotas, and jitter.                    |
+| `rate_limit_retry_after_updates_total`      | Counter | Total upstream cooldown hints accepted from `Retry-After` or `RateLimit` reset headers.                  |
+| `rate_limit_retry_after_waits_total`        | Counter | Total waits caused by `Retry-After` or `RateLimit` reset headers.                                        |
+| `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
+| `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
+
+Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+
+For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
-
-See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
@@ -54,13 +54,32 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 ## Metrics
 
-The GraphQL connector does not register connector-specific instruments. Monitor via:
+When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset:
+
+| Metric Name                                 | Type    | Description                                                                                              |
+| ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `inflight_operations`                       | Gauge   | Current number of HTTP requests holding a rate-control permit.                                           |
+| `rate_control_max_concurrent_requests`      | Gauge   | Configured maximum concurrent HTTP requests for this upstream origin; `0` means disabled.                |
+| `rate_control_requests_per_second_limit`    | Gauge   | Configured HTTP request-per-second limit for this upstream origin; `0` means disabled.                   |
+| `rate_control_requests_per_minute_limit`    | Gauge   | Configured HTTP request-per-minute limit for this upstream origin; `0` means disabled.                   |
+| `rate_control_jitter_min_ms`                | Gauge   | Configured minimum rate-control jitter (ms) before HTTP requests.                                        |
+| `rate_control_jitter_max_ms`                | Gauge   | Configured maximum rate-control jitter (ms) before HTTP requests.                                        |
+| `rate_control_available_permits`            | Gauge   | Current available permits in the HTTP request concurrency semaphore; `0` when concurrency is disabled.   |
+| `rate_control_acquisitions_total`           | Counter | Total HTTP request rate-control permits acquired.                                                        |
+| `rate_control_acquire_errors_total`         | Counter | Total HTTP request rate-control permit acquisition errors.                                               |
+| `rate_control_wait_duration_ms`             | Counter | Cumulative time (ms) spent waiting for HTTP rate-control permits, quotas, and jitter.                    |
+| `rate_limit_retry_after_updates_total`      | Counter | Total upstream cooldown hints accepted from `Retry-After` or `RateLimit` reset headers.                  |
+| `rate_limit_retry_after_waits_total`        | Counter | Total waits caused by `Retry-After` or `RateLimit` reset headers.                                        |
+| `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
+| `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
+
+Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+
+For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
-
-See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 ## Task History
 


### PR DESCRIPTION
## Summary

The GraphQL connector deployment guide stated:

> The GraphQL connector does not register connector-specific instruments.

This is **incorrect**. When used as a dataset connector (with a parseable URL), GraphQL returns an `HttpRateControlMetricsProvider` from `metrics_provider()`, registering the full HTTP rate-control metric suite under the `graphql` component — the same metrics already documented on the HTTPS connector page.

**Code evidence** (`spiceai/spiceai` @ origin/trunk, c7a744de5):
- `crates/data-connectors/connector-graphql/src/lib.rs:340-351` — `metrics_provider()` returns `Some(HttpRateControlMetricsProvider::new("graphql", ...))` when `emit_rate_control_metrics` is true.
- `emit_rate_control_metrics` is set true for any `Dataset` component with a parseable URL (`lib.rs:117-143`).
- The registered metrics are `HTTP_RATE_CONTROL_METRIC_SPECS` (`crates/runtime/src/dataconnector/http_rate_control.rs:324`).

The replacement reuses the verified metric table from the HTTPS connector page (the only other connector that wires this provider).

## What changed

Replaced the false claim with the actual per-origin rate-control metric table (15 metrics) and kept the broader-observability bullets.

## Version scope

The rate-control metrics shipped in **v2.0.0** (spiceai/spiceai#10648, 2026-05-04), so the claim is wrong only in:
- vNext (`website/docs/`)
- `version-2.0.x` (latest v2.0.x = v2.0.1, contains the commit)

v1.x has no GraphQL deployment guide and predates the feature, so it is correctly untouched. file/duckdb/elasticsearch carry the same sentence but genuinely register no connector metrics (only `https` and `graphql` wire this provider), so they are left as-is.

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked: 2 files (vNext + version-2.0.x), the only GraphQL deployment guides; v1.x correctly unchanged
- [x] Files updated: 2