### PR TITLE
docs(models): remove traditional ML (ONNX) inference (spiceai/spiceai#11684)

### DIFF
--- a/website/docs/components/models/filesystem/deployment.md
+++ b/website/docs/components/models/filesystem/deployment.md
@@ -10,7 +10,7 @@ tags:
   - observability
 ---
 
-Production operating guide for loading local language models from the filesystem (GGUF, safetensors, ONNX).
+Production operating guide for loading local language models from the filesystem (GGUF, safetensors).
 
 ## Authentication & Secrets
 
@@ -38,7 +38,6 @@ Model loading happens once at startup. A missing or unreadable file fails the sp
 | GGML (legacy)  | `.ggml`                        | Legacy llama.cpp format.                                               |
 | Safetensors    | `.safetensors`                 | Native tensor format; preferred over `.bin` for safety.                 |
 | PyTorch        | `.bin` / `.pt` / `.pth`         | Legacy PyTorch checkpoints.                                             |
-| ONNX           | `.onnx`                        | Supported via the tract runtime for classical ML models.               |
 
 ### Device Selection
 
@@ -78,7 +77,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 ## Known Limitations
 
 - **Single-process loading**: A model is loaded into the Spice process — it cannot be shared across process instances without a dedicated inference server.
-- **Format support depends on compile features**: CUDA, Metal, and ONNX support are conditional on the Spice build flavor (default, CUDA, ONNX-enabled).
+- **Format support depends on compile features**: CUDA and Metal support are conditional on the Spice build flavor (default, CUDA).
 - **No hot reload**: Swapping the underlying model file requires a spicepod reload.
 - **No integrity check**: The provider trusts the file on disk. Validate checksums out-of-band for supply-chain assurance.
 - **Model_type override**: When the loader cannot auto-detect the architecture, `model_type` can force a known architecture.

--- a/website/docs/components/models/filesystem/index.md
+++ b/website/docs/components/models/filesystem/index.md
@@ -13,7 +13,7 @@ models:
     name: llama3
 ```
 
-Supported formats include GGUF, GGML, and SafeTensor for large language models (LLMs) and ONNX for traditional machine learning (ML) models.
+Supported formats include GGUF, GGML, and SafeTensor for large language models (LLMs).
 
 ## Configuration
 
@@ -88,14 +88,6 @@ models:
 ```
 
 Note: The folder provided should contain all the expected files (see examples above).
-
-### Loading an ONNX Model
-
-```yaml
-models:
-  - from: file://absolute/path/to/my/model.onnx
-    name: local_fs_model
-```
 
 ### Loading a GGUF Model
 

--- a/website/docs/components/models/huggingface/deployment.md
+++ b/website/docs/components/models/huggingface/deployment.md
@@ -82,7 +82,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 - **Single-process loading**: A model is loaded into the Spice process — it cannot be shared across process instances without a dedicated inference server.
 - **No hot reload**: Switching model revisions requires a spicepod reload.
 - **Limited Responses API support**: Responses API routing is currently tied to specific providers (OpenAI, xAI); a local HF-loaded model does not serve the Responses API.
-- **Quantized formats**: Support depends on the local loader (mistral / candle / ONNX). Verify the format is supported before production deployment.
+- **Quantized formats**: Support depends on the local loader (mistral / candle). Verify the format is supported before production deployment.
 - **Disk-space requirements**: First-run downloads can be multi-GB; ensure `~/.spice/models/` has adequate space.
 
 ## Troubleshooting

--- a/website/docs/components/models/huggingface/index.md
+++ b/website/docs/components/models/huggingface/index.md
@@ -74,18 +74,6 @@ models:
 
 ## Examples
 
-### Load a ML model to predict taxi trips outcomes
-
-```yaml
-models:
-  - from: huggingface:huggingface.co/spiceai/darts:latest
-    name: hf_model
-    files:
-      - path: model.onnx
-    datasets:
-      - taxi_trips
-```
-
 ### Load a LLM model to generate text
 
 ```yaml
@@ -109,8 +97,8 @@ For more details on authentication, see [access tokens](#access-tokens).
 :::warning[Limitations]
 
 - The throughput, concurrency & latency of a locally hosted model will vary based on the underlying hardware and model size. Spice supports Apple Metal and CUDA for accelerated inference. See [CONTRIBUTING.md](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md) for build instructions.
-- ML models currently only support ONNX file format.
-  :::
+
+:::
 
 ## Cookbook
 

--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -1,26 +1,28 @@
 ---
 title: 'Model Providers'
 sidebar_label: 'Model Providers'
-description: 'Overview of supported model providers for ML and LLMs in Spice.'
+description: 'Overview of supported model providers for LLMs in Spice.'
 image: /img/og/models.png
 sidebar_position: 5
 ---
 
-Spice supports various model providers for traditional machine learning (ML) models and large language models (LLMs).
+Spice supports various model providers for large language models (LLMs).
 
-| Name                       | Description                                  | Status            | ML Format(s) | LLM Format(s)\*                 |
-| -------------------------- | -------------------------------------------- | ----------------- | ------------ | ------------------------------- |
-| [`openai`][openai]         | OpenAI (or compatible) LLM endpoint          | Stable            | -            | OpenAI-compatible HTTP endpoint |
-| [`bedrock`][bedrock]       | Amazon Bedrock                               | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`xai`][xai]               | Models hosted on xAI                         | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`file`][file]             | Local filesystem                             | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
-| [`huggingface`][hf]        | Models hosted on HuggingFace                 | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
-| [`spice.ai`][spice]        | Models hosted on the Spice.ai Cloud Platform | Release Candidate | ONNX         | OpenAI-compatible HTTP endpoint |
-| [`azure`][azure]           | Azure OpenAI                                 | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`anthropic`][ant]         | Models hosted on Anthropic                   | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`google`][google]         | Google AI language models                    | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])    | Deprecated        | -            | -                               |
+> **Note**: Support for traditional machine learning (ONNX) models was removed in vNext. See [Machine Learning Models](../../features/machine-learning-models) for details.
+
+| Name                       | Description                                  | Status            | LLM Format(s)\*                 |
+| -------------------------- | -------------------------------------------- | ----------------- | ------------------------------- |
+| [`openai`][openai]         | OpenAI (or compatible) LLM endpoint          | Stable            | OpenAI-compatible HTTP endpoint |
+| [`bedrock`][bedrock]       | Amazon Bedrock                               | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`xai`][xai]               | Models hosted on xAI                         | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`file`][file]             | Local filesystem                             | Release Candidate | GGUF, GGML, SafeTensor          |
+| [`huggingface`][hf]        | Models hosted on HuggingFace                 | Release Candidate | GGUF, GGML, SafeTensor          |
+| [`spice.ai`][spice]        | Models hosted on the Spice.ai Cloud Platform | Release Candidate | OpenAI-compatible HTTP endpoint |
+| [`azure`][azure]           | Azure OpenAI                                 | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`anthropic`][ant]         | Models hosted on Anthropic                   | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`google`][google]         | Google AI language models                    | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | OpenAI-compatible HTTP endpoint |
+| ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])    | Deprecated        | -                               |
 
 [openai]: ./openai/index.md
 [bedrock]: ./bedrock.md
@@ -170,7 +172,7 @@ To serve a model from the local filesystem, specify the `from` path as `file` an
 
 ```yaml
 models:
-  - from: file://absolute/path/to/my/model.onnx
+  - from: file://absolute/path/to/my/model.gguf
     name: local_fs_model
 ```
 

--- a/website/docs/features/machine-learning-models/index.md
+++ b/website/docs/features/machine-learning-models/index.md
@@ -8,28 +8,8 @@ tags:
   - models
 ---
 
-Spice supports loading and serving ONNX models for inference, from sources including local filesystems, Hugging Face, and the Spice.ai Cloud platform.
+> **Deprecated in vNext**: Support for loading and serving traditional machine learning (ONNX) models for inference was removed in vNext, along with the `/v1/predict` and `/v1/models/{name}/predict` prediction endpoints. See the [v2.1 docs](https://docs.spiceai.org/docs/2.1.x/features/machine-learning-models) for documentation of this feature.
 
-Example `spicepod.yml` loading an ONNX model from HuggingFace:
+Spice no longer loads or serves traditional machine learning (ONNX) models. The [Models](../../components/models) component now serves large language models (LLMs) only.
 
-```yaml
-models:
-  - from: huggingface:huggingface.co/spiceai/darts:latest
-    name: hf_model
-    files:
-      - path: model.onnx
-    datasets:
-      - taxi_trips
-```
-
-## Filesystem
-
-Models can be hosted on a local filesystem and referenced directly in the configuration. For more details, see the [Filesystem Model Component](../components/models/filesystem).
-
-## Hugging Face
-
-Spice integrates with Hugging Face, enabling you to use a wide range of pre-trained models. For more information, see the [Hugging Face Model Component](../components/models/huggingface).
-
-## Spice Cloud Platform
-
-The Spice Cloud platform provides a scalable environment for training, hosting, and managing your models. For further details, see the [Spice Cloud Platform Model Component](../components/models/spiceai).
+For LLM configuration and usage, see [Large Language Models](../features/large-language-models).

--- a/website/docs/getting-started/spicepods.md
+++ b/website/docs/getting-started/spicepods.md
@@ -36,7 +36,7 @@ A Spicepod is described by a YAML manifest file, typically named `spicepod.yaml`
 - **Metadata:** Basic information about the Spicepod, such as its name and version.
 - **Datasets:** Definitions of datasets that are used or produced within the Spicepod.
 - **Catalogs:** Definitions of catalogs that are used within the Spicepod.
-- **Models:** Definitions of language or traditional ML models that the Spicepod manages, including their sources and associated datasets.
+- **Models:** Definitions of language models that the Spicepod manages, including their sources and associated datasets.
 - **Secrets:** Configuration for any secret stores used within the Spicepod.
 
 ## Example Manifest

--- a/website/docs/reference/spicepod/models.md
+++ b/website/docs/reference/spicepod/models.md
@@ -5,14 +5,14 @@ description: 'Models YAML reference'
 pagination_next: null
 ---
 
-The `models` section of a Spicepod defines machine learning (ML) models and large language models (LLMs) for use with Spice. Models can be loaded from Hugging Face, OpenAI, local files, or other supported providers. The model type is automatically determined based on the source and file format.
+The `models` section of a Spicepod defines large language models (LLMs) for use with Spice. Models can be loaded from Hugging Face, OpenAI, local files, or other supported providers.
 
 | Field         | Description                                                              |
 | ------------- | ------------------------------------------------------------------------ |
 | `name`        | Unique, readable name for the model within the Spicepod.                 |
 | `from`        | Source-specific address to uniquely identify a model.                    |
 | `description` | Additional details about the model, useful for displaying to users.      |
-| `datasets`    | Datasets that the model depends on for inference.                        |
+| `datasets`    | Datasets the model's tools may access, forming a table allowlist.        |
 | `files`       | Specify additional files, or override default files needed by the model. |
 | `params`      | Additional parameters to be passed to the model.                         |
 
@@ -60,7 +60,7 @@ The `<model_source>` prefix of the `from` field indicates where the model is sou
 
 The `<model_id>` suffix of the `from` field is a unique (per source) identifier for the model:
 
-- For Spice AI: Supports only ML models. Represents the full path to the model in the Spice AI repository. Supports a version suffix (default to `latest`).
+- For Spice AI: Represents the full path to the model in the Spice AI repository. Supports a version suffix (default to `latest`).
   - Example: `lukekim/smart/models/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf`
 - For Hugging Face: A repo_id and, optionally, revision hash or tag.
   - `Qwen/Qwen1.5-0.5B` (no revision)
@@ -87,7 +87,6 @@ Optional. A list of files associated with this model. Each file has:
 File types include:
 
 - `weights`: Model weights
-  - For ML models: typically `.onnx` files
   - For LLMs: `.gguf`, `.ggml`, `.safetensors`, or `pytorch_model.bin` files
   - These files contain the trained parameters of the model
 
@@ -160,7 +159,7 @@ models:
 
 ### `datasets`
 
-Optional. A list of [dataset names](./datasets#name) that this model should be applied to. For ML models, this preselects the dataset to use for inference.
+Optional. A list of [dataset names](./datasets#name) that scope the model's tool access, forming a table allowlist for SQL and NSQL tool use. When omitted, the model's tools are not restricted to a specific set of datasets.
 
 ### `dependsOn`
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#11684` deleted the `model_components` crate and **all traditional machine learning (ONNX/Tract) inference**, including the `/v1/predict` and `/v1/models/{name}/predict` HTTP endpoints. The `spiced` build no longer carries any ONNX dependency, and the `ModelType` (ML vs LLM) distinction is gone — models are LLM-only.

Verified against today's `origin/trunk` (not just the merged diff): `crates/model_components` is gone, `crates/runtime/src/http/v1/inference.rs` is gone, no `predict` route remains in `http/routes.rs`, and no ONNX dependency exists in `Cargo.toml`.

This PR removes the now-inaccurate ONNX/traditional-ML documentation from the Models component and reference pages:

- **`features/machine-learning-models/index.md`** — converted to a deprecation notice (page kept to avoid broken links; links to the v2.1 docs, which correctly document the feature for that release).
- **`components/models/index.md`** — dropped the now-empty `ML Format(s)` column; intro and local-model example updated to LLM-only.
- **`components/models/filesystem/{index,deployment}.md`** — removed the ONNX format clause, the ONNX example, the ONNX row in the supported-formats table, and the ONNX build-flavor mention.
- **`components/models/huggingface/{index,deployment}.md`** — removed the ONNX "predict taxi trips" example, the "ML models only support ONNX" limitation, and the ONNX quantized-format mention.
- **`reference/spicepod/models.md`** — LLM-only intro; the `datasets` field now correctly documents its current behavior — an **LLM tool table allowlist** (`create_table_allowlist` / `with_table_patterns` in `crates/runtime/src/model/nsql.rs`), not ML-inference dataset preselection.
- **`getting-started/spicepods.md`** — "language or traditional ML models" → "language models".

### Versioned docs

vNext-only. `v2.1.x` (the latest cut release) still ships ONNX and correctly documents it, so no versioned snapshots are edited.

### Out of scope (follow-ups)

- `components/models/spiceai.md` (Spice Cloud Platform provider) still shows ML-inference examples and needs an LLM-usage rewrite — deferred pending confirmation of the current `spice.ai` LLM `from:` form.
- The OpenAPI-generated `/v1/predict` API pages (`api/HTTP/get-model-predict.api.mdx`, `post-batch-predict.api.mdx`) require regenerating `public/openapi.json` via the OpenAPI generator — a separate generator-driven change.
- The embeddings pages' `ONNX` format entries (unrelated to `model_components`) and vision-prose mentions of ML predictions are better handled by a docs-accuracy review.

## Source PRs

- spiceai/spiceai#11684 — remove(ml): delete model_components crate and ONNX/Tract ML inference

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'`; fixed one relative-link resolution)
- [x] Versioned-docs propagation checked — removal is vNext-only (v2.1.x correctly retains ONNX)
- [x] Files updated: 8