### PR TITLE
docs(postgres catalog): replica-identity-aware CDC eligibility; document exclude

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -175,7 +175,17 @@ Required — there is no catalog-level default. The only supported value is `cha
 ### Requirements
 
 - **Logical replication must be enabled.** Before accelerating any table, Spice validates the PostgreSQL prerequisites CDC requires — `wal_level = logical` and the replication privilege — and fails fast with a specific, actionable error if either is missing.
-- **Every included table must have a primary key.** Catalog setup fails and names the offending table if any included table lacks a primary key — tables are never silently skipped or downgraded to a heavier access pattern. Use `include`/`exclude` to keep primary-key-less tables out of an accelerated catalog's scope.
+
+### Table eligibility
+
+Each discovered table is accelerated according to its PostgreSQL [`REPLICA IDENTITY`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY), which determines the row identity available for change data capture:
+
+- **`DEFAULT` with a primary key** — accelerated, keyed by the primary key.
+- **`USING INDEX`** — accelerated, keyed by the nominated unique index.
+- **`FULL`** — accelerated, but heavier: PostgreSQL logs the full old-row image on every `UPDATE`/`DELETE`, so a warning is logged. Prefer a primary key or `USING INDEX` where possible.
+- **No usable CDC key** (`NOTHING`, a keyless `DEFAULT` or `FULL`, or an unusable identity index) — **skipped with an actionable warning** and left out of the catalog's namespace. The rest of the catalog still replicates; a single ineligible table never fails the whole catalog.
+
+Use `include`/`exclude` to narrow scope and suppress the skip warning for tables you will handle another way (federation, or a per-dataset `refresh_mode: full`).
 
 ### Behavior
 

--- a/website/docs/reference/spicepod/catalogs.md
+++ b/website/docs/reference/spicepod/catalogs.md
@@ -74,6 +74,10 @@ The name of the catalog to register in Spice. The schema hierarchy of the extern
 
 Optional. The `include` field is used to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+## `exclude`
+
+Optional. The `exclude` field specifies tables to omit from the catalog, using the same `schema.table` glob syntax as `include`. Multiple `exclude` patterns are OR'ed together, and `exclude` takes precedence over `include` — a table matched by both is omitted. It is currently honored by the [PostgreSQL catalog connector](../../components/catalogs/postgres). A common use is to keep tables that cannot be [CDC-accelerated](../../components/catalogs/postgres#catalog-level-cdc-acceleration) out of an accelerated catalog's scope.
+
 ## `access`
 
 Optional. Specifies the access level for the catalog. Supported values are:


### PR DESCRIPTION
## Summary

[spiceai/spiceai#11951](https://github.com/spiceai/spiceai/pull/11951) changed how PostgreSQL catalog-level CDC acceleration decides which tables to accelerate, superseding the model documented in docs #1949 (from spiceai/spiceai#11897).

**What the docs said (now wrong):** *"Every included table must have a primary key. Catalog setup fails and names the offending table if any included table lacks a primary key — tables are never silently skipped or downgraded."*

**What the code now does** (`crates/runtime/src/catalogconnector/postgres_accelerated.rs`, `crates/data-connectors/connector-postgres-common/src/lib.rs::classify_replica_identity`): eligibility is decided per-table by the source `REPLICA IDENTITY`:

- `DEFAULT` with a primary key → accelerated (keyed by PK)
- `USING INDEX` → accelerated (keyed by the nominated unique index)
- `FULL` → accelerated but heavier (warning logged)
- No usable CDC key (`NOTHING`, keyless `DEFAULT`/`FULL`, unusable identity index) → **skipped with a warning**, absent from the namespace — a single ineligible table no longer fails the whole catalog

Also documents the net-new `exclude` catalog field (added in the same PR; `included && !excluded`, exclude wins), which is not present in v2.1.x.

Scope: vNext-only. The feature is new in vNext (not in v2.1.x), so no versioned-docs propagation. The `cayenne_delta_encoding` size-gating text in v2.1.x is unrelated and correct.

## Source PRs
- spiceai/spiceai#11951 — feat(catalog): replica-identity-aware eligibility for PostgreSQL catalog CDC

## Pages changed
- `website/docs/components/catalogs/postgres.md` — replaced the PK-hard-fail requirement with a "Table eligibility" section keyed on `REPLICA IDENTITY`
- `website/docs/reference/spicepod/catalogs.md` — added the `exclude` field reference

## Test plan
- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: throw`)
- [x] Versioned-docs propagation checked — vNext-only (feature absent from v2.1.x; verified `exclude` and replica-identity eligibility both absent at the `v2.1.1` tag)
- [x] Files updated: 2