### PR TITLE
docs(otlp): document Histogram ingest, ingested schema, and time_format: unix_nanos

### DIFF
--- a/website/docs/features/data-ingestion/index.md
+++ b/website/docs/features/data-ingestion/index.md
@@ -98,6 +98,55 @@ By default, the runtime exposes an [OpenTelemetry](https://opentelemetry.io) (OT
 
 OTEL metrics will be inserted into datasets with matching names (metric name = dataset name) and optionally replicated to the dataset source.
 
+### Supported metric types
+
+| OTLP metric type        | Supported | Notes                                                                                            |
+| ----------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `Gauge`                 | Yes       | Ingested as number data points.                                                                  |
+| `Sum`                   | Yes       | Ingested as number data points.                                                                  |
+| `Histogram`             | Yes       | Ingested with explicit bucket bounds and counts.                                                 |
+| `ExponentialHistogram`  | No        | Dropped, logging an unsupported metric data type error.                                          |
+| `Summary`               | No        | Dropped, logging an unsupported metric data type error.                                          |
+
+Data points for a metric with no matching writable dataset are rejected and reported back to the exporter in the OTLP partial-success response.
+
+### Ingested schema
+
+`Gauge` and `Sum` metrics produce the following columns:
+
+| Column                 | Type                | Description                                                                                              |
+| ---------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `value`                | `Int64` or `Float64` | The data point value. The type is fixed by the first data point (or the existing table's `value` column). |
+| `time_unix_nano`       | `UInt64`            | Data point timestamp, in nanoseconds since the Unix epoch.                                               |
+| `start_time_unix_nano` | `UInt64`            | Start of the data point's aggregation interval, in nanoseconds since the Unix epoch.                      |
+
+`Histogram` metrics have a fixed set of value columns instead of `value`:
+
+| Column            | Type            | Description                                                                          |
+| ----------------- | --------------- | ------------------------------------------------------------------------------------ |
+| `count`           | `UInt64`        | Number of values in the population.                                                  |
+| `sum`             | `Float64`       | Sum of the values. `NULL` when the exporter does not record it.                       |
+| `min` / `max`     | `Float64`       | Extrema over the interval. `NULL` when the exporter does not record them.             |
+| `bucket_counts`   | `List<UInt64>`  | Per-bucket counts.                                                                   |
+| `explicit_bounds` | `List<Float64>` | The explicit bucket boundaries — one fewer element than `bucket_counts`.              |
+
+Histograms carry the same `time_unix_nano` and `start_time_unix_nano` columns as number data points.
+
+Data point attributes become additional columns named after the attribute key, typed by the attribute value (`Utf8`, `Boolean`, `Int64`, `Float64`, or `Binary`). When a metric starts reporting a new attribute, Spice evolves an accelerated table's schema in place before writing, subject to the dataset's [`on_schema_change`](../../reference/spicepod/datasets.md#on_schema_change) policy.
+
+Because OTLP timestamps are nanoseconds, set [`time_format: unix_nanos`](../../reference/spicepod/datasets.md#time_format) when using `time_unix_nano` as a dataset's `time_column`:
+
+```yaml
+datasets:
+  - from: spice.ai/coolorg/metrics/datasets/http_server_duration
+    name: http_server_duration # must match the OTEL metric name
+    access: read_write
+    time_column: time_unix_nano
+    time_format: unix_nanos
+    acceleration:
+      enabled: true
+```
+
 ## Benefits
 
 Spice.ai OSS includes built-in data ingestion support for collecting the latest data from edge nodes for use in subsequent queries. This feature eliminates the need for additional ETL pipelines and improves the speed of the feedback loop.

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -206,6 +206,7 @@ Optional. The format of the `time_column`. The following values are supported:
 - `timestamptz` - Timestamp with a timezone. E.g. `2016-06-22 19:10:25-07` with data type `timestamptz`.
 - `unix_seconds` - Unix timestamp in seconds. E.g. `1718756687`.
 - `unix_millis` - Unix timestamp in milliseconds. E.g. `1718756687000`.
+- `unix_nanos` - Unix timestamp in nanoseconds. E.g. `1718756687000000000`. Use this for OpenTelemetry's `time_unix_nano` columns — see [OpenTelemetry Data Ingestion](../../features/data-ingestion/index.md#opentelemetry-data-ingestion).
 - `ISO8601` - [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format.
 - `date` - Date in YYYY-MM-DD format. E.g. `2024-01-01`.
 


### PR DESCRIPTION
## Summary

Forward-sync for spiceai/spiceai#11992, which added OTLP `Histogram` ingest and the dataset `time_format: unix_nanos` value (OTLP delivers timestamps in nanoseconds).

The OpenTelemetry ingestion section previously said only that "OTEL metrics will be inserted into datasets with matching names", with no statement of which metric types are accepted or what columns they produce. This adds:

- **Supported metric types** — `Gauge`, `Sum`, `Histogram` supported; `ExponentialHistogram` and `Summary` are dropped with an unsupported-metric-data-type error (`metric_data_to_record_batch` has no arm for them — `crates/runtime/src/opentelemetry.rs`).
- **Ingested schema** — the number-data-point columns (`value` typed `Int64`/`Float64`, `time_unix_nano`, `start_time_unix_nano`) and the fixed histogram value columns (`count`, `sum`, `min`/`max`, `bucket_counts` as `List<UInt64>`, `explicit_bounds` as `List<Float64>`), copied from the registered column-name constants and builders in `opentelemetry.rs`.
- **Attribute columns** and their write-time schema evolution, which honors the dataset's `on_schema_change` policy.
- **`time_format: unix_nanos`** added to the `time_format` value list in the datasets reference, with an example using `time_unix_nano` as a `time_column`.

Verified against `origin/trunk` (not just the merged diff): `unix_nanos` is present in the `TimeFormat` enum and deserializer (`crates/spicepod/src/component/dataset.rs`), and `Data::Histogram` has a live dispatch arm.

vNext only — #11992 merged after v2.1.1 and is contained in no release tag, so the versioned snapshots correctly omit both.

## Source PRs

- spiceai/spiceai#11992 — feat: Support OTLP Histogram ingest, unix nanos time

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — addition, so `website/docs/` only
- [x] Files updated: 2 (`website/docs/features/data-ingestion/index.md`, `website/docs/reference/spicepod/datasets.md`)