### PR TITLE
docs(runtime): document metric_prefix validation rules (vNext)

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -563,6 +563,14 @@ runtime:
 
 With this configuration, the runtime metric `query_duration_ms` is exported as `spiceai.query_duration_ms`.
 
+The prefix is validated at spicepod load against the [OpenTelemetry instrument name syntax](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax) so `{prefix}{instrument}` stays a valid OTLP/Prometheus metric name. A non-empty prefix must:
+
+- start with an ASCII letter (`A`–`Z` or `a`–`z`);
+- contain only ASCII letters, digits, `_`, `.`, `-`, or `/`; and
+- be at most 128 characters (leaving ≥127 characters of headroom under the OpenTelemetry 255-character instrument-name limit for the base metric name).
+
+An invalid prefix fails fast with an actionable error rather than producing malformed metric names. An empty or unset `metric_prefix` applies no prefix.
+
 ### `runtime.telemetry.properties` {#runtimetelemetryproperties}
 
 Map of custom key/value attributes attached to telemetry metrics emitted by `spiced`. Applied as OpenTelemetry resource attributes on the runtime's `MeterProvider`, so they appear as dimensions/tags on every metric exported via the Prometheus scrape endpoint, the cluster on-demand OTLP reader, and the `otel_exporter` push exporter. Defaults to empty.


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12002` added base validation for `runtime.telemetry.metric_prefix` so invalid prefixes fail at spicepod load (and again at metrics init) instead of producing malformed OTLP/Prometheus metric names. The reference page described the param but not the accepted values; this documents the validation rules.

Rules (verified against `crates/spicepod/src/component/runtime.rs` on `trunk` — `validate_metric_prefix` / `METRIC_PREFIX_MAX_LEN = 128` / `METRIC_PREFIX_ALLOWED_NON_ALPHANUMERIC = ['_','.','-','/']`):

- must start with an ASCII letter;
- only ASCII letters, digits, `_`, `.`, `-`, `/`;
- max 128 characters;
- empty/unset applies no prefix.

The existing example (`metric_prefix: 'spiceai.'`) remains valid under these rules.

vNext-only: `#12002` merged post-v2.1.1, so the validation is not in a released version — `website/docs/` only (versioned snapshots correctly document the pre-validation behavior for their releases).

## Source PRs

- spiceai/spiceai#12002 — fix(telemetry): validate runtime.telemetry.metric_prefix against OTel name syntax

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only behavioral addition; `version-*` untouched
- [x] Files updated: 1 (`reference/spicepod/runtime.md`)