### PR TITLE
docs(search): document the Elasticsearch FTS warm tier (vNext)

### DIFF
--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -22,7 +22,7 @@ Spice supports two full-text search engines:
 | Engine | Description |
 | --- | --- |
 | **Tantivy** (default) | Built-in, in-process BM25 engine. No external dependencies. |
-| **Elasticsearch** | Delegates BM25 indexing and search to an external Elasticsearch cluster. Useful when Elasticsearch is already part of the infrastructure or when its operational characteristics (sharding, replication, snapshots) are preferred. |
+| **Elasticsearch** | Indexes into an external Elasticsearch cluster, fronted by a local Tantivy warm tier that serves searches. Useful when Elasticsearch is already part of the infrastructure or when its operational characteristics (sharding, replication, snapshots) are preferred. |
 
 When no engine is specified, Tantivy is used automatically.
 
@@ -83,6 +83,18 @@ datasets:
 ```
 
 The dataset-level `full_text_search` block selects the engine and provides connection parameters. Column-level `full_text_search.enabled` controls which columns are indexed.
+
+#### Warm tier
+
+With `engine: elasticsearch`, Spice maintains a **local Tantivy warm index in front of the Elasticsearch index**:
+
+- **Writes fan out to both tiers** — every indexed row is written to the local Tantivy index and to Elasticsearch.
+- **Searches are served from the local warm index.** Elasticsearch is queried only as a fallback, and only when the dataset sets [`acceleration.on_zero_results: use_source`](../../reference/spicepod/datasets.md#accelerationon_zero_results); with the default `return_empty`, searches are served from the warm tier alone.
+
+Two cases fall back to querying Elasticsearch directly, each logged at startup:
+
+- **More than one full-text column on the dataset.** The warm index is single-column, so multi-column datasets keep the Elasticsearch-only behavior.
+- **The warm index cannot be built or paired with the Elasticsearch index.** Warm-tier construction never fails dataset load — a warning is logged and Elasticsearch is registered alone. A primary key whose type Elasticsearch normalizes (for example `LargeUtf8` → `Utf8`) is a common cause, because the two tiers must agree on the search column and primary-key fields.
 
 :::note[Enterprise edition]
 The Elasticsearch full-text search engine is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions).


### PR DESCRIPTION
## Summary

Forward-sync for spiceai/spiceai#11971. The full-text search page described `engine: elasticsearch` as delegating "BM25 indexing and search to an external Elasticsearch cluster" — search is no longer delegated. Spice now registers a compound index: a local Tantivy warm tier in front of the Elasticsearch tier.

Documented from `crates/runtime/src/search/full_text/table.rs` (`add_compound_fts_to_table`) and `crates/search/src/index/compound/mod.rs` on `origin/trunk`:

- Writes fan out to both tiers (compound writethrough).
- **Searches are served from the warm Tantivy tier.** The Elasticsearch secondary is queried only on an empty warm result *and* only when the dataset sets `acceleration.on_zero_results: use_source` — the read mode is derived from that setting (`ZeroResultsAction::ReturnEmpty => CompoundReadMode::PrimaryOnly`, `UseSource => FallbackToSecondary`), and `ZeroResultsAction::default()` is `ReturnEmpty`, so the default is warm-tier-only.
- Datasets with more than one full-text column register the Elasticsearch index alone (the compound keys on a single search column; upstream tracks multi-column warm indexing in spiceai/spiceai#11963).
- Warm-tier construction never fails dataset load — on error Elasticsearch is registered alone with a warning. The compatibility check requires both tiers to agree on the search column and primary-key fields, which is why a primary key Elasticsearch normalizes (`LargeUtf8` → `Utf8`) trips it.

The Engines table row is reworded to match. The page's existing Enterprise-edition note still applies unchanged — the warm tier only exists when the Elasticsearch engine is configured.

vNext only — #11971 merged after v2.1.1 and is contained in no release tag.

## Source PRs

- spiceai/spiceai#11971 — feat(search): write-through warm + fallback compound index for FTS

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — addition, `website/docs/` only
- [x] Files updated: 1 (`website/docs/features/search/full-text.md`)