### PR TITLE
docs(runtime): document runtime.query.timeout parameter

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -473,6 +473,23 @@ Behavior:
 - If not set, the number of concurrent queries is **unbounded** (the default behavior).
 - A configured value is clamped to a minimum of `1`, so `max_concurrent_queries: 0` allows one concurrent query (not unbounded).
 
+## `runtime.query.timeout`
+
+The `timeout` parameter sets a maximum wall-clock duration a query may run before it is automatically cancelled, expressed as a human-readable duration (for example `30s` or `5m`). The clock covers the query's full lifetime: planning, admission-control waits (`max_concurrent_queries`), execution, and streaming results to the client.
+
+```yaml
+runtime:
+  query:
+    timeout: 30s
+```
+
+Behavior:
+
+- Applies to queries issued through the runtime's query APIs (HTTP, Flight, and Flight SQL). Internal runtime queries — acceleration refreshes and health checks — are exempt.
+- Enforcement is cooperative (best-effort): the query is cancelled at its next cancellation checkpoint, so actual runtime can slightly exceed the configured value.
+- On expiry, the query fails with a timeout error. If the timeout is observed before the response starts, the client receives an HTTP `504` / gRPC `DEADLINE_EXCEEDED`. If results are already streaming, the status can no longer change, so the in-progress stream is terminated with the error — data streamed before expiry will have been delivered, but the stream never ends silently as if complete.
+- If not set, queries run with **no timeout** (the default behavior). The value must be a positive duration greater than `0`.
+
 ## `runtime.query.spill_compression`
 
 The `spill_compression` parameter configures compression for spill files generated during large query execution in the Spice runtime.


### PR DESCRIPTION
## Summary

Documents the new `runtime.query.timeout` parameter, a global wall-clock query timeout added in spiceai/spiceai#11822. Adds a `runtime.query.timeout` section to the Spicepod runtime reference, placed after `runtime.query.max_concurrent_queries`.

Documented behavior (verified against `crates/spicepod/src/component/runtime.rs` on `trunk`):

- Human-readable duration (e.g. `30s`, `5m`); the clock covers the full query lifetime — planning, admission-control waits (`max_concurrent_queries`), execution, and result streaming.
- Applies to queries via HTTP, Flight, and Flight SQL; internal runtime queries (acceleration refreshes, health checks) are exempt.
- Cooperative/best-effort enforcement — cancelled at the next cancellation checkpoint, so actual runtime can slightly exceed the value.
- On expiry: HTTP `504` / gRPC `DEADLINE_EXCEEDED` before the response starts; if results are already streaming, the in-progress stream is terminated with the error.
- Unset = no timeout (default); the value must be a positive duration greater than `0`.

## Source PRs

- spiceai/spiceai#11822 — feat(runtime): add `runtime.query.timeout` parameter

## Versioned-docs propagation

Classified as an **addition** (net-new parameter). The feature is trunk-only — absent from the `v2.1.0` tag — so only `website/docs/` (vNext) is updated; older versioned snapshots correctly omit it.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks`/`onInlineTags` throw; build succeeded)
- [x] Versioned-docs propagation checked — addition, vNext-only (confirmed not present in `versioned_docs/`)
- [x] Files updated: 1 (`website/docs/reference/spicepod/runtime.md`)