### PR TITLE
docs(graphql): fix fabricated duplicate-column error message string

### DIFF
--- a/website/docs/components/data-connectors/graphql/index.md
+++ b/website/docs/components/data-connectors/graphql/index.md
@@ -343,7 +343,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid GraphQL object access: Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/graphql.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/graphql.md
@@ -296,7 +296,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid object access. Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/index.md
@@ -343,7 +343,7 @@ params:
 This example would fail with a runtime error:
 
 ```bash
-WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
+WARN runtime: Invalid GraphQL object access: Column 'name' already exists in the object.
 ```
 
 Avoid this error by [using aliases in the query](https://www.apollographql.com/docs/kotlin/advanced/using-aliases/) where possible. In the example above, a duplicate error was introduced from `emergency_contact { name }`.


### PR DESCRIPTION
## Summary

The GraphQL unnesting example shows this runtime error:

```
WARN runtime: GraphQL Data Connector Error: Invalid object access. Column 'name' already exists in the object.
```

Two problems:
1. The `GraphQL Data Connector Error:` prefix is **fabricated** — that literal string exists nowhere in `spiceai/spiceai` (verified by repo-wide grep).
2. The message body drifted from the actual snafu `Display`.

**Code evidence** (`crates/data_components/src/graphql/mod.rs:57`):
- v2.0+: `Invalid GraphQL object access: {message}` (test assertion at `client.rs:2339`)
- v1.x: `Invalid object access. {message}` (`git show v1.5.0:.../graphql/mod.rs:51`)

The `{message}` is `Column 'name' already exists in the object.` (`client.rs:623`).

## What changed

Removed the fabricated prefix and corrected the message body to the exact `Display` string, **version-aware**:
- **vNext + version-2.0.x** → `Invalid GraphQL object access: …`
- **version-1.5.x – 1.11.x** → `Invalid object access. …`

The display string changed in **v2.0** (spiceai/spiceai#9233 "v2.0 breaking changes"), so each snapshot now matches the runtime it documents.

## Version scope

Correction predating versioning → fixed in every snapshot that carries the line. Grep for the fabricated string now returns 0 source hits.

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: 9 files (vNext + 2.0.x + 1.5.x–1.11.x), all occurrences swept; v2.0+ vs v1.x wording differentiated
- [x] Files updated: 9