### PR TITLE
docs(postgres): correct replication metrics registration; complete the table

### DIFF
--- a/website/docs/components/data-connectors/postgres/deployment.md
+++ b/website/docs/components/data-connectors/postgres/deployment.md
@@ -73,27 +73,34 @@ Transient query failures are not automatically retried at the connector layer. D
 
 ## Metrics
 
-The PostgreSQL connector exposes observable metrics for its replication pipeline. Enable them in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The PostgreSQL connector exposes observable metrics for its replication pipeline. Every metric below is auto-registered — no configuration is required to export it — **except** `replication_truncates_total` and `replication_bootstrap_rows_total`, which are opt-in and must be listed in the dataset's `metrics` section. To turn an auto-registered metric off for a dataset, set `enabled: false` there. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
-| Metric Name                                  | Type            | Description                                                       |
-| -------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| `replication_lag_ms`                         | ObservableGauge | Replication lag in milliseconds.                                  |
-| `replication_lag_bytes`                      | ObservableGauge | Replication lag in bytes.                                         |
-| `replication_confirmed_flush_lsn`            | ObservableGauge | Confirmed flush LSN position.                                     |
-| `replication_server_wal_end_lsn`             | ObservableGauge | Server WAL end LSN position.                                      |
-| `replication_transactions_total`             | ObservableCounter | Total transactions received via replication.                    |
-| `replication_inserts_total`                  | ObservableCounter | Total insert operations received.                               |
-| `replication_updates_total`                  | ObservableCounter | Total update operations received.                               |
-| `replication_deletes_total`                  | ObservableCounter | Total delete operations received.                               |
-| `replication_truncates_total`                | ObservableCounter | Total truncate operations received.                             |
-| `replication_bootstrap_rows_total`           | ObservableCounter | Total rows fetched during initial bootstrap.                    |
-| `replication_bootstrap_complete`             | ObservableGauge | Bootstrap completion status.                                      |
-| `replication_decode_errors_total`            | ObservableCounter | Total WAL decode errors.                                        |
-| `replication_schema_mismatch_errors_total`   | ObservableCounter | Total schema mismatch errors during replication.                |
-| `replication_recv_errors_total`              | ObservableCounter | Total receive errors during replication.                        |
-| `replication_reconnects_total`               | ObservableCounter | Total reconnection attempts.                                    |
+| Metric Name                                     | Type              | Description                                                                                                                       |
+| ----------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `replication_lag_ms`                            | ObservableGauge   | Milliseconds between now and the Postgres commit timestamp of the most recently replicated transaction. Primary freshness signal.  |
+| `replication_lag_bytes`                         | ObservableGauge   | WAL bytes between the server's latest reported position and the last confirmed flush LSN.                                          |
+| `replication_confirmed_flush_lsn`               | ObservableGauge   | Most recent LSN acknowledged to Postgres. Matches `pg_replication_slots.confirmed_flush_lsn`.                                      |
+| `replication_server_wal_end_lsn`                | ObservableGauge   | Most recent WAL end LSN reported by the Postgres server.                                                                           |
+| `replication_reader_input_wait_micros_total`    | ObservableCounter | Microseconds the reader spent blocked awaiting the next source event. High relative to the processing counter ⇒ source-bound.       |
+| `replication_reader_processing_micros_total`    | ObservableCounter | Microseconds the reader spent decoding WAL and building change batches.                                                            |
+| `replication_transactions_total`                | ObservableCounter | Transactions committed and applied to the accelerator.                                                                             |
+| `replication_inserts_total`                     | ObservableCounter | `INSERT` operations received from WAL.                                                                                             |
+| `replication_updates_total`                     | ObservableCounter | `UPDATE` operations received from WAL.                                                                                             |
+| `replication_deletes_total`                     | ObservableCounter | `DELETE` operations received from WAL.                                                                                             |
+| `replication_truncates_total`                   | ObservableCounter | `TRUNCATE` operations received from WAL and applied. **Opt-in.**                                                                   |
+| `replication_bootstrap_rows_total`              | ObservableCounter | Rows loaded during the initial-snapshot bootstrap. **Opt-in.**                                                                     |
+| `replication_bootstrap_rows_expected`           | ObservableGauge   | Estimated bootstrap row count from schema inference. Absent when no estimate exists; `0` means a known-empty source table.          |
+| `replication_bootstrap_complete`                | ObservableGauge   | `1` once the initial snapshot finished (or was skipped on resume); `0` while it is still running.                                   |
+| `replication_decode_errors_total`               | ObservableCounter | pgoutput decoding errors encountered while parsing WAL events.                                                                     |
+| `replication_schema_mismatch_errors_total`      | ObservableCounter | Errors where the source relation no longer matches the declared accelerator schema.                                                |
+| `replication_recv_errors_total`                 | ObservableCounter | Transport-level errors while receiving from the replication connection.                                                            |
+| `replication_reconnects_total`                  | ObservableCounter | Times the stream reconnected after a transient failure. Non-zero with no user-visible error just means it recovered.                |
+| `replication_disconnected_ms_total`             | ObservableCounter | Cumulative milliseconds the stream was disconnected across all reconnects, including backoff.                                       |
+| `replication_member_send_stalled_seconds_total` | ObservableCounter | Seconds the shared-slot pump spent blocked delivering changes into this dataset's channel. Shared slots only.                       |
+| `replication_member_send_wait_micros_total`     | ObservableCounter | Microseconds the shared-slot pump spent awaiting this dataset's delivery channel. Dedicated-slot datasets export `0`.                |
+| `replication_member_attached`                   | ObservableGauge   | `1` while this dataset is an attached member of its shared slot, `0` once detached. Shared slots only.                              |
 
