### PR TITLE
docs(cayenne): correct cold object-store tier params to match v1 impl (datalake_location, s3-only, independent creds)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -125,16 +125,31 @@ These are acceleration parameters (set under `acceleration.params`) used when st
 
 ##### Cold object-store tier parameters
 
-These acceleration parameters (set under `acceleration.params`) configure the optional [cold object-store tier](#cold-object-store-tier). Setting `cayenne_cold_tier_location` enables the tier; the rest tune the clustering key, cold file size, and the warm→cold promotion trigger. When `cayenne_cold_tier_location` is unset (the default), the cold tier is dormant and behaves byte-identically to a warm-only table.
+These acceleration parameters (set under `acceleration.params`) configure the optional [cold object-store tier](#cold-object-store-tier). Setting `cayenne_datalake_location` enables the tier; the rest tune the clustering key, cold file size, the warm→cold promotion trigger, and the cold store's credentials. When `cayenne_datalake_location` is unset (the default), the cold tier is dormant and behaves byte-identically to a warm-only table.
 
 | Parameter                                  | Description                                                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cayenne_cold_tier_location`               | Object-store URL prefix for the cold tier (the bottom tier of the storage cascade), e.g. `s3://bucket/prefix` or `file:///mnt/cold`. When set, a background promotion stage graduates the warm local-disk tier to read-optimized, Z-order-clustered Vortex files on this store, and queries span the warm and cold tiers with per-tier pushdown. Unset (default) disables the cold tier. Requires key-based deletes and a primary key (auto-resolved — Cayenne forces `cayenne_deletion_mode: key`). **v1 constraints:** an `s3://` cold location must share the warm S3 Express bucket; partitioned and position-delete tables are not supported. |
-| `cayenne_cold_clustering_columns`          | Comma-separated liquid-clustering key columns for cold files (multi-column Z-order), e.g. `tenant_id,ts`. Clustering tightens each cold file's per-column zone maps so selective queries on any clustering dimension prune at the storage layer. When unset, falls back to `cayenne_sort_columns`, then the primary key.                                                                              |
+| `cayenne_datalake_location`                | Object-store URL prefix for the cold tier (the bottom tier of the storage cascade). Must be an `s3://` URL (e.g. `s3://bucket/prefix`) — a general-purpose S3 or S3-compatible bucket, distinct from the warm S3 Express One Zone store. When set, a background promotion stage graduates the warm local-disk tier to read-optimized, Z-order-clustered Vortex files on this store, and queries span the warm and cold tiers with per-tier pushdown. Unset (default) disables the cold tier. Requires key-based deletes and a primary key (auto-resolved — Cayenne forces `cayenne_deletion_mode: key`) and `refresh_mode: changes` or `append`. **v1 constraints:** local `file://` locations are not supported; partitioned and position-delete tables are not supported. |
+| `cayenne_datalake_clustering_columns`      | Comma-separated liquid-clustering key columns for cold files (multi-column Z-order), e.g. `tenant_id,ts`. Clustering tightens each cold file's per-column zone maps so selective queries on any clustering dimension prune at the storage layer. When unset, falls back to `cayenne_sort_columns`, then the primary key.                                                                              |
 | `cayenne_cold_target_file_size_mb`         | Target size for cold-tier Vortex files in MB. Larger than the warm `cayenne_target_file_size_mb` because object stores favor fewer, larger objects and cold scans are range reads. Accepts `auto` or an explicit MB value. Defaults to `512`.                                                                                                                                                        |
-| `cayenne_cold_tier_warm_max_bytes`         | The warm tier graduates to cold once its total Vortex bytes reach this threshold. `0` (default) disables the byte trigger; set alongside `cayenne_cold_tier_warm_max_files` to bound warm-tier size.                                                                                                                                                                                                 |
+| `cayenne_cold_tier_warm_max_bytes`         | The warm tier graduates to cold once its total Vortex bytes reach this threshold. `0` (default) disables the byte trigger; set alongside `cayenne_cold_tier_warm_max_files` to bound warm-tier size. When the tier is enabled and neither trigger is set, Cayenne applies a default byte trigger (16× `cayenne_cold_target_file_size_mb`) so promotion is not silently disabled.                       |
 | `cayenne_cold_tier_warm_max_files`         | The warm tier graduates to cold once its Vortex file count reaches this threshold. `0` (default) disables the file-count trigger.                                                                                                                                                                                                                                                                   |
 | `cayenne_cold_tier_background_interval_ms` | How often the background loop evaluates the warm→cold promotion trigger, in milliseconds. Cold tiering is not latency-critical, so this is coarser than compaction. Defaults to `60000` (60s).                                                                                                                                                                                                       |
+| `cayenne_datalake_gc_interval_ms`          | Physical-GC cadence (and orphan grace) for superseded cold-tier objects: the background sweep runs about this often and deletes an object no longer referenced by the manifest only after it has been observed orphaned for at least one interval. Defaults to `300000` (5m).                                                                                                                         |
+
+The cold store is authenticated independently from the warm tier (which uses the `cayenne_s3_*` parameters) via the following `acceleration.params`:
+
+| Parameter                              | Description                                                                                                                                                     |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cayenne_datalake_s3_auth`             | Authentication method for the cold S3 store: `iam_role` (default, uses environment/SDK credentials) or `key`.                                                   |
+| `cayenne_datalake_s3_key`              | AWS access key ID for the cold store (required when `cayenne_datalake_s3_auth: key`).                                                                            |
+| `cayenne_datalake_s3_secret`           | AWS secret access key for the cold store (required when `cayenne_datalake_s3_auth: key`).                                                                        |
+| `cayenne_datalake_s3_session_token`    | AWS session token for the cold store (optional, for temporary credentials).                                                                                     |
+| `cayenne_datalake_s3_region`           | AWS region of the cold bucket. Defaults to the environment region (`AWS_REGION` / `AWS_DEFAULT_REGION`), then `us-east-1`; inert for S3-compatible endpoints.    |
+| `cayenne_datalake_s3_endpoint`         | Custom S3 endpoint URL for the cold store (e.g. an S3-compatible store such as MinIO). `http://` endpoints implicitly allow HTTP.                                |
+| `cayenne_datalake_s3_allow_http`       | Allow plain-HTTP connections to the cold S3 endpoint. Defaults to `false`.                                                                                       |
+| `cayenne_datalake_s3_client_timeout`   | HTTP client timeout for cold-store requests, as a duration (e.g. `2m`). Defaults to `2m`.                                                                        |
+| `cayenne_datalake_s3_unsigned_payload` | Use unsigned payloads for cold S3 uploads. Defaults to `true`.                                                                                                   |
 
 #### Runtime parameters (`runtime.params`)
 
@@ -591,7 +606,7 @@ See AWS documentation for the complete list of [S3 Express One Zone availability
 
 ## Cold Object-Store Tier
 
-Cayenne can cascade data across three storage tiers — an in-RAM mem-tier, a local-disk **warm** tier, and an object-store **cold** tier — with each row living in exactly one tier. The cold tier is optional and disabled by default; it is enabled by setting [`cayenne_cold_tier_location`](#cold-object-store-tier-parameters). When unset, a table is warm-only and behaves byte-identically to before.
+Cayenne can cascade data across three storage tiers — an in-RAM mem-tier, a local-disk **warm** tier, and an object-store **cold** tier — with each row living in exactly one tier. The cold tier is optional and disabled by default; it is enabled by setting [`cayenne_datalake_location`](#cold-object-store-tier-parameters). When unset, a table is warm-only and behaves byte-identically to before.
 
 The cold tier lets a table grow beyond local NVMe capacity while keeping recent, hot data on fast local storage and graduating older data to cheaper, durable object storage — without sacrificing pushdown on the cold data.
 
@@ -599,12 +614,13 @@ The cold tier lets a table grow beyond local NVMe capacity while keeping recent,
 
 - **Promotion (write path).** A dedicated background worker graduates the warm tier once the size or file-count threshold (`cayenne_cold_tier_warm_max_bytes` / `cayenne_cold_tier_warm_max_files`) is crossed, evaluated every `cayenne_cold_tier_background_interval_ms`. Promotion re-materializes the visible table (all deletes applied, one version per key), **Z-order clusters** it for tight multi-column zone maps, writes read-optimized Vortex at the larger `cayenne_cold_target_file_size_mb`, and atomically registers the cold files while clearing the promoted warm files in a single transaction.
 - **Cross-tier scan (read path).** Queries span all tiers and push filters, projection, and limits down to each. Cold files are pruned from statistics held in the metastore, so pruning requires **no object-store round-trip on the query path**. A `DELETE` after promotion correctly hides a cold-resident row.
-- **Clustering.** Cold files are clustered by `cayenne_cold_clustering_columns` (multi-column Z-order / Morton order), falling back to `cayenne_sort_columns` and then the primary key. Clustering on more than one dimension prunes far better than a single-column sort for selective queries on any clustering column.
+- **Clustering.** Cold files are clustered by `cayenne_datalake_clustering_columns` (multi-column Z-order / Morton order), falling back to `cayenne_sort_columns` and then the primary key. Clustering on more than one dimension prunes far better than a single-column sort for selective queries on any clustering column.
 
 ### Requirements and v1 constraints
 
 - **Key-based deletes required.** The cold tier requires `cayenne_deletion_mode: key` and a primary key; Cayenne auto-forces key mode when the cold tier is enabled and logs an override if `cayenne_deletion_mode: position` was set.
-- **Shared bucket (S3).** In v1, an `s3://` cold location must share the warm S3 Express One Zone bucket. A local `file://` cold location has no such restriction.
+- **S3-only location.** The cold location must be an `s3://` URL — a general-purpose S3 or S3-compatible bucket (for example MinIO via `cayenne_datalake_s3_endpoint`), authenticated independently through the `cayenne_datalake_s3_*` parameters. It is a separate store from the warm S3 Express One Zone tier and does not need to share its bucket. Local `file://` cold locations are not supported in v1.
+- **Continuous refresh only.** The cold tier requires `refresh_mode: changes` or `refresh_mode: append`; a `full` refresh re-materializes the whole table each cycle and is rejected.
 - **Unsupported in v1:** partitioned tables and position-delete tables.
 
 ```yaml
@@ -614,11 +630,13 @@ datasets:
     acceleration:
       engine: cayenne
       mode: file
+      refresh_mode: changes
       primary_key: event_id
       params:
-        # Enable the cold object-store tier
-        cayenne_cold_tier_location: file:///mnt/cold/events
-        cayenne_cold_clustering_columns: tenant_id,created_at
+        # Enable the cold object-store tier (general-purpose S3, not S3 Express)
+        cayenne_datalake_location: s3://my-cold-bucket/events/
+        cayenne_datalake_s3_region: us-west-2
+        cayenne_datalake_clustering_columns: tenant_id,created_at
         # Graduate the warm tier to cold once it reaches 8 GiB
         cayenne_cold_tier_warm_max_bytes: 8589934592
 ```


### PR DESCRIPTION
## Summary

The Cayenne cold (datalake) object-store tier was finalized in spiceai/spiceai#11731 (2026-07-09), which renamed the enabling parameters and constrained the location scheme **after** the docs were first written in spiceai/docs#1882 (2026-07-03). The published docs were never updated, so several statements no longer match the runtime a reader actually runs. This corrects them.

**What the docs said → what the code does** (verified at `spiceai/spiceai` `origin/trunk`, commit `9db370e3c`):

| Docs claimed | Runtime reality | Source |
| --- | --- | --- |
| `cayenne_cold_tier_location` enables the tier | The runtime reads **`cayenne_datalake_location`**; `cayenne_cold_tier_location` is not a registered param and is silently ignored | `crates/runtime/src/dataaccelerator/cayenne/mod.rs:1332`, ParameterSpec `:2196` |
| `cayenne_cold_clustering_columns` | Real key is **`cayenne_datalake_clustering_columns`** | `mod.rs:1340`, ParameterSpec `:2198` |
| Cold location may be `s3://` **or** `file:///…` | Location **must** start with `s3://`; anything else is rejected at registration ("Expected 's3://bucket/prefix'") | `mod.rs:1980-1988` |
| An `s3://` cold location "must share the warm S3 Express bucket" | The cold store is an **independent general-purpose S3** endpoint (path-style, non-Express) with its own `cayenne_datalake_s3_*` credentials — explicitly "Unlike build_s3_object_store (warm tier, S3 Express One Zone only)" | `crates/runtime/src/dataaccelerator/cayenne/s3.rs:1476-1489` |

Also documents what was missing and required to use the corrected feature: the `cayenne_datalake_s3_*` credential params, `cayenne_datalake_gc_interval_ms` (default `300000`), the `refresh_mode: changes`/`append` requirement (`mod.rs:1993-2005`), and the default promotion trigger applied when the tier is enabled but no warm threshold is set (`mod.rs:1383-1397`).

All numeric cold-tier defaults already documented (`cayenne_cold_target_file_size_mb` 512, warm max 0/0, background interval 60000) were verified correct and left unchanged.

## Scope

vNext (unversioned) only — the cold object-store tier is a vNext feature and does not appear in any `versioned_docs/version-*/` snapshot.

## Source PRs
- spiceai/spiceai#11731 — feat(cayenne): finalize datalake (cold) tier v1 UX, credentials, and e2e integration test
- spiceai/docs#1882 — docs(cayenne): document cold object-store tier (the doc being corrected)

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: throw`; only pre-existing anchor links, no new tags)
- [x] Versioned-docs propagation checked — wrong names present only in vNext (new feature, not in versioned snapshots)
- [x] Files updated: 1