### PR TITLE
docs(cosmosdb): correct misleading data-plane RBAC guidance for key-only auth

### DIFF
--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -25,7 +25,7 @@ The connector currently supports key-based authentication only. Microsoft Entra 
 | `cosmosdb_account_endpoint`    | Account endpoint URL when storing endpoint and key separately.                                           |
 | `cosmosdb_account_key`         | Primary or secondary account key.                                                                        |
 
-Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Scope read-only RBAC role assignments where possible: the connector only requires **Cosmos DB Built-in Data Reader** at the data plane level.
+Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Because the connector authenticates with account keys, access cannot be narrowed with data-plane RBAC roles such as **Cosmos DB Built-in Data Reader** — those apply only to Microsoft Entra ID identities, which this connector does not yet support (see above).
 
 ### TLS
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
@@ -25,7 +25,7 @@ The connector currently supports key-based authentication only. Microsoft Entra 
 | `cosmosdb_account_endpoint`    | Account endpoint URL when storing endpoint and key separately.                                           |
 | `cosmosdb_account_key`         | Primary or secondary account key.                                                                        |
 
-Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Scope read-only RBAC role assignments where possible: the connector only requires **Cosmos DB Built-in Data Reader** at the data plane level.
+Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Because the connector authenticates with account keys, access cannot be narrowed with data-plane RBAC roles such as **Cosmos DB Built-in Data Reader** — those apply only to Microsoft Entra ID identities, which this connector does not yet support (see above).
 
 ### TLS
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
@@ -25,7 +25,7 @@ The connector currently supports key-based authentication only. Microsoft Entra 
 | `cosmosdb_account_endpoint`    | Account endpoint URL when storing endpoint and key separately.                                           |
 | `cosmosdb_account_key`         | Primary or secondary account key.                                                                        |
 
-Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Scope read-only RBAC role assignments where possible: the connector only requires **Cosmos DB Built-in Data Reader** at the data plane level.
+Credentials must be sourced from a [secret store](../../secret-stores/) in production. Prefer the **secondary** account key for Spice and rotate keys via the Azure portal — this lets you revoke access without taking the primary down. Because the connector authenticates with account keys, access cannot be narrowed with data-plane RBAC roles such as **Cosmos DB Built-in Data Reader** — those apply only to Microsoft Entra ID identities, which this connector does not yet support (see above).
 
 ### TLS
 


### PR DESCRIPTION
## Summary

The Azure Cosmos DB connector **deployment guide** recommended scoping access with a data-plane RBAC role, which contradicts the connector's own stated authentication model on the same page and is not actionable.

- **What the docs said** (Authentication & Secrets): *"Scope read-only RBAC role assignments where possible: the connector only requires **Cosmos DB Built-in Data Reader** at the data plane level."*
- **What the code does**: the connector authenticates **only** with account keys / connection strings — `CosmosClient::with_connection_string` and `CosmosClient::with_key` are the only credential paths; there is no Microsoft Entra ID / AAD token-credential path anywhere in the connector or its `data_components` module. The same page already states *"The connector currently supports key-based authentication only. Microsoft Entra ID and managed identity are tracked as a post-RC enhancement."*
- **Why it's wrong**: data-plane RBAC roles such as *Cosmos DB Built-in Data Reader* apply **only to Entra ID identities**. Under account-key auth, keys grant full account-level access and cannot be narrowed by an RBAC role assignment, so the advice sends operators after a control that does not exist for this connector.

## Change

Replaced the RBAC sentence with an accurate statement that account-key auth cannot be scoped via data-plane RBAC (which requires Entra ID — not yet supported), cross-referencing the key-only auth note already on the page. Key-management guidance (prefer the secondary key, rotate via the portal) is retained unchanged.

## Source refs (spiceai/spiceai @ origin/trunk 4afe0461)

- crates/data_components/src/cosmosdb/client.rs:80,89 — only with_connection_string / with_key; no AAD/token path (grep for aad|TokenCredential|DefaultAzureCredential|entra in the cosmosdb module returns nothing).
- crates/data-connectors/connector-cosmosdb/src/lib.rs:225-243 — credential build path (connection string precedence, else endpoint+key).

## Versioned-docs propagation

The same sentence predates versioning and is byte-identical in the two released snapshots that ship this connector; AAD is unimplemented in those releases too, so the correction applies to all three:

- website/docs/components/data-connectors/cosmosdb/deployment.md (vNext)
- website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
- website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md

Post-stage grep confirmed 3 files carry the corrected text and 0 stale occurrences remain.

## Test plan

- [x] \`cd website && npm run build\` passes (3745 documents, no broken links / undefined tags)
- [x] Versioned-docs propagation checked (grep-count gate: 3 files with new text, 3 staged)
- [x] Files updated: 3 (prose-only; the pre-existing [secret store] link is unchanged — no new links/tags)