### PR TITLE
docs: remove fabricated transport/IO metrics claims (object-store + Flight connectors)

### DIFF
--- a/website/docs/components/data-connectors/delta-lake/deployment.md
+++ b/website/docs/components/data-connectors/delta-lake/deployment.md
@@ -49,7 +49,7 @@ The Delta Lake connector reads the `_delta_log` transaction log on each query pl
 
 ## Metrics
 
-Object-store I/O metrics are collected via the shared `runtime-object-store` layer and exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs Delta Lake object-store I/O is not instrumented, so Spice does not emit object-store transport metrics. See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 

--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -43,7 +43,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 ## Metrics
 
-Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
+The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).

--- a/website/docs/components/data-connectors/s3/deployment.md
+++ b/website/docs/components/data-connectors/s3/deployment.md
@@ -74,7 +74,7 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 
 ## Metrics
 
-S3 I/O metrics are collected via the shared `runtime-object-store` layer (request counts, retries, bytes read) and are exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 

--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -177,7 +177,7 @@ datasets:
 
 ## Metrics
 
-Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
+The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/delta-lake/deployment.md
@@ -49,7 +49,7 @@ The Delta Lake connector reads the `_delta_log` transaction log on each query pl
 
 ## Metrics
 
-Object-store I/O metrics are collected via the shared `runtime-object-store` layer and exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs Delta Lake object-store I/O is not instrumented, so Spice does not emit object-store transport metrics. See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
@@ -43,7 +43,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 ## Metrics
 
-Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
+The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
@@ -74,7 +74,7 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 
 ## Metrics
 
-S3 I/O metrics are collected via the shared `runtime-object-store` layer (request counts, retries, bytes read) and are exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
@@ -177,7 +177,7 @@ datasets:
 
 ## Metrics
 
-Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
+The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/delta-lake/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/delta-lake/deployment.md
@@ -49,7 +49,7 @@ The Delta Lake connector reads the `_delta_log` transaction log on each query pl
 
 ## Metrics
 
-Object-store I/O metrics are collected via the shared `runtime-object-store` layer and exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs Delta Lake object-store I/O is not instrumented, so Spice does not emit object-store transport metrics. See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The Delta Lake connector does not currently register connector-specific dataset-level instruments. Monitor Delta operations via:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
@@ -43,7 +43,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 ## Metrics
 
-Flight SQL transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Dremio-specific dataset-level instruments. Monitor via:
+The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
@@ -74,7 +74,7 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 
 ## Metrics
 
-S3 I/O metrics are collected via the shared `runtime-object-store` layer (request counts, retries, bytes read) and are exposed through Spice's runtime metrics. See [Component Metrics](../../../features/observability/component_metrics) for configuration.
+The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.
 
 The connector does not currently register S3-specific dataset-level instruments. Monitor S3 health via:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
@@ -177,7 +177,7 @@ datasets:
 
 ## Metrics
 
-Flight transport metrics are collected via the shared Flight client instrumentation. The connector does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
+The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_processed_rows`, `query_failures_total`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).


### PR DESCRIPTION
## Summary

Four deployment guides assert that connector transport/IO metrics are "collected via" a shared instrumentation layer. **No such instrumentation exists** — the referenced layers emit no metrics, and the claim self-contradicts the very next sentence on each page ("does not currently register connector-specific instruments").

Verified against spiceai/spiceai at `trunk`:

- **Object-store connectors (S3, Delta Lake):** claimed "S3 I/O / Object-store I/O metrics are collected via the shared `runtime-object-store` layer (request counts, retries, bytes read)." A recursive grep of `crates/runtime-object-store/src/` for any metric instrumentation (`counter!`/`histogram!`/`gauge!`/meter/`bytes_read`) returns nothing — the crate does not instrument request counts, retries, or bytes read. There are no object-store transport metrics in `runtime.metrics`.
- **Flight connectors (Dremio, Spice.ai):** claimed "Flight (SQL) transport metrics are collected via the shared Flight client instrumentation." `crates/flight_client/src/` and `crates/data_components/src/flight.rs` contain no meter/counter/histogram instrumentation; a repo-wide grep for Flight transport metrics returns nothing.

These are the "registers a metric" behavior-claim class — invented runtime semantics with no code referent.

## What changed

Reworded the false first sentence on each page to accurately state the connector emits **no** transport-level metrics (the object-store / Flight layer is not instrumented), keeping the existing, correct guidance to monitor via query-execution runtime metrics, upstream/cloud metrics, and acceleration-refresh metrics. The pre-existing `[Component Metrics]` link is preserved unchanged (no new links or tags).

Affected pages: `s3`, `delta-lake`, `dremio`, `spiceai` deployment guides, propagated across vNext + version-2.0.x + version-2.1.x (12 files).

## Source PRs
- Verified against spiceai/spiceai at `trunk`: `crates/runtime-object-store/src/**`, `crates/flight_client/src/**`, `crates/data_components/src/flight.rs` (no metric instrumentation present).

## Test plan
- [x] `grep -rn "collected via the shared" website/` → 0 hits after fix
- [x] Prose-only edits; no links, tags, or frontmatter added or moved (existing Component Metrics link preserved verbatim). Local `npm run build` not run in this environment (no node_modules; full versioned build is memory-constrained) — CI `Deploy` check is the authoritative link/tag gate.
- [x] Files updated: 12 (vNext + version-2.0.x + version-2.1.x)