### PR TITLE
docs(elasticsearch): correct filter-pushdown claim — no WHERE predicates are pushed down

### DIFF
--- a/website/docs/components/data-connectors/elasticsearch/deployment.md
+++ b/website/docs/components/data-connectors/elasticsearch/deployment.md
@@ -74,7 +74,7 @@ For more, see [Search Functionality](../../../features/search) and the [SQL sear
 
 | Predicate                                    | Pushdown to ES Query DSL                                              |
 | -------------------------------------------- | --------------------------------------------------------------------- |
-| `WHERE` equality on `keyword` / numeric fields | Limited — most filters are evaluated locally by DataFusion after fetch. |
+| `WHERE` filters (any field) | None — the connector pushes down no `WHERE` predicates; all are evaluated locally by DataFusion after fetch (the scan issues `match_all`). |
 | `LIMIT N`                                    | Translated to `size: N`.                                               |
 | `ORDER BY`                                   | Evaluated locally unless paired with a search UDTF.                   |
 | `vector_search` / `text_search` / `rrf`      | Native — issued as kNN / BM25 query bodies.                           |
@@ -107,7 +107,7 @@ Elasticsearch requests participate in [task history](../../../reference/task_his
 - **`date` and `date_nanos` are strings**: Elasticsearch accepts heterogeneous date formats. The connector preserves them as `Utf8` — cast to `TIMESTAMP` in SQL when comparison is needed.
 - **`nested` and `object` are JSON strings**: Nested objects are exposed as `Utf8` JSON, not structured Arrow types.
 - **`dense_vector` without `dims`**: Falls back to `Utf8` and is not usable as a vector column. Declare `dims` in the index mapping.
-- **Limited filter pushdown**: Most SQL `WHERE` predicates are evaluated locally by DataFusion. For selective filters, accelerate the dataset.
+- **No filter pushdown**: The connector pushes down no SQL `WHERE` predicates — every filter is evaluated locally by DataFusion after fetch (the scan issues `match_all`; only `LIMIT` is pushed down, as the query `size`). For selective filters, accelerate the dataset.
 - **Tested against Elasticsearch 8.17**: Other major versions (7.x, 9.x) may work but are not part of the integration test matrix.
 
 ## Troubleshooting

--- a/website/docs/components/data-connectors/elasticsearch/index.md
+++ b/website/docs/components/data-connectors/elasticsearch/index.md
@@ -147,7 +147,7 @@ TLS is enabled automatically for `https://` endpoints.
 - `date` and `date_nanos` fields are preserved as strings because Elasticsearch accepts heterogeneous date formats; cast to a timestamp in SQL when numeric comparison is required.
 - `dense_vector` fields without a declared `dims` value fall back to `Utf8` and are not usable as a vector column.
 - For queries with `LIMIT N` where N ≤ 10,000, the connector issues a single `_search` request. For larger result sets or queries without `LIMIT`, the connector automatically paginates using Point-In-Time (PIT) + `search_after`, fetching all matching documents in 10,000-hit batches.
-- Pushdown of SQL predicates to Elasticsearch query DSL is limited; complex filter expressions are evaluated locally by DataFusion after fetching results.
+- SQL `WHERE` predicates are not pushed down to the Elasticsearch query DSL; all filter expressions are evaluated locally by DataFusion after fetching results (only `LIMIT` is pushed down, as the query `size`).
 
 Elasticsearch can also be configured as a [Vector Engine](../vectors/elasticsearch) for datasets sourced from other connectors (storing Spice-managed embeddings in Elasticsearch rather than querying an existing index).
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
@@ -74,7 +74,7 @@ For more, see [Search Functionality](../../../features/search) and the [SQL sear
 
 | Predicate                                    | Pushdown to ES Query DSL                                              |
 | -------------------------------------------- | --------------------------------------------------------------------- |
-| `WHERE` equality on `keyword` / numeric fields | Limited — most filters are evaluated locally by DataFusion after fetch. |
+| `WHERE` filters (any field) | None — the connector pushes down no `WHERE` predicates; all are evaluated locally by DataFusion after fetch (the scan issues `match_all`). |
 | `LIMIT N`                                    | Translated to `size: N`.                                               |
 | `ORDER BY`                                   | Evaluated locally unless paired with a search UDTF.                   |
 | `vector_search` / `text_search` / `rrf`      | Native — issued as kNN / BM25 query bodies.                           |
@@ -107,7 +107,7 @@ Elasticsearch requests participate in [task history](../../../reference/task_his
 - **`date` and `date_nanos` are strings**: Elasticsearch accepts heterogeneous date formats. The connector preserves them as `Utf8` — cast to `TIMESTAMP` in SQL when comparison is needed.
 - **`nested` and `object` are JSON strings**: Nested objects are exposed as `Utf8` JSON, not structured Arrow types.
 - **`dense_vector` without `dims`**: Falls back to `Utf8` and is not usable as a vector column. Declare `dims` in the index mapping.
-- **Limited filter pushdown**: Most SQL `WHERE` predicates are evaluated locally by DataFusion. For selective filters, accelerate the dataset.
+- **No filter pushdown**: The connector pushes down no SQL `WHERE` predicates — every filter is evaluated locally by DataFusion after fetch (the scan issues `match_all`; only `LIMIT` is pushed down, as the query `size`). For selective filters, accelerate the dataset.
 - **Tested against Elasticsearch 8.17**: Other major versions (7.x, 9.x) may work but are not part of the integration test matrix.
 
 ## Troubleshooting

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/index.md
@@ -147,7 +147,7 @@ TLS is enabled automatically for `https://` endpoints.
 - `date` and `date_nanos` fields are preserved as strings because Elasticsearch accepts heterogeneous date formats; cast to a timestamp in SQL when numeric comparison is required.
 - `dense_vector` fields without a declared `dims` value fall back to `Utf8` and are not usable as a vector column.
 - For queries with `LIMIT N` where N ≤ 10,000, the connector issues a single `_search` request. For larger result sets or queries without `LIMIT`, the connector automatically paginates using Point-In-Time (PIT) + `search_after`, fetching all matching documents in 10,000-hit batches.
-- Pushdown of SQL predicates to Elasticsearch query DSL is limited; complex filter expressions are evaluated locally by DataFusion after fetching results.
+- SQL `WHERE` predicates are not pushed down to the Elasticsearch query DSL; all filter expressions are evaluated locally by DataFusion after fetching results (only `LIMIT` is pushed down, as the query `size`).
 
 Elasticsearch can also be configured as a [Vector Engine](../vectors/elasticsearch) for datasets sourced from other connectors (storing Spice-managed embeddings in Elasticsearch rather than querying an existing index).
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
@@ -74,7 +74,7 @@ For more, see [Search Functionality](../../../features/search) and the [SQL sear
 
 | Predicate                                    | Pushdown to ES Query DSL                                              |
 | -------------------------------------------- | --------------------------------------------------------------------- |
-| `WHERE` equality on `keyword` / numeric fields | Limited — most filters are evaluated locally by DataFusion after fetch. |
+| `WHERE` filters (any field) | None — the connector pushes down no `WHERE` predicates; all are evaluated locally by DataFusion after fetch (the scan issues `match_all`). |
 | `LIMIT N`                                    | Translated to `size: N`.                                               |
 | `ORDER BY`                                   | Evaluated locally unless paired with a search UDTF.                   |
 | `vector_search` / `text_search` / `rrf`      | Native — issued as kNN / BM25 query bodies.                           |
@@ -107,7 +107,7 @@ Elasticsearch requests participate in [task history](../../../reference/task_his
 - **`date` and `date_nanos` are strings**: Elasticsearch accepts heterogeneous date formats. The connector preserves them as `Utf8` — cast to `TIMESTAMP` in SQL when comparison is needed.
 - **`nested` and `object` are JSON strings**: Nested objects are exposed as `Utf8` JSON, not structured Arrow types.
 - **`dense_vector` without `dims`**: Falls back to `Utf8` and is not usable as a vector column. Declare `dims` in the index mapping.
-- **Limited filter pushdown**: Most SQL `WHERE` predicates are evaluated locally by DataFusion. For selective filters, accelerate the dataset.
+- **No filter pushdown**: The connector pushes down no SQL `WHERE` predicates — every filter is evaluated locally by DataFusion after fetch (the scan issues `match_all`; only `LIMIT` is pushed down, as the query `size`). For selective filters, accelerate the dataset.
 - **Tested against Elasticsearch 8.17**: Other major versions (7.x, 9.x) may work but are not part of the integration test matrix.
 
 ## Troubleshooting

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/index.md
@@ -147,7 +147,7 @@ TLS is enabled automatically for `https://` endpoints.
 - `date` and `date_nanos` fields are preserved as strings because Elasticsearch accepts heterogeneous date formats; cast to a timestamp in SQL when numeric comparison is required.
 - `dense_vector` fields without a declared `dims` value fall back to `Utf8` and are not usable as a vector column.
 - For queries with `LIMIT N` where N ≤ 10,000, the connector issues a single `_search` request. For larger result sets or queries without `LIMIT`, the connector automatically paginates using Point-In-Time (PIT) + `search_after`, fetching all matching documents in 10,000-hit batches.
-- Pushdown of SQL predicates to Elasticsearch query DSL is limited; complex filter expressions are evaluated locally by DataFusion after fetching results.
+- SQL `WHERE` predicates are not pushed down to the Elasticsearch query DSL; all filter expressions are evaluated locally by DataFusion after fetching results (only `LIMIT` is pushed down, as the query `size`).
 
 Elasticsearch can also be configured as a [Vector Engine](../vectors/elasticsearch) for datasets sourced from other connectors (storing Spice-managed embeddings in Elasticsearch rather than querying an existing index).
 


### PR DESCRIPTION
## Summary

The Elasticsearch connector docs describe filter pushdown as **"limited"** / **"most filters are evaluated locally"**, which implies some `WHERE` predicates reach Elasticsearch. They do not — the connector pushes down **zero** `WHERE` filters.

**What the docs said** (3 spots):
- `deployment.md` Pushdown table row: `WHERE equality on keyword / numeric fields → Limited — most filters are evaluated locally`
- `deployment.md` Known Limitations: `Limited filter pushdown: Most SQL WHERE predicates are evaluated locally`
- `index.md` Limitations: `Pushdown of SQL predicates to Elasticsearch query DSL is limited`

**What the code does:** `ElasticsearchQueryTable::supports_filters_pushdown` returns `TableProviderFilterPushDown::Unsupported` for **every** filter unconditionally, and both scan paths issue `match_all_query()`, ignoring the `_filters` argument entirely. So all `WHERE` filtering is done locally by DataFusion after fetch; the only pushdown is `LIMIT` → query `size`.

Updated all three claims to say pushdown is **not** performed for `WHERE` predicates (and that only `LIMIT` is pushed down). Verified the behavior is identical at v2.0.1 and v2.1.0, so the fix propagates to both versioned snapshots.

## Source

- spiceai/spiceai @ `trunk` (5b16e7cc8):
  - `crates/data_components/src/elasticsearch/query_table.rs:82-93` — `supports_filters_pushdown` → `Unsupported` for all filters ("For now, we don't push filters down to ES; DataFusion handles filtering.")
  - `crates/data_components/src/elasticsearch/query_table.rs:248,286` — scan issues `match_all_query()`; `_filters` ignored
  - Same code present at tags `v2.0.1` and `v2.1.0`

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: vNext + version-2.1.x + version-2.0.x (earlier versions don't carry this text)
- [x] Files updated: 6 (2 pages × 3 versions)