### PR TITLE
docs(postgres cdc): spell out full metric names for replication update/delete counters

### DIFF
--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -297,7 +297,7 @@ Core freshness signals (auto-registered):
 | `dataset_postgres_replication_lag_ms`      | Gauge   | `now() − commit_time(latest ingested txn)`. Primary CDC freshness signal.                             |
 | `dataset_postgres_replication_lag_bytes`   | Gauge   | `server_wal_end_lsn − confirmed_flush_lsn`. Unacknowledged WAL held by Spice's slot.                  |
 | `dataset_postgres_replication_transactions_total` | Counter | Committed transactions applied.                                                                 |
-| `dataset_postgres_replication_inserts_total` / `updates_total` / `deletes_total` | Counter | Row-level events from WAL.                                      |
+| `dataset_postgres_replication_inserts_total` / `dataset_postgres_replication_updates_total` / `dataset_postgres_replication_deletes_total` | Counter | Row-level events from WAL.                                      |
 | `dataset_postgres_replication_reconnects_total` | Counter | Number of times the stream reconnected after a transient failure.                            |
 
 ## Troubleshooting

--- a/website/versioned_docs/version-2.0.x/features/cdc/postgres-replication.md
+++ b/website/versioned_docs/version-2.0.x/features/cdc/postgres-replication.md
@@ -254,7 +254,7 @@ Core freshness signals (auto-registered):
 | `dataset_postgres_replication_lag_ms`      | Gauge   | `now() − commit_time(latest ingested txn)`. Primary CDC freshness signal.                             |
 | `dataset_postgres_replication_lag_bytes`   | Gauge   | `server_wal_end_lsn − confirmed_flush_lsn`. Unacknowledged WAL held by Spice's slot.                  |
 | `dataset_postgres_replication_transactions_total` | Counter | Committed transactions applied.                                                                 |
-| `dataset_postgres_replication_inserts_total` / `updates_total` / `deletes_total` | Counter | Row-level events from WAL.                                      |
+| `dataset_postgres_replication_inserts_total` / `dataset_postgres_replication_updates_total` / `dataset_postgres_replication_deletes_total` | Counter | Row-level events from WAL.                                      |
 | `dataset_postgres_replication_reconnects_total` | Counter | Number of times the stream reconnected after a transient failure.                            |
 
 ## Troubleshooting

--- a/website/versioned_docs/version-2.1.x/features/cdc/postgres-replication.md
+++ b/website/versioned_docs/version-2.1.x/features/cdc/postgres-replication.md
@@ -297,7 +297,7 @@ Core freshness signals (auto-registered):
 | `dataset_postgres_replication_lag_ms`      | Gauge   | `now() − commit_time(latest ingested txn)`. Primary CDC freshness signal.                             |
 | `dataset_postgres_replication_lag_bytes`   | Gauge   | `server_wal_end_lsn − confirmed_flush_lsn`. Unacknowledged WAL held by Spice's slot.                  |
 | `dataset_postgres_replication_transactions_total` | Counter | Committed transactions applied.                                                                 |
-| `dataset_postgres_replication_inserts_total` / `updates_total` / `deletes_total` | Counter | Row-level events from WAL.                                      |
+| `dataset_postgres_replication_inserts_total` / `dataset_postgres_replication_updates_total` / `dataset_postgres_replication_deletes_total` | Counter | Row-level events from WAL.                                      |
 | `dataset_postgres_replication_reconnects_total` | Counter | Number of times the stream reconnected after a transient failure.                            |
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

The PostgreSQL replication metrics table abbreviated two of the three row-level counters as bare `` `updates_total` `` / `` `deletes_total` `` inside a slash-combined cell:

> `` `dataset_postgres_replication_inserts_total` / `updates_total` / `deletes_total` ``

As standalone tokens, `updates_total` and `deletes_total` are not valid metric names — a reader copying them to a scrape config or query gets nothing. The exported names carry the same `dataset_postgres_replication_` prefix as the already-spelled-out `inserts_total` entry.

Changed to the full names:

> `` `dataset_postgres_replication_inserts_total` / `dataset_postgres_replication_updates_total` / `dataset_postgres_replication_deletes_total` ``

## Source
- spiceai/spiceai@`d5618eb7` (origin/trunk) — `crates/data-connectors/connector-postgres/src/replication.rs` registers `replication_inserts_total` / `replication_updates_total` / `replication_deletes_total`, exported with the `dataset_postgres_` prefix.

## Test plan
- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] Correction propagated to all snapshots carrying the line (vNext + 2.0.x + 2.1.x)
- [x] Files updated: 3