### PR TITLE
docs(models): the spice.ai model source is not loadable in vNext

### DIFF
--- a/website/docs/components/models/index.md
+++ b/website/docs/components/models/index.md
@@ -17,11 +17,11 @@ Spice supports various model providers for large language models (LLMs).
 | [`xai`][xai]               | Models hosted on xAI                         | Alpha             | OpenAI-compatible HTTP endpoint |
 | [`file`][file]             | Local filesystem                             | Release Candidate | GGUF, GGML, SafeTensor          |
 | [`huggingface`][hf]        | Models hosted on HuggingFace                 | Release Candidate | GGUF, GGML, SafeTensor          |
-| [`spice.ai`][spice]        | Models hosted on the Spice.ai Cloud Platform | Release Candidate | OpenAI-compatible HTTP endpoint |
 | [`azure`][azure]           | Azure OpenAI                                 | Alpha             | OpenAI-compatible HTTP endpoint |
 | [`anthropic`][ant]         | Models hosted on Anthropic                   | Alpha             | OpenAI-compatible HTTP endpoint |
 | [`google`][google]         | Google AI language models                    | Alpha             | OpenAI-compatible HTTP endpoint |
 | [`databricks`][databricks] | Models deployed to Databricks Mosaic AI      | Alpha             | OpenAI-compatible HTTP endpoint |
+| ~~`spice.ai`~~             | ~~Spice.ai Cloud Platform~~ ([Deprecated][spice]) | Deprecated   | -                               |
 | ~~`perplexity`~~           | ~~Perplexity~~ ([Deprecated][perplexity])    | Deprecated        | -                               |
 
 [openai]: ./openai/index.md
@@ -69,7 +69,6 @@ The following provider prefixes are supported:
 | `google`     | Google AI                             |
 | `hf`         | Hugging Face                          |
 | `file`       | Local filesystem                      |
-| `spiceai`    | Spice.ai Cloud Platform               |
 | `databricks` | Databricks Mosaic AI                  |
 | `bedrock`    | Amazon Bedrock                        |
 

--- a/website/docs/components/models/spiceai.md
+++ b/website/docs/components/models/spiceai.md
@@ -1,54 +1,16 @@
 ---
-title: 'Spice Cloud Platform'
-description: 'Instructions for using models hosted on the Spice Cloud Platform with Spice.'
-sidebar_label: 'Spice Cloud Platform'
+title: 'Spice Cloud Platform (Deprecated)'
+description: 'Models hosted on the Spice Cloud Platform are no longer loadable in Spice.'
+sidebar_label: 'Spice Cloud Platform (Deprecated)'
 sidebar_position: 6
 ---
 
