### PR TITLE
docs(postgres catalog): register partitioned parent only, not child partitions

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -114,7 +114,7 @@ No configuration is required. If FK discovery fails for a schema (e.g., due to i
 :::warning
 
 - **Base tables and standard views only.** The connector discovers `BASE TABLE` and `VIEW` relations. Materialized views and foreign tables are not currently discovered and will not appear in the catalog ([#11725](https://github.com/spiceai/spiceai/issues/11725)).
-- **Partitioned tables.** For declaratively-partitioned tables, both the partitioned parent and each child partition are registered as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726)).
+- **Partitioned tables.** For declaratively-partitioned tables (and legacy table inheritance), only the partitioned parent is registered — leaf/child partitions are not registered as separate tables. Querying the parent returns rows from every partition. Registering the children too would double-count the data, since the parent is a union over its children.
 - **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
 - **Unsupported column types.** Tables containing a column of a type that cannot be mapped are skipped entirely and a warning is logged. The `unsupported_type_action` behavior available on individual PostgreSQL datasets is not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728)).
 - **Partial discovery failures.** If discovery of a schema's tables fails during the initial load, the catalog fails to register rather than loading the reachable schemas ([#11724](https://github.com/spiceai/spiceai/issues/11724)).


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11798](https://github.com/spiceai/spiceai/pull/11798) changed the PostgreSQL Catalog Connector to register **only the partitioned parent** and **exclude leaf partitions** (any relation that is a child in `pg_catalog.pg_inherits` — covering both declarative partitions and legacy table inheritance), resolving [#11726](https://github.com/spiceai/spiceai/issues/11726).

The published Limitations note said the **opposite** — "both the partitioned parent and each child partition are registered as separate tables" — so on trunk/vNext it now describes behavior that no longer exists. A reader would expect duplicated partition tables that are no longer there. This corrects the note: only the parent is registered, and querying it returns rows from every partition (registering the children too would double-count, since the parent is a union over its children).

## Verification (spiceai/spiceai @ trunk)

- `crates/data_components/src/postgres/provider.rs` now excludes any relation present as a child in `pg_catalog.pg_inherits` via a `NOT EXISTS` subquery, keeping only the parent (comment: "Registering both the parent and its children would double-count the data").
- Integration test `crates/runtime/tests/postgres/catalog.rs` seeds a range-partitioned parent with two leaf partitions and asserts the connector "register[s] the partitioned parent but *not* its leaf partitions"; querying the parent returns rows from every partition.
- `pg_inherits` exists on all supported PostgreSQL versions and is empty on Redshift, so this degrades to the prior behavior on engines without partitioning.

## Versioned-docs propagation

- **vNext-only.** 11798 is **not** in the `v2.1.0` tag, so the fix applies only to `website/docs/`.
- `website/versioned_docs/version-2.0.x/components/catalogs/postgres.md` keeps the "both parent and children" line — it correctly documents v2.0.x behavior (11798 not backported). `version-2.1.x` has no partition note. Cross-page grep confirms the claim appears on no other vNext page.

## Source PRs
- spiceai/spiceai#11798 — fix(postgres catalog): register partitioned parent, not child partitions

## Test plan
- [x] `cd website && npm run build` passes (`[SUCCESS] Generated static files`, exit 0)
- [x] Versioned-docs propagation checked — vNext-only correction; versioned copies correctly describe their releases
- [x] Files updated: 1