### PR TITLE
docs(duckdb): correct connector memory/spill guidance (no connection-string channel)

### DIFF
--- a/website/docs/components/data-connectors/duckdb/deployment.md
+++ b/website/docs/components/data-connectors/duckdb/deployment.md
@@ -35,9 +35,9 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Capacity & Sizing
 
-- **Memory**: DuckDB's default memory limit is self-managed based on system memory. For constrained environments, set a `memory_limit` pragma via the connection string.
+- **Memory**: DuckDB manages its own memory based on available system memory when executing queries against the file. The connector opens the database read-only and exposes no memory-limit or connection-string setting — its only parameter is `duckdb_open`. For a Spice-configurable memory limit, use the [DuckDB accelerator](../../data-accelerators/duckdb), which supports the `duckdb_memory_limit` acceleration parameter.
 - **Disk**: Plan for 1.5–2× the raw data size to accommodate DuckDB's internal compression, WAL, and temporary spill files during query execution.
-- **Temporary spill**: Large queries spill to DuckDB's temp directory; ensure adequate disk and set `temp_directory` to a fast local volume if the default (same as the database file) is on slow storage.
+- **Temporary spill**: Large queries can spill to DuckDB's temp directory (by default, alongside the database file). The connector exposes no spill-directory setting, so ensure the volume holding the database file has adequate free space.
 
 ## Metrics
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/duckdb/deployment.md
@@ -35,9 +35,9 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Capacity & Sizing
 
-- **Memory**: DuckDB's default memory limit is self-managed based on system memory. For constrained environments, set a `memory_limit` pragma via the connection string.
+- **Memory**: DuckDB manages its own memory based on available system memory when executing queries against the file. The connector opens the database read-only and exposes no memory-limit or connection-string setting — its only parameter is `duckdb_open`. For a Spice-configurable memory limit, use the [DuckDB accelerator](../../data-accelerators/duckdb), which supports the `duckdb_memory_limit` acceleration parameter.
 - **Disk**: Plan for 1.5–2× the raw data size to accommodate DuckDB's internal compression, WAL, and temporary spill files during query execution.
-- **Temporary spill**: Large queries spill to DuckDB's temp directory; ensure adequate disk and set `temp_directory` to a fast local volume if the default (same as the database file) is on slow storage.
+- **Temporary spill**: Large queries can spill to DuckDB's temp directory (by default, alongside the database file). The connector exposes no spill-directory setting, so ensure the volume holding the database file has adequate free space.
 
 ## Metrics
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/duckdb/deployment.md
@@ -35,9 +35,9 @@ DuckDB's WAL provides crash recovery for any process that wrote to the file. The
 
 ## Capacity & Sizing
 
-- **Memory**: DuckDB's default memory limit is self-managed based on system memory. For constrained environments, set a `memory_limit` pragma via the connection string.
+- **Memory**: DuckDB manages its own memory based on available system memory when executing queries against the file. The connector opens the database read-only and exposes no memory-limit or connection-string setting — its only parameter is `duckdb_open`. For a Spice-configurable memory limit, use the [DuckDB accelerator](../../data-accelerators/duckdb), which supports the `duckdb_memory_limit` acceleration parameter.
 - **Disk**: Plan for 1.5–2× the raw data size to accommodate DuckDB's internal compression, WAL, and temporary spill files during query execution.
-- **Temporary spill**: Large queries spill to DuckDB's temp directory; ensure adequate disk and set `temp_directory` to a fast local volume if the default (same as the database file) is on slow storage.
+- **Temporary spill**: Large queries can spill to DuckDB's temp directory (by default, alongside the database file). The connector exposes no spill-directory setting, so ensure the volume holding the database file has adequate free space.
 
 ## Metrics
 


### PR DESCRIPTION
## Summary

The DuckDB **data connector** deployment guide told users, in the *Capacity & Sizing* section, to configure DuckDB via a channel the connector does not expose:

- *Memory*: "set a `memory_limit` pragma via the connection string"
- *Temporary spill*: "set `temp_directory` to a fast local volume"

Neither is actionable. The DuckDB connector exposes exactly **one** parameter — `duckdb_open` (a file path or `:memory:`) — and opens the database read-only. There is no connection-string input, no `memory_limit` parameter, and no `temp_directory`/pragma channel. This is the same fabricated-mechanism class as the DuckDB/SQLite **accelerator** guides fixed in #1906; the connector guide was the latent second occurrence.

This corrects both bullets to describe DuckDB's actual (self-managed, internal) behavior and points readers to the DuckDB **accelerator**, which really does expose a configurable `duckdb_memory_limit` acceleration parameter, when they need a Spice-configurable limit.

## Verified against code (spiceai/spiceai)

- Connector params — only `open`, opened read-only: `crates/data-connectors/connector-duckdb/src/lib.rs:162` (`const PARAMETERS: &[ParameterSpec] = &[ParameterSpec::component("open")...]`); no connection-string / pragma parsing.
- Confirmed identical at the release tags backing the versioned docs: `open`-only at `v2.1.0` and `v2.0.1`.
- Accelerator `duckdb_memory_limit` exists (`crates/runtime/src/dataaccelerator/duckdb.rs:418`, `ParameterSpec::component("memory_limit")`) — present at `v2.1.0` too — so the cross-reference is accurate.

The identical wrong text lived in vNext + `version-2.1.x` + `version-2.0.x` (correction predates versioning), so all three are fixed here.

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'`; the added `../../data-accelerators/duckdb` link resolves — same path already used in the page's *Known Limitations* section, target confirmed present in each versioned tree)
- [x] Versioned-docs propagation checked — grep for "pragma via the connection string" now returns zero hits across connector pages in all versions
- [x] Files updated: 3 (vNext + 2.1.x + 2.0.x connector deployment guides)