### PR TITLE
docs(mongodb): correct missing-fullDocument CDC behavior (substitute delete / skip, not fail)

### DIFF
--- a/website/docs/components/data-connectors/mongodb.md
+++ b/website/docs/components/data-connectors/mongodb.md
@@ -360,7 +360,7 @@ The existing `mongodb_unnest_depth` parameter also applies to Change Stream docu
 - `delete`: delete, using `documentKey`; non-key columns are `null`.
 - `drop`, `rename`, `dropDatabase`, `invalidate`: truncate, because collection continuity is no longer guaranteed.
 
-If MongoDB does not include `fullDocument` for an update or replace event, Spice fails the stream with a clear error instead of applying a partial row.
+If MongoDB omits `fullDocument` for an `update` or `replace` event (for example, the document was deleted before the `fullDocument=updateLookup` post-image could be read), Spice substitutes a synthetic delete keyed on `documentKey` and logs a warning; if `documentKey` is also unavailable, the event is skipped with a warning. An `insert` event missing `fullDocument`, or a `delete` event missing `documentKey`, still fails the stream.
 
 #### Resumability across restarts
 


### PR DESCRIPTION
## Summary

The MongoDB connector's Change Stream section described a **fail-hard** behavior that no longer matches vNext.

**What the docs said:** "If MongoDB does not include `fullDocument` for an update or replace event, Spice fails the stream with a clear error instead of applying a partial row."

**What the code does (vNext):** For an `update`/`replace` event with no `fullDocument`, Spice **substitutes a synthetic delete** keyed on `documentKey` (op `d`) and logs a warning; if `documentKey` is also missing, it **skips the event** with a warning. It does **not** fail the stream. Only `insert` (missing `fullDocument`) and `delete` (missing `documentKey`) still hard-fail.

Source (trunk `c3036531c`): `crates/data_components/src/mongodb/stream.rs:93-138` — `OperationType::Update`/`Replace` arms match `full_document`: `Some` → op `u`; `None` + `Some(document_key)` → op `d` ("substituting a synthetic delete"); `None` + `None` → skip. `Insert`/`Delete` use `.context(Missing…Snafu)?` and still error (`stream.rs:88,140`).

## Version scope — vNext only

This behavior was introduced by spiceai/spiceai#11583 (`fix(mongodb): substitute delete when UpdateLookup finds no document`, commit `0675bdfc6`), which is **not** in any release tag (`git tag --contains 0675bdfc6` is empty). The prior fail-hard behavior is correct for the released versions:

- v2.1.0: `crates/data_components/src/mongodb/stream.rs:90-99` — `Update`/`Replace` use `.context(MissingFullDocumentSnafu)?` (fails).
- v2.0.1: same (`stream.rs:90-95`).

So the versioned docs (`version-2.1.x`, `version-2.0.x`) are **left unchanged** — they correctly document their release's behavior. Only the vNext page is corrected.

## Test plan

- [x] `cd website && npm run build` passes (exit 0; prose-only diff, no new links/tags)
- [x] Verified vNext substitute/skip behavior at `stream.rs:93-138` and fail-hard at v2.1.0/v2.0.1
- [x] Confirmed the change is vNext-only (not in any release tag) — versioned docs intentionally untouched
- [x] Files updated: 1 (vNext only)