### PR TITLE
docs(dynamodb): document S → Date32 mapping for YYYY-MM-DD strings

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/index.md
+++ b/website/docs/components/data-connectors/dynamodb/index.md
@@ -292,6 +292,7 @@ The table below shows the DynamoDB data types supported, along with the type map
 | `S`           | String      | `Utf8`                               |                                                                                                                                   |
 | `S`           | String      | `Timestamp(Millisecond)`             | Naive timestamp if it matches `time_format` without timezone                                                                      |
 | `S`           | String      | `Timestamp(Millisecond, <timezone>)` | Timezone-aware timestamp if it matches `time_format` with timezone                                                                |
+| `S`           | String      | `Date32`                             | Date-only string in `YYYY-MM-DD` format (when it does not match `time_format`)                                                    |
 | `Ss`          | String Set  | `List<Utf8>`                         |                                                                                                                                   |
 | `N`           | Number      | `Int64` \| `Float64`                 |                                                                                                                                   |
 | `Ns`          | Number Set  | `List<Int64\|Float64>`               |                                                                                                                                   |

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/dynamodb.md
@@ -241,6 +241,7 @@ The table below shows the DynamoDB data types supported, along with the type map
 | `S`           | String      | `Utf8`                               |                                                                                                                                     |
 | `S`           | String      | `Timestamp(Millisecond)`             | Naive timestamp if it matches `time_format` without timezone                                                                        |
 | `S`           | String      | `Timestamp(Millisecond, <timezone>)` | Timezone-aware timestamp if it matches `time_format` with timezone                                                                  |
+| `S`           | String      | `Date32`                             | Date-only string in `YYYY-MM-DD` format (when it does not match `time_format`)                                                      |
 | `Ss`          | String Set  | `List<Utf8>`                         |                                                                                                                                     |
 | `N`           | Number      | `Int64` \| `Float64`                 |                                                                                                                                     |
 | `Ns`          | Number Set  | `List<Int64\|Float64>`               |                                                                                                                                     |

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/dynamodb.md
@@ -285,6 +285,7 @@ The table below shows the DynamoDB data types supported, along with the type map
 | `S`           | String      | `Utf8`                               |                                                                                                                                   |
 | `S`           | String      | `Timestamp(Millisecond)`             | Naive timestamp if it matches `time_format` without timezone                                                                      |
 | `S`           | String      | `Timestamp(Millisecond, <timezone>)` | Timezone-aware timestamp if it matches `time_format` with timezone                                                                |
+| `S`           | String      | `Date32`                             | Date-only string in `YYYY-MM-DD` format (when it does not match `time_format`)                                                    |
 | `Ss`          | String Set  | `List<Utf8>`                         |                                                                                                                                   |
 | `N`           | Number      | `Int64` \| `Float64`                 |                                                                                                                                   |
 | `Ns`          | Number Set  | `List<Int64\|Float64>`               |                                                                                                                                   |

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/dynamodb.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/dynamodb.md
@@ -237,6 +237,7 @@ The table below shows the DynamoDB data types supported, along with the type map
 | `S`           | String      | `Utf8`                               |                                                                                                                                     |
 | `S`           | String      | `Timestamp(Millisecond)`             | Naive timestamp if it matches `time_format` without timezone                                                                        |
 | `S`           | String      | `Timestamp(Millisecond, <timezone>)` | Timezone-aware timestamp if it matches `time_format` with timezone                                                                  |
+| `S`           | String      | `Date32`                             | Date-only string in `YYYY-MM-DD` format (when it does not match `time_format`)                                                      |
 | `Ss`          | String Set  | `List<Utf8>`                         |                                                                                                                                     |
 | `N`           | Number      | `Int64` \| `Float64`                 |                                                                                                                                     |
 | `Ns`          | Number Set  | `List<Int64\|Float64>`               |                                                                                                                                     |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dynamodb/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dynamodb/index.md
@@ -292,6 +292,7 @@ The table below shows the DynamoDB data types supported, along with the type map
 | `S`           | String      | `Utf8`                               |                                                                                                                                   |
 | `S`           | String      | `Timestamp(Millisecond)`             | Naive timestamp if it matches `time_format` without timezone                                                                      |
 | `S`           | String      | `Timestamp(Millisecond, <timezone>)` | Timezone-aware timestamp if it matches `time_format` with timezone                                                                |
+| `S`           | String      | `Date32`                             | Date-only string in `YYYY-MM-DD` format (when it does not match `time_format`)                                                    |
 | `Ss`          | String Set  | `List<Utf8>`                         |                                                                                                                                   |
 | `N`           | Number      | `Int64` \| `Float64`                 |                                                                                                                                   |
 | `Ns`          | Number Set  | `List<Int64\|Float64>`               |                                                                                                                                   |


### PR DESCRIPTION
## Summary

The DynamoDB connector's supported-types table lists three mappings for the `S` (String) type — `Utf8`, `Timestamp(Millisecond)`, and `Timestamp(Millisecond, <timezone>)` — but omits a fourth: a string that does **not** match `time_format` but **is** a bare `YYYY-MM-DD` date is inferred as Arrow `Date32`. This adds the missing row across vNext and every versioned page where the behavior exists.

## What the code does (spiceai/spiceai @ trunk `679332b08`)

Schema inference precedence for `AttributeValue::S(s)` — `crates/data_components/src/dynamodb/schema.rs:88-104`:

1. `parse_datetime(s, time_format)` matches → `Timestamp(Millisecond[, tz])`
2. **else if `is_date_yyyy_mm_dd(s)` → `DataType::Date32`** ← undocumented
3. else → `Utf8`

`is_date_yyyy_mm_dd` (`schema.rs:231`) matches exactly 10 chars, two dashes, parseable as `%Y-%m-%d`. The value is populated end-to-end via a `Date32Builder` at `arrow.rs:438-450`, and asserted by tests (`schema.rs:730`, `schema.rs:841`, `arrow.rs:1072-1087`).

## Version scope

`is_date_yyyy_mm_dd` shipped in spiceai/spiceai#7715 ("Improved DynamoDB Data Connector"), first released in **v1.9.0** (`git tag --contains 3a133a72a` → v1.9.0+). So the row is added to vNext + `version-1.9.x`, `1.10.x`, `1.11.x`, `2.0.x`. Versions 1.5.x–1.8.x have no DynamoDB `Date32` inference and are correctly left unchanged.

## Source PRs
- spiceai/spiceai#7715 — Improved DynamoDB Data Connector

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: 5 source files (vNext + 1.9.x/1.10.x/1.11.x/2.0.x); grep-count reconciles (6th match is the gitignored `build/llms-full.txt` artifact)
- [x] Files updated: 5
