### PR TITLE
docs: memory_limit default drops to 75% under Cayenne acceleration

### DIFF
--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -138,11 +138,11 @@ Refresh modes affect memory usage as follows:
 
 ## DataFusion Query Memory Management
 
-Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of total system memory** (container-aware). This can be tuned through the `runtime.query.memory_limit` configuration.
+Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of total system memory** (container-aware; reduced to **75%** when Cayenne acceleration is active, to leave headroom for Cayenne's compaction memory pool and in-memory CDC tier). This can be tuned through the `runtime.query.memory_limit` configuration.
 
 ### Memory Limit Configuration
 
-The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of total system memory. Once the memory limit is reached, supported query operations spill data to disk.
+The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of total system memory (75% when Cayenne acceleration is active). Once the memory limit is reached, supported query operations spill data to disk.
 
 ```yaml
 runtime:

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -383,7 +383,7 @@ runtime:
 
 ### Memory Limit
 
-If not specified, `memory_limit` defaults to 90% of total system memory (container-aware). For deployments with co-located accelerators, set an explicit limit based on available memory:
+If not specified, `memory_limit` defaults to 90% of total system memory (container-aware); when Cayenne acceleration is active, the default is 75% instead, reserving headroom for Cayenne's compaction memory pool and in-memory CDC tier. For deployments with co-located accelerators, set an explicit limit based on available memory:
 
 ```text
 runtime memory_limit = Total Memory - Accelerator Memory - OS/Runtime Overhead (30%)

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -444,7 +444,7 @@ This configuration permits requests only from the `https://example.com` origin.
 
 The `memory_limit` parameter sets a memory usage cap for the Spice runtime query engine. This limit applies **only** to the query engine and should be used in addition to other memory configuration options, such as `duckdb_memory_limit`. When the limit is reached, DataFusion spills intermediate data to disk using the directory configured in `runtime.query.temp_directory`.
 
-If not specified, defaults to **90% of total system memory** (container-aware).
+If not specified, defaults to **90% of total system memory** (container-aware). When Cayenne acceleration is active, the default is reduced to **75%** to reserve headroom for Cayenne's dedicated compaction memory pool and its in-memory CDC tier.
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary

The docs state the query-memory default is a flat **90% of total system memory**, but the runtime reduces it to **75%** whenever Cayenne acceleration is active — to reserve headroom for Cayenne's dedicated compaction memory pool and its off-pool in-memory CDC tier (otherwise the query pool + compaction pool + CDC tier can sum to >100% of host RAM).

**What the docs said:** \"defaults to 90% of total system memory (container-aware)\" — with no mention of the Cayenne reduction.

**What the code does:**
- \`DEFAULT_QUERY_MEMORY_PERCENT = 90\`, \`CAYENNE_QUERY_MEMORY_PERCENT = 75\` (crates/runtime/src/datafusion/builder.rs:1465,1475).
- \`effective_query_memory_limit(memory_limit, cayenne_active)\` picks 75% when \`cayenne_active\`, else 90% (builder.rs:1477-1485).
- \`cayenne_active = compaction_memory_fraction.is_some()\` — true when Cayenne acceleration is configured with dedicated thread pools (the default) (builder.rs:687).

This is a conditional default; per docs conventions the condition is now documented rather than a single unconditional value.

## Scope / versioning

vNext-only. \`CAYENNE_QUERY_MEMORY_PERCENT\` was introduced by spiceai/spiceai#11463, which is **not** contained in the \`v2.0.1\` tag, so the versioned (\`version-*\`) docs correctly document the flat 90% for their releases and are intentionally left unchanged.

## Source ref
- spiceai/spiceai @ trunk (2ae56f1d0) — crates/runtime/src/datafusion/builder.rs (\`CAYENNE_QUERY_MEMORY_PERCENT\`, \`effective_query_memory_limit\`)
- Introduced by spiceai/spiceai#11463

## Files updated (3, vNext only)
- website/docs/reference/spicepod/runtime.md
- website/docs/reference/memory.md
- website/docs/reference/performance-tuning.md

## Test plan
- [ ] Prose-only diff; no links or frontmatter tags added or moved (verified via \`git diff | grep\`).
- [ ] Local \`npm run build\` was NOT run: this worktree has no \`node_modules\` and the disk is 97% full, so an install + full versioned build risks ENOSPC. Since the diff adds no links/tags, the build's broken-link/undefined-tag check is not exercised — CI's \`Deploy\` check is authoritative here.