### PR TITLE
docs: replace deprecated Google text-embedding-004 with gemini-embedding-2 (fixes #1926)

### DIFF
--- a/website/docs/components/embeddings/google.md
+++ b/website/docs/components/embeddings/google.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 To use a hosted Google AI embedding model, specify the `google` path in the `from` field of your configuration.
 
-For a specific model, include its model ID in the `from` field. If no model ID is specified, it defaults to `"text-embedding-004"`.
+Include the model ID in the `from` field; a model ID is required. For example, `google:gemini-embedding-2` selects Google's latest generally available embedding model.
 
 The following parameters are specific to Google AI embedding models:
 
@@ -19,13 +19,13 @@ Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }
       dimensions: 768 # optional parameter
 
-  - from: google:embedding-001
+  - from: google:gemini-embedding-001
     name: legacy_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/docs/deployment/gcp/integrations.md
+++ b/website/docs/deployment/gcp/integrations.md
@@ -117,13 +117,13 @@ Generate vector embeddings using Gemini embedding models for semantic search and
 
 | Provider      | Supported Models                                                                                                                        | Documentation                                              |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Google AI** | `text-embedding-004` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
+| **Google AI** | `gemini-embedding-2` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
 
 ### Example: Google AI Embeddings
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-1.11.x/components/embeddings/google.md
+++ b/website/versioned_docs/version-1.11.x/components/embeddings/google.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 To use a hosted Google AI embedding model, specify the `google` path in the `from` field of your configuration.
 
-For a specific model, include its model ID in the `from` field. If no model ID is specified, it defaults to `"text-embedding-004"`.
+Include the model ID in the `from` field; a model ID is required. For example, `google:gemini-embedding-2` selects Google's latest generally available embedding model.
 
 The following parameters are specific to Google AI embedding models:
 
@@ -19,13 +19,13 @@ Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }
       dimensions: 768 # optional parameter
 
-  - from: google:embedding-001
+  - from: google:gemini-embedding-001
     name: legacy_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.0.x/components/embeddings/google.md
+++ b/website/versioned_docs/version-2.0.x/components/embeddings/google.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 To use a hosted Google AI embedding model, specify the `google` path in the `from` field of your configuration.
 
-For a specific model, include its model ID in the `from` field. If no model ID is specified, it defaults to `"text-embedding-004"`.
+Include the model ID in the `from` field; a model ID is required. For example, `google:gemini-embedding-2` selects Google's latest generally available embedding model.
 
 The following parameters are specific to Google AI embedding models:
 
@@ -19,13 +19,13 @@ Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }
       dimensions: 768 # optional parameter
 
-  - from: google:embedding-001
+  - from: google:gemini-embedding-001
     name: legacy_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.0.x/deployment/gcp/integrations.md
+++ b/website/versioned_docs/version-2.0.x/deployment/gcp/integrations.md
@@ -117,13 +117,13 @@ Generate vector embeddings using Gemini embedding models for semantic search and
 
 | Provider      | Supported Models                                                                                                                        | Documentation                                              |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Google AI** | `text-embedding-004` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
+| **Google AI** | `gemini-embedding-2` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
 
 ### Example: Google AI Embeddings
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.1.x/components/embeddings/google.md
+++ b/website/versioned_docs/version-2.1.x/components/embeddings/google.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 To use a hosted Google AI embedding model, specify the `google` path in the `from` field of your configuration.
 
-For a specific model, include its model ID in the `from` field. If no model ID is specified, it defaults to `"text-embedding-004"`.
+Include the model ID in the `from` field; a model ID is required. For example, `google:gemini-embedding-2` selects Google's latest generally available embedding model.
 
 The following parameters are specific to Google AI embedding models:
 
@@ -19,13 +19,13 @@ Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }
       dimensions: 768 # optional parameter
 
-  - from: google:embedding-001
+  - from: google:gemini-embedding-001
     name: legacy_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.1.x/deployment/gcp/integrations.md
+++ b/website/versioned_docs/version-2.1.x/deployment/gcp/integrations.md
@@ -117,13 +117,13 @@ Generate vector embeddings using Gemini embedding models for semantic search and
 
 | Provider      | Supported Models                                                                                                                        | Documentation                                              |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Google AI** | `text-embedding-004` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
+| **Google AI** | `gemini-embedding-2` and other models from [Gemini API embeddings](https://ai.google.dev/gemini-api/docs/models/gemini#text-embedding). | [Google AI Embeddings](../../components/embeddings/google) |
 
 ### Example: Google AI Embeddings
 
 ```yaml
 embeddings:
-  - from: google:text-embedding-004
+  - from: google:gemini-embedding-2
     name: gemini_embeddings
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }


### PR DESCRIPTION
## Summary
Fixes #1926

Google shut down the `text-embedding-004` embedding model on 2026-01-14, but it was still the default model in every Google AI embedding example across the docs. Following the example configs verbatim now fails against Google's API.

This updates all Google AI embedding examples to `google:gemini-embedding-2` — Google's latest generally available (and now multimodal) embedding model — and updates the "legacy" example to `google:gemini-embedding-001`, which is still available (text-only, previous GA).

It also corrects a related inaccuracy on the Google AI embeddings page: the text claimed the model ID "defaults to `text-embedding-004`" when none is specified. There is no such default — the runtime's Google embedding path requires an explicit model ID and returns `ModelNotProvided` when it is absent. The line now states a model ID is required.

## Changes
- `website/docs/components/embeddings/google.md` — corrected the false default claim; primary example → `gemini-embedding-2`; legacy example → `gemini-embedding-001`
- `website/docs/deployment/gcp/integrations.md` — supported-models table row and example → `gemini-embedding-2`
- Same corrections propagated to `versioned_docs/version-1.11.x`, `version-2.0.x`, and `version-2.1.x` (Google's shutdown affects examples in every version equally, and the "default" claim was never true in any released version)

## Reference
- Model ID verified against Google's official docs: [`gemini-embedding-2`](https://ai.google.dev/gemini-api/docs/models/gemini-embedding-2) (GA) and [`gemini-embedding-001`](https://ai.google.dev/gemini-api/docs/embeddings) (still available). `text-embedding-004` shutdown date per [Google's Gemini Embedding GA announcement](https://developers.googleblog.com/gemini-embedding-available-gemini-api/).
- "No default model" behavior verified in spiceai/spiceai `crates/runtime/src/model/embed.rs` (`fn google` returns `EmbedError::ModelNotProvided`) at tags v1.11.0, v2.0.0, v2.1.0, and trunk.

## Test plan
- [x] `cd website && npm run build` passes locally (no broken-link failures)
- [x] Correction applied across all affected `website/versioned_docs/version-*/` directories
- [x] No remaining `text-embedding-004` / `google:embedding-001` references in source docs (release notes left as historical record)