-To use a model hosted on the [Spice Cloud Platform](https://docs.spice.ai/building-blocks/spice-models), specify the `spice.ai` path in the `from` field.
+:::warning Deprecated
 
-Example:
+The `spice.ai` model source is no longer usable. It loaded traditional machine learning (ONNX) models, which was removed in vNext by [spiceai/spiceai#11684](https://github.com/spiceai/spiceai/pull/11684) along with the `/v1/predict` and `/v1/models/{name}/predict` endpoints. The source has never served large language models — loading a `spiceai` model for chat completions fails with `UnsupportedTaskForModel`.
 
-```yaml
-models:
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats
-    name: drive_stats
-    datasets:
-      - drive_stats_inferencing
-```
+For documentation on Spice Cloud Platform models in previous versions, see the [v2.1.x Spice Cloud Platform documentation](https://docs.spiceai.org/docs/2.1.x/components/models/spiceai).
 
-Specific model versions can be referenced using a version label or Training Run ID.
+:::
 
-```yaml
-models:
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats:latest # Label
-    name: drive_stats_a
-    datasets:
-      - drive_stats_inferencing
-
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf # Training Run ID
-    name: drive_stats_b
-    datasets:
-      - drive_stats_inferencing
-```
-
-## `from` Format
-
-The from key must conform to the following regex format:
-
-```regex
-\A(?:spice\.ai\/)?(?<org>[\w\-]+)\/(?<app>[\w\-]+)(?:\/models)?\/(?<model>[\w\-]+):(?<version>[\w\d\-\.]+)\z
-```
-
-Examples:
-
-- `spice.ai/lukekim/smart/models/drive_stats:latest`: Refers to the latest version of the drive_stats model in the smart application by the user or organization lukekim.
-- `spice.ai/lukekim/smart/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf`: Specifies a model with a unique training run ID.
-
-### Specification
-
-1. **Prefix (Optional):** The value must start with `spice.ai/`.
-1. **Organization/User:** The name of the organization or user (`org`) hosting the model.
-1. **Application Name**: The name of the application (`app`) which the model belongs to.
-1. **Model Name:** The name of the model (`model`).
-1. **Version (Optional):** A colon (`:`) followed by the version identifier (`version`), which could be a semantic version, `latest` for the most recent version, or a specific training run ID.
+For large language models, use one of the [supported model providers](./index.md) — for example an [OpenAI-compatible endpoint](./openai/index.md). See also [Machine Learning Models](../../features/machine-learning-models).


### PR DESCRIPTION
## Summary

`components/models/spiceai.md` still documents the Spice Cloud Platform model source as a working provider — `from: spice.ai/<org>/<app>/models/<model>`, `datasets:` for inferencing, `:latest` / training-run-ID versions. That is the traditional ML (ONNX) path, and it no longer exists.

Two independent problems, one conclusion:

1. **The ML path was removed in vNext.** spiceai/spiceai#11684 (`remove(ml): delete model_components crate and ONNX/Tract ML inference`, merged 2026-07-09, post-v2.1.1) deleted the `model_components` crate and its `spiceai` ML model source. The docs sweep for that source PR correctly deprecated `features/machine-learning-models/index.md` and added the ML note to the Models overview, but missed this provider page.
2. **The source has never served LLMs.** `crates/runtime/src/model/chat.rs` maps `ModelSource::SpiceAI` to `Err(LlmError::UnsupportedTaskForModel { from: "spiceai", task: "llm" })` — verified identical at `v1.5.2`, `v1.6.0`, `v1.7.0`, `v1.8.3`, `v1.9.0`, `v1.10.2`, `v1.11.6`, `v2.0.0`, `v2.1.1` and `trunk`. So the provider table's `LLM Format(s)` cell of "OpenAI-compatible HTTP endpoint" for `spice.ai` was wrong regardless of #11684. The only `spiceai` code path left in `crates/llms/src/spiceai/` is `SpiceAiModelLister`, which just produces an "available models" hint string for error messages — it cannot back a chat model.

With the ML path gone and no LLM path, `spice.ai` supports no task in vNext. `ModelSource::try_from` also requires a `spiceai` prefix, so the page's documented `spice.ai/…` `from` form does not even resolve to a source (`get_source()` → `None` → `UnknownModelSource`).

## What changed

- `website/docs/components/models/spiceai.md` — replaced with a deprecation notice, following the existing convention on `models/perplexity.md` and `features/machine-learning-models/index.md`, linking the v2.1.x snapshot for the previous documentation.
- `website/docs/components/models/index.md` — moved the `spice.ai` row into the Deprecated group next to `perplexity` (same `~~strikethrough~~` + `Deprecated` status + `-` format cell), and removed `spiceai` from the **Model Provider Prefix** table (which is how `perplexity` is already handled — it is absent from that table).

Cross-page grep for the claim (`grep -rn 'spice\.ai/.*models\|Spice.ai Cloud Platform' website/docs/`) returns only these two files; the `spiceai` **data connector** and **catalog** pages are a different, working component and are untouched.

## Version scope

vNext only. The ML path worked through v2.1.x, so `versioned_docs/version-*/components/models/spiceai.md` correctly documents it for those releases (the vNext page was byte-identical to the `version-2.1.x` copy before this change).

Note for reviewers: the versioned provider tables carry the same wrong `LLM Format(s)` value for `spice.ai` (they have both an `ML Format(s)` column reading `ONNX` — correct — and an `LLM Format(s)` column reading `OpenAI-compatible HTTP endpoint` — never true). That is a pre-existing, separately-scoped correction across 9 snapshots and is deliberately **not** included here; happy to file it as a follow-up if you'd like it swept.

## Source refs

- spiceai/spiceai#11684 — `remove(ml): delete model_components crate and ONNX/Tract ML inference`
- `spiceai/spiceai@trunk` `crates/runtime/src/model/chat.rs` — `ModelSource::SpiceAI => Err(LlmError::UnsupportedTaskForModel { task: "llm" })`
- `spiceai/spiceai@trunk` `crates/spicepod/src/component/model.rs` — `TryFrom<&str> for ModelSource` requires a `spiceai` prefix
- `spiceai/spiceai@trunk` `crates/llms/src/spiceai/` — lister only, no chat provider

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only removal; versioned snapshots intentionally unchanged
- [x] Files updated: 2