### PR TITLE
docs(trace): dynamic MCP/custom tool_use task names are traceable

### DIFF
--- a/website/docs/cli/reference/trace.md
+++ b/website/docs/cli/reference/trace.md
@@ -33,6 +33,8 @@ spice trace [task] [flags]
 - `search`
 - `scheduled_worker`
 
+Tools proxied from MCP servers and custom tools are recorded dynamically as `tool_use::<tool>` or `tool_use::<server>/<tool>` (for example, `tool_use::github/search_code`). Any such `tool_use::`-prefixed task name can be traced, not just the built-in tools listed above.
+
 These tasks are from the `task` column in the Spice SQL `runtime.task_history` table.
 
 #### Flags


### PR DESCRIPTION
## Summary

`spice trace` now accepts dynamic `tool_use::<tool>` task names for MCP-proxied and custom tools, not just the fixed built-in `tool_use::*` list (spiceai/spiceai#11630, fixes spiceai/spiceai#10995). Previously the CLI rejected these with a static allowlist, so users could not trace MCP or custom tool invocations even though they are recorded in `runtime.task_history` as `tool_use::<server>/<tool>` / `tool_use::<tool>`.

Adds a note to the `spice trace` reference clarifying that any `tool_use::`-prefixed task name is traceable. vNext only (new behavior; released versions still enforce the static list).

Verified against `bin/spice/src/commands/trace.rs` on trunk: `is_valid_trace_task` now accepts any `tool_use::`-prefixed task with a non-empty suffix.

## Source PRs
- spiceai/spiceai#11630 — fix(cli): allow `spice trace` on dynamic MCP/custom tool_use tasks (fixes #10995)

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext-only change (new behavior ships in the next release)
- [x] Files updated: 1 (website/docs/cli/reference/trace.md)
