### PR TITLE
docs(cayenne): correct S3 Express request-timeout figure (2 min, not 5)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -609,7 +609,7 @@ See AWS documentation for the complete list of [S3 Express One Zone availability
 ### Important Considerations
 
 - **Standard S3 not supported**: Cayenne currently only supports S3 Express One Zone, not standard S3 buckets.
-- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (5 minutes per request) and retries.
+- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (a 2-minute per-request timeout by default, configurable via `cayenne_s3_client_timeout`) and retries.
 - **Bucket auto-creation**: When using `cayenne_s3_zone_ids`, Spice automatically creates the S3 Express directory bucket if it doesn't exist (requires appropriate IAM permissions).
 - **Metadata locality**: Cayenne metadata (SQLite catalog) remains on local disk. Only data files are stored in S3 Express.
 

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
@@ -89,7 +89,7 @@ datasets:
 | `cayenne_s3_secret`         | AWS secret access key (required when `cayenne_s3_auth: key`).                                                                                   |
 | `cayenne_s3_session_token`  | AWS session token (optional, for temporary credentials).                                                                                        |
 | `cayenne_s3_endpoint`       | Custom S3 endpoint URL (optional, overrides auto-generated endpoint).                                                                           |
-| `cayenne_s3_client_timeout` | Request timeout duration (e.g., `5m`). Defaults to 5 minutes for uploads.                                                                       |
+| `cayenne_s3_client_timeout` | Request timeout duration (e.g., `30s`, `2m`). Defaults to `120s` (2 minutes).                                                                       |
 | `cayenne_s3_allow_http`     | Set to `true` for testing with local S3-compatible storage. Defaults to `false`.                                                                |
 
 ## Performance Tuning
@@ -402,7 +402,7 @@ See AWS documentation for the complete list of [S3 Express One Zone availability
 ### Important Considerations
 
 - **Standard S3 not supported**: Cayenne currently only supports S3 Express One Zone, not standard S3 buckets.
-- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (5 minutes per request) and retries.
+- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (a 2-minute per-request timeout by default, configurable via `cayenne_s3_client_timeout`) and retries.
 - **Bucket auto-creation**: When using `cayenne_s3_zone_ids`, Spice automatically creates the S3 Express directory bucket if it doesn't exist (requires appropriate IAM permissions).
 - **Metadata locality**: Cayenne metadata (SQLite catalog) remains on local disk. Only data files are stored in S3 Express.
 

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
@@ -478,7 +478,7 @@ See AWS documentation for the complete list of [S3 Express One Zone availability
 ### Important Considerations
 
 - **Standard S3 not supported**: Cayenne currently only supports S3 Express One Zone, not standard S3 buckets.
-- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (5 minutes per request) and retries.
+- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (a 2-minute per-request timeout by default, configurable via `cayenne_s3_client_timeout`) and retries.
 - **Bucket auto-creation**: When using `cayenne_s3_zone_ids`, Spice automatically creates the S3 Express directory bucket if it doesn't exist (requires appropriate IAM permissions).
 - **Metadata locality**: Cayenne metadata (SQLite catalog) remains on local disk. Only data files are stored in S3 Express.
 

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
@@ -590,7 +590,7 @@ See AWS documentation for the complete list of [S3 Express One Zone availability
 ### Important Considerations
 
 - **Standard S3 not supported**: Cayenne currently only supports S3 Express One Zone, not standard S3 buckets.
-- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (5 minutes per request) and retries.
+- **Same-AZ optimization**: S3 Express One Zone is optimized for same-availability-zone access. For external access, Cayenne uses extended timeouts (a 2-minute per-request timeout by default, configurable via `cayenne_s3_client_timeout`) and retries.
 - **Bucket auto-creation**: When using `cayenne_s3_zone_ids`, Spice automatically creates the S3 Express directory bucket if it doesn't exist (requires appropriate IAM permissions).
 - **Metadata locality**: Cayenne metadata (SQLite catalog) remains on local disk. Only data files are stored in S3 Express.
 


### PR DESCRIPTION
## Summary

The Cayenne S3 Express docs claimed a per-request timeout of **5 minutes**; the actual default is **2 minutes (120s)**. The figure is also internally inconsistent with the same page's `cayenne_s3_client_timeout` row (already `120s` in 2.0.x/2.1.x/vNext).

In the code, every S3 path (warm, cold/datalake, and validation) builds its object-store client with `ClientOptions::default().with_timeout(Duration::from_mins(2))` (`= from_secs(120)`). The only larger value is the **overall retry budget** — `retry_timeout: 10 minutes`, `max_retries: 3` — which is not a per-request timeout. No 5-minute (300s) value exists anywhere in the Cayenne S3 code.

## What the docs said vs. what the code does

| Doc claim | Reality |
|---|---|
| "extended timeouts (5 minutes per request)" | Per-request client timeout defaults to **2 minutes (120s)**, configurable via `cayenne_s3_client_timeout` |
| 1.11.x: `cayenne_s3_client_timeout` "Defaults to 5 minutes for uploads" | Default is `120s` (2 min) — #1465 fixed this on 2.0.x+ but left 1.11.x stale |

## Changes

- `website/docs/.../cayenne/index.md` (vNext) — "5 minutes per request" → 2-minute default, ref `cayenne_s3_client_timeout`.
- `website/versioned_docs/version-2.0.x/.../cayenne/index.md` — same one-line fix.
- `website/versioned_docs/version-2.1.x/.../cayenne/index.md` — same one-line fix.
- `website/versioned_docs/version-1.11.x/.../cayenne.md` — same fix **plus** the `cayenne_s3_client_timeout` table-row default (5 minutes → `120s`).

Files updated: 4. (version-1.10.x and earlier do not document Cayenne S3 Express timeouts.)

## Verified source ref

- `spiceai/spiceai` `v1.11.6` `crates/runtime/src/dataaccelerator/cayenne/mod.rs:887,1203-1204` — `default_timeout = Duration::from_secs(120); // 2 minutes per request`; `retry_timeout: from_secs(600)` (10 min).
- `v2.0.1` / `v2.1.0` / `origin/trunk` `crates/runtime/src/dataaccelerator/cayenne/s3.rs` — `with_timeout(Duration::from_mins(2))` on warm/cold/validation paths; `retry_timeout: from_mins(10)`, `max_retries: 3`.

## Test plan

- [x] `cd website && npm run build` passes ("[SUCCESS] Generated static files"; no broken-link / undefined-tag errors)
- [x] Versioned-docs propagation checked — 0 remaining "5 minutes per request" hits across `website/`
- [x] Verified the timeout value against code at each release tag (v1.11.6, v2.0.1, v2.1.0, trunk), not just trunk