### PR TITLE
docs(datasets): sync Cayenne accelerator status label with engine status table

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -399,7 +399,7 @@ Enable or disable acceleration, defaults to `true`.
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:
 
 - `arrow` - Accelerated in-memory backed by Apache Arrow DataTables.
-- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Alpha, v1.9.0-rc.1+).
+- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Release Candidate, v1.9.0-rc.1+).
 - [`duckdb`](../../components/data-accelerators/duckdb) - Accelerated by an embedded DuckDB database.
 - [`postgres`](../../components/data-accelerators/postgres) - Accelerated by a Postgres database.
 - [`sqlite`](../../components/data-accelerators/sqlite) - Accelerated by an embedded SQLite database.

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -298,7 +298,7 @@ Enable or disable acceleration, defaults to `true`.
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:
 
 - `arrow` - Accelerated in-memory backed by Apache Arrow DataTables.
-- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Alpha, v1.9.0-rc.1+).
+- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Beta, v1.9.0-rc.1+).
 - [`duckdb`](../../components/data-accelerators/duckdb) - Accelerated by an embedded DuckDB database.
 - [`postgres`](../../components/data-accelerators/postgres) - Accelerated by a Postgres database.
 - [`sqlite`](../../components/data-accelerators/sqlite) - Accelerated by an embedded SQLite database.

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
@@ -351,7 +351,7 @@ Enable or disable acceleration, defaults to `true`.
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:
 
 - `arrow` - Accelerated in-memory backed by Apache Arrow DataTables.
-- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Alpha, v1.9.0-rc.1+).
+- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Release Candidate, v1.9.0-rc.1+).
 - [`duckdb`](../../components/data-accelerators/duckdb) - Accelerated by an embedded DuckDB database.
 - [`postgres`](../../components/data-accelerators/postgres) - Accelerated by a Postgres database.
 - [`sqlite`](../../components/data-accelerators/sqlite) - Accelerated by an embedded SQLite database.


### PR DESCRIPTION
## Summary

The `acceleration.engine` list in `reference/spicepod/datasets.md` still labeled the Cayenne engine as **Alpha**, but the authoritative *Supported Data Accelerators* status table in `components/data-accelerators/index.md` had advanced Cayenne **Alpha → Beta (v1.11) → Release Candidate (v2.0 / vNext)**. The `datasets.md` bullet was never kept in sync, so each affected docset contradicted its own status table.

**What the docs said vs. the current canonical status (per each version's own `data-accelerators/index.md`):**

| Docset | index.md status table | datasets.md bullet (before) | Fixed to |
| --- | --- | --- | --- |
| vNext | Release Candidate | Alpha | **Release Candidate** |
| v2.0.x | Release Candidate | Alpha | **Release Candidate** |
| v1.11.x | Beta | Alpha | **Beta** |
| v1.10.x | Alpha | Alpha | _unchanged (correct)_ |
| v1.9.x | Alpha | Alpha | _unchanged (correct)_ |

The status label is version-specific, so each version's bullet is aligned to that same version's status table; v1.9.x/v1.10.x already matched (Alpha) and are left untouched. The `v1.9.0-rc.1+` availability note is preserved.

History: status moved Alpha→Beta in spiceai/docs#1341 (which updated `index.md` but missed this `datasets.md` bullet), then Beta→Release Candidate in a later `index.md` edit; the bullet lagged both moves.

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus build SUCCESS)
- [x] Versioned-docs propagation: version-aware — only versions whose status table diverged were changed (vNext, v2.0.x → RC; v1.11.x → Beta)
- [x] Files updated: 3