### PR TITLE
docs(cayenne): correct 'memory mode not supported' on acceleration.mode reference (vNext)

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -409,7 +409,7 @@ The acceleration engine to use, defaults to `arrow`. The following engines are s
 
 Optional. The mode of acceleration. The following values are supported:
 
-- `memory` - Store acceleration data in-memory. Not supported for Spice Cayenne (`cayenne`).
+- `memory` - Store acceleration data in-memory. Supported for Spice Cayenne (`cayenne`), where the acceleration is ephemeral and reloads from its source on restart.
 - `file` - Store acceleration data in a file. Reuses any existing file on startup. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.
 - `file_create` - Always create a new acceleration file on startup, removing any existing file. When [snapshots](../../features/data-acceleration/snapshots) are enabled, the existing file is snapshotted before deletion. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.
 - `file_update` - Open an existing acceleration file if it exists, then check schema compatibility on refresh. If the source schema change is additive (new columns only), the existing file is kept. If the schema change is incompatible (columns removed, renamed, or type changed), the file is snapshotted (if [snapshots](../../features/data-acceleration/snapshots) are enabled) and recreated from scratch. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.

--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -101,7 +101,7 @@ The acceleration engine to use, defaults to `arrow`. The following engines are s
 
 Optional. The mode of acceleration. The following values are supported:
 
-- `memory` - Store acceleration data in-memory. Not supported for Spice Cayenne (`cayenne`).
+- `memory` - Store acceleration data in-memory. Supported for Spice Cayenne (`cayenne`), where the acceleration is ephemeral and reloads from its source on restart.
 - `file` - Store acceleration data in a file. Supported for Spice Cayenne (`cayenne`), `duckdb`, `sqlite`, and `turso` acceleration engines.
 
 ## `acceleration.snapshots`


### PR DESCRIPTION
## Summary

The spicepod `acceleration.mode` reference pages state that `memory` mode is **Not supported for Spice Cayenne (`cayenne`)**. That is stale on trunk/vNext: Cayenne shipped `mode: memory` (fully in-RAM accelerator) in spiceai/spiceai#11720, and the rest of the docs already document it.

**What the docs said** (both `datasets.md` and `views.md`):
> `- \`memory\` - Store acceleration data in-memory. Not supported for Spice Cayenne (\`cayenne\`).`

**What the code does** (trunk): Cayenne selects an in-RAM `memdb` metastore when the source isn't file-accelerated — `crates/runtime/src/dataaccelerator/cayenne/mod.rs` (`apply_memory_mode_overrides`, `is_file_accelerated`); `Memory` is the acceleration enum default in `crates/runtime-acceleration/src/acceleration.rs`. Only `partition_by` is rejected in memory mode.

This is the same false claim fixed page-only in #1928 (Cayenne accelerator page); the two `reference/spicepod/` stragglers were missed. The Cayenne accelerator page (`data-accelerators/cayenne/index.md`) and the accelerators index already describe `mode: memory` as supported/ephemeral, so this restores consistency.

## Scope — vNext only

Memory mode is **not** in any release: `git tag --contains` on the #11720 commit returns nothing, and neither `v2.1.0` nor `v2.0.1` contains the memory-mode code. So the versioned snapshots (`version-2.1.x`, `version-2.0.x`, `version-1.11.x`) correctly document it as unsupported and are intentionally left unchanged.

## Source ref
- spiceai/spiceai@trunk (`fc61c8774`) — `crates/runtime/src/dataaccelerator/cayenne/mod.rs`, `crates/runtime-acceleration/src/acceleration.rs`
- Prior related docs fix: #1928

## Test plan
- [x] `cd website && npm run build` passes (`[SUCCESS] Generated static files`)
- [x] Versioned-docs propagation checked — intentionally vNext-only (feature not in any release)
- [x] Files updated: 2 (`reference/spicepod/datasets.md`, `reference/spicepod/views.md`)