### PR TITLE
docs(spiceai): correct fabricated acceleration refresh metric names

### DIFF
--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -180,7 +180,7 @@ datasets:
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
+- Acceleration refresh metrics when the dataset is accelerated (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
@@ -180,7 +180,7 @@ datasets:
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
+- Acceleration refresh metrics when the dataset is accelerated (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
@@ -180,7 +180,7 @@ datasets:
 The Flight client is not instrumented, so this connector emits no transport-level metrics, and it does not currently register Spice.ai-specific dataset-level instruments. Monitor the connector via:
 
 - Query execution metrics (`query_duration_ms`, `query_returned_rows`, `query_failures`) from `runtime.metrics`.
-- Acceleration refresh metrics when the dataset is accelerated (`refresh_last_duration_ms`, `refresh_errors_total`).
+- Acceleration refresh metrics when the dataset is accelerated (`dataset_acceleration_refresh_duration_ms`, `dataset_acceleration_refresh_errors`).
 - For Cloud: upstream Console metrics on the source dataset.
 - For self-hosted: monitor the upstream's own `runtime.metrics` and acceleration metrics.
 


### PR DESCRIPTION
## Summary

The Spice.ai connector deployment guide named two acceleration refresh metrics that **do not exist** anywhere in the runtime — a user monitoring the connector by these names would find nothing.

| Docs (before) | Actual registered metric |
| --- | --- |
| `refresh_last_duration_ms` | `dataset_acceleration_refresh_duration_ms` (`f64_histogram`) |
| `refresh_errors_total` | `dataset_acceleration_refresh_errors` (`u64_counter`) |

Both the stems were wrong, and `refresh_errors_total` also carried a spurious `_total` suffix — `spiced` builds its Prometheus exporter with `.without_counter_suffixes()`, so counters are emitted under their registered name verbatim (no `_total`). Neither `refresh_errors` nor `refresh_errors_total` is registered; the real counter is `dataset_acceleration_refresh_errors`.

This correction predates versioning, so the same wrong line existed in vNext + 2.1.x + 2.0.x. Both correct names are registered in v2.0.1 and v2.1.1, so the fix is valid for all three snapshots.

## Source
- spiceai/spiceai@`d5618eb7` (origin/trunk) — `crates/runtime-metrics/src/acceleration.rs` (`.f64_histogram("dataset_acceleration_refresh_duration_ms")`, `.u64_counter("dataset_acceleration_refresh_errors")`)
- Counter-suffix behavior: `bin/spiced/src/lib.rs` (`.without_counter_suffixes()`)

## Test plan
- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] Correction propagated to all snapshots carrying the line (grep count = 3: vNext + 2.0.x + 2.1.x)
- [x] Files updated: 3