### PR TITLE
docs(github): correct labels/assignees/hashes column types to List(Struct)

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -236,14 +236,14 @@ datasets:
 
 | Column Name     | Data Type    | Is Nullable |
 | --------------- | ------------ | ----------- |
-| assignees       | List(Utf8)   | YES         |
+| assignees       | List(Struct(login: Utf8)) | YES         |
 | author          | Utf8         | YES         |
 | body            | Utf8         | YES         |
 | closed_at       | Timestamp    | YES         |
 | comments        | List(Struct) | YES         |
 | created_at      | Timestamp    | YES         |
 | id              | Utf8         | YES         |
-| labels          | List(Utf8)   | YES         |
+| labels          | List(Struct(name: Utf8)) | YES         |
 | milestone_id    | Utf8         | YES         |
 | milestone_title | Utf8         | YES         |
 | comments_count  | Int64        | YES         |
@@ -304,7 +304,7 @@ datasets:
 | Column Name     | Data Type                                                     | Is Nullable |
 | --------------- | ------------------------------------------------------------- | ----------- |
 | additions       | Int64                                                         | YES         |
-| assignees       | List(Utf8)                                                    | YES         |
+| assignees       | List(Struct(login: Utf8))                                     | YES         |
 | author          | Utf8                                                          | YES         |
 | body            | Utf8                                                          | YES         |
 | changed_files   | Int64                                                         | YES         |
@@ -314,9 +314,9 @@ datasets:
 | created_at      | Timestamp                                                     | YES         |
 | deletions       | Int64                                                         | YES         |
 | discussion      | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
-| hashes          | List(Utf8)                                                    | YES         |
+| hashes          | List(Struct(id: Utf8))                                        | YES         |
 | id              | Utf8                                                          | YES         |
-| labels          | List(Utf8)                                                    | YES         |
+| labels          | List(Struct(name: Utf8))                                      | YES         |
 | merged_at       | Timestamp                                                     | YES         |
 | number          | Int64                                                         | YES         |
 | review_comments | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
@@ -236,14 +236,14 @@ datasets:
 
 | Column Name     | Data Type    | Is Nullable |
 | --------------- | ------------ | ----------- |
-| assignees       | List(Utf8)   | YES         |
+| assignees       | List(Struct(login: Utf8)) | YES         |
 | author          | Utf8         | YES         |
 | body            | Utf8         | YES         |
 | closed_at       | Timestamp    | YES         |
 | comments        | List(Struct) | YES         |
 | created_at      | Timestamp    | YES         |
 | id              | Utf8         | YES         |
-| labels          | List(Utf8)   | YES         |
+| labels          | List(Struct(name: Utf8)) | YES         |
 | milestone_id    | Utf8         | YES         |
 | milestone_title | Utf8         | YES         |
 | comments_count  | Int64        | YES         |
@@ -304,7 +304,7 @@ datasets:
 | Column Name     | Data Type                                                     | Is Nullable |
 | --------------- | ------------------------------------------------------------- | ----------- |
 | additions       | Int64                                                         | YES         |
-| assignees       | List(Utf8)                                                    | YES         |
+| assignees       | List(Struct(login: Utf8))                                     | YES         |
 | author          | Utf8                                                          | YES         |
 | body            | Utf8                                                          | YES         |
 | changed_files   | Int64                                                         | YES         |
@@ -314,9 +314,9 @@ datasets:
 | created_at      | Timestamp                                                     | YES         |
 | deletions       | Int64                                                         | YES         |
 | discussion      | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
-| hashes          | List(Utf8)                                                    | YES         |
+| hashes          | List(Struct(id: Utf8))                                        | YES         |
 | id              | Utf8                                                          | YES         |
-| labels          | List(Utf8)                                                    | YES         |
+| labels          | List(Struct(name: Utf8))                                      | YES         |
 | merged_at       | Timestamp                                                     | YES         |
 | number          | Int64                                                         | YES         |
 | review_comments | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |


### PR DESCRIPTION
## Summary

The GitHub connector schema tables documented `labels`, `assignees`, and `hashes` as `List(Utf8)`. The connector actually returns these as single-field **struct lists**: `List(Struct(...))`. (`comments`, `discussion`, and `review_comments` on the same pages are already correctly documented as `List(Struct(...))`.)

Corrected 5 rows on each page:
- Issues table: `assignees` → `List(Struct(login: Utf8))`, `labels` → `List(Struct(name: Utf8))`
- Pull requests table: `assignees` → `List(Struct(login: Utf8))`, `hashes` → `List(Struct(id: Utf8))`, `labels` → `List(Struct(name: Utf8))`

The GitHub connector page exists only in vNext and the 2.0.x versioned docs; the `List(Struct)` schema predates both (introduced with explicit schemas in spiceai/spiceai#2661, shipped in v0.18-beta), so both copies are fixed here.

## Source

Verified against spiceai/spiceai at `trunk` (origin/trunk = `3cc242367`):
- [`crates/runtime/src/dataconnector/github/issues.rs#L195-L233`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/github/issues.rs#L195-L233) — `labels` = `List(Struct(name: Utf8))`, `assignees` = `List(Struct(login: Utf8))`
- [`crates/runtime/src/dataconnector/github/pull_requests.rs#L487-L527`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/github/pull_requests.rs#L487-L527) — `assignees` = `List(Struct(login))`, `hashes` = `List(Struct(id))`, `labels` = `List(Struct(name))`

## Test plan
- [x] `cd website && npm run build` passes
- [x] Files updated: 2 (vNext + version-2.0.x), 10 rows total