### PR TITLE
docs: correct Cayenne query-memory default 75% -> 70%

### DIFF
--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -138,11 +138,11 @@ Refresh modes affect memory usage as follows:
 
 ## DataFusion Query Memory Management
 
-Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of total system memory** (container-aware; reduced to **75%** when Cayenne acceleration is active, to leave headroom for Cayenne's compaction memory pool and in-memory CDC tier). This can be tuned through the `runtime.query.memory_limit` configuration.
+Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of total system memory** (container-aware; reduced to **70%** when Cayenne acceleration is active, to leave headroom for Cayenne's compaction memory pool and in-memory CDC tier). This can be tuned through the `runtime.query.memory_limit` configuration.
 
 ### Memory Limit Configuration
 
-The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of total system memory (75% when Cayenne acceleration is active). Once the memory limit is reached, supported query operations spill data to disk.
+The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of total system memory (70% when Cayenne acceleration is active). Once the memory limit is reached, supported query operations spill data to disk.
 
 ```yaml
 runtime:

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -383,7 +383,7 @@ runtime:
 
 ### Memory Limit
 
-If not specified, `memory_limit` defaults to 90% of total system memory (container-aware); when Cayenne acceleration is active, the default is 75% instead, reserving headroom for Cayenne's compaction memory pool and in-memory CDC tier. For deployments with co-located accelerators, set an explicit limit based on available memory:
+If not specified, `memory_limit` defaults to 90% of total system memory (container-aware); when Cayenne acceleration is active, the default is 70% instead, reserving headroom for Cayenne's compaction memory pool and in-memory CDC tier. For deployments with co-located accelerators, set an explicit limit based on available memory:
 
 ```text
 runtime memory_limit = Total Memory - Accelerator Memory - OS/Runtime Overhead (30%)

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -444,7 +444,7 @@ This configuration permits requests only from the `https://example.com` origin.
 
 The `memory_limit` parameter sets a memory usage cap for the Spice runtime query engine. This limit applies **only** to the query engine and should be used in addition to other memory configuration options, such as `duckdb_memory_limit`. When the limit is reached, DataFusion spills intermediate data to disk using the directory configured in `runtime.query.temp_directory`.
 
-If not specified, defaults to **90% of total system memory** (container-aware). When Cayenne acceleration is active, the default is reduced to **75%** to reserve headroom for Cayenne's dedicated compaction memory pool and its in-memory CDC tier.
+If not specified, defaults to **90% of total system memory** (container-aware). When Cayenne acceleration is active, the default is reduced to **70%** to reserve headroom for Cayenne's dedicated compaction memory pool and its in-memory CDC tier.
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary

The `runtime.query.memory_limit` default under active Cayenne acceleration was documented as **75%** of total system memory, but the current runtime value is **70%**.

- **Docs said:** "reduced to **75%** when Cayenne acceleration is active"
- **Code does:** `const CAYENNE_QUERY_MEMORY_PERCENT: u64 = 70;` (`crates/runtime/src/datafusion/builder.rs:1500`), guarded by a compile-time `assert!(CAYENNE_QUERY_MEMORY_PERCENT == 70)`.

The non-Cayenne default is unchanged at 90% (`DEFAULT_QUERY_MEMORY_PERCENT = 90`).

### How this drifted

The 75% value was introduced by spiceai/spiceai#11463 and documented in docs commit 4b6f6128 (Jul 5, 01:18 PT). Later the same day, spiceai/spiceai#11641 ("reservation-aware Cayenne CDC query-memory default (75%→70%)", commit `86b1a2147`, Jul 5 16:06 PT) reduced the constant to 70. The docs were left one revision stale.

### Scope

vNext-only. Like the original 75% value, the reduced 70% default is post-`v2.0.1`, so versioned docs correctly keep the flat 90% — confirmed no `75%` Cayenne-memory occurrences remain under `website/versioned_docs/`.

Files updated (3): `reference/memory.md` (2 occurrences), `reference/performance-tuning.md` (1), `reference/spicepod/runtime.md` (1).

## Source

- spiceai/spiceai @ trunk `86b1a2147` — `crates/runtime/src/datafusion/builder.rs:1500`

## Test plan

- [x] `grep -rn "75%"` across `website/docs/` and `website/versioned_docs/` returns no Cayenne query-memory hits; 4 `70%` occurrences now present.
- [ ] Local `npm run build`: skipped — `node_modules` not installed in this constrained env (ENOSPC risk). Diff is prose-only with **zero** added links or frontmatter tags, so the broken-link/undefined-tag check has nothing to validate; CI Deploy is the authoritative gate.