### PR TITLE
docs(observability): component metrics are not all disabled by default

### DIFF
--- a/website/docs/features/observability/component_metrics.md
+++ b/website/docs/features/observability/component_metrics.md
@@ -13,7 +13,9 @@ Component metrics provide detailed insights into the internal state and performa
 
 ## Enabling Component Metrics
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. Each component's own documentation states which of its metrics are auto-registered.
 
 ### Example Configuration
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -720,7 +720,9 @@ Optional. The maximum amount of jitter to add to the refresh interval. The jitte
 
 Optional. Enable component-specific metrics for the dataset. Each component can expose its own set of metrics that can be enabled selectively to monitor specific aspects of its operation.
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. See [Component Metrics](../../features/observability/component_metrics) and each component's own documentation for which metrics are auto-registered.
 
 ### Example Configuration
 

--- a/website/versioned_docs/version-2.0.x/features/observability/component_metrics.md
+++ b/website/versioned_docs/version-2.0.x/features/observability/component_metrics.md
@@ -13,7 +13,9 @@ Component metrics provide detailed insights into the internal state and performa
 
 ## Enabling Component Metrics
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. Each component's own documentation states which of its metrics are auto-registered.
 
 ### Example Configuration
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
@@ -677,7 +677,9 @@ Optional. The maximum amount of jitter to add to the refresh interval. The jitte
 
 Optional. Enable component-specific metrics for the dataset. Each component can expose its own set of metrics that can be enabled selectively to monitor specific aspects of its operation.
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. See [Component Metrics](../../features/observability/component_metrics) and each component's own documentation for which metrics are auto-registered.
 
 ### Example Configuration
 

--- a/website/versioned_docs/version-2.1.x/features/observability/component_metrics.md
+++ b/website/versioned_docs/version-2.1.x/features/observability/component_metrics.md
@@ -13,7 +13,9 @@ Component metrics provide detailed insights into the internal state and performa
 
 ## Enabling Component Metrics
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the component configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. Each component's own documentation states which of its metrics are auto-registered.
 
 ### Example Configuration
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/datasets.md
@@ -725,7 +725,9 @@ Optional. The maximum amount of jitter to add to the refresh interval. The jitte
 
 Optional. Enable component-specific metrics for the dataset. Each component can expose its own set of metrics that can be enabled selectively to monitor specific aspects of its operation.
 
-Component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+Most component metrics are disabled by default and can be enabled by adding a `metrics` section to the dataset configuration. Each metric can be enabled individually by specifying its name in the metrics list.
+
+Some metrics are **auto-registered**: they export without any `metrics` configuration, and an entry with `enabled: false` is what turns one off. See [Component Metrics](../../features/observability/component_metrics) and each component's own documentation for which metrics are auto-registered.
 
 ### Example Configuration
 


### PR DESCRIPTION
## Summary

Two reference pages state flatly: *"Component metrics are disabled by default and can be enabled by adding a `metrics` section…"*

**What the code does:** `MetricSpec` has an `.auto_register()` builder, and dataset init registers a metric when `metric.auto_register || user_enabled`, skipping only an explicit `enabled: false`. Auto-registered metrics therefore export with **no** `metrics` block, and a `metrics` entry is how you *disable* one — the inverse of what these pages describe. As of trunk that covers the whole HTTP rate-control family (14 metrics, shared by the HTTP and GraphQL connectors), 20 of 22 PostgreSQL replication metrics, 15 MySQL replication metrics, and the `inflight_operations` gauge on the Cosmos DB, Databricks, and Git connectors.

Softened to "Most component metrics are disabled by default" plus a sentence naming the auto-registered behaviour and pointing at the component pages for which metrics it applies to. No connector is enumerated in the shared text, because the auto-registered set differs per release.

Completes the sweep with #1970 (HTTP/GraphQL rate-control metrics) and #1971 (PostgreSQL replication metrics), which fix the same claim on the individual connector guides.

## Version scoping

`auto_register` does not exist before v2.0 — `git grep -c 'auto_register' v1.9.0 v1.10.0 v1.11.0 -- 'crates/*'` returns zero for all three — so the 1.5.x–1.11.x snapshots correctly document opt-in-only behaviour and are deliberately left untouched. Fixed in vNext, 2.0.x, and 2.1.x only, where `git grep -c auto_register` at `v2.0.1` and `v2.1.1` confirms auto-registered specs exist.

## Verified against

`spiceai/spiceai` @ `trunk` (`cdaf65a86c`), plus tags `v1.9.0` / `v1.10.0` / `v1.11.0` / `v2.0.1` / `v2.1.1` for scoping.

- `crates/runtime-metrics/src/component.rs` — `MetricSpec::auto_register()` and the `auto_register: bool` field
- `crates/runtime/src/init/dataset.rs` — `if explicitly_disabled || (!metric.auto_register && !user_enabled) { continue }`

## Test plan

- [x] `cd website && npm run build` passes (exit 0) — the added link in `datasets.md` uses the same `../../features/observability/component_metrics` target already linked further down that page
- [x] Versioned-docs propagation checked — `grep -rln "Component metrics are disabled by default" website/` now matches only the 1.5.x–1.11.x snapshots, where the claim is correct
- [x] Files updated: 6 (2 pages × vNext + version-2.0.x + version-2.1.x)