### PR TITLE
docs(duckdb): fix stale memory-limit guidance in 2.1.x accelerator guide

### DIFF
--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/deployment.md
@@ -53,7 +53,7 @@ Datasets sharing a DuckDB instance share the pool. For write-heavy refresh plus 
 
 ### Memory
 
-DuckDB self-tunes its memory limit based on system memory. For containers, set a `memory_limit` pragma via the connection string to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
+DuckDB self-tunes its memory limit based on system memory. For containers, set the `duckdb_memory_limit` acceleration parameter to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
 
 ### Index Parameters
 
@@ -92,7 +92,7 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Symptom                                                | Likely cause                                                  | Resolution                                                                                                  |
 | ------------------------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Slow first startup after restart                       | WAL replay due to ungraceful shutdown.                        | Use graceful shutdown (`SIGTERM`). Subsequent starts will be fast once the checkpoint is clean.             |
-| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set a `memory_limit` pragma via the connection string.                                                      |
+| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set the `duckdb_memory_limit` acceleration parameter.                                                       |
 | Disk fills during large queries                        | Spill directory on undersized volume.                         | Point `runtime.query.temp_directory` at a larger volume; monitor free space.                                |
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |


### PR DESCRIPTION
## Summary

The DuckDB **accelerator** deployment guide for `version-2.1.x` still told users to set memory via a channel that does not exist — "set a `memory_limit` pragma via the connection string" (in the *Memory* sizing note and the *OOM on refresh* troubleshooting row).

PR #1906 already corrected this fabricated mechanism to the real `duckdb_memory_limit` **acceleration parameter**, but that fix landed in vNext and `version-2.0.x` only and **missed the `version-2.1.x` snapshot**, leaving the just-released docs wrong. This propagates the same correction to 2.1.x so all live versions agree.

## Verified against code (spiceai/spiceai)

- The DuckDB accelerator exposes `duckdb_memory_limit` (`crates/runtime/src/dataaccelerator/duckdb.rs`, `ParameterSpec::component("memory_limit")`), confirmed present at the **`v2.1.0`** release tag that backs `version-2.1.x`.
- The accelerator has no connection-string / pragma configuration channel — `duckdb_memory_limit` is the supported knob, matching what vNext and `version-2.0.x` already document.

## Scope

Version-specific propagation fix — only `version-2.1.x` was stale (vNext and `version-2.0.x` were already fixed by #1906), so this touches a single file.

## Test plan
- [x] `cd website && npm run build` passes (prose-only change; no links/tags added)
- [x] Grep confirms zero remaining "connection string" references on the 2.1.x accelerator page
- [x] Wording matches the already-corrected vNext / 2.0.x accelerator pages
- [x] Files updated: 1 (version-2.1.x accelerator deployment guide)