### PR TITLE
docs: fix nonexistent query_processed_rows metric (should be query_returned_rows)

### DIFF
--- a/website/docs/components/catalogs/unity-catalog/deployment.md
+++ b/website/docs/components/catalogs/unity-catalog/deployment.md
@@ -92,7 +92,7 @@ The Unity Catalog connector does not currently register UC-specific OpenTelemetr
 
 Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Task-history spans listed below.
 - Databricks / UC workspace audit logs for API-level visibility.
 

--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/docs/components/data-connectors/delta-lake/deployment.md
+++ b/website/docs/components/data-connectors/delta-lake/deployment.md
@@ -53,7 +53,7 @@ Object-store I/O metrics are collected via the shared `runtime-object-store` lay
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Upstream cloud metrics (S3 request count, Azure blob throughput).
 - Acceleration refresh metrics when the dataset is accelerated.
 

--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -41,7 +41,7 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Metrics
 
-The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For DuckDB-internal metrics, use DuckDB's `duckdb_memory()` and `pragma database_size` via a SQL query against the connector.
 

--- a/website/docs/components/data-connectors/elasticsearch/deployment.md
+++ b/website/docs/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/docs/components/data-connectors/file/deployment.md
+++ b/website/docs/components/data-connectors/file/deployment.md
@@ -47,7 +47,7 @@ See [File Formats](../../../reference/file_format) for format-specific parameter
 
 ## Metrics
 
-The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For filesystem-level issues (disk utilization, IOPS), use the underlying OS metrics (Prometheus `node_exporter`, CloudWatch agent, etc.).
 

--- a/website/docs/components/data-connectors/github/deployment.md
+++ b/website/docs/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -136,7 +136,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/docs/components/data-connectors/s3/deployment.md
+++ b/website/docs/components/data-connectors/s3/deployment.md
@@ -79,7 +79,7 @@ S3 I/O metrics are collected via the shared `runtime-object-store` layer (reques
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 
 - Standard AWS CloudWatch metrics on the bucket (`AllRequests`, `4xxErrors`, `5xxErrors`, `TotalRequestLatency`).
-- Spice's query-execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice's query-execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 
 ## Task History
 

--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.

--- a/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
@@ -92,7 +92,7 @@ The Unity Catalog connector does not currently register UC-specific OpenTelemetr
 
 Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Task-history spans listed below.
 - Databricks / UC workspace audit logs for API-level visibility.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
@@ -53,7 +53,7 @@ Object-store I/O metrics are collected via the shared `runtime-object-store` lay
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Upstream cloud metrics (S3 request count, Azure blob throughput).
 - Acceleration refresh metrics when the dataset is accelerated.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
@@ -41,7 +41,7 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Metrics
 
-The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For DuckDB-internal metrics, use DuckDB's `duckdb_memory()` and `pragma database_size` via a SQL query against the connector.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
@@ -47,7 +47,7 @@ See [File Formats](../../../reference/file_format) for format-specific parameter
 
 ## Metrics
 
-The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For filesystem-level issues (disk utilization, IOPS), use the underlying OS metrics (Prometheus `node_exporter`, CloudWatch agent, etc.).
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
@@ -127,7 +127,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
@@ -79,7 +79,7 @@ S3 I/O metrics are collected via the shared `runtime-object-store` layer (reques
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 
 - Standard AWS CloudWatch metrics on the bucket (`AllRequests`, `4xxErrors`, `5xxErrors`, `TotalRequestLatency`).
-- Spice's query-execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice's query-execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.

--- a/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
@@ -92,7 +92,7 @@ The Unity Catalog connector does not currently register UC-specific OpenTelemetr
 
 Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Task-history spans listed below.
 - Databricks / UC workspace audit logs for API-level visibility.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/delta-lake/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/delta-lake/deployment.md
@@ -53,7 +53,7 @@ Object-store I/O metrics are collected via the shared `runtime-object-store` lay
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 - Upstream cloud metrics (S3 request count, Azure blob throughput).
 - Acceleration refresh metrics when the dataset is accelerated.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/duckdb/deployment.md
@@ -41,7 +41,7 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Metrics
 
-The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The DuckDB connector does not register connector-specific instruments. Monitor via Spice's query metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For DuckDB-internal metrics, use DuckDB's `duckdb_memory()` and `pragma database_size` via a SQL query against the connector.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
@@ -47,7 +47,7 @@ See [File Formats](../../../reference/file_format) for format-specific parameter
 
 ## Metrics
 
-The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_processed_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The File connector does not register connector-specific instruments. Monitor via Spice's query execution metrics (`query_duration_ms`, `query_returned_rows`). See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For filesystem-level issues (disk utilization, IOPS), use the underlying OS metrics (Prometheus `node_exporter`, CloudWatch agent, etc.).
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
@@ -136,7 +136,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
@@ -79,7 +79,7 @@ S3 I/O metrics are collected via the shared `runtime-object-store` layer (reques
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 
 - Standard AWS CloudWatch metrics on the bucket (`AllRequests`, `4xxErrors`, `5xxErrors`, `TotalRequestLatency`).
-- Spice's query-execution metrics (`query_duration_ms`, `query_processed_rows`) from `runtime.metrics`.
+- Spice's query-execution metrics (`query_duration_ms`, `query_returned_rows`) from `runtime.metrics`.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.


### PR DESCRIPTION
## Summary

Deployment guides across many connectors list a Spice query-execution metric named `query_processed_rows` under `runtime.metrics`. **No such metric exists.** The runtime's query telemetry defines:

- `query_processed_bytes` (u64 counter)
- `query_returned_bytes` (u64 counter)
- `query_returned_rows` (u64 histogram) ← the actual rows metric
- `query_duration_ms` (f64 histogram)
- `query_failures` (u64 counter; exported as `query_failures_total`)

Source: `crates/runtime/src/metrics/telemetry/mod.rs:59-99` and `crates/runtime-metrics/src/telemetry/mod.rs:59-99` (`.u64_histogram("query_returned_rows")` at line 85). A repo-wide grep for `query_processed_rows` returns no instrument — the only `processed_rows` match is the unrelated `dataset_acceleration_refresh_processed_rows`.

This corrects `query_processed_rows` → `query_returned_rows` everywhere it appears.

## What changed

Replaced the fabricated `query_processed_rows` with the real `query_returned_rows` in all deployment/monitoring sections. Affected connectors/catalogs: s3, dremio, delta-lake, spiceai, cosmosdb, elasticsearch, github, graphql, https, duckdb, file, and the unity-catalog catalog page. Propagated across vNext + version-2.0.x + version-2.1.x (36 files).

## Source PRs
- Verified against spiceai/spiceai at `trunk`: `crates/runtime/src/metrics/telemetry/mod.rs` (metric definitions).

## Test plan
- [x] `grep -rn query_processed_rows website/` → 0 hits after fix
- [x] Pure inline-code token rename; no links, tags, or frontmatter changed (Docusaurus link/tag validation unaffected). Local `npm run build` not run in this environment (no node_modules; full versioned build is memory-constrained) — CI `Deploy` check is the authoritative link/tag gate for this prose-only diff.
- [x] Files updated: 36 (1 unversioned set + version-2.0.x + version-2.1.x)