### PR TITLE
docs(metrics): remove fabricated metric claims from deployment guides (_total suffix + resilient_http instrumentation)

### DIFF
--- a/website/docs/components/data-accelerators/postgres/deployment.md
+++ b/website/docs/components/data-accelerators/postgres/deployment.md
@@ -65,7 +65,7 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 
 Monitor via:
 
-- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors_total`).
+- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - Postgres server metrics: `pg_stat_activity`, `pg_stat_bgwriter`, `pg_stat_user_tables`, `pg_stat_statements`.
 - Infrastructure metrics on the Postgres host (CPU, I/O wait, WAL throughput).
 

--- a/website/docs/components/data-connectors/cosmosdb/deployment.md
+++ b/website/docs/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/docs/components/data-connectors/dremio/deployment.md
+++ b/website/docs/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/docs/components/data-connectors/elasticsearch/deployment.md
+++ b/website/docs/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/docs/components/data-connectors/github/deployment.md
+++ b/website/docs/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/docs/components/data-connectors/github/deployment.md
+++ b/website/docs/components/data-connectors/github/deployment.md
@@ -64,7 +64,6 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -78,7 +78,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 
 ## Task History

--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -136,7 +136,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -137,7 +137,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History
 

--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/postgres/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/postgres/deployment.md
@@ -65,7 +65,7 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 
 Monitor via:
 
-- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors_total`).
+- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - Postgres server metrics: `pg_stat_activity`, `pg_stat_bgwriter`, `pg_stat_user_tables`, `pg_stat_statements`.
 - Infrastructure metrics on the Postgres host (CPU, I/O wait, WAL throughput).
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/deployment.md
@@ -64,7 +64,6 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
@@ -78,7 +78,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 
 ## Task History

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
@@ -128,7 +128,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
@@ -127,7 +127,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/postgres/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/postgres/deployment.md
@@ -65,7 +65,7 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 
 Monitor via:
 
-- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors_total`).
+- Spice acceleration metrics (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - Postgres server metrics: `pg_stat_activity`, `pg_stat_bgwriter`, `pg_stat_user_tables`, `pg_stat_statements`.
 - Infrastructure metrics on the Postgres host (CPU, I/O wait, WAL throughput).
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/cosmosdb/deployment.md
@@ -116,7 +116,7 @@ See [Component Metrics](../../../features/observability/component_metrics) for g
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Azure portal **Cosmos DB account → Insights → Throughput** for RU/s consumption and 429 rates.
 - Account-level Azure Monitor metrics: `TotalRequestUnits`, `TotalRequests`, `MetadataRequests`.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/dremio/deployment.md
@@ -45,7 +45,7 @@ Dremio is a federated engine; the connector pushes SQL predicates and projection
 
 The Flight SQL client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Dremio-specific dataset-level instruments. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Dremio's own job metrics exposed via the Dremio UI / API (`job_id` correlation).
 
 See [Component Metrics](../../../features/observability/component_metrics) for configuration.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/elasticsearch/deployment.md
@@ -91,7 +91,7 @@ For schema-evolution-friendly workloads, prefer accelerating the dataset and ref
 
 The Elasticsearch connector does not register connector-specific instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Elasticsearch's own `/_nodes/stats` endpoint and Kibana dashboards for cluster-side request latency, CPU, JVM heap, and shard health.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
@@ -63,7 +63,7 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/github/deployment.md
@@ -64,7 +64,6 @@ Transient 5xx responses are retried with exponential backoff up to a bounded ret
 The GitHub connector does not register connector-specific dataset-level instruments in the current release. Monitor via:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - GitHub's own rate-limit UI at `/settings/tokens` for token-level quota tracking.
 
 See [Component Metrics](../../../features/observability/component_metrics) for general configuration.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
@@ -77,7 +77,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
@@ -78,7 +78,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 - The upstream GraphQL provider's rate-limit dashboards.
 
 ## Task History

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
@@ -136,7 +136,7 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 
 For broader observability, also monitor:
 
-- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
@@ -137,7 +137,6 @@ Enable component metrics in the dataset's `metrics` section. See [Component Metr
 For broader observability, also monitor:
 
 - Spice query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- HTTP response status distribution via the shared `resilient_http` instrumentation.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
@@ -179,7 +179,7 @@ datasets:
 
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
-- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures_total`) from `runtime.metrics`.
+- Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
 - Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.


### PR DESCRIPTION
## Summary

Two related classes of fabricated metric/observability claims in connector & accelerator deployment guides, corrected together because they live in the same observability bullet lists (adjacent lines in the same files):

### 1. Fabricated `_total` counter suffix (original scope)

The spiced Prometheus exporter is built with `.without_counter_suffixes()`, so an OTel counter registered as `query_failures` is exported as `query_failures`, **not** `query_failures_total`. The deployment-guide "query execution metrics" bullet listed `query_failures_total`, which matches no registered instrument or exported name. Corrected to `query_failures` across every deployment guide and versioned copy. (`query_duration_ms` / `query_returned_rows` were already correct.)

### 2. Fabricated `resilient_http` observability claim (added scope)

The bullet "HTTP response status distribution via the shared `resilient_http` instrumentation" was fabricated on the **github**, **graphql**, and **https** deployment guides:

- **github** does not use `resilient_http` at all — it builds a plain `reqwest::Client` and does its own throttling in `connector-github/src/rate_limit.rs`.
- **graphql** does not use `resilient_http` at all — it builds `default_spice_client("application/json")` (a plain `reqwest::Client`, no middleware) and runs its own `execute_with_retry` loop (`data_components/src/graphql/client.rs`).
- `resilient_http` registers **no** OpenTelemetry instruments — it only increments caller-provided `AtomicU64` retry/inflight counters (`data_components/src/resilient_http.rs`). There is no "HTTP response status distribution" metric emitted for any of these connectors.

Removed the bullet from those 3 guides (vNext + 2.1.x + 2.0.x). Left intact the **accurate** `resilient_http` *retry-policy* statements on the https connector and the Unity Catalog catalog (both genuinely route through `resilient_http`); those describe retry behavior, not a fabricated metric.

## Source refs (spiceai/spiceai @ origin/trunk)
- Exporter suffix: `.without_counter_suffixes()` on the Prometheus exporter build.
- `crates/runtime-metrics/src/query.rs` — `query_failures` counter registration.
- `crates/data-connectors/connector-graphql/src/lib.rs:236` (`default_spice_client`) + `crates/data_components/src/graphql/client.rs` (`execute_with_retry`).
- `crates/data-connectors/connector-github/src/lib.rs` (plain `reqwest::Client::builder()`) + `connector-github/src/rate_limit.rs`.
- `crates/data_components/src/resilient_http.rs` — atomic retry/inflight counters only, no OTel instruments.

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'` — clean, deletion-only for scope #2, no links/tags touched)
- [x] Versioned-docs propagation: `_total` fix swept all versioned copies; `resilient_http` bullet removed from vNext + 2.1.x + 2.0.x (3 guides × 3 versions = 9 files)
- [x] Confirmed the surviving `resilient_http` mentions (https retry policy, unity-catalog retry policy) are accurate and intentionally kept