-Metric instruments are exposed with the prefix `dataset_postgres_`. Each instrument carries a `name` attribute set to the dataset name.
+Metric instruments are exposed with the prefix `dataset_postgres_`. Each instrument carries a `name` attribute set to the dataset name; `replication_member_attached` also carries a `slot` attribute for grouping shared-slot members.
 
 ## Task History
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/postgres/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/postgres/deployment.md
@@ -73,25 +73,25 @@ Transient query failures are not automatically retried at the connector layer. D
 
 ## Metrics
 
-The PostgreSQL connector exposes observable metrics for its replication pipeline. Enable them in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The PostgreSQL connector exposes observable metrics for its replication pipeline. Most are auto-registered — no configuration is required to export them. `replication_confirmed_flush_lsn`, `replication_server_wal_end_lsn`, `replication_truncates_total`, and `replication_bootstrap_rows_total` are opt-in and must be listed in the dataset's `metrics` section. To turn an auto-registered metric off for a dataset, set `enabled: false` there. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
-| Metric Name                                  | Type            | Description                                                       |
-| -------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| `replication_lag_ms`                         | ObservableGauge | Replication lag in milliseconds.                                  |
-| `replication_lag_bytes`                      | ObservableGauge | Replication lag in bytes.                                         |
-| `replication_confirmed_flush_lsn`            | ObservableGauge | Confirmed flush LSN position.                                     |
-| `replication_server_wal_end_lsn`             | ObservableGauge | Server WAL end LSN position.                                      |
-| `replication_transactions_total`             | ObservableCounter | Total transactions received via replication.                    |
-| `replication_inserts_total`                  | ObservableCounter | Total insert operations received.                               |
-| `replication_updates_total`                  | ObservableCounter | Total update operations received.                               |
-| `replication_deletes_total`                  | ObservableCounter | Total delete operations received.                               |
-| `replication_truncates_total`                | ObservableCounter | Total truncate operations received.                             |
-| `replication_bootstrap_rows_total`           | ObservableCounter | Total rows fetched during initial bootstrap.                    |
-| `replication_bootstrap_complete`             | ObservableGauge | Bootstrap completion status.                                      |
-| `replication_decode_errors_total`            | ObservableCounter | Total WAL decode errors.                                        |
-| `replication_schema_mismatch_errors_total`   | ObservableCounter | Total schema mismatch errors during replication.                |
-| `replication_recv_errors_total`              | ObservableCounter | Total receive errors during replication.                        |
-| `replication_reconnects_total`               | ObservableCounter | Total reconnection attempts.                                    |
+| Metric Name                                | Type              | Description                                                                                                                       |
+| ------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `replication_lag_ms`                       | ObservableGauge   | Milliseconds between now and the Postgres commit timestamp of the most recently replicated transaction. Primary freshness signal.  |
+| `replication_lag_bytes`                    | ObservableGauge   | WAL bytes between the server's latest reported position and the last confirmed flush LSN.                                          |
+| `replication_confirmed_flush_lsn`          | ObservableGauge   | Most recent LSN acknowledged to Postgres. Matches `pg_replication_slots.confirmed_flush_lsn`. **Opt-in.**                          |
+| `replication_server_wal_end_lsn`           | ObservableGauge   | Most recent WAL end LSN reported by the Postgres server. **Opt-in.**                                                              |
+| `replication_transactions_total`           | ObservableCounter | Transactions committed and applied to the accelerator.                                                                             |
+| `replication_inserts_total`                | ObservableCounter | `INSERT` operations received from WAL.                                                                                             |
+| `replication_updates_total`                | ObservableCounter | `UPDATE` operations received from WAL.                                                                                             |
+| `replication_deletes_total`                | ObservableCounter | `DELETE` operations received from WAL.                                                                                             |
+| `replication_truncates_total`              | ObservableCounter | `TRUNCATE` operations received from WAL and applied. **Opt-in.**                                                                   |
+| `replication_bootstrap_rows_total`         | ObservableCounter | Rows loaded during the initial-snapshot bootstrap. **Opt-in.**                                                                     |
+| `replication_bootstrap_complete`           | ObservableGauge   | `1` once the initial snapshot finished (or was skipped on resume); `0` while it is still running.                                   |
+| `replication_decode_errors_total`          | ObservableCounter | pgoutput decoding errors encountered while parsing WAL events.                                                                     |
+| `replication_schema_mismatch_errors_total` | ObservableCounter | Errors where the source relation no longer matches the declared accelerator schema.                                                |
+| `replication_recv_errors_total`            | ObservableCounter | Transport-level errors while receiving from the replication connection.                                                            |
+| `replication_reconnects_total`             | ObservableCounter | Times the stream reconnected after a transient failure. Non-zero with no user-visible error just means it recovered.                |
 
 Metric instruments are exposed with the prefix `dataset_postgres_`. Each instrument carries a `name` attribute set to the dataset name.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/postgres/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/postgres/deployment.md
