### PR TITLE
docs(cayenne): add CDC section + split Performance Tuning into a /performance subpage

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -77,8 +77,8 @@ Set under a dataset's `acceleration.params`:
 
 | Parameter                         | Description                                                                                                                                                                                   |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cayenne_tuning`                  | Auto-tuning mode. Accepts `auto` or `adaptive` (preview). `auto` derives the memory-, CPU-, and storage-sensitive knobs statically from the detected environment (cgroup-aware cores and memory, storage class) and the inferred schema (cardinality, row width, primary key) — no feedback loop. `adaptive` additionally runs a per-table closed-feedback controller that measures the live CDC ingest rate (and delete fraction and arrival burstiness) and the runtime's response (apply latency vs. offered load, read amplification, memory pressure) and adjusts the inline-memtable flush caps, the in-memory CDC tier byte cap, compaction cadence/trigger, and write concurrency over time, within the environment-derived bounds. **When unset, the mode defaults to `auto`; set `cayenne_tuning: adaptive` explicitly to enable the closed loop.** A configured `cayenne_goal_*` SLO also implies `adaptive` unless you set `cayenne_tuning: auto` explicitly. `adaptive` needs a non-zero `cayenne_compaction_background_interval_ms` (the controller runs on the background compaction tick); if it is `0`, Cayenne falls back to `auto`. Schema inference (always on) sharpens the `adaptive` warm-start but is not required — without inferred metadata the controller relearns the observed row width from live ingest. In both modes an explicit per-knob value overrides the derived value; under `adaptive` an explicitly-set knob is pinned (the loop will not move it). See [Self-Tuning](#self-tuning). |
-| `cayenne_goal_replication_lag`    | Goal-driven adaptive tuning (preview): target end-to-end CDC replication lag, as a duration (e.g. `5s`). **Best set globally** under `runtime.params`; a value here overrides the global setpoint for this dataset. When set, the closed-loop controller converges toward this SLO in small, bounded steps within `cayenne_goal_convergence_window`. Setting any `cayenne_goal_*` parameter enables the closed loop unless `cayenne_tuning: auto` is set explicitly, and requires a non-zero `cayenne_compaction_background_interval_ms`. See [Goal-driven tuning](#goal-driven-tuning). |
+| `cayenne_tuning`                  | Auto-tuning mode. Accepts `auto` or `adaptive` (preview). `auto` derives the memory-, CPU-, and storage-sensitive knobs statically from the detected environment (cgroup-aware cores and memory, storage class) and the inferred schema (cardinality, row width, primary key) — no feedback loop. `adaptive` additionally runs a per-table closed-feedback controller that measures the live CDC ingest rate (and delete fraction and arrival burstiness) and the runtime's response (apply latency vs. offered load, read amplification, memory pressure) and adjusts the inline-memtable flush caps, the in-memory CDC tier byte cap, compaction cadence/trigger, and write concurrency over time, within the environment-derived bounds. **When unset, the mode defaults to `auto`; set `cayenne_tuning: adaptive` explicitly to enable the closed loop.** A configured `cayenne_goal_*` SLO also implies `adaptive` unless you set `cayenne_tuning: auto` explicitly. `adaptive` needs a non-zero `cayenne_compaction_background_interval_ms` (the controller runs on the background compaction tick); if it is `0`, Cayenne falls back to `auto`. Schema inference (always on) sharpens the `adaptive` warm-start but is not required — without inferred metadata the controller relearns the observed row width from live ingest. In both modes an explicit per-knob value overrides the derived value; under `adaptive` an explicitly-set knob is pinned (the loop will not move it). See [Self-Tuning](./performance.md#self-tuning). |
+| `cayenne_goal_replication_lag`    | Goal-driven adaptive tuning (preview): target end-to-end CDC replication lag, as a duration (e.g. `5s`). **Best set globally** under `runtime.params`; a value here overrides the global setpoint for this dataset. When set, the closed-loop controller converges toward this SLO in small, bounded steps within `cayenne_goal_convergence_window`. Setting any `cayenne_goal_*` parameter enables the closed loop unless `cayenne_tuning: auto` is set explicitly, and requires a non-zero `cayenne_compaction_background_interval_ms`. See [Goal-driven tuning](./performance.md#goal-driven-tuning). |
 | `cayenne_goal_freshness`          | Goal-driven adaptive tuning (preview): target data freshness — the age of the newest queryable data — as a duration (e.g. `30s`). Best set globally under `runtime.params`; a value here overrides the global setpoint for this dataset. |
 | `cayenne_goal_query_latency`      | Goal-driven adaptive tuning (preview): target p99 query latency on this table, as a duration (e.g. `250ms` or `10s`). Best set globally under `runtime.params`; a value here overrides the global setpoint for this dataset. |
 | `cayenne_goal_convergence_window` | Goal-driven adaptive tuning (preview): the time budget to converge toward the configured `cayenne_goal_*` SLOs, as a duration (e.g. `1m`). Defaults to `60s`. A per-dataset control-cadence knob — it paces how fast the loop chases the goals rather than declaring an outcome, so it is not part of the global SLO surface and has no `runtime.params` form. |
@@ -166,7 +166,7 @@ Set once under the top-level `runtime.params` and applied to every Cayenne-accel
 | `cayenne_compaction_memory_fraction`       | Fraction of the query memory pool carved out for a dedicated Cayenne compaction memory pool. Defaults to `0.2` and is clamped to a supported range. Only applied when at least one Cayenne-accelerated dataset is enabled and dedicated thread pools are not disabled. |
 | `cayenne_sort_merge_min_rows`              | Advanced anti-join tuning: row-count threshold above which the filter-propagation optimizer switches to a sort-merge strategy. Defaults to an internally tuned value; override only when profiling indicates a need.                                                    |
 | `cayenne_sort_merge_memory_pool_fraction`  | Advanced anti-join tuning: fraction of the memory pool the sort-merge anti-join strategy may use. Defaults to an internally tuned value.                                                                                                                                |
-| `cayenne_goal_replication_lag`             | Goal-driven adaptive tuning (preview): global target end-to-end CDC replication lag, as a duration (e.g. `5s`), applied to every Cayenne dataset. Override per-dataset under a dataset's `acceleration.params`. See [Goal-driven tuning](#goal-driven-tuning).            |
+| `cayenne_goal_replication_lag`             | Goal-driven adaptive tuning (preview): global target end-to-end CDC replication lag, as a duration (e.g. `5s`), applied to every Cayenne dataset. Override per-dataset under a dataset's `acceleration.params`. See [Goal-driven tuning](./performance.md#goal-driven-tuning).            |
 | `cayenne_goal_freshness`                   | Goal-driven adaptive tuning (preview): global target data freshness — the age of the newest queryable data — as a duration (e.g. `30s`). Override per-dataset under a dataset's `acceleration.params`.                                                                   |
 | `cayenne_goal_query_latency`               | Goal-driven adaptive tuning (preview): global target p99 query latency, as a duration (e.g. `250ms` or `10s`). Override per-dataset under a dataset's `acceleration.params`.                                                                                             |
 | `cayenne_goal_qph`                         | Goal-driven adaptive tuning (preview): target query throughput in queries per hour (higher is better), e.g. `5000`. Must be a positive number. **Global-only** — query throughput is measured system-wide (a query spanning multiple datasets, such as a join, is counted once), so it has no per-dataset form; a value set under `acceleration.params` is ignored. |
@@ -197,151 +197,7 @@ datasets:
 
 ## Performance Tuning
 
-Spice Cayenne performance can be optimized through cache configuration, compression strategy selection, and resource allocation. By default Cayenne is self-tuning — see [Self-Tuning](#self-tuning) — so manual tuning is only needed to override a specific knob.
-
-### Self-Tuning
-
-Cayenne sizes its memory-, CPU-, and storage-sensitive knobs automatically so it runs well on any host without hand-tuning, from a small container to a large multi-core box across different storage classes. Every numeric `cayenne_*` knob also accepts the literal `auto`, which lets the runtime derive that knob's value while leaving the rest of the configuration untouched.
-
-The mode is controlled by the `cayenne_tuning` acceleration parameter:
-
-- **`auto`** — derive the correct configuration values statically from the detected environment (cgroup-aware cores and memory, storage class) and the inferred schema (cardinality, row width, primary key). No feedback loop runs.
-- **`adaptive`** (preview) — in addition to the static derivation, run a per-table closed-feedback controller that measures the live CDC ingest rate and the runtime's response (apply latency vs. offered load, read amplification, memory pressure) and adjusts the inline-memtable flush caps, compaction cadence/trigger, and write concurrency over time. Adjustments are bounded by the same environment-derived `[floor, ceiling]` the static tier uses, so the loop can only ever pick a value the static tier could have picked.
-
-Environment detection feeds both modes. On AWS EC2, the runtime additionally probes the [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) once at first table registration to detect T-family burstable CPU and the instance's EBS baseline bandwidth, and measures real storage write throughput with a cloud-agnostic calibration probe — both refine the environment-derived `[floor, ceiling]` bounds. The IMDS probe is non-blocking and fail-open: it uses a tight timeout and a single attempt, so off-AWS (or when the metadata service is unreachable) it is a fast no-op and detection falls back to the calibration probe alone. To skip the IMDS probe entirely, set `SPICE_DISABLE_IMDS=1` (the standard AWS `AWS_EC2_METADATA_DISABLED` environment variable is also honored).
-
-When `cayenne_tuning` is left unset, the mode defaults to `auto`. Set `cayenne_tuning: adaptive` explicitly to enable the closed loop. Configuring any `cayenne_goal_*` SLO also implies `adaptive` (a goal with tuning off is inert) unless you set `cayenne_tuning: auto` explicitly. Schema inference is always attempted and seeds the controller's warm-start, but is not what selects the mode.
-
-```yaml
-acceleration:
-  engine: cayenne
-  params:
-    cayenne_tuning: adaptive
-```
-
-:::warning[Preview]
-
-`cayenne_tuning: adaptive` is in preview. Cayenne logs a startup warning when it is enabled; verify query correctness and performance before using it for production workloads. The static `auto` mode is recommended for production.
-
-:::
-
-`adaptive` needs a non-zero `cayenne_compaction_background_interval_ms`, since the controller runs on the background compaction tick; if it is `0`, Cayenne logs a warning and falls back to `auto`. Schema inference (always on) sharpens the `adaptive` warm-start — the loop's data-aware warm-start uses the inferred cardinality and size — but is not required for an explicit `cayenne_tuning: adaptive`; without inferred metadata the controller relearns the observed row width from live ingest and converges from the hardware-derived warm-start.
-
-In both modes, setting any `cayenne_*` knob to an explicit value overrides the derived value. Under `adaptive`, an explicitly-set knob is **pinned** — the controller will not move it.
-
-#### Goal-driven tuning
-
-Under `adaptive`, you can give the controller high-level service-level objectives (SLOs) instead of leaving it to optimize from its built-in signals alone. Set one or more `cayenne_goal_*` SLOs — **globally under `runtime.params`**, where they apply to every Cayenne-accelerated dataset — and the closed loop converges toward each target in small, bounded steps:
-
-| Goal | Parameter | Example |
-| --- | --- | --- |
-| End-to-end CDC replication lag | `cayenne_goal_replication_lag` | `5s` |
-| Data freshness (age of the newest queryable data) | `cayenne_goal_freshness` | `30s` |
-| p99 query latency | `cayenne_goal_query_latency` | `250ms` |
-| Query throughput (queries per hour, higher is better) | `cayenne_goal_qph` | `5000` |
-
-The time-based goals accept a duration string (e.g. `5s`, `1m`, `250ms`); `cayenne_goal_qph` is a positive number.
-
-Scope each goal where the runtime reads it:
-
-- **Time-based goals** (`cayenne_goal_replication_lag`, `cayenne_goal_freshness`, `cayenne_goal_query_latency`) are set globally under `runtime.params` and may be overridden per-dataset under a dataset's `acceleration.params`.
-- **`cayenne_goal_qph`** is **global-only**: query throughput is measured system-wide — a query spanning multiple datasets (such as a join) is counted once — so it is read only from `runtime.params`, and a value set under `acceleration.params` is ignored.
-- **`cayenne_goal_convergence_window`** (duration, default `60s`) sets the time budget the controller targets for convergence. It is a per-dataset control-cadence knob (set under `acceleration.params`) and is not part of the global SLO surface.
-
-Setting any `cayenne_goal_*` parameter implies the closed loop — a goal is inert without it — so the goals also enable `adaptive` unless you explicitly set `cayenne_tuning: auto` (in which case the goals are ignored and Cayenne logs a warning). Goal-seeking also requires a non-zero `cayenne_compaction_background_interval_ms`, like `adaptive` itself.
-
-```yaml
-runtime:
-  params:
-    # Global SLOs — apply to every Cayenne-accelerated dataset
-    cayenne_goal_replication_lag: 5s
-    cayenne_goal_query_latency: 250ms
-    cayenne_goal_qph: 5000 # global-only — no per-dataset form
-
-datasets:
-  - from: postgres:public.orders
-    name: orders
-    acceleration:
-      engine: cayenne
-      params:
-        # Per-dataset override of the global query-latency SLO
-        cayenne_goal_query_latency: 100ms
-        cayenne_goal_convergence_window: 1m
-```
-
-### Cache Tuning
-
-Spice Cayenne uses two in-memory caches to accelerate query performance:
-
-**Footer Cache (`cayenne_footer_cache_mb`) — runtime parameter:**
-
-The footer cache stores Vortex file metadata, including schemas, statistics, and encoding information. It is engine-global and shared across every Cayenne-accelerated dataset, so it is set under `runtime.params`, not per dataset. Larger cache sizes benefit workloads with many files.
-
-- Default: unset — when omitted, DataFusion's default file-metadata-cache limit of 50 MB applies
-- Increase for datasets with many small files
-- Each file requires approximately 1-10 KB of footer cache
-
-**Segment Cache (`cayenne_segment_cache_mb`) — acceleration parameter:**
-
-The segment cache stores decompressed data segments. It is configured per dataset under `acceleration.params`. Larger cache sizes benefit workloads with repeated queries on the same data.
-
-- Default: 256 MB
-- Increase for workloads with hot data patterns
-- Size based on frequently accessed data volume
-
-**Example - High-throughput configuration:**
-
-```yaml
-runtime:
-  params:
-    # Engine-global footer cache, shared by all Cayenne datasets
-    cayenne_footer_cache_mb: 512
-
-datasets:
-  - from: s3://analytics-bucket/events/
-    name: events
-    acceleration:
-      engine: cayenne
-      mode: file
-      params:
-        # Per-dataset segment cache
-        cayenne_segment_cache_mb: 1024
-```
-
-### Compression Strategy
-
-Spice Cayenne supports two compression strategies, each with different performance characteristics. The [BtrBlocks](https://www.cs.cit.tum.de/fileadmin/w00cfj/dis/papers/btrblocks.pdf) compression algorithm is designed for fast analytical queries, while [zstd](https://facebook.github.io/zstd/) provides fast write performance. Additionally, `zstd` achieves better compression ratios when data contains large chunks of binary or text.
-
-| Strategy    | Compression | Read Speed | Write Speed | Best For                                         |
-| ----------- | ----------- | ---------- | ----------- | ------------------------------------------------ |
-| `btrblocks` | Higher      | Faster     | Moderate    | Read-heavy analytics (default)                   |
-| `zstd`      | High        | Moderate   | Faster      | Write-heavy workloads, large binary or text data |
-
-**Example - Write-optimized configuration:**
-
-```yaml
-datasets:
-  - from: kafka:events
-    name: realtime_events
-    acceleration:
-      engine: cayenne
-      mode: file
-      refresh_mode: append
-      params:
-        cayenne_compression_strategy: zstd
-```
-
-### File Size Tuning
-
-The `cayenne_target_file_size_mb` parameter controls when new Vortex files are created during writes:
-
-- **Smaller files (32-64 MB)**: Better parallelism, finer-grained statistics, faster ingestion
-- **Larger files (128-256 MB)**: Fewer files to manage, reduced metadata overhead
-
-```yaml
-params:
-  cayenne_target_file_size_mb: 64  # More parallelism for high-concurrency workloads
-```
+Spice Cayenne is self-tuning by default and rarely needs manual tuning. For the full tuning reference — [self-tuning and goal-driven SLOs](./performance.md#self-tuning), [cache sizing](./performance.md#cache-tuning), [compression strategy](./performance.md#compression-strategy), and [file-size tuning](./performance.md#file-size-tuning) — see the dedicated **[Performance Tuning](./performance.md)** page.
 
 ## Features
 
@@ -421,6 +277,42 @@ For point lookups and selective queries, Spice Cayenne with Vortex often matches
 - Data sorting (sorted columns benefit most from segment pruning)
 - Segment cache hit rate (hot data patterns)
 - Compression encoding match to data characteristics
+
+## Change Data Capture (`refresh_mode: changes`)
+
+Spice Cayenne is the recommended accelerator for [Change Data Capture (CDC)](../../../features/cdc/index.md). A dataset configured with `refresh_mode: changes` is bootstrapped from a source snapshot and then kept continuously in sync by applying the source's row-level change stream — inserts, updates, and deletes — so the acceleration reflects the current state of the source row-for-row.
+
+CDC into Cayenne is available for every Spice CDC connector:
+
+- [PostgreSQL Logical Replication](../../../features/cdc/postgres-replication.md)
+- [MySQL Binlog Replication](../../../features/cdc/mysql-replication.md)
+- [MongoDB Change Streams](../../../features/cdc/mongodb-streams.md)
+- [DynamoDB Streams](../../../features/cdc/dynamodb-streams.md)
+- [Debezium](../../../features/cdc/debezium.md) (over Kafka)
+
+See [Change Data Capture](../../../features/cdc/index.md) for source-side setup and the [Changes refresh mode](../../../features/data-acceleration/refresh-modes/changes.md) reference for the acceleration-side configuration.
+
+```yaml
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    acceleration:
+      engine: cayenne
+      mode: file
+      refresh_mode: changes
+```
+
+Cayenne is not the only engine that can apply a change stream — `arrow`, `duckdb`, and `sqlite` are also valid `changes` sinks — but Cayenne adds CDC-specific capabilities built for large-scale, continuously-updated datasets:
+
+- **Incrementally maintained aggregate views (IVM).** Aggregate views declared with `maintained_aggregates` are updated in place as each change event is applied, rather than recomputed, so `GROUP BY` rollups stay fresh at CDC speed. See [Maintained Aggregates](#maintained-aggregates).
+- **Key-based incremental deletes.** With a primary key, `cayenne_deletion_mode: auto` resolves to key-based deletion vectors so source `DELETE` and `UPDATE` events apply efficiently. See [Deletion Vectors](#deletion-vectors).
+- **In-memory CDC tier.** Change events can be staged through an in-memory tier (`cayenne_cdc_durability` and the `cayenne_cdc_mem_tier_*` parameters) for low apply latency, with exactly-once semantics via primary-key-idempotent replay. The [deployment guide](./deployment.md#cdc-apply-metrics) documents the CDC apply metrics for monitoring lag and throughput.
+- **Replication-lag and freshness SLOs.** The adaptive self-tuner can target an end-to-end replication-lag or data-freshness goal (`cayenne_goal_replication_lag`, `cayenne_goal_freshness`) and adjust its apply behavior to meet it. See [Goal-driven tuning](./performance.md#goal-driven-tuning).
+
+### CDC Requirements
+
+- **A primary key is required.** In `changes` mode Cayenne always applies an inferred or declared primary key and routes source updates through an upsert. Declare `primary_key` on the dataset (and, where the connector requires it, `on_conflict: upsert`); the per-connector CDC pages document the exact requirement.
+- **File or memory mode.** Durable resume across restarts requires `mode: file`. `mode: memory` is supported for ephemeral, in-RAM CDC where the accelerator is rebuilt from the source on restart.
 
 ## Maintained Aggregates
 

--- a/website/docs/components/data-accelerators/cayenne/performance.md
+++ b/website/docs/components/data-accelerators/cayenne/performance.md
@@ -1,0 +1,159 @@
+---
+title: 'Spice Cayenne Performance Tuning'
+sidebar_label: 'Performance Tuning'
+description: 'Tuning Spice Cayenne: self-tuning and goal-driven SLOs, cache sizing, compression strategy, and file-size tuning.'
+sidebar_position: 5
+pagination_prev: null
+pagination_next: null
+tags:
+  - data-accelerators
+  - cayenne
+  - performance
+---
+
+Spice Cayenne performance can be optimized through cache configuration, compression strategy selection, and resource allocation. By default Cayenne is self-tuning — see [Self-Tuning](#self-tuning) — so manual tuning is only needed to override a specific knob.
+
+## Self-Tuning
+
+Cayenne sizes its memory-, CPU-, and storage-sensitive knobs automatically so it runs well on any host without hand-tuning, from a small container to a large multi-core box across different storage classes. Every numeric `cayenne_*` knob also accepts the literal `auto`, which lets the runtime derive that knob's value while leaving the rest of the configuration untouched.
+
+The mode is controlled by the `cayenne_tuning` acceleration parameter:
+
+- **`auto`** — derive the correct configuration values statically from the detected environment (cgroup-aware cores and memory, storage class) and the inferred schema (cardinality, row width, primary key). No feedback loop runs.
+- **`adaptive`** (preview) — in addition to the static derivation, run a per-table closed-feedback controller that measures the live CDC ingest rate and the runtime's response (apply latency vs. offered load, read amplification, memory pressure) and adjusts the inline-memtable flush caps, compaction cadence/trigger, and write concurrency over time. Adjustments are bounded by the same environment-derived `[floor, ceiling]` the static tier uses, so the loop can only ever pick a value the static tier could have picked.
+
+Environment detection feeds both modes. On AWS EC2, the runtime additionally probes the [Instance Metadata Service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) once at first table registration to detect T-family burstable CPU and the instance's EBS baseline bandwidth, and measures real storage write throughput with a cloud-agnostic calibration probe — both refine the environment-derived `[floor, ceiling]` bounds. The IMDS probe is non-blocking and fail-open: it uses a tight timeout and a single attempt, so off-AWS (or when the metadata service is unreachable) it is a fast no-op and detection falls back to the calibration probe alone. To skip the IMDS probe entirely, set `SPICE_DISABLE_IMDS=1` (the standard AWS `AWS_EC2_METADATA_DISABLED` environment variable is also honored).
+
+When `cayenne_tuning` is left unset, the mode defaults to `auto`. Set `cayenne_tuning: adaptive` explicitly to enable the closed loop. Configuring any `cayenne_goal_*` SLO also implies `adaptive` (a goal with tuning off is inert) unless you set `cayenne_tuning: auto` explicitly. Schema inference is always attempted and seeds the controller's warm-start, but is not what selects the mode.
+
+```yaml
+acceleration:
+  engine: cayenne
+  params:
+    cayenne_tuning: adaptive
+```
+
+:::warning[Preview]
+
+`cayenne_tuning: adaptive` is in preview. Cayenne logs a startup warning when it is enabled; verify query correctness and performance before using it for production workloads. The static `auto` mode is recommended for production.
+
+:::
+
+`adaptive` needs a non-zero `cayenne_compaction_background_interval_ms`, since the controller runs on the background compaction tick; if it is `0`, Cayenne logs a warning and falls back to `auto`. Schema inference (always on) sharpens the `adaptive` warm-start — the loop's data-aware warm-start uses the inferred cardinality and size — but is not required for an explicit `cayenne_tuning: adaptive`; without inferred metadata the controller relearns the observed row width from live ingest and converges from the hardware-derived warm-start.
+
+In both modes, setting any `cayenne_*` knob to an explicit value overrides the derived value. Under `adaptive`, an explicitly-set knob is **pinned** — the controller will not move it.
+
+### Goal-driven tuning
+
+Under `adaptive`, you can give the controller high-level service-level objectives (SLOs) instead of leaving it to optimize from its built-in signals alone. Set one or more `cayenne_goal_*` SLOs — **globally under `runtime.params`**, where they apply to every Cayenne-accelerated dataset — and the closed loop converges toward each target in small, bounded steps:
+
+| Goal | Parameter | Example |
+| --- | --- | --- |
+| End-to-end CDC replication lag | `cayenne_goal_replication_lag` | `5s` |
+| Data freshness (age of the newest queryable data) | `cayenne_goal_freshness` | `30s` |
+| p99 query latency | `cayenne_goal_query_latency` | `250ms` |
+| Query throughput (queries per hour, higher is better) | `cayenne_goal_qph` | `5000` |
+
+The time-based goals accept a duration string (e.g. `5s`, `1m`, `250ms`); `cayenne_goal_qph` is a positive number.
+
+Scope each goal where the runtime reads it:
+
+- **Time-based goals** (`cayenne_goal_replication_lag`, `cayenne_goal_freshness`, `cayenne_goal_query_latency`) are set globally under `runtime.params` and may be overridden per-dataset under a dataset's `acceleration.params`.
+- **`cayenne_goal_qph`** is **global-only**: query throughput is measured system-wide — a query spanning multiple datasets (such as a join) is counted once — so it is read only from `runtime.params`, and a value set under `acceleration.params` is ignored.
+- **`cayenne_goal_convergence_window`** (duration, default `60s`) sets the time budget the controller targets for convergence. It is a per-dataset control-cadence knob (set under `acceleration.params`) and is not part of the global SLO surface.
+
+Setting any `cayenne_goal_*` parameter implies the closed loop — a goal is inert without it — so the goals also enable `adaptive` unless you explicitly set `cayenne_tuning: auto` (in which case the goals are ignored and Cayenne logs a warning). Goal-seeking also requires a non-zero `cayenne_compaction_background_interval_ms`, like `adaptive` itself.
+
+```yaml
+runtime:
+  params:
+    # Global SLOs — apply to every Cayenne-accelerated dataset
+    cayenne_goal_replication_lag: 5s
+    cayenne_goal_query_latency: 250ms
+    cayenne_goal_qph: 5000 # global-only — no per-dataset form
+
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    acceleration:
+      engine: cayenne
+      params:
+        # Per-dataset override of the global query-latency SLO
+        cayenne_goal_query_latency: 100ms
+        cayenne_goal_convergence_window: 1m
+```
+
+## Cache Tuning
+
+Spice Cayenne uses two in-memory caches to accelerate query performance:
+
+**Footer Cache (`cayenne_footer_cache_mb`) — runtime parameter:**
+
+The footer cache stores Vortex file metadata, including schemas, statistics, and encoding information. It is engine-global and shared across every Cayenne-accelerated dataset, so it is set under `runtime.params`, not per dataset. Larger cache sizes benefit workloads with many files.
+
+- Default: unset — when omitted, DataFusion's default file-metadata-cache limit of 50 MB applies
+- Increase for datasets with many small files
+- Each file requires approximately 1-10 KB of footer cache
+
+**Segment Cache (`cayenne_segment_cache_mb`) — acceleration parameter:**
+
+The segment cache stores decompressed data segments. It is configured per dataset under `acceleration.params`. Larger cache sizes benefit workloads with repeated queries on the same data.
+
+- Default: 256 MB
+- Increase for workloads with hot data patterns
+- Size based on frequently accessed data volume
+
+**Example - High-throughput configuration:**
+
+```yaml
+runtime:
+  params:
+    # Engine-global footer cache, shared by all Cayenne datasets
+    cayenne_footer_cache_mb: 512
+
+datasets:
+  - from: s3://analytics-bucket/events/
+    name: events
+    acceleration:
+      engine: cayenne
+      mode: file
+      params:
+        # Per-dataset segment cache
+        cayenne_segment_cache_mb: 1024
+```
+
+## Compression Strategy
+
+Spice Cayenne supports two compression strategies, each with different performance characteristics. The [BtrBlocks](https://www.cs.cit.tum.de/fileadmin/w00cfj/dis/papers/btrblocks.pdf) compression algorithm is designed for fast analytical queries, while [zstd](https://facebook.github.io/zstd/) provides fast write performance. Additionally, `zstd` achieves better compression ratios when data contains large chunks of binary or text.
+
+| Strategy    | Compression | Read Speed | Write Speed | Best For                                         |
+| ----------- | ----------- | ---------- | ----------- | ------------------------------------------------ |
+| `btrblocks` | Higher      | Faster     | Moderate    | Read-heavy analytics (default)                   |
+| `zstd`      | High        | Moderate   | Faster      | Write-heavy workloads, large binary or text data |
+
+**Example - Write-optimized configuration:**
+
+```yaml
+datasets:
+  - from: kafka:events
+    name: realtime_events
+    acceleration:
+      engine: cayenne
+      mode: file
+      refresh_mode: append
+      params:
+        cayenne_compression_strategy: zstd
+```
+
+## File Size Tuning
+
+The `cayenne_target_file_size_mb` parameter controls when new Vortex files are created during writes:
+
+- **Smaller files (32-64 MB)**: Better parallelism, finer-grained statistics, faster ingestion
+- **Larger files (128-256 MB)**: Fewer files to manage, reduced metadata overhead
+
+```yaml
+params:
+  cayenne_target_file_size_mb: 64  # More parallelism for high-concurrency workloads
+```
+


### PR DESCRIPTION
## Summary

Two Cayenne-accelerator documentation improvements requested for the CDC + performance docs pass:

**1. Consolidated Change Data Capture section.** The Cayenne page previously threaded its CDC story through ~6 scattered subsections (maintained aggregates, deletion vectors, CDC durability, goal SLOs) with no single entry point. Adds a `## Change Data Capture (refresh_mode: changes)` section that:
- frames Cayenne as the recommended `changes` sink and links to every Spice CDC connector (PostgreSQL, MySQL, MongoDB, DynamoDB, Debezium) and the [Changes refresh mode](https://docs.spiceai.org/features/data-acceleration/refresh-modes/changes) reference;
- notes that `arrow`/`duckdb`/`sqlite` are also valid `changes` sinks (code-verified — Cayenne is not the only one);
- summarizes the Cayenne-specific CDC capabilities (IVM maintained aggregates, key-based deletes via `cayenne_deletion_mode`, in-memory CDC tier via `cayenne_cdc_durability`/`cayenne_cdc_mem_tier_*`, replication-lag/freshness SLOs) with in-page links;
- states the primary-key and `mode: file`/`mode: memory` requirements.

All cited parameter names verified present on the page; all connector/feature links verified against existing pages.

**2. Performance Tuning `/performance` subpage.** Extracts the large `## Performance Tuning` section (self-tuning, goal-driven SLOs, cache sizing, compression strategy, file-size tuning) into a dedicated `cayenne/performance.md`, auto-added to the sidebar. The index page keeps a short pointer, and the parameter-table references were repointed to the new page's anchors. No inbound links to the moved anchors existed elsewhere (verified).

## Scope

vNext only. The CDC section references vNext-only capabilities (MySQL CDC, `mode: memory`, in-memory CDC tier), and restructuring a frozen versioned snapshot is not appropriate — versioned docs keep the inline section.

## Test plan

- [x] `cd website && npm run build` passes (broken-link + broken-anchor checks green after fixing index-page `.md`-suffix link resolution and repointing moved anchors)
- [x] Files updated: 2 (`cayenne/index.md` modified, `cayenne/performance.md` new)