### PR TITLE
docs(mongodb,debezium): document json_object column nesting

### DIFF
--- a/website/docs/components/data-connectors/debezium.md
+++ b/website/docs/components/data-connectors/debezium.md
@@ -150,6 +150,35 @@ The following settings are required:
 | `refresh_mode` | Optional. The refresh mode to use. If specified, this must be set to `changes`. Any other value is an error.                                                                                                                                                                                                                                               |
 | `mode`         | Optional. The persistence mode to use. When using the `duckdb` and `sqlite` engines, it is recommended to set this to `file` to persist the data across restarts. Spice also persists metadata about the dataset, so it can resume from the last known state of the dataset instead of re-fetching the entire dataset.                                     |
 
+## JSON Nesting
+
+When a change event carries many fields but you only need a few as discrete columns, you can consolidate the rest into a single JSON column using the `json_object` metadata option. Declare the fields you want as top-level columns explicitly in the `columns` list, then add a "catch-all" column with `json_object: "*"` metadata — every field not otherwise listed is nested into it as a JSON object. This applies to the change-stream (CDC) events the connector decomposes into the accelerator.
+
+```yaml
+datasets:
+  - from: debezium:my_kafka_topic_with_debezium_changes
+    name: orders
+    columns:
+      - name: id
+      - name: status
+      - name: data_json
+        metadata:
+          json_object: '*'
+    acceleration:
+      enabled: true
+      engine: duckdb
+      refresh_mode: changes
+```
+
+Any field other than `id`, `status`, and `data_json` is folded into `data_json` as a JSON object. Primary-key columns must be declared explicitly and cannot be folded into the catch-all column.
+
+:::warning[Limitations]
+
+- The `json_object` metadata only accepts `"*"` as its value, which captures all unspecified fields.
+- Only one column can carry the `json_object` metadata; declaring more than one is an error.
+
+:::
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores/). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores/#using-secrets).

--- a/website/docs/components/data-connectors/mongodb.md
+++ b/website/docs/components/data-connectors/mongodb.md
@@ -183,6 +183,34 @@ sql> select * from test_table;
 +-----------+-------------+---------------+
 ```
 
+## JSON Nesting
+
+When a MongoDB collection has many fields but you only need a few as discrete columns, you can consolidate the rest into a single JSON column using the `json_object` metadata option. Declare the fields you want as top-level columns explicitly in the `columns` list, then add a "catch-all" column with `json_object: "*"` metadata — every field not otherwise listed is nested into it as a JSON object. This applies to both the query (scan) path and the [Change Streams](#using-mongodb-change-streams) (CDC) path.
+
+```yaml
+datasets:
+  - from: mongodb:orders
+    name: orders
+    params:
+      mongodb_host: localhost
+      mongodb_db: shop
+    columns:
+      - name: _id
+      - name: status
+      - name: data_json
+        metadata:
+          json_object: '*'
+```
+
+Any field other than `_id`, `status`, and `data_json` is folded into `data_json` as a JSON object. The `_id` field must be declared explicitly and cannot be folded into the catch-all column.
+
+:::warning[Limitations]
+
+- The `json_object` metadata only accepts `"*"` as its value, which captures all unspecified fields.
+- Only one column can carry the `json_object` metadata; declaring more than one is an error.
+
+:::
+
 ## Examples
 
 ### Connecting using username and password and custom auth table


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11555](https://github.com/spiceai/spiceai/pull/11555) ("Unified JSON nesting") migrated the runtime onto a shared `schema_projection` core and, in doing so, gave **MongoDB and Debezium `json_object` column nesting for the first time**, on both the scan and CDC/change-stream paths. Neither connector page documented it.

Adds a **JSON Nesting** section to each page, mirroring the existing DynamoDB precedent: declare the columns you want as discrete fields, add a catch-all column with `json_object: "*"` metadata, and all unlisted fields nest into it as a JSON object. Documents the per-connector required-column rule verified from source (`ProjectionPolicy`): `_id` for MongoDB and primary-key columns for Debezium must be declared explicitly and cannot be folded into the catch-all.

## Source PRs

- spiceai/spiceai#11555 — Unified JSON nesting

## Test plan

- [x] Behavior verified against `origin/trunk`: `ProjectionPolicy::new("mongodb").with_required_columns(["_id"])` and `ProjectionPolicy::new("debezium").with_required_columns(primary_keys)`; only `"*"` accepted; single catch-all enforced by `SchemaProjection::new`.
- [x] `cd website && npm run build` **passes** (exit 0, `Generated static files`) — the new same-page `#using-mongodb-change-streams` anchor link resolves; no broken links or undefined tags.
- Versioned docs: **vNext only** — MongoDB/Debezium `json_object` nesting is new in this change and not in any released version.
- Files updated: 2 (`mongodb.md`, `debezium.md`)