### PR TITLE
docs(distributed-query): document scheduler failover for async query job state

### DIFF
--- a/website/docs/features/distributed-query/index.md
+++ b/website/docs/features/distributed-query/index.md
@@ -673,7 +673,13 @@ runtime:
       region: us-east-1
 ```
 
-The object store is used for scheduler registration and discovery. Job state persistence for query handoff between schedulers is planned for a future release.
+The object store is used for scheduler registration and discovery, and to persist [async query](#async-queries-api) job state (the execution graph plus its status) so that schedulers are effectively stateless for async queries.
+
+### Scheduler Failover
+
+When `runtime.scheduler.state_location` is configured, each async query's execution graph and status are persisted to the shared object store. If the scheduler driving an async query becomes unavailable, another scheduler detects the orphaned job and resumes it to completion from the persisted execution graph — the query is re-driven rather than replanned, and consumers and executors do not need to know which scheduler is running it. Takeover is single-winner: ownership transfers via a compare-and-set on the job's metadata, and a scheduler never reclaims its own in-flight jobs.
+
+This failover applies to async queries, which require `scheduler.state_location`. Synchronous queries in flight on a scheduler that becomes unavailable are not resumed automatically; the client should retry them against another scheduler. Without `scheduler.state_location`, job state is held in memory and a single-scheduler cluster behaves as before (no failover).
 
 ### S3 Configuration
 


### PR DESCRIPTION
## Summary

The **High Availability** section of the distributed query docs stated that "Job state persistence for query handoff between schedulers is planned for a future release." That feature has now shipped, so the doc was stale.

[spiceai/spiceai#11436](https://github.com/spiceai/spiceai/pull/11436) added object-store-backed shared Ballista job state (`SharedJobState`) with scheduler failover: when `runtime.scheduler.state_location` is configured, each async query's execution graph and status are persisted to the shared object store, and if the scheduler driving an async query becomes unavailable, another scheduler detects the orphaned job and resumes it to completion (single-winner compare-and-set takeover). Without `state_location`, job state stays in memory and single-scheduler behavior is unchanged.

This replaces the "planned for a future release" sentence with an accurate description and adds a short **Scheduler Failover** subsection, scoped accurately to async queries (synchronous in-flight queries are not auto-resumed).

## Source PRs

- [spiceai/spiceai#11436](https://github.com/spiceai/spiceai/pull/11436) — feat(cluster): shared Ballista job state with scheduler failover (closes spiceai/spiceai#8944)

## Versioning

Addition (feature shipped after v2.0, unreleased) → **vNext only**. The `version-1.11.x` and `version-2.0.x` copies correctly retain "planned for a future release" because the feature is not in those releases.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'`); the new `#async-queries-api` anchor link resolves
- [x] Versioned-docs propagation checked — addition, vNext only; versioned copies intentionally untouched
- [x] Files updated: 1 (`website/docs/features/distributed-query/index.md`)
