### PR TITLE
docs(postgres): correct and complete the CDC replication params table (vNext)

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -124,11 +124,13 @@ The following parameters configure PostgreSQL [logical replication](https://www.
 | Parameter Name                     | Description                                                                                                                                              |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pg_replication_slot`              | Optional. Name of the replication slot to create/reuse. Defaults to `spice_<dataset>_<dataset-hash>_<instance-hash>`. Each Spice replica MUST have its own unique slot. |
-| `pg_publication`                   | Optional. Name of the publication to create/reuse. Defaults to `spice_<dataset>_<dataset-hash>_pub`. Shared across replicas for the same dataset.        |
-| `pg_replication_initial_snapshot`  | Optional. Whether to take an initial snapshot of existing rows before streaming WAL changes. Default: `true`.                                            |
+| `pg_publication`                   | Optional. Name of the publication to create/reuse. Defaults to `spice_<dataset>_<dataset-hash>_pub`, or `<slot>_pub` when `pg_replication_slot` is set. Shared across replicas for the same dataset. |
+| `pg_replication_initial_snapshot`  | Optional. When `refresh_mode: changes` first loads the table's existing rows: `auto` (default) snapshots a freshly-created replication slot and resumes an existing one without a snapshot; `disabled` streams WAL changes only; `always` snapshots on every start, including slot resume. The legacy booleans `true`/`false` map to `auto`/`disabled`. Default: `auto`. |
 | `pg_replication_temporary_slot`    | Optional. If `true`, create a temporary replication slot that is dropped when the Spice process disconnects. Default: `false` (durable slot).            |
 | `pg_replication_status_interval`   | Optional. How often to send StandbyStatusUpdate to Postgres (e.g. `10s`). Default: `10s`.                                                               |
+| `pg_replication_ready_lag`         | Optional. For `refresh_mode: changes`, the dataset is marked Ready once its replication lag (now minus the newest applied commit's source time) falls below this. Default: `2s`. |
 | `pg_replication_bootstrap_batch_size` | Optional. Number of rows per emitted batch during the initial replication snapshot. Default: `8192`. Maximum: `1048576`.                              |
+| `pg_replication_member_channel_capacity` | Optional. Shared-slot only: envelopes buffered per member table before the shared replication pump back-pressures. Default: `1024`. Maximum: `1048576`. |
 
 :::warning[`pg_sslmode` and `pg_sslrootcert` differ on the WAL replication transport]
 


### PR DESCRIPTION
## Summary

The PostgreSQL connector reference's **Replication parameters** table drifted from the connector's `PARAMETERS` array after spiceai/spiceai#11777 (unified CDC config). docs#1967 corrected the CDC feature page but not this page — the classic sibling-page miss — so the connector reference still described the pre-#11777 shape.

Audited the whole table against `crates/data-connectors/connector-postgres/src/lib.rs` on `origin/trunk` and fixed every row:

| Row | Docs said | Code says |
| --- | --- | --- |
| `pg_replication_initial_snapshot` | "Whether to take an initial snapshot… Default: `true`" | enum `auto` (default) / `always` / `disabled`, legacy booleans mapping to `auto`/`disabled` (`.default("auto")`, lib.rs:177) |
| `pg_publication` | defaults to `spice_<dataset>_<dataset-hash>_pub` | also derives `<slot>_pub` when `pg_replication_slot` is set (lib.rs:171) |
| `pg_replication_ready_lag` | absent | `.default("2s")` (lib.rs:199) |
| `pg_replication_member_channel_capacity` | absent | `.default("1024")`, max `1048576` (lib.rs:213) |

Wording matches the already-correct table on [PostgreSQL Logical Replication](https://docs.spiceai.org/docs/features/cdc/postgres-replication) so the two pages agree.

**Propagation:** vNext only. #11777 is contained in no release tag (`git tag --contains 74bfe57` is empty), so `version-2.0.x` / `version-2.1.x` correctly document the boolean `pg_replication_initial_snapshot` and correctly omit the two new params — deliberately unchanged.

## Source PRs

- spiceai/spiceai#11777 — Unified CDC config

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext-only per the tag-containment check above
- [x] Files updated: 1 (`website/docs/components/data-connectors/postgres/index.md`)