### PR TITLE
docs(postgres catalog): add Limitations and Cookbook sections

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -109,6 +109,24 @@ The PostgreSQL Catalog Connector automatically discovers foreign key relationshi
 
 No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
 
+## Limitations
+
+:::warning
+
+- **Base tables and standard views only.** The connector discovers `BASE TABLE` and `VIEW` relations. Materialized views and foreign tables are not currently discovered and will not appear in the catalog ([#11725](https://github.com/spiceai/spiceai/issues/11725)).
+- **Partitioned tables.** For declaratively-partitioned tables, both the partitioned parent and each child partition are registered as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726)).
+- **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
+- **Unsupported column types.** Tables containing a column of a type that cannot be mapped are skipped entirely and a warning is logged. The `unsupported_type_action` behavior available on individual PostgreSQL datasets is not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728)).
+- **Partial discovery failures.** If discovery of a schema's tables fails during the initial load, the catalog fails to register rather than loading the reachable schemas ([#11724](https://github.com/spiceai/spiceai/issues/11724)).
+- **Amazon Redshift.** Redshift is supported over the PostgreSQL wire protocol, but its `pg_catalog` coverage is partial and it does not enforce foreign keys, so table/column comment and foreign-key metadata are often unavailable. Discovery degrades gracefully (tables are still registered).
+- **Read-only.** Catalog tables are read-only. Accelerations cannot be configured on tables discovered through an external catalog.
+
+:::
+
+## Cookbook
+
+There is a [cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/postgres) demonstrating the PostgreSQL Catalog Connector with the TPC-H dataset.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).

--- a/website/versioned_docs/version-2.0.x/components/catalogs/postgres.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/postgres.md
@@ -109,6 +109,24 @@ The PostgreSQL Catalog Connector automatically discovers foreign key relationshi
 
 No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
 
+## Limitations
+
+:::warning
+
+- **Base tables and standard views only.** The connector discovers `BASE TABLE` and `VIEW` relations. Materialized views and foreign tables are not currently discovered and will not appear in the catalog ([#11725](https://github.com/spiceai/spiceai/issues/11725)).
+- **Partitioned tables.** For declaratively-partitioned tables, both the partitioned parent and each child partition are registered as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726)).
+- **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
+- **Unsupported column types.** Tables containing a column of a type that cannot be mapped are skipped entirely and a warning is logged. The `unsupported_type_action` behavior available on individual PostgreSQL datasets is not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728)).
+- **Partial discovery failures.** If discovery of a schema's tables fails during the initial load, the catalog fails to register rather than loading the reachable schemas ([#11724](https://github.com/spiceai/spiceai/issues/11724)).
+- **Amazon Redshift.** Redshift is supported over the PostgreSQL wire protocol, but its `pg_catalog` coverage is partial and it does not enforce foreign keys, so table/column comment and foreign-key metadata are often unavailable. Discovery degrades gracefully (tables are still registered).
+- **Read-only.** Catalog tables are read-only. Accelerations cannot be configured on tables discovered through an external catalog.
+
+:::
+
+## Cookbook
+
+There is a [cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/postgres) demonstrating the PostgreSQL Catalog Connector with the TPC-H dataset.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).


### PR DESCRIPTION
## Summary

Adds a **Limitations** section and a **Cookbook** link to the PostgreSQL Catalog Connector documentation, satisfying the Alpha Catalog release criteria requirement that "Documentation includes all known issues/limitations for the Catalog."

Applied to both the current (vNext) docs and the released `version-2.0.x` docs.

## Limitations documented

- Materialized views and foreign tables are not discovered ([spiceai/spiceai#11725](https://github.com/spiceai/spiceai/issues/11725))
- Child partitions of partitioned tables register as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726))
- `include` filters tables, not schemas
- Unsupported column types drop the whole table; `unsupported_type_action` not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728))
- Partial discovery failure fails the whole catalog load ([#11724](https://github.com/spiceai/spiceai/issues/11724))
- Amazon Redshift metadata caveats (partial `pg_catalog`, no enforced FKs)
- Catalog tables are read-only

Also adds a `## Cookbook` section linking the [PostgreSQL catalog recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/postgres), matching the pattern used by the Glue catalog docs.

Part of the PostgreSQL Catalog Connector Alpha effort (spiceai/spiceai#10373).
