### PR TITLE
docs(cayenne): promote accelerator status to Stable (vNext)

### DIFF
--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -29,7 +29,7 @@ By default, datasets are locally materialized using in-memory Arrow records.
 
 | Name       | Description                     | Status            | Engine Modes     |
 | ---------- | ------------------------------- | ----------------- | ---------------- |
-| `cayenne`  | [Spice Cayenne][cayenne]        | Release Candidate | `memory`, `file`, `file_create`, `file_update` |
+| `cayenne`  | [Spice Cayenne][cayenne]        | Stable            | `memory`, `file`, `file_create`, `file_update` |
 | `arrow`    | In-Memory Arrow Records         | Stable            | `memory`         |
 | `duckdb`   | Embedded [DuckDB][duckdb]       | Stable            | `memory`, `file`, `file_create`, `file_update` |
 | `postgres` | Attached [PostgreSQL][postgres] (Spice.ai Enterprise) | Release Candidate | N/A              |

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -394,7 +394,7 @@ Enable or disable acceleration, defaults to `true`.
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:
 
 - `arrow` - Accelerated in-memory backed by Apache Arrow DataTables.
-- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Release Candidate, v1.9.0-rc.1+).
+- [`cayenne`](../../components/data-accelerators/cayenne) - Accelerated by Spice Cayenne (Vortex) engine (Stable, v1.9.0-rc.1+).
 - [`duckdb`](../../components/data-accelerators/duckdb) - Accelerated by an embedded DuckDB database.
 - [`postgres`](../../components/data-accelerators/postgres) - Accelerated by a Postgres database.
 - [`sqlite`](../../components/data-accelerators/sqlite) - Accelerated by an embedded SQLite database.


### PR DESCRIPTION
## Summary
The Spice Cayenne accelerator was promoted from **Release Candidate** to **Stable** on `trunk` in spiceai/spiceai#11970 (Stable criteria signed off — `docs/criteria/accelerators/stable.md`, ✅ @peasee). The published vNext docs still labeled it **Release Candidate**, understating its maturity.

- `trunk` `README.md`: `cayenne … Stable`
- `v2.1.1` `README.md`: `cayenne … Release Candidate`

The promotion landed on `trunk` **after** v2.1.1 was cut, so this is **vNext-only**: `version-2.1.x` and `version-2.0.x` correctly remain Release Candidate for their releases, and `version-1.11.x` remains Beta.

## Changes (vNext only)
- `website/docs/components/data-accelerators/index.md` — accelerator table status `Release Candidate` → `Stable`
- `website/docs/reference/spicepod/datasets.md` — `cayenne` accelerator note `(Release Candidate, v1.9.0-rc.1+)` → `(Stable, v1.9.0-rc.1+)`

Follows the version-aware status-sync precedent in #1874 (Alpha→RC/Beta per release).

## Source
- spiceai/spiceai#11970 — "docs: align component statuses with signed release criteria" (`trunk`, commit 269b92714)

## Test plan
- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only (version boundary confirmed against v2.1.1 vs trunk README); no versioned dirs touched
- [x] Files updated: 2