### PR TITLE
docs(cayenne): document cayenne_metastore_* runtime.params tuning knobs

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -170,6 +170,12 @@ Set once under the top-level `runtime.params` and applied to every Cayenne-accel
 | `cayenne_goal_freshness`                   | Goal-driven adaptive tuning (preview): global target data freshness — the age of the newest queryable data — as a duration (e.g. `30s`). Override per-dataset under a dataset's `acceleration.params`.                                                                   |
 | `cayenne_goal_query_latency`               | Goal-driven adaptive tuning (preview): global target p99 query latency, as a duration (e.g. `250ms` or `10s`). Override per-dataset under a dataset's `acceleration.params`.                                                                                             |
 | `cayenne_goal_qph`                         | Goal-driven adaptive tuning (preview): target query throughput in queries per hour (higher is better), e.g. `5000`. Must be a positive number. **Global-only** — query throughput is measured system-wide (a query spanning multiple datasets, such as a join, is counted once), so it has no per-dataset form; a value set under `acceleration.params` is ignored. |
+| `cayenne_metastore_cache_mb`               | SQLite metastore page-cache size in megabytes. Applies to the default `sqlite` metastore backend (see `cayenne_metastore`); the `turso` backend uses MVCC and ignores the `cayenne_metastore_*` family. Defaults to `256`. |
+| `cayenne_metastore_mmap_mb`                | SQLite metastore memory-mapped I/O size in megabytes. Defaults to `1024` (1 GiB). |
+| `cayenne_metastore_busy_timeout_ms`        | SQLite metastore `busy_timeout` in milliseconds — how long a blocked connection waits for a lock before erroring. Defaults to `30000`. |
+| `cayenne_metastore_wal_autocheckpoint_pages` | SQLite metastore WAL auto-checkpoint threshold in pages. `0` disables the inline auto-checkpoint so the WAL is drained off the hot commit path by a dedicated background checkpoint instead. Defaults to `0`. |
+| `cayenne_metastore_wal_truncate_threshold_mb` | WAL size in megabytes above which the background checkpoint escalates to a TRUNCATE checkpoint to reclaim file space. Defaults to `160`. |
+| `cayenne_metastore_auto_vacuum`            | SQLite metastore `auto_vacuum` mode: `none`, `incremental`, or `full`. Takes effect only on a fresh database (an existing database needs a full `VACUUM` to change it). Defaults to `none`. |
 
 ```yaml
 runtime:

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
@@ -123,6 +123,11 @@ Set once under the top-level `runtime.params` and applied to every Cayenne-accel
 | `cayenne_compaction_memory_fraction`       | Fraction of the query memory pool carved out for a dedicated Cayenne compaction memory pool. Defaults to `0.2` and is clamped to a supported range. Only applied when at least one Cayenne-accelerated dataset is enabled and dedicated thread pools are not disabled. |
 | `cayenne_sort_merge_min_rows`              | Advanced anti-join tuning: row-count threshold above which the filter-propagation optimizer switches to a sort-merge strategy. Defaults to an internally tuned value; override only when profiling indicates a need.                                                    |
 | `cayenne_sort_merge_memory_pool_fraction`  | Advanced anti-join tuning: fraction of the memory pool the sort-merge anti-join strategy may use. Defaults to an internally tuned value.                                                                                                                                |
+| `cayenne_metastore_cache_mb`               | SQLite metastore page-cache size in megabytes. Applies to the default `sqlite` metastore backend (see `cayenne_metastore`); the `turso` backend uses MVCC and ignores the `cayenne_metastore_*` family. Defaults to `256`. |
+| `cayenne_metastore_mmap_mb`                | SQLite metastore memory-mapped I/O size in megabytes. Defaults to `1024` (1 GiB). |
+| `cayenne_metastore_busy_timeout_ms`        | SQLite metastore `busy_timeout` in milliseconds — how long a blocked connection waits for a lock before erroring. Defaults to `30000`. |
+| `cayenne_metastore_wal_autocheckpoint_pages` | SQLite metastore WAL auto-checkpoint threshold in pages; the WAL is checkpointed automatically once it grows past this many pages. Defaults to `10000`. |
+| `cayenne_metastore_auto_vacuum`            | SQLite metastore `auto_vacuum` mode: `none`, `incremental`, or `full`. Takes effect only on a fresh database (an existing database needs a full `VACUUM` to change it). Defaults to `none`. |
 
 ```yaml
 runtime:

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
@@ -140,6 +140,12 @@ Set once under the top-level `runtime.params` and applied to every Cayenne-accel
 | `cayenne_goal_freshness`                   | Goal-driven adaptive tuning (preview): global target data freshness — the age of the newest queryable data — as a duration (e.g. `30s`). Override per-dataset under a dataset's `acceleration.params`.                                                                   |
 | `cayenne_goal_query_latency`               | Goal-driven adaptive tuning (preview): global target p99 query latency, as a duration (e.g. `250ms` or `10s`). Override per-dataset under a dataset's `acceleration.params`.                                                                                             |
 | `cayenne_goal_qph`                         | Goal-driven adaptive tuning (preview): target query throughput in queries per hour (higher is better), e.g. `5000`. Must be a positive number. **Global-only** — query throughput is measured system-wide (a query spanning multiple datasets, such as a join, is counted once), so it has no per-dataset form; a value set under `acceleration.params` is ignored. |
