### PR TITLE
docs(dynamodb): rename CDC Streams params to unified vocabulary (vNext)

### DIFF
--- a/website/docs/components/data-connectors/dynamodb/deployment.md
+++ b/website/docs/components/data-connectors/dynamodb/deployment.md
@@ -37,18 +37,20 @@ The DynamoDB connector supports CDC via DynamoDB Streams with an accelerated dat
 | Parameter                      | Default  | Description                                                                                                              |
 | ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `scan_interval` | `0s` | Interval between polls for new records in a DynamoDB stream.                                                 |
-| `ready_lag` | `2s` | Once lag falls below this threshold, the dataset is reported as `Ready`.                                                 |
-| `lag_exceeds_shard_retention_behavior` | `error` | Behavior when stream lag exceeds shard retention (24h): `error`, `ready_before_load`, or `ready_after_load`. |
+| `dynamodb_replication_ready_lag` | `2s` | Once replication lag falls below this threshold, the dataset is reported as `Ready`. (Previously `ready_lag`, still accepted as a deprecated alias.) |
+| `dynamodb_replication_initial_snapshot` | `auto` | When `refresh_mode: changes` first loads existing items: `auto` scans only when no resumable checkpoint exists, `disabled` streams changes only, `always` scans on every start. |
+| `dynamodb_replication_invalid_checkpoint_behavior` | `error` | Behavior when the persisted checkpoint can no longer be honored (past ~24h shard retention): `error` or `restart`. (Previously `lag_exceeds_shard_retention_behavior`, still accepted as a deprecated alias.) |
 
 ### Shard Retention and Lag
 
-DynamoDB Streams retain records for 24 hours. If Spice is offline longer than the retention window, the checkpoint becomes stale and the next stream open returns `ShardNotFound`. Behavior is controlled by `lag_exceeds_shard_retention_behavior`:
+DynamoDB Streams retain records for 24 hours. If Spice is offline longer than the retention window, the checkpoint becomes stale and the next stream open returns `ShardNotFound`. Behavior is controlled by `dynamodb_replication_invalid_checkpoint_behavior`:
 
 - **`error`** (default): Mark the dataset `Error`. Requires operator intervention to re-bootstrap.
-- **`ready_before_load`**: Mark the dataset `Ready` immediately, then re-bootstrap the accelerated dataset in the background. Queries see stale data until the bootstrap completes.
-- **`ready_after_load`**: Re-bootstrap the accelerated dataset, then mark it `Ready`. Queries block / return `Error` during bootstrap.
+- **`restart`**: Drop the stale checkpoint and re-bootstrap the accelerated dataset from a fresh scan.
 
 A checkpoint older than **18 hours** is treated as near-expired and triggers the same recovery path even if the shard has not yet been dropped by DynamoDB.
+
+The deprecated `lag_exceeds_shard_retention_behavior` alias is still accepted: `ready_after_load` maps to `restart`, and `ready_before_load` (which briefly served stale data before reloading) has been removed and also maps to `restart`.
 
 ## Capacity & Sizing
 
