### PR TITLE
docs(clickhouse): add Date32 to supported type table (shipped in v2.0.0)

### DIFF
--- a/website/docs/components/data-connectors/clickhouse.md
+++ b/website/docs/components/data-connectors/clickhouse.md
@@ -89,6 +89,7 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `FixedString`    | `Utf8`                      |
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
+| `Date32`         | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/clickhouse.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/clickhouse.md
@@ -89,6 +89,7 @@ The table below shows the ClickHouse data types supported, along with the type m
 | `FixedString`    | `Utf8`                      |
 | `UUID`           | `Utf8`                      |
 | `Date`           | `Date32`                    |
+| `Date32`         | `Date32`                    |
 | `DateTime`       | `Timestamp(Second, None)`   |
 | `Nullable(T)`    | Mapped inner type `T`       |
 


### PR DESCRIPTION
## Summary

The ClickHouse connector's supported-types table omits `Date32`, but ClickHouse `Date32` columns are supported end-to-end as of Spice **v2.0.0**. This adds the missing row (`Date32` → Arrow `Date32`), scoped to vNext and `version-2.0.x` only.

## Why now (and why this is not a flip-flop re-add)

`Date32` support has a genuine history of removals (#1592, #1794) — but those were **correct at the time**. The support was added by spiceai/spiceai#10132 (`feat: Add ClickHouse Date32 type support`, commit `c65c565a1`, authored Apr 4 2026), which merged to **develop** first and only reached **trunk** with the **v2.0.0 release (tagged 2026-06-05)**. The last docs removal (#1794, merged 2026-06-03) predates that trunk merge, so trunk genuinely lacked `Date32` when #1794 ran. Trunk has shipped it since v2.0.0, so vNext + `version-2.0.x` docs should now list it. `git tag --contains c65c565a1` → `v2.0.0`, `v2.0.1` (not in any v1.x).

## Verified end-to-end (spiceai/spiceai @ trunk `679332b08`)

- **Schema inference**: `crates/db_connection_pool/src/dbconnection/clickhouseconn.rs:268` — `"Date" | "Date32" => Ok(DataType::Date32)` (source type on the LHS). Tests at `:331-332` assert `("Date32", Date32)` and `("Nullable(Date32)", Date32)`.
- **Data read path works (no `unimplemented!()` panic)**: the pinned `clickhouse-rs` fork (`tag 0.2.2`, rev `7e98394`) surfaces a `Date32` wire column as `SqlType::Date` — `src/types/column/factory.rs:80` (`"Date32" => DateColumnData::<i32>::load`), `src/types/value.rs:312` (`Value::Date32(_) => SqlType::Date`), `src/types/from_sql.rs:306` (`ValueRef::Date32(v) => NaiveDate`). So `arrow_sql_gen/src/clickhouse.rs:525` (`SqlType::Date => DataType::Date32`) handles it via the existing `SqlType::Date` builder arm.
- #10132's own message: "Fixes loading of datasets using Date32 columns (e.g. TPC-H orders, lineitem tables)."

## Scope

- **`DateTime64` is intentionally NOT added** — there is no code handling for it in either path; it remains unsupported.
- Older versioned docs (1.5.x–1.11.x) are correctly left unchanged — the feature did not exist in those releases.

## Source PRs
- spiceai/spiceai#10132 — feat: Add ClickHouse Date32 type support

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs scope: vNext + `version-2.0.x` only (2 files) — feature shipped in v2.0.0
- [x] Files updated: 2
