### PR TITLE
docs(datasets): add MySQL to schema_inference: extended connector list

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -287,7 +287,7 @@ Not all connectors support specifying an `unsupported_type_action`. When specifi
 Optional. Controls the depth of source-schema inference. Applies to all refresh modes. Supported values:
 
 - `standard` - Default. Infer the base column schema (names, types, nullability) from the source, exactly as before. No primary-key, secondary-index, or sort/clustering-column detection is performed.
-- `extended` - In addition to the base column schema, auto-detect the source's primary key, secondary indexes, and sort/clustering columns and apply them to any acceleration settings left unset. Only connectors that emit inferred-schema metadata are affected — currently the [PostgreSQL](../../components/data-connectors/postgres) and [MongoDB](../../components/data-connectors/mongodb) connectors; other connectors treat `extended` as a no-op.
+- `extended` - In addition to the base column schema, auto-detect the source's primary key, secondary indexes, and sort/clustering columns and apply them to any acceleration settings left unset. Only connectors that emit inferred-schema metadata are affected — currently the [PostgreSQL](../../components/data-connectors/postgres), [MySQL](../../components/data-connectors/mysql), and [MongoDB](../../components/data-connectors/mongodb) connectors; other connectors treat `extended` as a no-op.
 
 ```yaml
 datasets:


### PR DESCRIPTION
## Summary

The MySQL connector now implements `schema_inference: extended` (spiceai/spiceai#11742, merged 2026-07-10), mirroring PostgreSQL — it queries `information_schema` for the primary key and row/byte estimates so accelerated datasets without a declared `primary_key` can still use `refresh_mode: changes` (CDC).

The `schema_inference` reference listed only PostgreSQL and MongoDB as the connectors that emit inferred-schema metadata. Verified against `origin/trunk`: exactly three connectors implement `is_extended()` inference — PostgreSQL, MySQL, and MongoDB (`crates/data-connectors/connector-{postgres,mysql,mongodb}/src/lib.rs`). This adds MySQL to that list.

Not yet in any release tag (vNext-only), so this touches only `website/docs/` — older versioned snapshots correctly omit MySQL.

## Source PRs
- spiceai/spiceai#11742 — Extended schema inference for mysql

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — addition (new capability), vNext-only; `version-2.1.x` does not contain #11742
- [x] Files updated: 1 (`website/docs/reference/spicepod/datasets.md`)