### PR TITLE
docs(accelerators): correct non-existent connection-string config guidance (duckdb/sqlite)

### DIFF
--- a/website/docs/components/data-accelerators/duckdb/deployment.md
+++ b/website/docs/components/data-accelerators/duckdb/deployment.md
@@ -53,7 +53,7 @@ Datasets sharing a DuckDB instance share the pool. For write-heavy refresh plus 
 
 ### Memory
 
-DuckDB self-tunes its memory limit based on system memory. For containers, set a `memory_limit` pragma via the connection string to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
+DuckDB self-tunes its memory limit based on system memory. For containers, set the `duckdb_memory_limit` acceleration parameter to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
 
 ### Index Parameters
 
@@ -92,7 +92,7 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Symptom                                                | Likely cause                                                  | Resolution                                                                                                  |
 | ------------------------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Slow first startup after restart                       | WAL replay due to ungraceful shutdown.                        | Use graceful shutdown (`SIGTERM`). Subsequent starts will be fast once the checkpoint is clean.             |
-| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set a `memory_limit` pragma via the connection string.                                                      |
+| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set the `duckdb_memory_limit` acceleration parameter.                                                       |
 | Disk fills during large queries                        | Spill directory on undersized volume.                         | Point `runtime.query.temp_directory` at a larger volume; monitor free space.                                |
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |

--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -47,7 +47,7 @@ For file-mode databases, the connection pool automatically sets the following pr
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
 
-These are no-ops for in-memory databases. For custom durability tuning beyond these defaults, set pragmas via a custom connection string or post-startup SQL.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -81,6 +81,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | Raise `PRAGMA cache_size` via connection string; consider DuckDB for large-scan workloads.        |
+| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/duckdb/deployment.md
@@ -53,7 +53,7 @@ Datasets sharing a DuckDB instance share the pool. For write-heavy refresh plus 
 
 ### Memory
 
-DuckDB self-tunes its memory limit based on system memory. For containers, set a `memory_limit` pragma via the connection string to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
+DuckDB self-tunes its memory limit based on system memory. For containers, set the `duckdb_memory_limit` acceleration parameter to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
 
 ### Index Parameters
 
@@ -92,7 +92,7 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Symptom                                                | Likely cause                                                  | Resolution                                                                                                  |
 | ------------------------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Slow first startup after restart                       | WAL replay due to ungraceful shutdown.                        | Use graceful shutdown (`SIGTERM`). Subsequent starts will be fast once the checkpoint is clean.             |
-| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set a `memory_limit` pragma via the connection string.                                                      |
+| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set the `duckdb_memory_limit` acceleration parameter.                                                       |
 | Disk fills during large queries                        | Spill directory on undersized volume.                         | Point `runtime.query.temp_directory` at a larger volume; monitor free space.                                |
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
@@ -47,7 +47,7 @@ For file-mode databases, the connection pool automatically sets the following pr
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
 
-These are no-ops for in-memory databases. For custom durability tuning beyond these defaults, set pragmas via a custom connection string or post-startup SQL.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -81,6 +81,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | Raise `PRAGMA cache_size` via connection string; consider DuckDB for large-scan workloads.        |
+| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |


### PR DESCRIPTION
## Summary

The DuckDB and SQLite accelerator **deployment guides** tell users to configure the accelerator "via the connection string" — a mechanism neither accelerator exposes. Their parameters are set through Spicepod `acceleration.params`, not a connection string.

- **DuckDB (Memory + Troubleshooting):** "set a `memory_limit` pragma via the connection string" → the correct mechanism is the `duckdb_memory_limit` acceleration parameter.
- **SQLite (Journal Mode note):** "set pragmas via a custom connection string or post-startup SQL" → the SQLite accelerator exposes no connection string; the pragmas are runtime-managed and the one tunable knob is the `busy_timeout` parameter.
- **SQLite (Troubleshooting):** "Raise `PRAGMA cache_size` via connection string" → `cache_size` is not a user parameter; the page cache is runtime-managed. Kept the actionable fallback (use DuckDB for large-scan workloads).

## Source of truth

spiceai/spiceai @ `trunk` (commit `1afadc281`):

- DuckDB accelerator params: `crates/runtime/src/dataaccelerator/duckdb.rs:404` — `ParameterSpec::component("memory_limit")` → the `duckdb_memory_limit` key. No connection-string parameter exists.
- SQLite accelerator params: `crates/runtime/src/dataaccelerator/sqlite.rs:324-326` — only `file` (`sqlite_file`), `busy_timeout`, and `file_watcher`. No connection-string / pragma / init-SQL parameter; pragmas are set internally in `datafusion-table-providers` `sqlitepool.rs`.

## Scope note

This fixes only the **accelerator** deployment guides (the audited surface). The DuckDB *connector* deployment guide carries a similar phrase but was not part of this audit and is left unchanged.

## Changes

- 4 files: `duckdb/deployment.md` + `sqlite/deployment.md`, each in `website/docs/` (vNext) and `website/versioned_docs/version-2.0.x/`.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus, `onBrokenLinks: throw`)
- [x] Versioned-docs propagation: vNext + version-2.0.x (the two versions where these pages exist with this text)
- [x] Files updated: 4