### PR TITLE
docs(sqlite-accel): remove fabricated pragma/connection-string config guidance

### DIFF
--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -56,7 +56,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`). For read-heavy workloads on large databases, increase this via `PRAGMA cache_size = -<KB>` in post-startup SQL.
+- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
@@ -56,7 +56,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`). For read-heavy workloads on large databases, increase this via `PRAGMA cache_size = -<KB>` in post-startup SQL.
+- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
@@ -47,7 +47,7 @@ For file-mode databases, the connection pool automatically sets the following pr
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
 
-These are no-ops for in-memory databases. For custom durability tuning beyond these defaults, set pragmas via a custom connection string or post-startup SQL.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -56,7 +56,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`). For read-heavy workloads on large databases, increase this via `PRAGMA cache_size = -<KB>` in post-startup SQL.
+- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics
@@ -81,6 +81,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | Raise `PRAGMA cache_size` via connection string; consider DuckDB for large-scan workloads.        |
+| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |


### PR DESCRIPTION
## Summary

The SQLite **accelerator** deployment guide told users to set pragmas (notably `cache_size`) "via a custom connection string or post-startup SQL" — but the SQLite accelerator exposes **no** connection-string, post-startup-SQL, init-SQL, or pragma channel. Its only user knobs are `busy_timeout` and `file` (`ParameterSpec` list in `crates/runtime/src/dataaccelerator/sqlite.rs`). Pragmas (`cache_size`, `journal_mode`, `synchronous`, `foreign_keys`, `temp_store`) are set by the runtime/connection pool at setup and are not user-overridable. Following the guidance is a silent no-op.

This is the same fabricated-config-mechanism class as #1906, which corrected the connection-string language on **vNext + 2.0.x** but:
- **missed** the "Capacity & Sizing" bullet (`increase this via PRAGMA cache_size = -<KB> in post-startup SQL`) on both, and
- **skipped 2.1.x entirely** — so 2.1.x still carried the original pre-#1906 text in three places.

## What the docs said vs. what the code does

| Doc claim | Reality |
|---|---|
| "set pragmas via a custom connection string or post-startup SQL" | No connection-string/SQL channel exists; only `busy_timeout` + `file` params |
| "increase this via \`PRAGMA cache_size = -<KB>\` in post-startup SQL" | \`cache_size\` is runtime-managed (base \`-20000\`); no user override channel |
| troubleshooting: "Raise \`PRAGMA cache_size\` via connection string" | same — not user-configurable |

## Changes

- \`website/docs/components/data-accelerators/sqlite/deployment.md\` (vNext) — fix the Capacity & Sizing \`cache_size\` bullet.
- \`website/versioned_docs/version-2.0.x/...\` — same one-line fix (#1906 fixed the other two spots here).
- \`website/versioned_docs/version-2.1.x/...\` — apply all three #1906 corrections it never received (connection-string sentence, Capacity bullet, troubleshooting row).

Files updated: 3. (version-1.11.x and earlier have no SQLite accelerator deployment guide.)

## Verified source ref

- \`spiceai/spiceai\` \`origin/trunk\` + tag \`v2.1.0\`: SQLite accelerator \`PARAMETERS\` = \`file\`, \`busy_timeout\`, \`file_watcher\` only; storage-profile pragmas hardcoded (\`storage_setup_pragmas\`), no user SQL channel.
- Base pragmas incl. \`cache_size=-20000\` in pinned \`datafusion-table-providers\` rev \`12321c06\` (\`sqlitepool.rs:170\`).

## Test plan

- [x] \`cd website && npm run build\` passes (exit 0; broken-link / undefined-tag check clean)
- [x] Versioned-docs propagation checked — 0 remaining \`post-startup SQL\` hits after the fix
- [x] Cross-checked DuckDB accelerator deployment guide — no analogous straggler