### PR TITLE
docs(scylladb): decimal now errors on lossy conversion, not truncate/NULL

### DIFF
--- a/website/docs/components/data-connectors/scylladb.md
+++ b/website/docs/components/data-connectors/scylladb.md
@@ -113,7 +113,7 @@ CQL `decimal` is an arbitrary-precision type, while Arrow `Decimal128` has a max
 - **Precision**: 38 (maximum for Decimal128)
 - **Scale**: 2 (suitable for monetary/financial data)
 
-For decimals that exceed this precision, values may be truncated or rounded.
+If a CQL `decimal` value cannot be represented exactly at this precision and scale — because rescaling to scale 2 would drop non-zero fractional digits, or the mantissa does not fit in 128 bits — the connector returns a query error rather than silently truncating, rounding, or returning `NULL`. Values that rescale losslessly are converted normally.
 
 ### Date/Time Handling
 
@@ -283,7 +283,7 @@ The following SQL operations cannot be pushed down to ScyllaDB and are performed
 ### Connector Limitations
 
 - **Read-only**: The connector does not support INSERT, UPDATE, or DELETE operations
-- **Decimal precision**: Fixed at precision=38, scale=2; may not suit all use cases
+- **Decimal precision**: Fixed at precision=38, scale=2; values that cannot be rescaled to this precision and scale without loss error rather than being silently truncated
 - **Collection types**: Lists, sets, and maps are converted to JSON string representation
 - **Large tables**: Without acceleration, large tables cause significant data transfer
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11604](https://github.com/spiceai/spiceai/pull/11604) (fixes [#11267](https://github.com/spiceai/spiceai/issues/11267)) changed the ScyllaDB connector so a CQL `decimal` that cannot be represented exactly as `Decimal128(38, 2)` now returns a **query error** instead of silently truncating, rounding, or emitting `NULL`. `cql_decimal_to_i128` now returns `Err` (surfaced as `ConversionError`) when rescaling would drop non-zero fractional digits or the mantissa exceeds 128 bits; losslessly-representable values still convert.

The published docs said *"For decimals that exceed this precision, values may be truncated or rounded"* — now the opposite of the runtime behavior. This corrects the **Decimal Handling** section and the **Connector Limitations** bullet.

## Source PRs

- spiceai/spiceai#11604 — fix(scylladb): error on lossy CQL decimal conversion instead of silent truncation/NULL

## Test plan

- [x] Verified new behavior in `crates/db_connection_pool/src/dbconnection/scylladbconn.rs` (`cql_decimal_to_i128` → `Result`, `ConversionError` on lossy conversion) on `origin/trunk`.
- Versioned docs: **vNext only** — the error behavior is not yet in a release; `version-1.11.x` and `version-2.0.x` correctly document the prior truncate/NULL behavior for those releases and are left unchanged.
- [x] Prose-only diff (no added links or `tags:`). Local `npm run build` skipped — no `node_modules` and host disk at 98% (full versioned build risks ENOSPC); CI `Deploy` is the authoritative link/tag gate.
- Files updated: 1