@@ -73,25 +73,26 @@ Transient query failures are not automatically retried at the connector layer. D
 
 ## Metrics
 
-The PostgreSQL connector exposes observable metrics for its replication pipeline. Enable them in the dataset's `metrics` section. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+The PostgreSQL connector exposes observable metrics for its replication pipeline. Most are auto-registered — no configuration is required to export them. `replication_confirmed_flush_lsn`, `replication_server_wal_end_lsn`, `replication_truncates_total`, and `replication_bootstrap_rows_total` are opt-in and must be listed in the dataset's `metrics` section. To turn an auto-registered metric off for a dataset, set `enabled: false` there. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
-| Metric Name                                  | Type            | Description                                                       |
-| -------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| `replication_lag_ms`                         | ObservableGauge | Replication lag in milliseconds.                                  |
-| `replication_lag_bytes`                      | ObservableGauge | Replication lag in bytes.                                         |
-| `replication_confirmed_flush_lsn`            | ObservableGauge | Confirmed flush LSN position.                                     |
-| `replication_server_wal_end_lsn`             | ObservableGauge | Server WAL end LSN position.                                      |
-| `replication_transactions_total`             | ObservableCounter | Total transactions received via replication.                    |
-| `replication_inserts_total`                  | ObservableCounter | Total insert operations received.                               |
-| `replication_updates_total`                  | ObservableCounter | Total update operations received.                               |
-| `replication_deletes_total`                  | ObservableCounter | Total delete operations received.                               |
-| `replication_truncates_total`                | ObservableCounter | Total truncate operations received.                             |
-| `replication_bootstrap_rows_total`           | ObservableCounter | Total rows fetched during initial bootstrap.                    |
-| `replication_bootstrap_complete`             | ObservableGauge | Bootstrap completion status.                                      |
-| `replication_decode_errors_total`            | ObservableCounter | Total WAL decode errors.                                        |
-| `replication_schema_mismatch_errors_total`   | ObservableCounter | Total schema mismatch errors during replication.                |
-| `replication_recv_errors_total`              | ObservableCounter | Total receive errors during replication.                        |
-| `replication_reconnects_total`               | ObservableCounter | Total reconnection attempts.                                    |
+| Metric Name                                | Type              | Description                                                                                                                       |
+| ------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `replication_lag_ms`                       | ObservableGauge   | Milliseconds between now and the Postgres commit timestamp of the most recently replicated transaction. Primary freshness signal.  |
+| `replication_lag_bytes`                    | ObservableGauge   | WAL bytes between the server's latest reported position and the last confirmed flush LSN.                                          |
+| `replication_confirmed_flush_lsn`          | ObservableGauge   | Most recent LSN acknowledged to Postgres. Matches `pg_replication_slots.confirmed_flush_lsn`. **Opt-in.**                          |
+| `replication_server_wal_end_lsn`           | ObservableGauge   | Most recent WAL end LSN reported by the Postgres server. **Opt-in.**                                                              |
+| `replication_transactions_total`           | ObservableCounter | Transactions committed and applied to the accelerator.                                                                             |
+| `replication_inserts_total`                | ObservableCounter | `INSERT` operations received from WAL.                                                                                             |
+| `replication_updates_total`                | ObservableCounter | `UPDATE` operations received from WAL.                                                                                             |
+| `replication_deletes_total`                | ObservableCounter | `DELETE` operations received from WAL.                                                                                             |
+| `replication_truncates_total`              | ObservableCounter | `TRUNCATE` operations received from WAL and applied. **Opt-in.**                                                                   |
+| `replication_bootstrap_rows_total`         | ObservableCounter | Rows loaded during the initial-snapshot bootstrap. **Opt-in.**                                                                     |
+| `replication_bootstrap_rows_expected`      | ObservableGauge   | Estimated bootstrap row count from schema inference. Absent when no estimate exists; `0` means a known-empty source table.          |
+| `replication_bootstrap_complete`           | ObservableGauge   | `1` once the initial snapshot finished (or was skipped on resume); `0` while it is still running.                                   |
+| `replication_decode_errors_total`          | ObservableCounter | pgoutput decoding errors encountered while parsing WAL events.                                                                     |
+| `replication_schema_mismatch_errors_total` | ObservableCounter | Errors where the source relation no longer matches the declared accelerator schema.                                                |
+| `replication_recv_errors_total`            | ObservableCounter | Transport-level errors while receiving from the replication connection.                                                            |
+| `replication_reconnects_total`             | ObservableCounter | Times the stream reconnected after a transient failure. Non-zero with no user-visible error just means it recovered.                |
 
 Metric instruments are exposed with the prefix `dataset_postgres_`. Each instrument carries a `name` attribute set to the dataset name.
 


