### PR TITLE
docs(cayenne): scope metastore journal_mode=WAL to SQLite backend (Turso uses mvcc)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -25,13 +25,15 @@ Cayenne is file-mode only. Segments are written as Vortex files on local disk or
 
 ### Metastore Durability
 
-Cayenne's metastore (table list, segment index, delete vectors) is backed by SQLite or Turso. The metastore configures:
+Cayenne's metastore (table list, segment index, delete vectors) is backed by SQLite (default) or Turso. With the default **SQLite** backend, the metastore configures:
 
 - `journal_mode=WAL` for crash-safe writes.
 - `busy_timeout` to handle concurrent access.
 - `synchronous=NORMAL` for WAL-safe durability with acceptable write latency.
 
-On shutdown, Cayenne performs a WAL checkpoint and runs `PRAGMA optimize` to minimize restart overhead. Graceful shutdown via `SIGTERM` is important — abrupt kills leave the WAL un-checkpointed (still recoverable, but restart is slower).
+The **Turso** backend (opt-in, requires the `turso` feature flag) uses its MVCC journal mode (`journal_mode='mvcc'`) instead of WAL.
+
+On shutdown, Cayenne performs a WAL checkpoint (SQLite) and runs `PRAGMA optimize` to minimize restart overhead. Graceful shutdown via `SIGTERM` is important — abrupt kills leave the WAL un-checkpointed (still recoverable, but restart is slower).
 
 ### Append WAL Crash Safety
 

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/deployment.md
@@ -25,13 +25,15 @@ Cayenne is file-mode only. Segments are written as Vortex files on local disk or
 
 ### Metastore Durability
 
-Cayenne's metastore (table list, segment index, delete vectors) is backed by SQLite or Turso. The metastore configures:
+Cayenne's metastore (table list, segment index, delete vectors) is backed by SQLite (default) or Turso. With the default **SQLite** backend, the metastore configures:
 
 - `journal_mode=WAL` for crash-safe writes.
 - `busy_timeout` to handle concurrent access.
 - `synchronous=NORMAL` for WAL-safe durability with acceptable write latency.
 
-On shutdown, Cayenne performs a WAL checkpoint and runs `PRAGMA optimize` to minimize restart overhead. Graceful shutdown via `SIGTERM` is important — abrupt kills leave the WAL un-checkpointed (still recoverable, but restart is slower).
+The **Turso** backend (opt-in, requires the `turso` feature flag) uses its MVCC journal mode (`journal_mode='mvcc'`) instead of WAL.
+
+On shutdown, Cayenne performs a WAL checkpoint (SQLite) and runs `PRAGMA optimize` to minimize restart overhead. Graceful shutdown via `SIGTERM` is important — abrupt kills leave the WAL un-checkpointed (still recoverable, but restart is slower).
 
 ### Append WAL Crash Safety
 


### PR DESCRIPTION
## Summary

The Cayenne deployment guide states that the metastore, "backed by SQLite or Turso," configures `journal_mode=WAL`. That is correct only for the default **SQLite** backend. The opt-in **Turso** backend (requires the `turso` feature flag) sets `journal_mode='mvcc'`, not WAL.

- **Docs said:** "backed by SQLite or Turso. The metastore configures: `journal_mode=WAL` …"
- **What the code does:** SQLite backend → `journal_mode=WAL`; Turso backend → `journal_mode='mvcc'`.

## Source of truth

spiceai/spiceai @ `trunk` (commit `1afadc281`):

- SQLite: `crates/cayenne/src/metastore/sqlite.rs` — `journal_mode=WAL`, `synchronous=NORMAL`, `busy_timeout`.
- Turso: `crates/cayenne/src/metastore/turso.rs:152` sets `journal_mode` to `turso_shared::JOURNAL_MODE_SQL_LITERAL`, defined as `"'mvcc'"` in `crates/turso-shared/src/lib.rs:42`.
- Turso backend is feature-gated: `#[cfg(feature = "turso")] pub mod turso;` (`crates/cayenne/src/metastore.rs:26`).

Verified the same at the `v2.0.1` tag (`JOURNAL_MODE_SQL_LITERAL = "'mvcc'"`, `#[cfg(feature = "turso")]`), so the version-2.0.x snapshot is corrected too.

## Changes

- Scope the PRAGMA list to the default SQLite backend and add a one-line note that the Turso backend uses MVCC (`journal_mode='mvcc'`) instead of WAL.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus, `onBrokenLinks: throw`)
- [x] Versioned-docs propagation: fixed in `website/docs/` (vNext) + `website/versioned_docs/version-2.0.x/` (only the deployment guide carries this claim)
- [x] Files updated: 2