### PR TITLE
docs(http/graphql): rate-control metrics are auto-registered, not opt-in

### DIFF
--- a/website/docs/components/data-connectors/graphql/deployment.md
+++ b/website/docs/components/data-connectors/graphql/deployment.md
@@ -54,7 +54,7 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 ## Metrics
 
-When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset:
+When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component. They are registered automatically for every GraphQL dataset — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Catalog components expose none:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -73,7 +73,18 @@ When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control m
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: graphql:https://api.example.com/graphql
+    name: api_data
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_graphql_`, and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 

--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -115,7 +115,7 @@ When using `refresh_mode: caching`, transient HTTP errors (5xx, 429) are exclude
 
 ## Metrics
 
-When rate control is active, the connector exposes per-origin metrics that can be enabled per-dataset:
+The connector exposes per-origin HTTP rate-control metrics for every dynamic JSON API dataset. They are registered automatically — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Structured file-format datasets (`parquet`, `csv`, and the other listing-table formats) do not expose them:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -134,7 +134,20 @@ When rate control is active, the connector exposes per-origin metrics that can b
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_data
+    params:
+      file_format: json
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_http_` — the HTTP connector's component name is `http`, not `https` — and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/graphql/deployment.md
@@ -54,7 +54,7 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 ## Metrics
 
-When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset:
+When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component. They are registered automatically for every GraphQL dataset — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Catalog components expose none:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -73,7 +73,18 @@ When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control m
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: graphql:https://api.example.com/graphql
+    name: api_data
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_graphql_`, and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/https/deployment.md
@@ -104,7 +104,7 @@ When using `refresh_mode: caching`, transient HTTP errors (5xx, 429) are exclude
 
 ## Metrics
 
-When rate control is active, the connector exposes per-origin metrics that can be enabled per-dataset:
+The connector exposes per-origin HTTP rate-control metrics for every dynamic JSON API dataset. They are registered automatically — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Structured file-format datasets (`parquet`, `csv`, and the other listing-table formats) do not expose them:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -123,7 +123,20 @@ When rate control is active, the connector exposes per-origin metrics that can b
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_data
+    params:
+      file_format: json
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_http_` — the HTTP connector's component name is `http`, not `https` — and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/graphql/deployment.md
@@ -54,7 +54,7 @@ GraphQL APIs (GitHub, Shopify, etc.) typically enforce query-cost-based rate lim
 
 ## Metrics
 
-When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset:
+When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control metrics under the `graphql` component. They are registered automatically for every GraphQL dataset — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Catalog components expose none:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -73,7 +73,18 @@ When used as a dataset connector, GraphQL exposes per-origin HTTP rate-control m
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: graphql:https://api.example.com/graphql
+    name: api_data
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_graphql_`, and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/https/deployment.md
@@ -113,7 +113,7 @@ When using `refresh_mode: caching`, transient HTTP errors (5xx, 429) are exclude
 
 ## Metrics
 
-When rate control is active, the connector exposes per-origin metrics that can be enabled per-dataset:
+The connector exposes per-origin HTTP rate-control metrics for every dynamic JSON API dataset. They are registered automatically — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Structured file-format datasets (`parquet`, `csv`, and the other listing-table formats) do not expose them:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -132,7 +132,20 @@ When rate control is active, the connector exposes per-origin metrics that can b
 | `rate_limit_retry_after_wait_duration_ms`   | Counter | Cumulative time (ms) spent waiting because of `Retry-After` or `RateLimit` reset headers.                |
 | `rate_limit_retry_after_remaining_ms`       | Gauge   | Current remaining `Retry-After` / `RateLimit` cooldown (ms) for this upstream origin.                    |
 
-Enable component metrics in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+These metrics are auto-registered — no configuration is required to export them. To turn one off for a dataset, set `enabled: false` in the dataset's `metrics` section:
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_data
+    params:
+      file_format: json
+    metrics:
+      - name: rate_control_wait_duration_ms
+        enabled: false
+```
+
+Instruments are exposed with the prefix `dataset_http_` — the HTTP connector's component name is `http`, not `https` — and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 


### PR DESCRIPTION
## Summary

The HTTP and GraphQL deployment guides described the shared HTTP rate-control metrics as opt-in:

- https: *"When rate control is active, the connector exposes per-origin metrics that can be enabled per-dataset"* → *"Enable component metrics in the dataset's `metrics` section."*
- graphql: *"…exposes per-origin HTTP rate-control metrics under the `graphql` component that can be enabled per-dataset"* → same closing instruction.

**What the code does:** every one of the 14 specs in `HTTP_RATE_CONTROL_METRIC_SPECS` is declared with `.auto_register()`, and dataset init registers a metric when `metric.auto_register || user_enabled` (skipping only an explicit `enabled: false`). So the metrics export with no `metrics:` block at all, and the documented instruction is a no-op — a reader who wants them believes configuration is required, and a reader who does not want them never learns they are already being exported.

Corrected on both pages:

- The metrics are auto-registered; `enabled: false` is what a `metrics:` entry is actually for (example added, matching the convention set by #1856 for Cosmos DB).
- The limit gauges report `0` when the corresponding limit is unset, so "when rate control is active" was not the gating condition either. The real gating condition is the component: the HTTP connector emits them for dynamic JSON API datasets only (structured file-format datasets get `emit_rate_control_metrics: false`), and GraphQL emits them for dataset components only (catalogs get `None`).
- Added the instrument prefix and attribute, neither of which was documented: `dataset_http_` for the HTTP connector (its component name is `http`, **not** `https`, so the natural guess is wrong) and `dataset_graphql_`; each instrument carries an `origin` attribute (`scheme://host:port`) that *replaces* the usual dataset `name` attribute, because datasets sharing an origin share one rate controller.

This is the same claim class #1856 corrected for Cosmos DB's `inflight_operations`; that sweep missed these two pages.

## Verified against

`spiceai/spiceai` @ `trunk` (`cdaf65a86c`), and re-checked at tags `v2.0.1` and `v2.1.1` — all 14 specs carry `.auto_register()` in every version, so the correction applies to vNext, 2.0.x, and 2.1.x alike.

- `crates/runtime/src/dataconnector/http_rate_control.rs` — `HTTP_RATE_CONTROL_METRIC_SPECS` (14 × `.auto_register()`), `HttpRateControlMetricsProvider::callback_to_observe_metric` (swaps `name` → `origin`), `rate_control_key` (`scheme://host:port`)
- `crates/runtime/src/init/dataset.rs` — `if explicitly_disabled || (!metric.auto_register && !user_enabled) { continue }`
- `crates/runtime/src/dataconnector/https.rs` — `metrics_provider()` returns `None` unless `emit_rate_control_metrics`; provider constructed with the component name `"http"`
- `crates/data-connectors/connector-graphql/src/lib.rs` — provider constructed with `"graphql"`; non-dataset components get `emit_rate_control_metrics: false`
- `crates/runtime-metrics/src/components/mod.rs` — `{component_type}_{component_name}_{metric_name}`

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — `grep -rn 'that can be enabled per-dataset' website/docs website/versioned_docs` and `grep -rn "Enable component metrics in the dataset" …` both return zero hits after the change
- [x] Files updated: 6 (vNext + version-2.0.x + version-2.1.x, × https and graphql)