### PR TITLE
docs(cayenne): correct false 'memory mode not supported' claim (mode: memory shipped)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -19,9 +19,9 @@ When Cayenne stores segments on S3 / S3 Express One Zone, authentication follows
 
 ## Resilience & Durability
 
-### File-Mode Only
+### Storage Modes
 
-Cayenne is file-mode only. Segments are written as Vortex files on local disk or S3 / S3 Express One Zone.
+Cayenne supports two storage modes. In **`mode: file`** (durable, the recommended production mode), segments are written as Vortex files on local disk or S3 / S3 Express One Zone and the acceleration survives restarts — this guide is oriented to operating it. In **`mode: memory`** (ephemeral), all data lives fully in RAM with an in-memory metastore, nothing is written to disk, and the dataset reloads from its source on restart; it does not support partitioned tables and enforces a hard per-table RAM bound (no disk spill). Use `mode: file` when persistence across restarts is required.
 
 ### Metastore Durability
 
@@ -152,7 +152,7 @@ Cayenne refresh, append, and query operations participate in [task history](../.
 
 ## Known Limitations
 
-- **File-mode only**: In-memory mode is not supported; use [Arrow](../arrow/deployment) for pure in-memory acceleration.
+- **Memory mode is ephemeral**: `mode: memory` keeps all data in RAM with no durable storage — the dataset reloads from its source on restart and enforces a hard RAM bound (no disk spill). Use `mode: file` when persistence across restarts is required; for a non-Cayenne pure in-memory accelerator, see [Arrow](../arrow/deployment).
 - **Single-writer per table**: Two Spice instances cannot write the same Cayenne table concurrently.
 - **Vortex version compatibility**: Cayenne files are tied to the Vortex binary version shipped with Spice. Cross-version reads may be supported but not cross-version writes.
 - **Object-store write atomicity**: Standard S3 is eventually consistent for multipart uploads. S3 Express One Zone provides strong read-after-write consistency and is recommended for latency-sensitive workloads.

--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -48,7 +48,10 @@ Use [S3 Express One Zone](#aws-s3-express-one-zone-storage) when persistence of 
 
 ## Configuration
 
-To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne supports `mode: file`, `mode: file_create`, and `mode: file_update` and stores data on disk.
+To use Spice Cayenne as the data accelerator, specify `cayenne` as the `engine` for acceleration. Spice Cayenne supports two storage modes:
+
+- **`mode: file`** (durable) — data is written as Vortex files on local disk or S3 Express One Zone, with a SQLite/Turso metastore, and the acceleration survives restarts. This is the recommended mode for Cayenne and is used in the examples throughout this page. The `mode: file_create` and `mode: file_update` variants control how an existing on-disk acceleration is reused or rebuilt on startup.
+- **`mode: memory`** (ephemeral) — all data lives fully in RAM with an in-memory metastore; nothing is written to disk. The dataset is ephemeral and reloads from its source on restart (like the [Arrow](arrow) accelerator). Memory mode works for all refresh modes (`full`/`append`/`changes`) and for both keyed and no-primary-key datasets, but does not support partitioned tables (`partition_by`), and it enforces a hard per-table RAM bound rather than spilling to disk (see [`cayenne_cdc_mem_tier_max_bytes`](#acceleration-parameters-accelerationparams)).
 
 ```yaml
 datasets:
@@ -744,7 +747,7 @@ Query performance scales with available CPU cores. Vortex's columnar format supp
 
 Consider the following limitations when using Spice Cayenne acceleration:
 
-- **File Mode Only**: Spice Cayenne only supports `mode: file` and does not support in-memory (`mode: memory`) acceleration.
+- **Memory Mode Constraints**: `mode: memory` (fully in-RAM, ephemeral) is supported alongside `mode: file`, but it does not persist any data (the dataset reloads from its source on restart), does not support partitioned tables (`partition_by`), and enforces a hard per-table RAM bound instead of spilling to disk — a breach returns an error rather than growing without limit. Use `mode: file` when persistence across restarts is required.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
 - **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.

--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -29,7 +29,7 @@ By default, datasets are locally materialized using in-memory Arrow records.
 
 | Name       | Description                     | Status            | Engine Modes     |
 | ---------- | ------------------------------- | ----------------- | ---------------- |
-| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `file`, `file_create`, `file_update` |
+| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `memory`, `file`, `file_create`, `file_update` |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file`, `file_create`, `file_update` |
 | `postgres` | Attached [PostgreSQL][postgres] (Spice.ai Enterprise) | Release Candidate | N/A              |


### PR DESCRIPTION
## Summary

Cayenne shipped **`mode: memory`** (a fully in-RAM, ephemeral accelerator) on `trunk` in spiceai/spiceai#11720, but the vNext Cayenne docs still stated memory mode is **not** supported in three places. This corrects the false claim.

**What the docs said vs. what the code does:**

| Docs (vNext) | Reality on `trunk` |
| --- | --- |
| Accelerators table: Cayenne modes = `file`, `file_create`, `file_update` | Also supports `memory` (like `duckdb`/`sqlite`/`turso`) |
| Cayenne Limitations: *"File Mode Only … does not support in-memory (`mode: memory`)"* | `mode: memory` is supported |
| Deployment guide: *"Cayenne is file-mode only"* / *"In-memory mode is not supported"* | `mode: memory` is supported |

**Verified against code** (`spiceai/spiceai` @ `trunk`, PR #11720):
- `crates/runtime/src/dataaccelerator/cayenne/mod.rs` — `let memory_mode = !source.is_file_accelerated();` selects memory mode; `apply_memory_mode_overrides` sets `config.memory_mode = true`, disables checkpoint/seal/compaction/cold-tier, and leaves `cdc_mem_tier_max_bytes` unbounded unless set.
- `crates/runtime/src/component/dataset/mod.rs:709` `is_file_accelerated()` returns `false` for `Mode::Memory` (true for `File`/`FileCreate`/`FileUpdate`).
- `mod.rs` ~L2887 — partitioned memory tables are rejected (`"Cayenne mode: memory is not supported with partitioning"`).
- `crates/cayenne/README.md` L24-29 — authoritative `mode: file` vs `mode: memory` description (ephemeral, reloads from source, hard RAM bound, no disk spill, all refresh modes, keyed & no-PK).

**Scope:** vNext only. `mode: memory` is **not** in any release tag (trunk-only), so the `version-2.1.x` / `version-2.0.x` / older snapshots correctly document file-mode-only and are intentionally left unchanged.

Note: I did **not** assert a default mode — the spicepod `Mode` enum default is `Memory`, but Cayenne's examples all use `mode: file`, so the docs describe `mode: file` as the recommended durable mode without claiming it is the default.

## Source PRs
- spiceai/spiceai#11720 — feat(cayenne): add memory mode (mode: memory) — fully in-RAM accelerator

## Test plan
- [x] `cd website && npm run build` passes (fixed one broken `../arrow` link on the index page → bare `arrow`, matching the existing `[DuckDB](duckdb)` sibling-link pattern; deployment page's `../arrow/deployment` is correct for that route and unchanged)
- [x] Versioned-docs propagation checked — addition/vNext-only, versioned snapshots correctly unchanged
- [x] Files updated: 3 (accelerators index table, cayenne/index.md, cayenne/deployment.md)