### PR DESCRIPTION
## Summary

The PostgreSQL deployment guide said: *"The PostgreSQL connector exposes observable metrics for its replication pipeline. Enable them in the dataset's `metrics` section."*

**What the code does:** almost every spec in `connector-postgres`'s `METRICS` is declared with `.auto_register()`, and dataset init registers a metric when `metric.auto_register || user_enabled`. So the documented instruction is a no-op for nearly all of them — a reader believes configuration is required to get replication lag, and a reader who never adds a `metrics:` block does not learn that lag, LSN, and error counters are already being exported.

The opt-in set is release-specific, so each snapshot is fixed to its own release rather than flattened to trunk:

| Release | Total specs | Opt-in (must be listed in `metrics:`) |
| --- | --- | --- |
| vNext | 22 | `replication_truncates_total`, `replication_bootstrap_rows_total` |
| 2.1.x | 16 | those two + `replication_confirmed_flush_lsn`, `replication_server_wal_end_lsn` |
| 2.0.x | 15 | same four as 2.1.x |

Because the table had to be reconciled against the source list anyway, the whole table was audited (per the "fix one row → audit the table" rule). That surfaced metrics the guide never listed:

- **vNext** was missing seven: `replication_reader_input_wait_micros_total`, `replication_reader_processing_micros_total`, `replication_bootstrap_rows_expected`, `replication_disconnected_ms_total`, `replication_member_send_stalled_seconds_total`, `replication_member_send_wait_micros_total`, `replication_member_attached`.
- **2.1.x** was missing `replication_bootstrap_rows_expected` (added in that release; 2.0.x correctly omits it).
- Every row's `Type` was checked against its `MetricType`, and descriptions were tightened to what the spec descriptions actually say (e.g. `replication_lag_ms` uses the source's pgoutput `commit_time`, not local ingest time; `replication_bootstrap_rows_expected` is *absent* rather than `0` when no estimate exists).
- Noted the extra `slot` attribute on `replication_member_attached` — the page previously claimed `name` was the only attribute.

Companion to #1970, which corrects the same opt-in-vs-auto-registered claim class for the HTTP rate-control metric family. Both descend from #1856, which corrected it for Cosmos DB and did not sweep the other connectors.

## Verified against

`spiceai/spiceai` @ `trunk` (`cdaf65a86c`), plus tags `v2.0.1` and `v2.1.1` for the versioned snapshots.

- `crates/data-connectors/connector-postgres/src/replication.rs` — `const METRICS: &[MetricSpec]` (spec names, `MetricType`s, `.auto_register()` per entry) and `PostgresMetricsProvider::callback_to_observe_metric` (the `slot` attribute on `replication_member_attached`; the `Option` guards that make `bootstrap_rows_expected` / `member_attached` absent rather than `0`)
- `crates/data-connectors/connector-postgres/src/lib.rs` — `metrics_provider()` exposes only this replication provider, so this table is the connector's complete metric surface
- `crates/runtime/src/init/dataset.rs` — `if explicitly_disabled || (!metric.auto_register && !user_enabled) { continue }`
- `crates/runtime-metrics/src/components/mod.rs` — `dataset_postgres_<metric>` naming, `name` attribute set to the instance name

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — `grep -rn "Enable them in the dataset's \`metrics\` section" website/` now matches only the MySQL guide, where it is **correct** (none of the MySQL connection-pool specs carry `.auto_register()`, verified in `connector-mysql/src/lib.rs`)
- [x] Version scoping checked — `auto_register` does not exist in v1.9/v1.10/v1.11, so the 1.x snapshots correctly document opt-in-only and are untouched
- [x] Files updated: 3 (vNext + version-2.0.x + version-2.1.x)