### PR TITLE
docs(adbc): correct false connection_pool_min_idle coercion claim

### DIFF
--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -273,7 +273,7 @@ The ADBC connector maintains a pool of database connections for concurrent query
 - `connection_pool_size`: The maximum number of connections. Increase for workloads with many concurrent queries.
 - `connection_pool_min_idle`: The minimum number of idle connections kept open to reduce connection setup latency.
 
-Both values must be positive integers. A `connection_pool_min_idle` greater than `connection_pool_size` is coerced to `connection_pool_size`.
+Both values must be positive integers, and `connection_pool_min_idle` must not exceed `connection_pool_size` — a larger value causes connection pool initialization to fail.
 
 ### Query Pushdown
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/adbc.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/adbc.md
@@ -273,7 +273,7 @@ The ADBC connector maintains a pool of database connections for concurrent query
 - `connection_pool_size`: The maximum number of connections. Increase for workloads with many concurrent queries.
 - `connection_pool_min_idle`: The minimum number of idle connections kept open to reduce connection setup latency.
 
-Both values must be positive integers. A `connection_pool_min_idle` greater than `connection_pool_size` is coerced to `connection_pool_size`.
+Both values must be positive integers, and `connection_pool_min_idle` must not exceed `connection_pool_size` — a larger value causes connection pool initialization to fail.
 
 ### Query Pushdown
 


### PR DESCRIPTION
## Summary

The ADBC connector page claimed: *"A `connection_pool_min_idle` greater than `connection_pool_size` is coerced to `connection_pool_size`."* This is wrong — the connector performs **no coercion**. Both parsed values are passed straight to the pool builder, and the underlying `r2d2` pool builder asserts `max_size >= min_idle`, so a `connection_pool_min_idle` larger than `connection_pool_size` makes connection pool initialization **fail** rather than being silently clamped.

Reworded to: *"Both values must be positive integers, and `connection_pool_min_idle` must not exceed `connection_pool_size` — a larger value causes connection pool initialization to fail."*

Fixed in vNext and the 2.0.x versioned docs (the only two docs that carry this sentence).

## Source

Verified against spiceai/spiceai at `trunk` (origin/trunk = `3cc242367`):
- [`crates/runtime/src/dataconnector/adbc.rs#L397-L474`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/adbc.rs#L397-L474) — `parse_pool_param` only validates `> 0`; values pass unmodified to `.with_max_size(pool_size).with_min_idle(pool_min_idle)`. No `min()`/`clamp`/coercion exists.
- `datafusion-table-providers` `adbcpool.rs` builds via `r2d2::Pool::builder()...build()`; `r2d2` `config.rs` asserts `max_size >= min_idle` ("min_idle must be no larger than max_size").

## Test plan
- [x] `cd website && npm run build` passes
- [x] Files updated: 2 (vNext + version-2.0.x)