### PR TITLE
docs(cdc): surface MySQL + MongoDB native CDC; fix Kafka-as-changes claim

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -45,7 +45,7 @@ Supported Data Connectors include:
 | `github`                           | GitHub                                | Stable            | GitHub API                   |
 | `postgres`                         | PostgreSQL (with native WAL CDC)      | Stable            |                              |
 | `s3`                               | [S3][s3]                              | Stable            | Parquet, CSV                 |
-| `mysql`                            | MySQL                                 | Stable            |                              |
+| `mysql`                            | MySQL (with native binlog CDC)        | Stable            |                              |
 | `spice.ai`                         | [Spice.ai][spiceai]                   | Stable            | Arrow Flight                 |
 | `dynamodb`                         | Amazon DynamoDB (with Streams)        | Stable            |                              |
 | `graphql`                          | GraphQL                               | Release Candidate | JSON                         |
@@ -73,7 +73,7 @@ Supported Data Connectors include:
 | `http`, `https`                    | HTTP(s) (dynamic headers, pagination) | Alpha             | Parquet, CSV, JSON           |
 | `imap`                             | IMAP                                  | Alpha             | IMAP Emails                  |
 | `localpod`                         | [Local dataset replication][localpod] | Alpha             |                              |
-| `mongodb`                          | MongoDB                               | Alpha             |                              |
+| `mongodb`                          | MongoDB (with native Change Streams CDC) | Alpha          |                              |
 | `scylladb`                         | ScyllaDB                              | Alpha             |                              |
 | `smb`                              | SMB 3.1.1                             | Alpha             | SMB                          |
 | `nfs`                              | NFS (Spice.ai Enterprise)             | Alpha             | Parquet, CSV, JSON           |

--- a/website/docs/features/data-acceleration/refresh-modes/changes.md
+++ b/website/docs/features/data-acceleration/refresh-modes/changes.md
@@ -17,7 +17,15 @@ Use `changes` when:
 
 ## Configuration
 
-`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [DynamoDB Streams](../../../components/data-connectors/dynamodb#streams), [Apache Kafka](../../../components/data-connectors/kafka), and [Debezium](../../../components/data-connectors/debezium). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [MySQL Binlog Replication](../../cdc/mysql-replication), [MongoDB Change Streams](../../cdc/mongodb-streams), [DynamoDB Streams](../../cdc/dynamodb-streams), and [Debezium](../../cdc/debezium) (over Kafka). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+
+:::note
+
+[Apache Kafka](../../../components/data-connectors/kafka) is a real-time streaming source but is append-only — it uses [`refresh_mode: append`](./append), not `changes`.
+
+:::
+
+Any accelerator engine that supports writes can be a `changes` sink — `arrow`, `duckdb`, `sqlite`, and `cayenne`. [Spice Cayenne](../../../components/data-accelerators/cayenne) is recommended for large-scale CDC (incremental materialized views, in-memory CDC tier, and replication-lag/freshness SLOs).
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/changes.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/changes.md
@@ -17,7 +17,13 @@ Use `changes` when:
 
 ## Configuration
 
-`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [DynamoDB Streams](../../../components/data-connectors/dynamodb#streams), [Apache Kafka](../../../components/data-connectors/kafka), and [Debezium](../../../components/data-connectors/debezium). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [MongoDB Change Streams](../../cdc/mongodb-streams), [DynamoDB Streams](../../cdc/dynamodb-streams), and [Debezium](../../cdc/debezium) (over Kafka). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+
+:::note
+
+[Apache Kafka](../../../components/data-connectors/kafka) is a real-time streaming source but is append-only — it uses [`refresh_mode: append`](./append), not `changes`.
+
+:::
 
 ```yaml
 datasets:

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/changes.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/changes.md
@@ -17,7 +17,13 @@ Use `changes` when:
 
 ## Configuration
 
-`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [DynamoDB Streams](../../../components/data-connectors/dynamodb#streams), [Apache Kafka](../../../components/data-connectors/kafka), and [Debezium](../../../components/data-connectors/debezium). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+`refresh_mode: changes` requires a CDC-capable data connector. Spice supports CDC via [PostgreSQL Logical Replication](../../cdc/postgres-replication), [MongoDB Change Streams](../../cdc/mongodb-streams), [DynamoDB Streams](../../cdc/dynamodb-streams), and [Debezium](../../cdc/debezium) (over Kafka). See [Supported Data Connectors](../../cdc#supported-data-connectors) for details.
+
+:::note
+
+[Apache Kafka](../../../components/data-connectors/kafka) is a real-time streaming source but is append-only — it uses [`refresh_mode: append`](./append), not `changes`.
+
+:::
 
 ```yaml
 datasets:


### PR DESCRIPTION
## Summary

The global [Changes Refresh Mode](https://docs.spiceai.org/features/data-acceleration/refresh-modes/changes) reference listed **Kafka** as a CDC/`changes`-capable connector and **omitted MySQL and MongoDB**, both of which have full CDC feature docs. This corrects the canonical `refresh_mode: changes` connector list against the code-verified set.

Code-verified CDC connectors (each implements `supports_changes_stream() -> true` in `spiceai/spiceai` trunk): **PostgreSQL, MySQL, MongoDB, DynamoDB, Debezium**. Kafka and Spice.ai are **append-only** (`append_stream`, no `changes_stream`).

Changes:
- `features/data-acceleration/refresh-modes/changes.md` — list PostgreSQL, MySQL, MongoDB, DynamoDB, Debezium; move Kafka to a `:::note` clarifying it is append-only (`refresh_mode: append`); note that `arrow`/`duckdb`/`sqlite`/`cayenne` can all be `changes` sinks (Cayenne recommended for large-scale CDC).
- `components/data-connectors/index.md` — advertise native CDC on the MySQL and MongoDB rows, matching the existing PostgreSQL/DynamoDB rows.
- Versioned `2.1.x` + `2.0.x` `changes.md` — same Kafka correction + MongoDB omission. **MySQL CDC is not in those releases** (`features/cdc/mysql-replication.md` does not exist there), so MySQL is not added to the versioned copies.

## Test plan

- [x] `cd website && npm run build` passes (no broken links / anchors / tags)
- [x] Versioned propagation applied to 2.1.x + 2.0.x where linked pages exist; MySQL correctly excluded from versioned
- [x] Files updated: 4