### PR TITLE
ci: overlay docs from base_branch onto trunk for release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Create release branch and run release script
         working-directory: website
         run: |
-          git checkout -b "release/docs-v${{ inputs.version }}"
+          git checkout -b "release/docs-v${{ inputs.version }}-${{ github.run_id }}"
           ./create-release.sh "${{ inputs.version }}"
 
       - name: Commit and push
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Add versioned docs for v${{ inputs.version }}"
-          git push --force origin "release/docs-v${{ inputs.version }}"
+          git push origin "release/docs-v${{ inputs.version }}-${{ github.run_id }}"
 
       - name: Create Pull Request
         env:
@@ -51,7 +51,7 @@ jobs:
         run: |
           gh pr create \
             --base trunk \
-            --head "release/docs-v${{ inputs.version }}" \
+            --head "release/docs-v${{ inputs.version }}-${{ github.run_id }}" \
             --title "Add versioned docs for v${{ inputs.version }}" \
             --body "Creates versioned documentation snapshot for v${{ inputs.version }}." \
             --label "area/docs"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout trunk -- website/docs
           git add -A
           git commit -m "Add versioned docs for v${{ inputs.version }}"
           git push origin "release/docs-v${{ inputs.version }}-${{ github.run_id }}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -27,8 +27,14 @@ jobs:
           ref: trunk
 
       - name: Overlay docs from base branch
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
-          git fetch origin ${{ inputs.base_branch }}
+          if ! git check-ref-format --branch "$BASE_BRANCH" > /dev/null; then
+            echo "Invalid base branch: $BASE_BRANCH" >&2
+            exit 1
+          fi
+          git fetch origin "refs/heads/$BASE_BRANCH"
           git checkout FETCH_HEAD -- website/docs
 
       - name: Create release branch and run release script

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,10 +21,15 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base branch
+      - name: Checkout trunk
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base_branch }}
+          ref: trunk
+
+      - name: Overlay docs from base branch
+        run: |
+          git fetch origin ${{ inputs.base_branch }}
+          git checkout FETCH_HEAD -- website/docs
 
       - name: Create release branch and run release script
         working-directory: website

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -43,7 +43,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Add versioned docs for v${{ inputs.version }}"
-          git push origin "release/docs-v${{ inputs.version }}"
+          git push --force origin "release/docs-v${{ inputs.version }}"
 
       - name: Create Pull Request
         env:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version number (e.g. 2.0)"
+        description: "Version number (e.g. 2.0). Becomes `website/versioned_docs/version-{version_number}.x`."
         required: true
+        type: string
+      base_branch:
+        description: "Git branch to copy from as the versioned docs."
+        required: false
+        default: "trunk"
         type: string
 
 permissions:
@@ -16,10 +21,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout trunk
+      - name: Checkout base branch
         uses: actions/checkout@v4
         with:
-          ref: trunk
+          ref: ${{ inputs.base_branch }}
 
       - name: Create release branch and run release script
         working-directory: website


### PR DESCRIPTION
Instead of checking out `base_branch` directly (which caused the release branch to carry unrelated commits), this:

1. Checks out `trunk` as the release branch base
2. Overlays only `website/docs/` from `base_branch`
3. Runs the release script — so the resulting PR to trunk contains only the versioned docs snapshot commit