### PR TITLE
docs(databricks/ducklake/unity catalog): document aws_session_token for temporary S3 credentials

### DIFF
--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -164,6 +164,7 @@ The following parameters control resilience and concurrency for the SQL Statemen
 | `databricks_aws_region`            | The AWS region for the S3 object store. E.g. `us-west-2`.                |
 | `databricks_aws_access_key_id`     | The access key ID for the S3 object store.                               |
 | `databricks_aws_secret_access_key` | The secret access key for the S3 object store.                           |
+| `databricks_aws_session_token`     | Optional. The AWS session token for the S3 object store. Required with temporary (STS) credentials. |
 | `databricks_aws_endpoint`          | The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`. |
 
 Example:

--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -78,6 +78,7 @@ The `access` field controls what operations are allowed on the catalog:
 | `ducklake_aws_region`              | Optional. The AWS region for S3 storage. Default: `us-east-1` when explicit credentials are provided.                                                 |
 | `ducklake_aws_access_key_id`       | Optional. The AWS access key ID for S3 storage. Must be set together with `ducklake_aws_secret_access_key`.                                           |
 | `ducklake_aws_secret_access_key`   | Optional. The AWS secret access key for S3 storage. Must be set together with `ducklake_aws_access_key_id`.                                           |
+| `ducklake_aws_session_token`       | Optional. The AWS session token for S3 storage. Required with temporary (STS) credentials. Ignored, with a warning, unless `ducklake_aws_access_key_id` is also set. |
 | `ducklake_aws_endpoint`            | Optional. Custom S3-compatible endpoint URL (e.g., for MinIO).                                                                                        |
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                                                                  |
 | `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**.                        |

--- a/website/docs/components/catalogs/unity-catalog/index.md
+++ b/website/docs/components/catalogs/unity-catalog/index.md
@@ -70,6 +70,7 @@ The `dataset_params` field is used to configure the dataset-specific parameters 
 - `unity_catalog_aws_region`: The AWS region for the S3 object store. E.g. `us-west-2`.
 - `unity_catalog_aws_access_key_id`: The access key ID for the S3 object store.
 - `unity_catalog_aws_secret_access_key`: The secret access key for the S3 object store.
+- `unity_catalog_aws_session_token`: Optional. The AWS session token for the S3 object store. Required with temporary (STS) credentials.
 - `unity_catalog_aws_endpoint`: The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.
 - `unity_catalog_aws_allow_http`: Enables insecure HTTP connections to the AWS endpoint, useful for S3-compatible servers (e.g. MinIO). Defaults to `false`.
 

--- a/website/docs/components/data-connectors/databricks/index.md
+++ b/website/docs/components/data-connectors/databricks/index.md
@@ -172,6 +172,7 @@ Configure the connection to the object store when using `mode: delta_lake`. Use 
 | `databricks_aws_region`            | Optional. The AWS region for the S3 object store. E.g. `us-west-2`.                            |
 | `databricks_aws_access_key_id`     | The access key ID for the S3 object store.                                                     |
 | `databricks_aws_secret_access_key` | The secret access key for the S3 object store.                                                 |
+| `databricks_aws_session_token`     | Optional. The AWS session token for the S3 object store. Required with temporary (STS) credentials. |
 | `databricks_aws_endpoint`          | Optional. The endpoint for the S3 object store. E.g. `s3.us-west-2.amazonaws.com`.             |
 | `databricks_aws_allow_http`        | Optional. Enables insecure HTTP connections to `databricks_aws_endpoint`. Defaults to `false`. |
 

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -59,6 +59,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `ducklake_aws_region`              | Optional. The AWS region for S3 storage. Default: `us-east-1` when explicit credentials are provided.          |
 | `ducklake_aws_access_key_id`       | Optional. The AWS access key ID for S3 storage. Must be set together with `ducklake_aws_secret_access_key`.    |
 | `ducklake_aws_secret_access_key`   | Optional. The AWS secret access key for S3 storage. Must be set together with `ducklake_aws_access_key_id`.    |
+| `ducklake_aws_session_token`       | Optional. The AWS session token for S3 storage. Required with temporary (STS) credentials. Ignored, with a warning, unless `ducklake_aws_access_key_id` is also set. |
 | `ducklake_aws_endpoint`            | Optional. Custom S3-compatible endpoint URL (e.g., for MinIO).                                                 |
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                           |
 | `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**. |


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12041` added an `aws_session_token` component parameter so temporary (STS) credentials authenticate against the S3 object store. It landed on five components whose docs listed only the access key ID and secret:

| Component | Parameter | Source |
| --- | --- | --- |
| Databricks data connector | `databricks_aws_session_token` | `crates/data-connectors/connector-databricks/src/lib.rs:205` |
| DuckLake data connector | `ducklake_aws_session_token` | `crates/data-connectors/connector-ducklake/src/lib.rs:112` |
| Databricks catalog | `databricks_aws_session_token` | `crates/runtime/src/catalogconnector/databricks.rs:146` |
| DuckLake catalog | `ducklake_aws_session_token` | `crates/runtime/src/catalogconnector/ducklake.rs:69` |
| Unity Catalog | `unity_catalog_aws_session_token` | `crates/runtime/src/catalogconnector/unity_catalog.rs:74` |

End-to-end wiring verified, not just the `ParameterSpec` declaration: the Databricks/Unity Catalog paths carry the token into the Delta Lake storage options, and the DuckLake path emits it as `SESSION_TOKEN` in the DuckDB `CREATE OR REPLACE SECRET __ducklake_s3` statement (`crates/data_components/src/ducklake/mod.rs:117`).

The DuckLake rows also document the guard at `crates/data_components/src/ducklake/mod.rs:70-88`: a session token supplied without `aws_access_key_id` resolves no secret and is logged as ignored.

Delta Lake, DynamoDB, S3 Vectors and Bedrock already documented their `aws_session_token` rows — no change needed there.

## Source PRs

- spiceai/spiceai#12041 — fix(aws): accept aws_session_token for temporary credentials (fixes #10932)

## Versioned-docs propagation

**Addition** — vNext only. The parameter shipped post-v2.1.1 and does not exist in any released version, so `website/versioned_docs/version-*/` is intentionally untouched.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (addition → vNext only)
- [x] Files updated: 5 (matches the diff)