### PR TITLE
docs(cayenne): maintained SUM/AVG now support Decimal128 (vNext)

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -361,7 +361,7 @@ Each item in `aggregates` has:
 Supported input column types by function:
 
 - `count` — any column (or `COUNT(*)` when `column` is omitted).
-- `sum` and `avg` — signed integers (`Int8`–`Int64`), unsigned integers (`UInt8`–`UInt64`), and floats (`Float32`/`Float64`). `sum` widens to `BIGINT`/`Float64`; `avg` always returns `Float64`.
+- `sum` and `avg` — signed integers (`Int8`–`Int64`), unsigned integers (`UInt8`–`UInt64`), floats (`Float32`/`Float64`), and `Decimal128`. For integer and float inputs, `sum` widens to `BIGINT`/`Float64` and `avg` returns `Float64`. For a `Decimal128(p, s)` input, `sum` returns `Decimal128(min(38, p + 10), s)` and `avg` returns `Decimal128(min(38, p + 4), min(38, s + 4))`, matching DataFusion's exact decimal return types (`avg` requires a non-negative scale). `Decimal256` is not supported.
 - `min` and `max` — signed/unsigned integers, `Date32`/`Date64`, `Timestamp`, and `Decimal128`, preserving the input type (`MIN(Int32) -> Int32`). Float `min`/`max` is not yet supported.
 
 ### Query matching


### PR DESCRIPTION
## Summary

spiceai/spiceai#11979 extends Cayenne's incrementally-maintained aggregate views (`maintained_aggregates`) so `SUM` and `AVG` accept `Decimal128` input columns — the CDC money-column case (e.g. Postgres `NUMERIC(6,2)`). Previously a `Decimal128` column was rejected at dataset registration, taking the dataset unhealthy. The maintained-aggregate supported-type list on the Cayenne page listed only integer and float families for `sum`/`avg` and said "`avg` always returns `Float64`", both now inaccurate.

Updated the `sum`/`avg` supported-input-types bullet to add `Decimal128` and document DataFusion's exact decimal return types:

- `SUM(Decimal128(p, s))` → `Decimal128(min(38, p + 10), s)`
- `AVG(Decimal128(p, s))` → `Decimal128(min(38, p + 4), min(38, s + 4))`, non-negative scale only
- `Decimal256` is not supported

## Verified against source (`origin/trunk`)

- `crates/cayenne/src/maintained_aggregate.rs` — `AggregateOutputType::Decimal128`, `SumDecimal128`/`AvgDecimal128` accumulators, and the documented output precision/scale formulas; `Decimal256` and negative-scale `AVG` safe-decline.

## Source PRs

- spiceai/spiceai#11979 — fix(cayenne): support Decimal128 in maintained SUM/AVG aggregates

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] vNext-only addition (feature is post-v2.1.1); the "avg always returns Float64" text is correct for v2.1.x, so no versioned-docs change
- [x] Files updated: 1