### PR TITLE
docs(databricks): document databricks_auth_mode for pinning the authentication flow

### DIFF
--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -58,6 +58,7 @@ The following parameters are supported for configuring the connection to the Dat
 | `databricks_endpoint` | The Databricks workspace endpoint, e.g. `dbc-a12cd3e4-56f7.cloud.databricks.com`                                                                                                                                                                                                                   |
 | `databricks_token`    | The Databricks API token to authenticate with the Unity Catalog API. Use the [secret replacement syntax](../secret-stores) to reference a secret, e.g. `${secrets:my_databricks_token}`.                                                                                                           |
 | `databricks_use_ssl`  | If true, use a TLS connection to connect to the Databricks endpoint. Default is `true`.                                                                                                                                                                                                            |
+| `databricks_auth_mode` | Optional. Pins the authentication flow instead of inferring it from the credentials that are set. One of `auto`, `token`, `m2m`, `u2m` (case-insensitive). Defaults to `auto`. See [Pinning the authentication mode](#pinning-the-authentication-mode).                                            |
 
 To locate the Databricks endpoint, do the following:
 
@@ -103,6 +104,34 @@ catalogs:
       databricks_endpoint: dbc-a12cd3e4-56f7.cloud.databricks.com
       databricks_client_id: ${secrets:DATABRICKS_CLIENT_ID} # service principal client id
       databricks_client_secret: ${secrets:DATABRICKS_CLIENT_SECRET} # service principal client secret
+```
+
+### Pinning the authentication mode
+
+By default (`databricks_auth_mode: auto`) the catalog connector infers the flow from whichever credentials resolve: a `databricks_token` alone selects personal access token, `databricks_client_id` alone selects U2M, and `databricks_client_id` together with `databricks_client_secret` selects M2M.
+
+Credentials do not only come from the Spicepod. `databricks_token`, `databricks_client_secret`, and the other secret parameters are auto-loaded from the [secret stores](../secret-stores) and the environment (e.g. `DATABRICKS_CLIENT_SECRET`, `SPICE_DATABRICKS_CLIENT_SECRET`) when the Spicepod omits them — so an ambient client secret on the host is enough to switch a U2M catalog to machine-to-machine, which then fails with a service principal `401`.
+
+Set `databricks_auth_mode` to pin the flow. A pinned mode ignores the credentials the flow does not use:
+
+| Value            | Flow                              | Requires                                           |
+| ---------------- | --------------------------------- | -------------------------------------------------- |
+| `auto` (default) | Inferred from the credentials set | —                                                  |
+| `token`          | Personal access token             | `databricks_token`                                 |
+| `m2m`            | Service principal (M2M) OAuth     | `databricks_client_id`, `databricks_client_secret` |
+| `u2m`            | User-to-machine OAuth             | `databricks_client_id`                             |
+
+Values are matched case-insensitively, so `M2M` and `U2M` are also accepted. A required parameter that is missing for the pinned mode fails at load with an error naming it; an unrecognized value is rejected.
+
+```yaml
+catalogs:
+  - from: databricks:my_uc_catalog
+    name: uc_catalog
+    params:
+      databricks_endpoint: dbc-a12cd3e4-56f7.cloud.databricks.com
+      databricks_auth_mode: m2m # ignore any ambient databricks_token
+      databricks_client_id: ${secrets:DATABRICKS_CLIENT_ID}
+      databricks_client_secret: ${secrets:DATABRICKS_CLIENT_SECRET}
 ```
 
 ## `dataset_params`

--- a/website/docs/components/data-connectors/databricks/index.md
+++ b/website/docs/components/data-connectors/databricks/index.md
@@ -77,6 +77,7 @@ Use the [secret replacement syntax](../secret-stores/) to reference a secret, e.
 | `databricks_token`            | The Databricks API token to authenticate with the Unity Catalog API. Can't be used with `databricks_client_id` and `databricks_client_secret`.                                                                                                                                                                                                       |
 | `databricks_client_id`        | The Databricks OAuth client ID. Used with `databricks_client_secret` for service-principal (M2M) auth, or alone for interactive User-to-Machine (U2M) auth. Can't be used with `databricks_token`.                                                                                                                                                   |
 | `databricks_client_secret`    | The Databricks Service Principal Client Secret. Required for M2M auth; omit for U2M auth. Can't be used with `databricks_token`.                                                                                                                                                                                                                     |
+| `databricks_auth_mode`        | Optional. Pins the authentication flow instead of inferring it from the credentials that are set. One of `auto`, `token`, `m2m`, `u2m` (case-insensitive). Defaults to `auto`. See [Pinning the authentication mode](#pinning-the-authentication-mode).                                                                                              |
 
 #### SQL Warehouse tuning
 
@@ -140,7 +141,7 @@ datasets:
 
 ### User-to-Machine (U2M) OAuth
 
-Spice supports the User-to-Machine (U2M) OAuth flow for interactive sign-in against Databricks. To use U2M auth, supply only `databricks_client_id` (without `databricks_token` or `databricks_client_secret`).
+Spice supports the User-to-Machine (U2M) OAuth flow for interactive sign-in against Databricks. To use U2M auth, supply only `databricks_client_id` (without `databricks_token` or `databricks_client_secret`), or set `databricks_auth_mode: u2m` to pin the flow — see [Pinning the authentication mode](#pinning-the-authentication-mode).
 
 When U2M auth is configured, the connector defers initialization until first use. On the first query the runtime opens a browser to complete the Databricks OAuth sign-in, then caches and refreshes the resulting token for subsequent requests.
 
@@ -158,6 +159,35 @@ datasets:
       mode: sql_warehouse
       databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
       databricks_sql_warehouse_id: 2b4e24cff378fb24
+      databricks_client_id: ${secrets:DATABRICKS_CLIENT_ID} # OAuth app client id
+```
+
+### Pinning the authentication mode
+
+By default (`databricks_auth_mode: auto`) the connector infers the flow from whichever credentials resolve: a `databricks_token` alone selects personal access token, `databricks_client_id` alone selects U2M, and `databricks_client_id` together with `databricks_client_secret` selects M2M.
+
+Credentials do not only come from the Spicepod. `databricks_token`, `databricks_client_secret`, and the other secret parameters are auto-loaded from the [secret stores](../secret-stores/) and the environment (e.g. `DATABRICKS_CLIENT_SECRET`, `SPICE_DATABRICKS_CLIENT_SECRET`) when the Spicepod omits them — so an ambient client secret on the host is enough to switch a U2M dataset to machine-to-machine, which then fails with a service principal `401`.
+
+Set `databricks_auth_mode` to pin the flow. A pinned mode ignores the credentials the flow does not use:
+
+| Value            | Flow                            | Requires                                          |
+| ---------------- | ------------------------------- | ------------------------------------------------- |
+| `auto` (default) | Inferred from the credentials set | —                                                |
+| `token`          | Personal access token           | `databricks_token`                                |
+| `m2m`            | Service principal (M2M) OAuth   | `databricks_client_id`, `databricks_client_secret` |
+| `u2m`            | User-to-machine OAuth           | `databricks_client_id`                            |
+
+Values are matched case-insensitively, so `M2M` and `U2M` are also accepted. A required parameter that is missing for the pinned mode fails at load with an error naming it; an unrecognized value is rejected.
+
+```yaml
+datasets:
+  - from: databricks:spiceai.datasets.my_awesome_table
+    name: my_awesome_table
+    params:
+      mode: sql_warehouse
+      databricks_endpoint: dbc-a1b2345c-d6e7.cloud.databricks.com
+      databricks_sql_warehouse_id: 2b4e24cff378fb24
+      databricks_auth_mode: u2m # ignore any ambient client secret or token
       databricks_client_id: ${secrets:DATABRICKS_CLIENT_ID} # OAuth app client id
 ```
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12040` added a `databricks_auth_mode` component parameter to both the Databricks data connector (`crates/data-connectors/connector-databricks/src/lib.rs:185`) and the Databricks catalog connector (`crates/runtime/src/catalogconnector/databricks.rs:127`). Neither page documented it.

The parameter matters beyond being a new knob: `databricks_token` and `databricks_client_secret` are `secret()` parameters, so they are auto-loaded from the secret stores and the environment when the Spicepod omits them. Under the previous (still default) `auto` inference, an ambient `DATABRICKS_CLIENT_SECRET` on the host was enough to switch a U2M Spicepod to machine-to-machine and fail with a service principal `401` — the bug fixed in spiceai/spiceai#11508.

Documented on both pages:

- A `databricks_auth_mode` row in the params table — accepted values `auto` (default), `token`, `m2m`, `u2m`.
- A **Pinning the authentication mode** section: what `auto` infers, why an ambient credential can redirect the flow, the value → flow → required-parameters table, and a worked example.

Verified against source, not the PR description:

- Accepted values and default: `AUTH_MODES = &["auto", "token", "m2m", "u2m"]`, `.default("auto")` (`crates/runtime/src/token_providers/databricks.rs:380`).
- Case-insensitivity is real, not assumed — `one_of_ignore_ascii_case(AUTH_MODES)` on the spec and `value.to_ascii_lowercase()` in `AuthMode::from_params`, so the `M2M` / `U2M` spellings used in these docs are accepted.
- Every documented value has a dispatch arm in `build_auth_credentials`, and each arm's required parameter matches the table (`token` → `databricks_token`; `m2m` → `client_id` + `client_secret`; `u2m` → `client_id`).
- "A pinned mode ignores the credentials the flow does not use" is the `AuthMode::U2M` arm, which reads only `client_id` and never `client_secret`/`token`.
- The load-time failure claims come from `missing_for_mode` and the `InvalidConfiguration` arm for an unrecognized value.

The existing U2M section now cross-links the new section rather than implying omitting the credential is the only way to select U2M.

## Source PRs

- spiceai/spiceai#12040 — fix(databricks): pin the authentication mode with databricks_auth_mode so an auto-loaded client secret can't switch U2M to M2M (fixes #11508)

## Versioned-docs propagation

**Addition** — vNext only. The parameter shipped post-v2.1.1 and does not exist in any released version, so `website/versioned_docs/version-*/` is intentionally untouched.

## Test plan

- [x] `cd website && npm run build` passes (both new `#pinning-the-authentication-mode` anchors resolve)
- [x] Versioned-docs propagation checked (addition → vNext only)
- [x] Files updated: 2 (matches the diff)