### PR TITLE
docs(ducklake): document ducklake_automatic_migration param

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -80,6 +80,7 @@ The `access` field controls what operations are allowed on the catalog:
 | `ducklake_aws_secret_access_key`   | Optional. The AWS secret access key for S3 storage. Must be set together with `ducklake_aws_access_key_id`.                                           |
 | `ducklake_aws_endpoint`            | Optional. Custom S3-compatible endpoint URL (e.g., for MinIO).                                                                                        |
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                                                                  |
+| `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**.                        |
 
 ## Authentication
 
@@ -198,7 +199,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -61,6 +61,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `ducklake_aws_secret_access_key`   | Optional. The AWS secret access key for S3 storage. Must be set together with `ducklake_aws_access_key_id`.    |
 | `ducklake_aws_endpoint`            | Optional. Custom S3-compatible endpoint URL (e.g., for MinIO).                                                 |
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                           |
+| `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**. |
 
 ### Connection string formats
 
@@ -201,7 +202,7 @@ datasets:
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.


### PR DESCRIPTION
## Summary

Both DuckLake pages (data connector and catalog) omit the real, user-facing `ducklake_automatic_migration` parameter. The Limitations note on each page already tells readers that "older DuckLake catalogs require a metadata migration before use" but never names the knob that performs it, leaving no documented way to act on the limitation.

**What the code does:** both the DuckLake data connector and catalog connector declare `ParameterSpec::component("automatic_migration")` (auto-prefixed to `ducklake_automatic_migration`), default `false`, parsed as a boolean (`eq_ignore_ascii_case("true")`) and passed through to `build_ducklake_attach_sql`. When `true`, an older catalog schema is migrated to the version required by the DuckLake extension on attach; the migration rewrites catalog metadata and cannot be undone.

**What changed:** added a `ducklake_automatic_migration` row to the `params` table on both pages, and updated the migration Limitations bullet to reference the parameter.

Net-new parameter (absent from v2.1.0 and v2.0.1) → vNext (`website/docs/`) only; no versioned-docs propagation.

## Source

- `spiceai/spiceai` @ `trunk` (`3f710af`):
  - `crates/data-connectors/connector-ducklake/src/lib.rs:168` (ParameterSpec), `:341-346` (consume, default false), `:290` (wired into `build_ducklake_attach_sql`)
  - `crates/runtime/src/catalogconnector/ducklake.rs:72` (ParameterSpec), `:201-204`, `:333`

## Test plan
- [x] `cd website && npm run build` passes
- [x] No versioned-docs propagation needed (param is vNext-only)
- [x] Files updated: 2 (both DuckLake page types)