@@ -87,7 +89,7 @@ Stream polling and bootstrap operations emit spans that participate in [task his
 
 | Symptom                                         | Likely cause                                                           | Resolution                                                                                                       |
 | ----------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Dataset stuck in `Error` after restart with stream enabled | Checkpoint older than 18h or exceeded 24h retention.              | Set `lag_exceeds_shard_retention_behavior: ready_after_load` to auto-recover, or trigger a manual refresh.   |
+| Dataset stuck in `Error` after restart with stream enabled | Checkpoint older than 18h or exceeded 24h retention.              | Set `dynamodb_replication_invalid_checkpoint_behavior: restart` to auto-recover, or trigger a manual refresh.   |
 | `ProvisionedThroughputExceededException`         | RCU exhausted during initial scan.                                     | Switch to on-demand billing, raise RCU for the refresh window, or slow the refresh via acceleration settings.    |
 | `TrimmedDataAccessException`                     | Records trimmed from the stream before they could be processed.        | Same recovery path as `ShardNotFound` — re-bootstrap. Reduce bootstrap duration via parallel segments if supported. |
 | `AccessDeniedException` on `DescribeStream`      | IAM role lacks stream permissions.                                     | Add `dynamodb:DescribeStream`, `GetShardIterator`, `GetRecords` to the role.                     |

--- a/website/docs/components/data-connectors/dynamodb/index.md
+++ b/website/docs/components/data-connectors/dynamodb/index.md
@@ -71,9 +71,12 @@ The DynamoDB data connector supports the following configuration parameters:
 | `schema_infer_max_records`             | Optional. The number of documents to use to infer the schema. Defaults to 10                                                                                                                                                                               |
 | `scan_segments`                        | Optional. Number of segments for `Scan` request. 'auto' by default, which will calculate number of segments based on number of the records in a table                                                                                                      |
 | `scan_interval`                        | Optional. Interval between polling for new records in a DynamoDB stream. Default: `0s`. See [Streams](#streams).                                                                                                                                           |
-| `ready_lag`                            | Optional. When using Streams, once the table reaches this lag the dataset will be reported as Ready. Default: `2s`. See [Streams](#streams).                                                                                                               |
+| `dynamodb_replication_ready_lag`       | Optional. For `refresh_mode: changes`, the dataset is marked Ready once its replication lag (now minus the newest applied source-commit time) falls below this. It stays not-ready while snapshotting or draining a backlog, so it never serves stale data. Default: `2s`. See [Streams](#streams). |
+| `dynamodb_replication_initial_snapshot` | Optional. When `refresh_mode: changes` first loads the table's existing items: `auto` (default) scans when no resumable stream checkpoint exists and resumes without a scan when one does; `disabled` streams changes only, from the current stream tip; `always` scans on every start, discarding any persisted checkpoint. Default: `auto`. |
+| `dynamodb_replication_invalid_checkpoint_behavior` | Optional. Behavior when the persisted stream checkpoint can no longer be honored (past the ~24h shard retention). One of `error` (default — marks dataset as Error) or `restart` (re-bootstraps from a fresh scan). Default: `error`. |
 | `endpoint_url`                         | Optional. Custom endpoint URL for DynamoDB-compatible services (e.g., DynamoDB Local, ScyllaDB Alternator).                                                                                                                                                |
-| `lag_exceeds_shard_retention_behavior` | Optional. Behavior when stream lag exceeds shard retention (24h). One of `error` (default — marks dataset as Error), `ready_before_load` (marks Ready then re-bootstraps), or `ready_after_load` (re-bootstraps then marks Ready).                         |
+| `ready_lag`                            | _Deprecated._ Renamed to `dynamodb_replication_ready_lag`; still accepted as an alias.                                                                                                                                                                     |
+| `lag_exceeds_shard_retention_behavior` | _Deprecated._ Renamed to `dynamodb_replication_invalid_checkpoint_behavior` (`error` \| `restart`). `ready_after_load` maps to `restart`; `ready_before_load` has been removed and also maps to `restart`.                                                  |
 | `time_format`                          | Optional. Go-style time format used for parsing/formatting timestamps. See [Time Format](#time-format)                                                                                                                                                     |
 | `write_parallelism`                    | Optional. Number of parallel operations for writing and deleting data to DynamoDB. Default: `10`                                                                                                                                                           |
 
@@ -646,7 +649,7 @@ datasets:
 
 #### Dataset Parameters
 
-- **`ready_lag`** - Defines the maximum lag threshold before the dataset is reported as "Ready". Once the stream lag falls below this value, queries can be executed against the dataset. Default behavior reports ready immediately after bootstrap completes.
+- **`dynamodb_replication_ready_lag`** - Defines the maximum lag threshold before the dataset is reported as "Ready". Once the stream lag falls below this value, queries can be executed against the dataset. Default: `2s`. (Previously `ready_lag`, still accepted as a deprecated alias.)
 
 - **`scan_interval`** - Controls the polling frequency for checking new records in the DynamoDB stream. Lower values provide more real-time updates but increase API calls. Higher values reduce API usage but may introduce additional latency.
 
@@ -698,8 +701,8 @@ datasets:
    - from: dynamodb:my_table
      name: orders_stream
      params:
-        ready_lag: 1s          # Dataset reports as Ready when lag is below 1 second
-        scan_interval: 100ms   # Poll for new stream records every 100 milliseconds
+        dynamodb_replication_ready_lag: 1s  # Dataset reports as Ready when lag is below 1 second
+        scan_interval: 100ms                # Poll for new stream records every 100 milliseconds
      acceleration:
         enabled: true
         engine: duckdb

--- a/website/docs/features/cdc/dynamodb-streams.md
+++ b/website/docs/features/cdc/dynamodb-streams.md
@@ -29,7 +29,7 @@ On first start the connector:
 2. Subscribes to each open **stream shard** and begins polling for records.
 3. Applies each `INSERT` / `MODIFY` / `REMOVE` event as a row-level change to the accelerator.
 
-The dataset reports `Ready` once stream lag drops below `ready_lag` (default `2s`).
+The dataset reports `Ready` once stream lag drops below `dynamodb_replication_ready_lag` (default `2s`).
 
 On subsequent restarts, file-backed accelerators resume from the persisted shard checkpoint instead of re-scanning the source table.
 
@@ -100,8 +100,8 @@ datasets:
     name: orders_stream
     params:
       scan_interval: 100ms    # Poll DynamoDB Streams every 100 ms (default 0s)
-      ready_lag: 1s           # Report Ready when stream lag drops below 1s (default 2s)
-      lag_exceeds_shard_retention_behavior: ready_before_load   # Behavior on > 24h lag
+      dynamodb_replication_ready_lag: 1s   # Report Ready when stream lag drops below 1s (default 2s)
+      dynamodb_replication_invalid_checkpoint_behavior: restart   # Re-bootstrap on > 24h lag (default error)
     acceleration:
       enabled: true
       engine: duckdb
@@ -113,8 +113,8 @@ datasets:
 ```
 
 - `scan_interval` — Polling frequency for new records. Lower values give lower latency at the cost of more `GetRecords` API calls.
-- `ready_lag` — Maximum stream lag before the dataset is reported `Ready` for queries. Defaults to `2s`.
-- `lag_exceeds_shard_retention_behavior` — What to do when stream lag exceeds the DynamoDB shard retention window (24h). One of `error` (default), `ready_before_load`, or `ready_after_load`. See the [connector parameter reference](../../components/data-connectors/dynamodb/index.md#params) for the full description.
+- `dynamodb_replication_ready_lag` — Maximum stream lag before the dataset is reported `Ready` for queries. Defaults to `2s`. (Previously `ready_lag`, still accepted as a deprecated alias.)
+- `dynamodb_replication_invalid_checkpoint_behavior` — What to do when the persisted checkpoint can no longer be honored because stream lag exceeds the DynamoDB shard retention window (~24h). One of `error` (default) or `restart`. Replaces the deprecated `lag_exceeds_shard_retention_behavior` (`ready_after_load` → `restart`; `ready_before_load` removed → `restart`). See the [connector parameter reference](../../components/data-connectors/dynamodb/index.md#params) for the full description.
 - `snapshots_trigger: stream_batches` and `snapshots_trigger_threshold` let you trigger acceleration snapshots based on stream-batch counts rather than wall time. See [Acceleration Snapshots](../data-acceleration/snapshots.md).
 
 ## Metrics
@@ -133,7 +133,7 @@ These metrics are opt-in. See the [DynamoDB Streams Metrics](../../components/da
 
 ## Limitations
 
-- DynamoDB Streams shards are retained for 24 hours. If Spice falls behind by more than that, the connector follows `lag_exceeds_shard_retention_behavior` (default: `error`).
+- DynamoDB Streams shards are retained for 24 hours. If Spice falls behind by more than that, the connector follows `dynamodb_replication_invalid_checkpoint_behavior` (default: `error`).
 - `refresh_sql` is not supported with DynamoDB Streams.
 
 ## See also


### PR DESCRIPTION
## Summary

The Unified CDC config change (spiceai/spiceai#11777, merged post-v2.1.1, trunk/vNext only) renamed the DynamoDB Streams parameters to the shared replication vocabulary and deprecated the old names as dual-read aliases. The docs still presented the **deprecated** names as canonical, and listed the **removed** `ready_before_load` value as a valid option — even using it in example YAML.

**What the docs said vs. what the code does:**

| Docs (before) | Code (trunk) |
| --- | --- |
| `ready_lag` (canonical) | Deprecated alias of `dynamodb_replication_ready_lag` (`ParameterSpec::runtime("ready_lag").deprecated(...)`) |
| `lag_exceeds_shard_retention_behavior` with values `error` / `ready_before_load` / `ready_after_load` | Deprecated alias of `dynamodb_replication_invalid_checkpoint_behavior` (values `error` \| `restart`); `ready_after_load` → `restart`, `ready_before_load` **removed** → `restart` |
| _(missing)_ | `dynamodb_replication_initial_snapshot` (`auto` \| `always` \| `disabled`, default `auto`) |

Changes:
- Present `dynamodb_replication_ready_lag`, `dynamodb_replication_invalid_checkpoint_behavior` (`error`/`restart`), and the newly-documented `dynamodb_replication_initial_snapshot` as canonical.
- Mark `ready_lag` and `lag_exceeds_shard_retention_behavior` as deprecated aliases; remove the non-existent `ready_before_load` option from valid-value lists and examples.
- Updated across the connector reference, the deployment guide, and the CDC feature page.

**vNext-only:** the rename came from spiceai/spiceai#11777 (not in v2.1.1). Versioned snapshots (2.0.x, 2.1.x) correctly keep the pre-rename names and are left untouched.

## Source
- spiceai/spiceai@`d5618eb7` (origin/trunk) — `crates/data-connectors/connector-dynamodb/src/connector.rs`, `crates/data_components/src/cdc/config.rs`
- spiceai/spiceai#11777 — Unified CDC config

## Test plan
- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] vNext-only; versioned-docs left unchanged (rename not in v2.1.1)
- [x] Files updated: 3 (connector index.md, deployment.md, features/cdc/dynamodb-streams.md)