### PR TITLE
docs(mysql-cdc): document invalid_position_behavior guarding source-layout drift

### DIFF
--- a/website/docs/components/data-connectors/mysql/index.md
+++ b/website/docs/components/data-connectors/mysql/index.md
@@ -115,7 +115,7 @@ The following parameters configure MySQL [binlog replication](../../features/cdc
 | `mysql_replication_snapshot_mode`             | Optional. When existing rows load: `auto` (default) snapshots when no resumable position exists; `never` streams changes only; `always` re-snapshots on every start.                                     |
 | `mysql_replication_checkpoint_interval`       | Optional. How often the committed binlog position persists to the accelerator sidecar (e.g. `10s`). Default: `10s`.                                                                                      |
 | `mysql_replication_bootstrap_batch_size`      | Optional. Number of rows per emitted batch during the initial snapshot. Default: `8192`. Maximum: `1048576`.                                                                                            |
-| `mysql_replication_invalid_position_behavior` | Optional. What to do when the persisted position was purged from the source: `error` (default) or `rebootstrap` (drop the position and re-snapshot). Default: `error`.                                   |
+| `mysql_replication_invalid_position_behavior` | Optional. What to do when the persisted position cannot be resumed losslessly — either it was purged from the source, or the source table's column layout drifted incompatibly with the recorded position: `error` (default) or `rebootstrap` (drop the position and re-snapshot). Default: `error`. |
 
 ### `metrics`
 

--- a/website/docs/features/cdc/mysql-replication.md
+++ b/website/docs/features/cdc/mysql-replication.md
@@ -91,7 +91,7 @@ Configure replication behavior with the following `params` on the MySQL dataset:
 | `mysql_replication_snapshot_mode`            | `auto`    | When existing rows load: `auto` snapshots when no resumable position exists; `never` streams changes only; `always` re-snapshots on every start.                                                                                    |
 | `mysql_replication_checkpoint_interval`      | `10s`     | How often the committed position persists to the sidecar. Bounds crash-replay volume.                                                                                                                                              |
 | `mysql_replication_bootstrap_batch_size`     | `8192`    | Rows per emitted snapshot batch. Maximum: `1048576`.                                                                                                                                                                              |
-| `mysql_replication_invalid_position_behavior` | `error`   | What to do when the persisted position was purged from the source: `error`, or `rebootstrap` (drop the position and re-snapshot).                                                                                                  |
+| `mysql_replication_invalid_position_behavior` | `error`   | What to do when the persisted position cannot be resumed losslessly — either it was purged from the source, or the source table's column layout drifted incompatibly with the recorded position: `error`, or `rebootstrap` (drop the position and re-snapshot). |
 
 The runtime-level CDC apply tunables (`cdc_prefetch_buffer`, `cdc_max_coalesced_envelopes`, `cdc_max_coalesced_bytes`, `cdc_max_coalesce_age_ms`, `cdc_commit_timeout_ms`) apply to this connector the same way they do to the PostgreSQL one — see [Tuning ingestion](./index.md#tuning-ingestion).
 
@@ -105,6 +105,12 @@ params:
 ```
 
 to instead drop the stale position, truncate the accelerator, and re-snapshot the table automatically.
+
+## When the source layout changes
+
+Binlog row events are positional — each event carries column values in source-ordinal order, not by name — so the connector tracks the source table's column layout and refuses to apply events it can't line up against that layout. Compatible changes are adopted automatically: an additive `ALTER TABLE` is picked up from `information_schema` at the schema-change boundary and the stream continues without interruption.
+
+An **incompatible** change — one where the recorded position would replay row images against a layout that no longer matches (for example resuming after the source table's shape drifted while spiced was down, in a way the stream cannot reconcile with the events it still needs to replay) — cannot be applied without risking silent column misalignment. Rather than corrupt the accelerator, the connector stops and leaves the last known-good position in place. As with a purged position, `mysql_replication_invalid_position_behavior` controls the response: `error` (the default) surfaces an actionable error, and `rebootstrap` drops the position and re-snapshots the table from the current layout.
 
 ## Semantics and type notes
 


### PR DESCRIPTION
## Summary

spiceai/spiceai#11761 (merged 2026-07-10) broadens the MySQL binlog CDC resume guard. Previously `mysql_replication_invalid_position_behavior` only handled a persisted position that was **purged** from the source. It now also refuses to resume when the source table's column **layout drifted incompatibly** with the recorded position — binlog row events are positional, so replaying them against a mismatched layout would silently scramble columns. The connector stops (keeping the last known-good position) rather than corrupt the accelerator, and the same `error` / `rebootstrap` parameter controls the response.

Verified against `origin/trunk` (`crates/data_components/src/mysql_replication/binlog.rs`): compatible additive `ALTER TABLE` changes are adopted automatically from `information_schema` at the schema-change boundary; incompatible layouts (column-count mismatch that can't be adopted) raise an error naming `mysql_replication_invalid_position_behavior: rebootstrap`.

Changes:
- Expand the `mysql_replication_invalid_position_behavior` description on the connector reference and the CDC feature page.
- Add a **"When the source layout changes"** section to the feature page covering the compatible-vs-incompatible handling.

Not yet in any release tag (vNext-only), so this touches only `website/docs/` — the `version-2.1.x` snapshot correctly describes the original purge-only scope.

## Source PRs
- spiceai/spiceai#11761 — fix(mysql): refuse binlog resume across source layout drift

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — behavioral addition, vNext-only; `version-2.1.x` does not contain #11761
- [x] Files updated: 2 (`website/docs/components/data-connectors/mysql/index.md`, `website/docs/features/cdc/mysql-replication.md`)