### PR TITLE
docs(imap): date column is Timestamp(Millisecond), not Date64

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -19,7 +19,7 @@ datasets:
 
 | Field Name    | Data Type    | Nullable | Description                                                                      |
 | ------------- | ------------ | -------- | -------------------------------------------------------------------------------- |
-| `date`        | `Date64`     | No       | The date and time when the email was sent.                                       |
+| `date`        | `Timestamp(Millisecond, None)` | No       | The date and time when the email was sent, as milliseconds since the Unix epoch. |
 | `subject`     | `Utf8`       | Yes      | The subject line of the email.                                                   |
 | `from`        | `List<Utf8>` | Yes      | The sender(s) of the email.                                                      |
 | `to`          | `List<Utf8>` | Yes      | The primary recipient(s) of the email.                                           |


### PR DESCRIPTION
## Summary

The IMAP Data Connector's `date` column schema changed from `Date64` to `Timestamp(Millisecond, None)` in spiceai/spiceai#11624 (fixes spiceai/spiceai#11547). The previous `Date64` mapping stored whole seconds into a millisecond-precision array, making every timestamp 1000× too small so an entire mailbox collapsed onto a single near-epoch instant. The connector now parses the RFC822 `Date:` header into milliseconds since the Unix epoch and reports the column as `Timestamp(Millisecond, None)`.

This updates the Schema table on the IMAP connector page to match trunk. vNext only — released versions (≤ 2.0.x) genuinely emit `Date64`, so their versioned docs are left unchanged.

Verified against `crates/data_components/src/imap/provider.rs` on trunk: `Field::new("date", DataType::Timestamp(TimeUnit::Millisecond, None), false)`.

## Source PRs
- spiceai/spiceai#11624 — fix(imap): store message date as millisecond Timestamp, not seconds in Date64 (fixes #11547)

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext-only change (behavior ships in the next release; older versions correctly document `Date64`)
- [x] Files updated: 1 (website/docs/components/data-connectors/imap.md)