+| `cayenne_metastore_cache_mb`               | SQLite metastore page-cache size in megabytes. Applies to the default `sqlite` metastore backend (see `cayenne_metastore`); the `turso` backend uses MVCC and ignores the `cayenne_metastore_*` family. Defaults to `256`. |
+| `cayenne_metastore_mmap_mb`                | SQLite metastore memory-mapped I/O size in megabytes. Defaults to `1024` (1 GiB). |
+| `cayenne_metastore_busy_timeout_ms`        | SQLite metastore `busy_timeout` in milliseconds — how long a blocked connection waits for a lock before erroring. Defaults to `30000`. |
+| `cayenne_metastore_wal_autocheckpoint_pages` | SQLite metastore WAL auto-checkpoint threshold in pages. `0` disables the inline auto-checkpoint so the WAL is drained off the hot commit path by a dedicated background checkpoint instead. Defaults to `0`. |
+| `cayenne_metastore_wal_truncate_threshold_mb` | WAL size in megabytes above which the background checkpoint escalates to a TRUNCATE checkpoint to reclaim file space. Defaults to `160`. |
+| `cayenne_metastore_auto_vacuum`            | SQLite metastore `auto_vacuum` mode: `none`, `incremental`, or `full`. Takes effect only on a fresh database (an existing database needs a full `VACUUM` to change it). Defaults to `none`. |
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary

The Cayenne `runtime.params` reference omits the entire `cayenne_metastore_*` sub-family — SQLite-metastore tuning knobs that the runtime reads from `runtime.params` at startup (`crates/runtime/src/builder.rs`) but that appear nowhere in the docs. This documents them, scoped per version (the family and its defaults differ across releases; verified against each tag).

These apply to the default `sqlite` metastore backend (already documented via `cayenne_metastore`); the `turso` backend uses MVCC and ignores them.

**vNext + version-2.1.x (identical — 6 params):**
| Param | Default |
| --- | --- |
| `cayenne_metastore_cache_mb` | `256` |
| `cayenne_metastore_mmap_mb` | `1024` (1 GiB) |
| `cayenne_metastore_busy_timeout_ms` | `30000` |
| `cayenne_metastore_wal_autocheckpoint_pages` | `0` (inline auto-checkpoint disabled; WAL drained by background checkpoint) |
| `cayenne_metastore_wal_truncate_threshold_mb` | `160` |
| `cayenne_metastore_auto_vacuum` | `none` (`none`\|`incremental`\|`full`) |

**version-2.0.x (5 params):** no `cayenne_metastore_wal_truncate_threshold_mb` (the background-truncate mechanism landed after v2.0), and `cayenne_metastore_wal_autocheckpoint_pages` defaults to **`10000`** in v2.0, not `0`. Both differences verified against the v2.0.1 source, so the 2.0.x snapshot documents the 2.0 values, not the trunk values.

Not documented for v1.x — the `cayenne_metastore_*` params do not exist there (absent from v1.11.0 `builder.rs`).

## Source (per version)

- `spiceai/spiceai` @ `trunk`/`v2.1.0`:
  - `crates/runtime/src/builder.rs` — reads all 6 keys from `runtime.params`
  - `crates/cayenne/src/metastore/sqlite.rs` `impl Default for SqliteMetastoreConfig` — `cache_size_mb: 256`, `mmap_size_bytes: 1 GiB`, `busy_timeout_ms: 30_000`, `wal_autocheckpoint_pages: 0`, `wal_truncate_threshold_bytes: 160 MiB`, `auto_vacuum: None`
- `spiceai/spiceai` @ `v2.0.1`:
  - `crates/runtime/src/builder.rs:273-295` — reads 5 keys (no `wal_truncate_threshold_mb`)
  - `crates/cayenne/src/metastore/sqlite.rs` default — `wal_autocheckpoint_pages: 10_000`, no `wal_truncate_threshold_bytes` field

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: vNext + 2.1.x (6 params) + 2.0.x (5 params, version-correct defaults); v1.x excluded (params absent)
- [x] Files updated: 3