### PR TITLE
docs(google): correct false default-model claim; use current GA model in example

### DIFF
--- a/website/docs/components/models/google.md
+++ b/website/docs/components/models/google.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 To use a language model hosted on Google AI, specify `google` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `gemini-2.0-flash-exp`.
+Include a model ID in the `from` field (see example below); a model ID is required. Spice does not apply a default model — the model fails to load if the ID is omitted (`from: google`).
 
 The following parameters are specific to Google AI models:
 
@@ -19,7 +19,7 @@ Example `spicepod.yml` configuration:
 
 ```yaml
 models:
-  - from: google:gemini-2.0-flash-exp
+  - from: google:gemini-3.5-flash
     name: flash
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-1.11.x/components/models/google.md
+++ b/website/versioned_docs/version-1.11.x/components/models/google.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 To use a language model hosted on Google AI, specify `google` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `gemini-2.0-flash-exp`.
+Include a model ID in the `from` field (see example below); a model ID is required. Spice does not apply a default model — the model fails to load if the ID is omitted (`from: google`).
 
 The following parameters are specific to Google AI models:
 
@@ -19,7 +19,7 @@ Example `spicepod.yml` configuration:
 
 ```yaml
 models:
-  - from: google:gemini-2.0-flash-exp
+  - from: google:gemini-3.5-flash
     name: flash
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.0.x/components/models/google.md
+++ b/website/versioned_docs/version-2.0.x/components/models/google.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 To use a language model hosted on Google AI, specify `google` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `gemini-2.0-flash-exp`.
+Include a model ID in the `from` field (see example below); a model ID is required. Spice does not apply a default model — the model fails to load if the ID is omitted (`from: google`).
 
 The following parameters are specific to Google AI models:
 
@@ -19,7 +19,7 @@ Example `spicepod.yml` configuration:
 
 ```yaml
 models:
-  - from: google:gemini-2.0-flash-exp
+  - from: google:gemini-3.5-flash
     name: flash
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }

--- a/website/versioned_docs/version-2.1.x/components/models/google.md
+++ b/website/versioned_docs/version-2.1.x/components/models/google.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 
 To use a language model hosted on Google AI, specify `google` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `gemini-2.0-flash-exp`.
+Include a model ID in the `from` field (see example below); a model ID is required. Spice does not apply a default model — the model fails to load if the ID is omitted (`from: google`).
 
 The following parameters are specific to Google AI models:
 
@@ -19,7 +19,7 @@ Example `spicepod.yml` configuration:
 
 ```yaml
 models:
-  - from: google:gemini-2.0-flash-exp
+  - from: google:gemini-3.5-flash
     name: flash
     params:
       google_api_key: ${ secrets:GEMINI_API_KEY }


### PR DESCRIPTION
## Summary

The Google AI Models page claimed a **default model** that does not exist, and used a **discontinued experimental model** in its example.

**What the docs said:** "If not specified, the default model is `gemini-2.0-flash-exp`." + example `from: google:gemini-2.0-flash-exp`.

**What the code does:** The Google chat builder returns `LlmError::ModelNotProvided` when no model ID is given — there is **no default**, the model fails to load. Contrast xAI (`DEFAULT_MODEL = "grok-4.3"`) and Anthropic (`DEFAULT_ANTHROPIC_MODEL`), which do default; Google does not. This matches the embeddings Google page, which already states "a model ID is required."

- vNext (trunk `c3036531c`): `crates/runtime/src/model/chat.rs:270-275` — `google()` returns `ModelNotProvided` when `model_id` is `None`.
- v2.1.0: `crates/runtime/src/model/chat.rs:270-273` (same behavior).
- v2.0.1: `crates/runtime/src/model/chat.rs:270-273` (same behavior).
- v1.11.1: `crates/runtime/src/model/chat.rs:263-266` (same behavior).

The "no default" error path predates versioning, so this correction applies to every documented version.

**Deprecated example model:** `gemini-2.0-flash-exp` was pulled from Google AI Studio, and the entire Gemini 2.0 Flash family was discontinued **June 1, 2026**. Since Spice forwards the model ID to the provider as an opaque string, a copied example fails at the provider. Updated the example to the current GA model `gemini-3.5-flash` (GA 2026-05-19; `gemini-flash-latest` aliases it). Same class of fix as #1930 (deprecated `text-embedding-004` → `gemini-embedding-2`).

## Changes

- Replaced the false "default model is `gemini-2.0-flash-exp`" sentence with "a model ID is required; Spice does not apply a default model."
- Updated the example `from:` to `google:gemini-3.5-flash`.
- Applied to vNext + all versioned copies that carried the claim (v2.1.x, v2.0.x, v1.11.x).

## Test plan

- [x] `npm run build` passes (exit 0; prose-only diff, no new links/tags)
- [x] Verified `ModelNotProvided` behavior at trunk, v2.1.0, v2.0.1, v1.11.1
- [x] Files updated: 4 (vNext + 3 versioned)