### PR TITLE
docs(performance-tuning): correct Cayenne footer-cache default (unset → 50 MB)

### DIFF
--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -69,7 +69,7 @@ datasets:
 The footer cache stores file metadata. Size based on file count:
 
 - 1-10 KB per file
-- Default 128 MB supports ~10,000-100,000 files
+- Default: unset — when omitted, DataFusion's 50 MB file-metadata-cache limit applies
 - Increase for datasets with more files
 
 **Segment Cache Sizing:**

--- a/website/versioned_docs/version-2.0.x/reference/performance-tuning.md
+++ b/website/versioned_docs/version-2.0.x/reference/performance-tuning.md
@@ -69,7 +69,7 @@ datasets:
 The footer cache stores file metadata. Size based on file count:
 
 - 1-10 KB per file
-- Default 128 MB supports ~10,000-100,000 files
+- Default: unset — when omitted, DataFusion's 50 MB file-metadata-cache limit applies
 - Increase for datasets with more files
 
 **Segment Cache Sizing:**

--- a/website/versioned_docs/version-2.1.x/reference/performance-tuning.md
+++ b/website/versioned_docs/version-2.1.x/reference/performance-tuning.md
@@ -69,7 +69,7 @@ datasets:
 The footer cache stores file metadata. Size based on file count:
 
 - 1-10 KB per file
-- Default 128 MB supports ~10,000-100,000 files
+- Default: unset — when omitted, DataFusion's 50 MB file-metadata-cache limit applies
 - Increase for datasets with more files
 
 **Segment Cache Sizing:**


### PR DESCRIPTION
## Summary

The Performance Tuning guide's "Footer Cache Sizing" section stated the Cayenne footer cache **defaults to 128 MB**. Since v2.0, `cayenne_footer_cache_mb` is `Option<usize> = None` (`footer_cache_mb: Option<usize>` in `crates/cayenne`), and when unset the runtime applies **DataFusion's 50 MB** file-metadata-cache limit. The 128 MB figure materializes nowhere in v2.0+.

This aligns the guide with the [Cayenne accelerator page](https://docs.spiceai.org/components/data-accelerators/cayenne), which already documents the correct `unset → 50 MB` behavior (corrected earlier in #1908/#1932). This was the remaining stale copy.

## Scope / versioned propagation

- Fixed in **vNext + 2.1.x + 2.0.x** (the versions where the field is `Option`/`None`).
- **1.11.x left unchanged** — the field was a real `usize = 128` in v1.10/v1.11, so 128 MB is correct there.
- The unrelated "128 MB" mentions on other lines refer to Parquet **row-group** sizes, not the footer cache — untouched.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Files updated: 3