### PR TITLE
docs(delta-lake): remove duplicated word in connector intro

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/index.md
+++ b/website/docs/components/data-connectors/delta-lake/index.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/delta-lake.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/index.md
@@ -9,7 +9,7 @@ tags:
   - data-lake
 ---
 
-Delta Lake data connector connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
+Delta Lake data connector enables SQL queries from [Delta Lake](https://delta.io/) tables.
 
 ```yaml
 datasets:


### PR DESCRIPTION
## Summary
The Delta Lake connector page intro reads "Delta Lake data connector **connector** enables SQL queries" — the word "connector" is duplicated. This corrects it to "Delta Lake data connector enables SQL queries".

## What the docs said vs. what changed
- Before: `Delta Lake data connector connector enables SQL queries from [Delta Lake] tables.`
- After: `Delta Lake data connector enables SQL queries from [Delta Lake] tables.`

## Propagation
The duplicated word predates versioning, so it existed in the unversioned page **and every versioned snapshot**. Fixed in all 9 files in one PR (verified 0 remaining `connector connector` source hits):
- `website/docs/components/data-connectors/delta-lake/index.md` (vNext)
- versioned snapshots 1.5.x–2.0.x

## Source of truth
Pure prose typo — no behavioral claim. Surfaced during a docs-accuracy audit of connector pages against spiceai/spiceai @ `origin/trunk`; the Delta Lake parameter/type tables and capability claims were separately verified accurate and left unchanged.

## Test plan
- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — 9 files, 0 remaining source hits
- [x] Files updated: 9 (1 vNext + 8 versioned)