### PR TITLE
docs(cayenne): document maintained aggregates (incl. min/max)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -422,6 +422,87 @@ For point lookups and selective queries, Spice Cayenne with Vortex often matches
 - Segment cache hit rate (hot data patterns)
 - Compression encoding match to data characteristics
 
+## Maintained Aggregates
+
+Spice Cayenne can incrementally maintain aggregate views over a CDC-accelerated dataset so that `GROUP BY` aggregate queries are answered from continuously-updated summary state instead of re-scanning the full table. As change events are applied (`refresh_mode: changes`), each maintained view is updated with the incoming deltas; a matching query is then rewritten by the physical optimizer to read the maintained state directly. When a query does not match a declared view — or the view is not currently fresh — Cayenne transparently falls back to a full scan, so results are always correct.
+
+Maintained aggregates are declared per dataset under `acceleration.maintained_aggregates`:
+
+```yaml
+datasets:
+  - from: postgres:orders
+    name: orders
+    acceleration:
+      enabled: true
+      engine: cayenne
+      refresh_mode: changes
+      primary_key: id
+      maintained_aggregates:
+        - group_by: [customer_id]
+          aggregates:
+            - function: count
+            - function: sum
+              column: amount
+            - function: avg
+              column: amount
+            - function: min
+              column: amount
+            - function: max
+              column: amount
+```
+
+Each entry declares one maintained view:
+
+| Field        | Required | Description                                                                                                                                                    |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `group_by`   | Optional | Columns used as the `GROUP BY` key, in query output order. Omit for a single-group (grand total) view.                                                         |
+| `aggregates` | Required | Aggregate expressions maintained for each group, in query output order.                                                                                        |
+| `filter_sql` | Optional | A SQL row predicate (a `WHERE` expression over the dataset's columns, e.g. `ol_delivery_d > '2007-01-02'`) restricting which rows contribute to the view.      |
+
+Each item in `aggregates` has:
+
+| Field      | Required    | Description                                                                                         |
+| ---------- | ----------- | -------------------------------------------------------------------------------------------------- |
+| `function` | Required    | One of `count`, `sum`, `avg`, `min`, or `max`.                                                      |
+| `column`   | Conditional | The column to aggregate. Omit for `count` (`COUNT(*)`); required for `sum`, `avg`, `min`, and `max`. |
+
+Supported input column types by function:
+
+- `count` — any column (or `COUNT(*)` when `column` is omitted).
+- `sum` and `avg` — signed integers (`Int8`–`Int64`), unsigned integers (`UInt8`–`UInt64`), and floats (`Float32`/`Float64`). `sum` widens to `BIGINT`/`Float64`; `avg` always returns `Float64`.
+- `min` and `max` — signed/unsigned integers, `Date32`/`Date64`, `Timestamp`, and `Decimal128`, preserving the input type (`MIN(Int32) -> Int32`). Float `min`/`max` is not yet supported.
+
+### Query matching
+
+A query is served from a maintained view only when it matches the view exactly:
+
+- The query's `GROUP BY` keys match the view's `group_by`, in order.
+- The query's `WHERE` predicate matches the view's `filter_sql` exactly — an unfiltered view (no `filter_sql`) answers only unfiltered queries, and a filtered view answers only a query carrying the identical predicate. A view whose `filter_sql` mirrors a common dashboard filter lets that filtered analytical query be served incrementally instead of by a full re-scan.
+
+Any query that does not match a declared view (or that reaches the view while it is stale) falls back to the base-table scan — correct, but not accelerated.
+
+### Constraints
+
+- Maintained aggregates are a Spice Cayenne feature designed for CDC-accelerated datasets (`refresh_mode: changes`).
+- `min` and `max` are retraction-hard: they require a `primary_key` on the acceleration so that `UPDATE` and `DELETE` changes can retract a prior extremum. Set `acceleration.primary_key`, enable extended schema inference for a source primary key, or omit `min`/`max`. `count`, `sum`, and `avg` do not require a primary key.
+- Maintained aggregates are not supported on partitioned tables (`partition_by`).
+
+### Retaining specs without maintaining them
+
+To keep a view's declaration in configuration without materializing or maintaining it, use the policy form with `mode: disabled`:
+
+```yaml
+      maintained_aggregates:
+        mode: disabled
+        views:
+          - group_by: [customer_id]
+            aggregates:
+              - function: sum
+                column: amount
+```
+
+When any view is declared with the list form above, maintenance is enabled by default; the policy form's `mode: enabled` is equivalent.
+
 ## Deletion Vectors
 
 Spice Cayenne implements efficient deletes without rewriting data files using deletion vectors. Deletion vectors track which rows have been logically deleted, and the information is applied transparently during query execution.

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
@@ -392,6 +392,81 @@ For point lookups and selective queries, Spice Cayenne with Vortex often matches
 - Segment cache hit rate (hot data patterns)
 - Compression encoding match to data characteristics
 
+## Maintained Aggregates
+
+Spice Cayenne can incrementally maintain aggregate views over a CDC-accelerated dataset so that `GROUP BY` aggregate queries are answered from continuously-updated summary state instead of re-scanning the full table. As change events are applied (`refresh_mode: changes`), each maintained view is updated with the incoming deltas; a matching query is then rewritten by the physical optimizer to read the maintained state directly. When a query does not match a declared view — or the view is not currently fresh — Cayenne transparently falls back to a full scan, so results are always correct.
+
+Maintained aggregates are declared per dataset under `acceleration.maintained_aggregates`:
+
+```yaml
+datasets:
+  - from: postgres:orders
+    name: orders
+    acceleration:
+      enabled: true
+      engine: cayenne
+      refresh_mode: changes
+      maintained_aggregates:
+        - group_by: [customer_id]
+          aggregates:
+            - function: count
+            - function: sum
+              column: amount
+            - function: avg
+              column: latency_ms
+```
+
+Each entry declares one maintained view:
+
+| Field        | Required | Description                                                                                                                                                    |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `group_by`   | Optional | Columns used as the `GROUP BY` key, in query output order. Omit for a single-group (grand total) view.                                                         |
+| `aggregates` | Required | Aggregate expressions maintained for each group, in query output order.                                                                                        |
+| `filter_sql` | Optional | A SQL row predicate (a `WHERE` expression over the dataset's columns, e.g. `ol_delivery_d > '2007-01-02'`) restricting which rows contribute to the view.      |
+
+Each item in `aggregates` has:
+
+| Field      | Required    | Description                                                                        |
+| ---------- | ----------- | --------------------------------------------------------------------------------- |
+| `function` | Required    | One of `count`, `sum`, or `avg`.                                                   |
+| `column`   | Conditional | The column to aggregate. Omit for `count` (`COUNT(*)`); required for `sum` and `avg`. |
+
+Supported input column types by function:
+
+- `count` — any column (or `COUNT(*)` when `column` is omitted).
+- `sum` — signed integers (`Int8`–`Int64`), unsigned integers (`UInt8`–`UInt64`), and floats (`Float32`/`Float64`), widening to `BIGINT`/`Float64`.
+- `avg` — floats (`Float32`/`Float64`), always returning `Float64`.
+
+### Query matching
+
+A query is served from a maintained view only when it matches the view exactly:
+
+- The query's `GROUP BY` keys match the view's `group_by`, in order.
+- The query's `WHERE` predicate matches the view's `filter_sql` exactly — an unfiltered view (no `filter_sql`) answers only unfiltered queries, and a filtered view answers only a query carrying the identical predicate. A view whose `filter_sql` mirrors a common dashboard filter lets that filtered analytical query be served incrementally instead of by a full re-scan.
+
+Any query that does not match a declared view (or that reaches the view while it is stale) falls back to the base-table scan — correct, but not accelerated.
+
+### Constraints
+
+- Maintained aggregates are a Spice Cayenne feature designed for CDC-accelerated datasets (`refresh_mode: changes`).
+- Maintained aggregates are not supported on partitioned tables (`partition_by`).
+
+### Retaining specs without maintaining them
+
+To keep a view's declaration in configuration without materializing or maintaining it, use the policy form with `mode: disabled`:
+
+```yaml
+      maintained_aggregates:
+        mode: disabled
+        views:
+          - group_by: [customer_id]
+            aggregates:
+              - function: sum
+                column: amount
+```
+
+When any view is declared with the list form above, maintenance is enabled by default; the policy form's `mode: enabled` is equivalent.
+
 ## Deletion Vectors
 
 Spice Cayenne implements efficient deletes without rewriting data files using deletion vectors. Deletion vectors track which rows have been logically deleted, and the information is applied transparently during query execution.


### PR DESCRIPTION
## Summary

Documents the previously-undocumented **Cayenne maintained aggregates** feature (`acceleration.maintained_aggregates`): incrementally-maintained `GROUP BY` aggregate views over a CDC-accelerated dataset that let matching aggregate queries be served from continuously-updated summary state instead of a full re-scan.

Version split verified against source:
- **vNext** (`website/docs/`): documents all functions — `count`, `sum`, `avg`, `min`, `max`. `min`/`max` and integer `avg` are vNext additions.
- **v2.1.x** (`website/versioned_docs/version-2.1.x/`): documents `count`, `sum`, `avg` only (avg is float-only in v2.1.0); `min`/`max` are omitted because they shipped after the v2.1.0 tag.

The feature shipped in v2.1.0 (introduced by spiceai/spiceai#11235) and does not exist in v2.0.x or earlier, so only vNext + v2.1.x are edited.

Documented facts verified against `crates/spicepod/src/acceleration/mod.rs`, `crates/runtime/src/dataaccelerator/cayenne/mod.rs`, and `crates/cayenne/src/maintained_aggregate.rs` on `origin/trunk` and the `v2.1.0` tag:
- Config surface: `group_by`, `aggregates` (`function` + `column`), `filter_sql`; list form and policy form (`mode: disabled` + `views`).
- `column` omitted only for `count` (`COUNT(*)`); required for the others.
- Supported input types per function (sum/avg int+uint+float; min/max int/date/timestamp/decimal, no float).
- Constraints: Cayenne-only, designed for `refresh_mode: changes`; `min`/`max` require a `primary_key` (retraction-hard); not supported on partitioned tables (`partition_by`).
- Query matching: exact `group_by` + exact `filter_sql`; otherwise transparent fallback to a full scan.

## Source PRs
- spiceai/spiceai#11862 — feat(cayenne): min/max maintained aggregates + N>1 CDC retract (in-window trigger)
- spiceai/spiceai#11235 — Add Cayenne maintained aggregates (base feature, shipped in v2.1.0)

## Test plan
- [x] `cd website && npm run build` passes (no broken links / undefined tags)
- [x] Versioned-docs propagation checked — feature exists only in v2.1.0+, so vNext + version-2.1.x edited; v2.0.x and earlier correctly untouched
- [x] Files updated: 2