### PR TITLE
docs(postgres cdc): document pg_connection_string support for CDC (vNext)

### DIFF
--- a/website/docs/components/data-connectors/postgres/index.md
+++ b/website/docs/components/data-connectors/postgres/index.md
@@ -134,6 +134,8 @@ The following parameters configure PostgreSQL [logical replication](https://www.
 
 The `pg_sslmode` default of `verify-full` documented above applies to the federated read/query path. On the WAL replication transport used by `refresh_mode: changes`, an unset `pg_sslmode` defaults to **`prefer`**, which negotiates a **plaintext** connection (no certificate verification). Set `pg_sslmode` to `require`, `verify-ca`, or `verify-full` to force TLS on the WAL stream — see [`pg_sslmode` for WAL streaming](../../features/cdc/postgres-replication#pg_sslmode-for-wal-streaming).
 
+This applies to the discrete-parameter path. When the connection is configured with `pg_connection_string` and the string omits `sslmode`, the WAL transport defaults to `verify-full` — see [Connecting with `pg_connection_string`](../../features/cdc/postgres-replication#connecting-with-pg_connection_string).
+
 `pg_sslrootcert` also behaves differently on this transport: inline PEM content is supported only on the federated read/query path, while the WAL replication transport requires `pg_sslrootcert` to be a **file path**.
 
 :::

--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -137,6 +137,30 @@ All replication-specific parameters live under `params:` on the dataset and star
 
 All existing `pg_host`, `pg_port`, `pg_user`, `pg_pass`, `pg_db`, `pg_sslmode`, `pg_connection_string` parameters continue to apply — see the [PostgreSQL Data Connector](../../components/data-connectors/postgres) reference.
 
+### Connecting with `pg_connection_string`
+
+`refresh_mode: changes` accepts `pg_connection_string` in place of the discrete `pg_host` / `pg_port` / `pg_user` / `pg_pass` / `pg_db` parameters, in both libpq `key=value` and `postgresql://` URI form, following the same rules as the federated read path:
+
+```yaml
+datasets:
+  - from: postgres:public.users
+    name: users
+    params:
+      pg_connection_string: postgresql://spice:${secrets:pg_pass}@pg.internal:5432/myapp
+    acceleration:
+      enabled: true
+      engine: duckdb
+      refresh_mode: changes
+      primary_key: id
+      on_conflict:
+        id: upsert
+```
+
+- The connection string **takes precedence** over discrete host/user/database parameters when both are set.
+- `pg_sslmode` and `pg_sslrootcert` are the exception: set discretely, they override whatever the connection string carries.
+- A connection string that omits `sslmode` defaults to **`verify-full`** on the replication transport — unlike the discrete-parameter path, where an unset `pg_sslmode` defaults to `prefer` (see below).
+- Unix-socket hosts are not supported for replication; the connection string must name a TCP host.
+
 ### `pg_sslmode` for WAL streaming
 
 `verify-full` is the recommended production default.
@@ -144,13 +168,15 @@ All existing `pg_host`, `pg_port`, `pg_user`, `pg_pass`, `pg_db`, `pg_sslmode`, 
 | `pg_sslmode`       | Replication transport | Cert chain verified | Hostname verified |
 |--------------------|-----------------------|:-------------------:|:-----------------:|
 | `disable`          | plaintext             | —                   | —                 |
-| `prefer` (default) | plaintext             | —                   | —                 |
+| `prefer` (default with discrete parameters) | plaintext | —          | —                 |
 | `require`          | TLS                   | ❌                  | ❌                |
 | `verify-ca`        | TLS                   | ✅                  | ❌                |
 | `verify-full`      | TLS                   | ✅                  | ✅                |
 
 :::info
 `prefer` behaves as plaintext on the replication transport because the replication client does not expose a safe "try TLS, fall back to plaintext" path. Set `require`, `verify-ca`, or `verify-full` to force TLS on the WAL stream.
+
+When the connection is configured with [`pg_connection_string`](#connecting-with-pg_connection_string) and the string omits `sslmode`, the replication transport defaults to `verify-full` instead of `prefer`.
 :::
 
 ### Accelerator engines


### PR DESCRIPTION
## Summary

Forward-sync for spiceai/spiceai#12000. `refresh_mode: changes` previously built its replication connection only from discrete `pg_host` / `pg_user` / `pg_db`, so a spicepod using `pg_connection_string` registered fine and then failed the changes stream with `missing required parameter pg_host`. CDC now goes through a shared connection helper that mirrors the read pool's rules.

Added a **Connecting with `pg_connection_string`** section to the PostgreSQL CDC page covering what the new helper actually does (`crates/data-connectors/connector-postgres/src/connection.rs` on `origin/trunk`):

- Both libpq `key=value` and `postgresql://` URI forms are accepted (`is_postgres_uri` → `peel_uri_ssl_params`, else `parse_connection_string`).
- The connection string takes precedence over discrete host/user/database params (`connection_identity_from_params` returns early when `connection_string` is set — the regression tests assert a discrete `host: "ignored"` is dropped).
- Discrete `pg_sslmode` / `pg_sslrootcert` still override whatever the string carries (explicit override block after the parse).
- **A connection string that omits `sslmode` yields `verify-full` on the replication transport**, whereas the discrete path's unset `pg_sslmode` still resolves to `prefer` (`SslMode::from_str_strict(None) => Prefer`). Both parsers seed `verify-full`, and `connection_string_flows_into_replication_params` / `uri_connection_string_flows_into_replication_params` assert `repl.sslmode == SslMode::VerifyFull`.
- Unix-socket hosts are rejected for replication (`must specify a TCP host`).

The existing `prefer` default row and info admonition are kept and scoped to the discrete-parameter path rather than flipped — per the docs' `pg_sslmode` flip-flop history, the discrete-path default is unchanged by #12000, and this documents a second, string-specific path alongside it. The connector reference's WAL-transport warning gets the same cross-reference.

vNext only — #12000 merged after v2.1.1 and is in no release tag.

## Source PRs

- spiceai/spiceai#12000 — fix(postgres): honor pg_connection_string for CDC (closes #11994)

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — addition, `website/docs/` only
- [x] Files updated: 2 (`website/docs/features/cdc/postgres-replication.md`, `website/docs/components/data-connectors/postgres/index.md`)