### PR TITLE
docs(cayenne): correct footer_cache_mb default in v2.1.x (50 MB when unset, not 128)

### DIFF
--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
@@ -130,7 +130,7 @@ Set once under the top-level `runtime.params` and applied to every Cayenne-accel
 
 | Parameter                                  | Description                                                                                                                                                                                                                                                            |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cayenne_footer_cache_mb`                  | Size of the engine-wide in-memory Vortex footer cache in megabytes. The footer cache stores Vortex file metadata (schemas, statistics, encoding information) and is shared across all Cayenne datasets. Larger values improve query performance for repeated scans. Defaults to `128`. |
+| `cayenne_footer_cache_mb`                  | Size of the engine-wide in-memory Vortex footer cache in megabytes. The footer cache stores Vortex file metadata (schemas, statistics, encoding information) and is shared across all Cayenne datasets. Larger values improve query performance for repeated scans. Optional; when unset, no explicit limit is applied and DataFusion's default file-metadata-cache limit of 50 MB applies (there is no fixed 128 MB default). |
 | `cayenne_filter_propagation`               | Enables Cayenne's filter-propagation optimizer rules. Accepts `enabled` or `disabled`; defaults to `disabled`.                                                                                                                                                         |
 | `cayenne_optimizer_rules`                  | Selects which Cayenne optimizer rules run. Accepts `auto` (default — enables the recommended set, gated by `cayenne_filter_propagation`), `all`, `none` / `disabled`, or a comma-separated list of individual rule names.                                               |
 | `cayenne_compaction_memory_fraction`       | Fraction of the query memory pool carved out for a dedicated Cayenne compaction memory pool. Defaults to `0.2` and is clamped to a supported range. Only applied when at least one Cayenne-accelerated dataset is enabled and dedicated thread pools are not disabled. |
@@ -241,7 +241,7 @@ Spice Cayenne uses two in-memory caches to accelerate query performance:
 
 The footer cache stores Vortex file metadata, including schemas, statistics, and encoding information. It is engine-global and shared across every Cayenne-accelerated dataset, so it is set under `runtime.params`, not per dataset. Larger cache sizes benefit workloads with many files.
 
-- Default: 128 MB
+- Default: unset — when omitted, DataFusion's default file-metadata-cache limit of 50 MB applies
 - Increase for datasets with many small files
 - Each file requires approximately 1-10 KB of footer cache
 
@@ -648,7 +648,7 @@ Spice Cayenne manages memory efficiently through columnar storage and selective 
 | Component        | Default  | Notes                                                    |
 | ---------------- | -------- | -------------------------------------------------------- |
 | Runtime overhead | ~500 MB  | Fixed baseline for the Spice runtime                     |
-| Footer cache     | 128 MB   | Increase for datasets with many files (1-10 KB per file) |
+| Footer cache     | 50 MB    | Unset by default (DataFusion file-metadata-cache default); increase for datasets with many files (1-10 KB per file) |
 | Segment cache    | 256 MB   | Increase based on hot data volume                        |
 | Query execution  | Variable | Depends on query complexity and concurrency              |
 


### PR DESCRIPTION
## Summary

The `version-2.1.x` Cayenne accelerator page still documents `cayenne_footer_cache_mb` as **"Defaults to `128`"**, but at v2.1.0 the field is `footer_cache_mb: Option<usize>` = `None` when unset, and the runtime applies it to DataFusion's metadata cache **only when `Some`** — so when unset, no explicit limit is set and DataFusion's own default file-metadata-cache limit of **50 MB** applies. There is no 128 MB default in v2.1.0.

This is the correction docs#1908 made for **vNext** and **version-2.0.x**, which was missed on the `version-2.1.x` snapshot (it was cut around the same time as #1908 and inherited the pre-correction "128" text). vNext and 2.0.x already read correctly; v1.10.x/v1.11.x correctly keep `128` (the field was a real `usize = 128` in those releases).

**What changed (version-2.1.x only, 3 spots to match vNext/2.0.x):**
- `runtime.params` table row for `cayenne_footer_cache_mb`
- the "Footer Cache" tuning bullet (`Default: 128 MB` → `Default: unset — … 50 MB applies`)
- the memory-budget table row (`Footer cache | 128 MB` → `50 MB | Unset by default …`)

## Source

- `spiceai/spiceai` @ `v2.1.0`:
  - `crates/cayenne/src/catalog_provider.rs:52` — `pub footer_cache_mb: Option<usize>`
  - `crates/runtime/src/builder.rs:473` — applied only `if cayenne_footer_cache_mb.is_some()`
- Prior correction: spiceai/docs#1908 (fixed vNext + 2.0.x; this sweeps the missed 2.1.x snapshot)

## Test plan
- [x] `cd website && npm run build` passes
- [x] Scope: version-2.1.x only (vNext + 2.0.x already correct; v1.x correctly keeps 128)
- [x] Files updated: 1