### PR TITLE
docs(duckdb accelerator): document the coordinated DuckDB/query memory budget

### DIFF
--- a/website/docs/components/data-accelerators/duckdb/deployment.md
+++ b/website/docs/components/data-accelerators/duckdb/deployment.md
@@ -53,7 +53,9 @@ Datasets sharing a DuckDB instance share the pool. For write-heavy refresh plus 
 
 ### Memory
 
-DuckDB self-tunes its memory limit based on system memory. For containers, set the `duckdb_memory_limit` acceleration parameter to prevent OOM due to cgroup misdetection. Plan for the DuckDB working set plus ~2× for query execution headroom.
+DuckDB self-tunes its memory limit from **host** memory, not the cgroup limit, so in a container each instance's own default over-states what the process may use. When `duckdb_memory_limit` is unset, Spice caps each un-limited DuckDB instance from a cgroup-aware [coordinated memory budget](./index.md#coordinated-memory-budget) shared with the query pool, and warns when it does so.
+
+Set the `duckdb_memory_limit` acceleration parameter to replace that automatic split with a deliberate ceiling. Plan for the DuckDB working set plus ~2× for query execution headroom.
 
 ### Index Parameters
 
@@ -92,7 +94,7 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Symptom                                                | Likely cause                                                  | Resolution                                                                                                  |
 | ------------------------------------------------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Slow first startup after restart                       | WAL replay due to ungraceful shutdown.                        | Use graceful shutdown (`SIGTERM`). Subsequent starts will be fast once the checkpoint is clean.             |
-| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set the `duckdb_memory_limit` acceleration parameter.                                                       |
+| OOM on refresh                                         | DuckDB memory limit too high for container cgroup.            | Set the `duckdb_memory_limit` acceleration parameter. Check the startup log for the coordinated-budget warning to see what the runtime capped each un-limited instance to. |
 | Disk fills during large queries                        | Spill directory on undersized volume.                         | Point `runtime.query.temp_directory` at a larger volume; monitor free space.                                |
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |

--- a/website/docs/components/data-accelerators/duckdb/index.md
+++ b/website/docs/components/data-accelerators/duckdb/index.md
@@ -36,7 +36,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 
 - `duckdb_file` (string, default:`.spice/data/accelerated_duckdb.db`): Path to the DuckDB database file. Applies if `mode` is set to `file`. If the file does not exist, Spice creates it automatically.
 - `duckdb_data_dir` (string, default:`.spice/data/`): Path to the directory the DuckDB database file(s) will be placed in. If both `duckdb_data_dir` and `duckdb_file` are specified, `duckdb_file` will be used and `duckdb_data_dir` will be ignored.
