### PR TITLE
docs(connectors): split MSSQL + ScyllaDB Performance sections into /performance subpages

### DIFF
--- a/website/docs/components/data-connectors/mssql/index.md
+++ b/website/docs/components/data-connectors/mssql/index.md
@@ -31,7 +31,7 @@ datasets:
 The `from` field takes the form `mssql:database.schema.table` where `database.schema.table` is the fully-qualified table name in the SQL server.
 
 :::info
-Unquoted identifiers are normalized to lowercase. To reference a table, schema, or database with mixed-case characters, wrap each case-sensitive part in double quotes: `mssql:my_database."MySchema"."MyTable"`. See [Identifier Case Sensitivity](./index.md#identifier-case-sensitivity-and-quoting).
+Unquoted identifiers are normalized to lowercase. To reference a table, schema, or database with mixed-case characters, wrap each case-sensitive part in double quotes: `mssql:my_database."MySchema"."MyTable"`. See [Identifier Case Sensitivity](../index.md#identifier-case-sensitivity-and-quoting).
 :::
 
 ### `name`
@@ -100,32 +100,7 @@ datasets:
 
 ## Performance
 
-### TopK / ORDER BY ... LIMIT pushdown
-
-Spice pushes `ORDER BY ... LIMIT N` queries down to SQL Server as `SELECT TOP N ... ORDER BY ...`, avoiding transferring unnecessary rows over the network. This pushdown is applied when the sort can be satisfied exactly by SQL Server — which depends on NULL ordering.
-
-SQL Server treats `NULL` as the smallest possible value, so its native ordering is:
-
-| Direction | NULLs position |
-| --------- | -------------- |
-| `ASC`     | First          |
-| `DESC`    | Last           |
-
-Most SQL clients and tools (including Spice's default planner) use the opposite convention (`ASC NULLS LAST`, `DESC NULLS FIRST`). When the requested NULL ordering doesn't match SQL Server's native behavior, Spice falls back to fetching all matching rows and applying the limit locally.
-
-**To guarantee TopK pushdown on nullable columns**, explicitly specify the NULL ordering that matches SQL Server's native behavior:
-
-```sql
--- Pushed down: DESC NULLS LAST matches SQL Server native ordering
-SELECT id, value FROM my_dataset ORDER BY value DESC NULLS LAST LIMIT 10;
-
--- Pushed down: ASC NULLS FIRST matches SQL Server native ordering
-SELECT id, value FROM my_dataset ORDER BY value ASC NULLS FIRST LIMIT 10;
-```
-
-:::tip
-Sorting on `NOT NULL` columns (e.g. primary keys) always pushes the limit down regardless of the `NULLS` clause, since there are no NULLs to order.
-:::
+See the dedicated **[Performance](./performance.md)** page for query-pushdown tuning — TopK / `ORDER BY ... LIMIT` pushdown and its NULL-ordering rules.
 
 ## Secrets
 

--- a/website/docs/components/data-connectors/mssql/performance.md
+++ b/website/docs/components/data-connectors/mssql/performance.md
@@ -1,0 +1,38 @@
+---
+title: 'Microsoft SQL Server Performance'
+sidebar_label: 'Performance'
+description: 'Performance tuning for the Microsoft SQL Server connector: TopK / ORDER BY ... LIMIT pushdown and NULL ordering.'
+sidebar_position: 5
+pagination_prev: null
+pagination_next: null
+---
+
+Performance tuning for the [Microsoft SQL Server connector](./index.md).
+
+## TopK / ORDER BY ... LIMIT pushdown
+
+Spice pushes `ORDER BY ... LIMIT N` queries down to SQL Server as `SELECT TOP N ... ORDER BY ...`, avoiding transferring unnecessary rows over the network. This pushdown is applied when the sort can be satisfied exactly by SQL Server — which depends on NULL ordering.
+
+SQL Server treats `NULL` as the smallest possible value, so its native ordering is:
+
+| Direction | NULLs position |
+| --------- | -------------- |
+| `ASC`     | First          |
+| `DESC`    | Last           |
+
+Most SQL clients and tools (including Spice's default planner) use the opposite convention (`ASC NULLS LAST`, `DESC NULLS FIRST`). When the requested NULL ordering doesn't match SQL Server's native behavior, Spice falls back to fetching all matching rows and applying the limit locally.
+
+**To guarantee TopK pushdown on nullable columns**, explicitly specify the NULL ordering that matches SQL Server's native behavior:
+
+```sql
+-- Pushed down: DESC NULLS LAST matches SQL Server native ordering
+SELECT id, value FROM my_dataset ORDER BY value DESC NULLS LAST LIMIT 10;
+
+-- Pushed down: ASC NULLS FIRST matches SQL Server native ordering
+SELECT id, value FROM my_dataset ORDER BY value ASC NULLS FIRST LIMIT 10;
+```
+
+:::tip
+Sorting on `NOT NULL` columns (e.g. primary keys) always pushes the limit down regardless of the `NULLS` clause, since there are no NULLs to order.
+:::
+

--- a/website/docs/components/data-connectors/scylladb/index.md
+++ b/website/docs/components/data-connectors/scylladb/index.md
@@ -164,42 +164,7 @@ Query results are streamed using the scylla driver's paging mechanism in batches
 
 ## Performance Considerations
 
-Partition key and clustering key filters reduce the amount of data transferred from ScyllaDB, but queries without these filters fetch all table data. Consider the following optimizations:
-
-### Enable Acceleration
-
-For frequently queried data, enable Spice acceleration to cache data locally:
-
-```yaml
-datasets:
-  - from: scylladb:products
-    name: products
-    params:
-      scylladb_host: ${env:SCYLLADB_HOST}
-      scylladb_keyspace: catalog
-    acceleration:
-      enabled: true
-      engine: duckdb
-      refresh_check_interval: 1h
-```
-
-### Configure Datacenter Locality
-
-Set the datacenter preference to route queries to the nearest nodes:
-
-```yaml
-params:
-  scylladb_datacenter: us-east-1
-```
-
-### Adjust Connection Timeout
-
-Set connection timeouts appropriately for your network:
-
-```yaml
-params:
-  connection_timeout: 30000  # 30 seconds
-```
+See the dedicated **[Performance](./performance.md)** page — partition/clustering-key filters, enabling acceleration, datacenter locality, and connection-timeout tuning.
 
 ## Examples
 

--- a/website/docs/components/data-connectors/scylladb/performance.md
+++ b/website/docs/components/data-connectors/scylladb/performance.md
@@ -1,0 +1,48 @@
+---
+title: 'ScyllaDB Performance'
+sidebar_label: 'Performance'
+description: 'Performance considerations for the ScyllaDB connector: partition/clustering key filters, acceleration, and datacenter locality.'
+sidebar_position: 5
+pagination_prev: null
+pagination_next: null
+---
+
+Performance considerations for the [ScyllaDB connector](./index.md).
+
+Partition key and clustering key filters reduce the amount of data transferred from ScyllaDB, but queries without these filters fetch all table data. Consider the following optimizations:
+
+## Enable Acceleration
+
+For frequently queried data, enable Spice acceleration to cache data locally:
+
+```yaml
+datasets:
+  - from: scylladb:products
+    name: products
+    params:
+      scylladb_host: ${env:SCYLLADB_HOST}
+      scylladb_keyspace: catalog
+    acceleration:
+      enabled: true
+      engine: duckdb
+      refresh_check_interval: 1h
+```
+
+## Configure Datacenter Locality
+
+Set the datacenter preference to route queries to the nearest nodes:
+
+```yaml
+params:
+  scylladb_datacenter: us-east-1
+```
+
+## Adjust Connection Timeout
+
+Set connection timeouts appropriately for your network:
+
+```yaml
+params:
+  connection_timeout: 30000  # 30 seconds
+```
+


### PR DESCRIPTION
## Summary

Extends the dedicated `/performance` subpage pattern (established for the [Cayenne accelerator](https://github.com/spiceai/docs/pull/1951)) to the two connectors that carried a top-level `Performance` section, per the docs-organization pass:

- **Microsoft SQL Server** — `mssql.md` → `mssql/index.md` + new `mssql/performance.md`. Moves the `## Performance` section (TopK / `ORDER BY ... LIMIT` pushdown and its NULL-ordering rules) to the subpage, leaving a pointer.
- **ScyllaDB** — `scylladb.md` → `scylladb/index.md` + new `scylladb/performance.md`. Moves `## Performance Considerations` (partition/clustering-key filters, enabling acceleration, datacenter locality, connection-timeout tuning).

The autogenerated sidebar picks up the new subpages from frontmatter (`sidebar_label: Performance`, `sidebar_position: 5`), so no `sidebars.ts` change is needed.

## Link safety

- **URLs unchanged**: `mssql.md` and `mssql/index.md` both serve `/…/data-connectors/mssql`, so all inbound links (all bare URL-relative; verified) keep resolving.
- Fixed one link that became self-referential after the move: `./index.md#…` → `../index.md#…` on the MSSQL page.
- No same-page anchor references to the moved sections existed (verified).

## Scope

vNext only. Restructuring a frozen versioned snapshot is not appropriate — versioned docs keep the inline sections.

Components whose only performance content is a short operational `## Capacity & Sizing` block (in `deployment.md`) or a brief H3 note keep that content in place; `s3_vectors.md` (`## Optimizations`) and the HTTPS H3 `Performance Considerations` note are left as-is as borderline candidates.

## Test plan

- [x] `cd website && npm run build` passes (broken-link/anchor checks green)
- [x] Files: 2 renamed (`mssql.md`, `scylladb.md` → `<name>/index.md`) + 2 new `performance.md`