-- `duckdb_memory_limit` (string, default: none): Limits DuckDB's memory usage for instance. Acceptable units are KB, MB, GB, TB (decimal: 1000^i) or KiB, MiB, GiB, TiB (binary: 1024^i). See [DuckDB memory limit documentation](https://duckdb.org/docs/stable/configuration/overview).
+- `duckdb_memory_limit` (string, default: none — the runtime computes a [coordinated memory budget](#coordinated-memory-budget) when this is unset): Limits DuckDB's memory usage for instance. Acceptable units are KB, MB, GB, TB (decimal: 1000^i) or KiB, MiB, GiB, TiB (binary: 1024^i). See [DuckDB memory limit documentation](https://duckdb.org/docs/stable/configuration/overview).
 - `duckdb_preserve_insertion_order` (boolean, default: `true`): Controls whether DuckDB preserves the insertion order of rows in tables. When set to `true`, rows are returned in the order they were inserted. See [DuckDB preserve insertion order documentation](https://duckdb.org/docs/stable/guides/performance/how_to_tune_workloads#the-preserve_insertion_order-option) and [order preservation documentation](https://duckdb.org/docs/stable/sql/dialect/order_preservation).
 - `connection_pool_size` (integer, default: `10` for local SSD / tmpfs / unspecified storage profiles, or `4` for `ebs`; whichever is larger between that floor and the number of datasets sharing the same DuckDB file): Controls the maximum number of connections to keep open in the connection pool for concurrent query execution. See [`acceleration.storage_profile`](../../reference/spicepod/datasets#accelerationstorage_profile) for how the storage profile is selected.
 - `on_refresh_recompute_statistics` (string, default: `enabled`, `disabled` when `refresh_mode` is `changes`): Triggers automatic `ANALYZE` execution after data refreshes. This keeps DuckDB optimizer statistics up-to-date for efficient query plans and performance. Set to `disabled` to turn automatic statistics recomputation off. See [DuckDB ANALYZE statement documentation](https://duckdb.org/docs/stable/sql/statements/analyze).
@@ -80,7 +80,7 @@ Resource requirements depend on workload, dataset size, query complexity, and re
 
 ### Memory
 
-DuckDB manages memory through streaming execution, intermediate spilling, and buffer management. By default, each DuckDB instance (one per DuckDB file) uses up to 80% of available system memory. To control memory usage, set the `duckdb_memory_limit` parameter:
+DuckDB manages memory through streaming execution, intermediate spilling, and buffer management. Left to itself, each DuckDB instance (one per distinct DuckDB file, plus one shared instance for all `mode: memory` datasets) sizes its own `memory_limit` at roughly 80% of **host** RAM — independently of every other instance and of the Spice query engine. To control memory usage explicitly, set the `duckdb_memory_limit` parameter:
 
 ```yaml
 datasets:
@@ -97,6 +97,23 @@ datasets:
 Note that `duckdb_memory_limit` only limits the DuckDB instance it is set on, not the entire runtime process. Additionally, it does not cover all DuckDB operations, such as some insert operations. Index creation and scans are limited by the `duckdb_memory_limit` so ensure adequate memory is provisioned.
 
 Allocate at least 30% more container/machine memory for the runtime process.
+
+#### Coordinated memory budget
+
+Because those per-instance ceilings do not know about each other, a Spicepod with several DuckDB files declares several independent 80%-of-RAM ceilings, stacked on top of the [`runtime.query.memory_limit`](../../reference/spicepod/runtime#runtimequerymemory_limit) pool (90% of RAM by default, 70% when Cayenne acceleration is also active) — an over-commit that risks an OOM kill under load.
+
+At startup, and again on hot-reload, Spice computes a coordinated budget so the **sum** of those ceilings fits within the memory the process can actually use (the cgroup limit in a container). It is always on and has no configuration parameter:
+
+- Each distinct DuckDB instance with **no** `duckdb_memory_limit` is capped at an equal share of what the query pool and any explicit ceilings leave, with a floor of 128 MiB per instance.
+- The query pool is reduced by the same amount, taking roughly half of the contested region and never dropping below a quarter of its uncoordinated default (or 256 MiB when every instance has an explicit ceiling).
+- An explicit `runtime.query.memory_limit` is honored verbatim, and an explicit `duckdb_memory_limit` remains that instance's ceiling — the coordination only sizes what you have not.
+- If the floors above cannot fit the projection, the ceilings are still applied and the residual over-commit is reported.
+
+Coordination is skipped entirely when no DuckDB accelerator is configured, or when the uncoordinated ceilings already fit. Whenever it engages, the runtime logs a warning naming the un-limited instances, the projected uncoordinated ceiling, and the caps it applied — set `duckdb_memory_limit` (and, if needed, `runtime.query.memory_limit`) to replace the automatic split with a deliberate one.
+
+:::note
+Because `memory_limit` is a per-instance DuckDB setting, an automatic cap is not applied to an instance where any dataset sharing the same DuckDB file sets `duckdb_memory_limit` explicitly — that would clobber the explicit value.
+:::
 
 ### Indexes and Memory
 

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -94,17 +94,19 @@ datasets:
 
 ### DuckDB
 
-[DuckDB](../components/data-accelerators/duckdb) manages memory through streaming execution, intermediate spilling, and buffer management. By default, each DuckDB instance uses up to 80% of available system memory.
+[DuckDB](../components/data-accelerators/duckdb) manages memory through streaming execution, intermediate spilling, and buffer management. Left to itself, each DuckDB instance sizes its own limit at roughly 80% of host memory.
 
 **Memory Configuration Parameters:**
 
-| Parameter             | Default           | Description                            |
-| --------------------- | ----------------- | -------------------------------------- |
-| `duckdb_memory_limit` | 80% of system RAM | Maximum memory for the DuckDB instance |
+| Parameter             | Default                                       | Description                            |
+| --------------------- | --------------------------------------------- | -------------------------------------- |
+| `duckdb_memory_limit` | A coordinated share of the query memory budget | Maximum memory for the DuckDB instance |
+
+When `duckdb_memory_limit` is not set, Spice does not leave the instance on DuckDB's own ~80%-of-host-RAM default. At startup it computes a [coordinated memory budget](../components/data-accelerators/duckdb#coordinated-memory-budget) across the query pool and every DuckDB instance so their combined ceilings fit within the memory the process can use, capping each un-limited instance at an equal share and reducing the query pool to match. Explicit `duckdb_memory_limit` and `runtime.query.memory_limit` values are always honored as-is.
 
 **Memory Usage Guidelines:**
 
-- Set `duckdb_memory_limit` to control memory per DuckDB instance
+- Set `duckdb_memory_limit` to control memory per DuckDB instance, rather than relying on the automatic split
 - DuckDB indexes do not support spilling and may consume significant memory
 - Allocate at least 30% additional container/machine memory for the runtime process
 
@@ -251,7 +253,7 @@ For time-series data, sort by timestamp. For multi-tenant data, consider sorting
 | DuckDB        | Memory or Disk | `duckdb_memory_limit`        | Yes             | Medium datasets, complex queries          |
 | SQLite        | Memory or Disk | None                         | No              | Small-medium datasets, simple queries     |
 
-Spice Cayenne and Arrow both use DataFusion as the query execution engine and share the same `runtime.query.memory_limit` configuration. DuckDB manages its own memory pool separately via the `duckdb_memory_limit` parameter.
+Spice Cayenne and Arrow both use DataFusion as the query execution engine and share the same `runtime.query.memory_limit` configuration. DuckDB manages its own memory pool separately via the `duckdb_memory_limit` parameter — though when that parameter is unset, the runtime sizes the two together rather than independently (see [Coordinated memory budget](../components/data-accelerators/duckdb#coordinated-memory-budget)).
 
 ## Memory Allocators
 

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -444,7 +444,7 @@ This configuration permits requests only from the `https://example.com` origin.
 
 The `memory_limit` parameter sets a memory usage cap for the Spice runtime query engine. This limit applies **only** to the query engine and should be used in addition to other memory configuration options, such as `duckdb_memory_limit`. When the limit is reached, DataFusion spills intermediate data to disk using the directory configured in `runtime.query.temp_directory`.
 
-If not specified, defaults to **90% of total system memory** (container-aware). When Cayenne acceleration is active, the default is reduced to **70%** to reserve headroom for Cayenne's dedicated compaction memory pool and its in-memory CDC tier.
+If not specified, defaults to **90% of total system memory** (container-aware). When Cayenne acceleration is active, the default is reduced to **70%** to reserve headroom for Cayenne's dedicated compaction memory pool and its in-memory CDC tier. When DuckDB accelerators are configured, that default is reduced further so the query pool and the DuckDB instance ceilings together fit within available memory — see [Coordinated memory budget](../../components/data-accelerators/duckdb#coordinated-memory-budget). An explicitly configured `memory_limit` is always honored verbatim and is never reduced.
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary

`spiceai/spiceai#11985` added an always-on, cgroup-aware coordinated memory budget (`crates/runtime/src/accelerator_memory_budget.rs`). The docs still described the behavior it replaced.

**What the docs said:** "By default, each DuckDB instance (one per DuckDB file) uses up to 80% of available system memory", and `| duckdb_memory_limit | 80% of system RAM |` in the memory reference.

**What the code does:** when `duckdb_memory_limit` is unset, the instance is no longer left on DuckDB's own default. At startup and on hot-reload the runtime projects the uncoordinated ceiling (query pool + explicit limits + N × DuckDB's ~80%-of-**host**-RAM default) and, when it exceeds the memory the process can use, caps each un-limited instance at an equal share of the query region and reduces the query pool to match. There is no configuration parameter — the only opt-out is setting the limits yourself.

Changes:

- **`data-accelerators/duckdb/index.md`** — new `#### Coordinated memory budget` section; corrected the "each instance uses up to 80% of available system memory" sentence (it is host RAM, and only what DuckDB would do unmanaged); `duckdb_memory_limit`'s "default: none" now points at the coordinated budget.
- **`data-accelerators/duckdb/deployment.md`** — the Memory section said to set `duckdb_memory_limit` "to prevent OOM due to cgroup misdetection", which the runtime now does automatically; troubleshooting row now points at the startup warning.
- **`reference/memory.md`** — default cell corrected; added the coordination paragraph; qualified "DuckDB manages its own memory pool separately".
- **`reference/spicepod/runtime.md`** — `runtime.query.memory_limit`'s documented 90%/70% default is reduced further when DuckDB accelerators are present; an explicit value is honored verbatim.

Every number and behavior claim traced to source rather than the PR description:

- 80% of **host** RAM (not cgroup total): `duckdb_default_per_instance_bytes` × `DUCKDB_DEFAULT_MEMORY_PERCENT = 80`, called with `resource_monitor::get_host_memory()` (`builder.rs:537`).
- "roughly half of the contested region": `DUCKDB_QUERY_SPLIT_PERCENT = 50`.
- "never below a quarter of its uncoordinated default": `DUCKDB_COORD_QUERY_MIN_FRACTION = 4`.
- "128 MiB per-instance floor" / "256 MiB when every instance has an explicit ceiling": `DUCKDB_MIN_INSTANCE_CAP_BYTES` / `DUCKDB_MIN_QUERY_POOL_BYTES`.
- "one per distinct DuckDB file, plus one shared instance for `mode: memory`": the instance-keying documented on `DuckDbBudgetInputs`.
- "always on, no configuration parameter": no `ParameterSpec` is added anywhere in the PR; `plan` is called unconditionally when a DuckDB accelerator exists.
- Explicit values honored: `query_explicit` returns `query_pool_cap_bytes: None`, and the accelerator only inserts the auto limit behind `!cmd.options.contains_key("memory_limit")` (`dataaccelerator/duckdb.rs:758`).
- The shared-instance note: the `has_explicit_sibling` guard in the same block.
- Skipped cases and the warning: the `num_duckdb == 0` / `projected_ceiling_bytes <= total_memory` `NoOp` branches and `emit_duckdb_memory_budget_warning`.
- Residual over-commit still applies the ceilings: `residual_overcommit` is reported, not acted on.

## Source PRs

- spiceai/spiceai#11985 — Auto-cap DuckDB accelerator memory to prevent startup over-commit

## Versioned-docs propagation

**Addition** — vNext only. The coordination shipped post-v2.1.1, so the versioned snapshots correctly document the uncoordinated per-instance default for their releases; `website/versioned_docs/version-*/` is intentionally untouched.

## Test plan

- [x] `cd website && npm run build` passes — the four new cross-page links to `#coordinated-memory-budget` and `#runtimequerymemory_limit` all resolve
- [x] Versioned-docs propagation checked (addition → vNext only)
- [x] Files updated: 4 (matches the diff)