### PR TITLE
docs(postgres catalog): document the deterministic shared replication slot

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -149,7 +149,7 @@ No configuration is required. If FK discovery fails for a schema (e.g., due to i
 
 ## Catalog-Level CDC Acceleration
 
-A PostgreSQL catalog can be accelerated as a whole. Adding an `acceleration` block bootstraps and CDC-accelerates every discovered table (subject to `include`/`exclude`) with no per-table dataset configuration. All accelerated tables share a single replication slot and publication — derived once from the catalog `name` — so the source's write-ahead log (WAL) is decoded once for the entire catalog instead of once per table.
+A PostgreSQL catalog can be accelerated as a whole. Adding an `acceleration` block bootstraps and CDC-accelerates every discovered table (subject to `include`/`exclude`) with no per-table dataset configuration. All accelerated tables share a single replication slot and publication — derived deterministically from the catalog `name`, see [Shared replication slot](#shared-replication-slot) — so the source's write-ahead log (WAL) is decoded once for the entire catalog instead of once per table.
 
 ```yaml
 catalogs:
@@ -176,6 +176,21 @@ Required — there is no catalog-level default. The only supported value is `cha
 
 - **Logical replication must be enabled.** Before accelerating any table, Spice validates the PostgreSQL prerequisites CDC requires — `wal_level = logical` and the replication privilege — and fails fast with a specific, actionable error if either is missing.
 
+### Shared replication slot
+
+The catalog's slot name is `spice_catalog_{catalog_name}_{hash}` — the sanitized catalog `name`, followed by a short hash of the full name so two long names that share a truncated prefix stay distinct, all within PostgreSQL's 63-byte identifier limit. The `spice_catalog_` prefix distinguishes it from the per-dataset `spice_` slots, so a catalog slot and a same-named dataset slot can never collide.
+
+The name is a pure function of the catalog `name`: it carries no instance, host, or process component, and Spice persists no slot identity of its own — the durable state is the PostgreSQL slot itself. Two consequences follow:
+
+- **Restarts and reschedules reuse the slot.** Restarting the runtime, or rescheduling the catalog onto a different node, recomputes the identical name and resumes from the existing slot instead of orphaning it and re-snapshotting the catalog from scratch.
+- **Two Spice instances cannot accelerate the same catalog.** PostgreSQL permits one consumer per replication slot, so before it starts streaming Spice checks whether the slot is already **actively** held. An absent slot is created by the per-table replication path; a present-but-inactive slot is reused; an actively-held slot fails the catalog to load with an error naming the slot and the consumer holding it.
+
+Because a slot can also read as active immediately after the runtime's *own* ungraceful exit — PostgreSQL keeps the walsender marked active until `wal_sender_timeout` elapses — Spice waits for it to free before concluding another consumer owns it. The wait is the server's `wal_sender_timeout` plus a 5-second grace, polled once a second, capped at 3 minutes; when `wal_sender_timeout` is `0` (disabled) a 90-second budget is used instead, because the server will not time out the dropped consumer on its own.
+
+:::warning
+Run only one Spice instance per accelerated PostgreSQL catalog. Because the slot name is instance-independent, a second instance configured with the same catalog `name` competes for the same slot and fails to load rather than silently splitting the change stream.
+:::
+
 ### Table eligibility
 
 Each discovered table is accelerated according to its PostgreSQL [`REPLICA IDENTITY`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY), which determines the row identity available for change data capture:
@@ -187,7 +202,7 @@ Each discovered table is accelerated according to its PostgreSQL [`REPLICA IDENT
 
 Use `include`/`exclude` to narrow scope and suppress the skip warning for tables you will handle another way (federation, or a per-dataset `refresh_mode: full`).
 
-The startup summary reports the accelerated tables broken down by the CDC key each one resolved to — primary key, `USING INDEX`, or `FULL` — alongside the skipped and excluded counts.
+The startup summary reports the accelerated tables broken down by the CDC key each one resolved to — primary key, `USING INDEX`, or `FULL` — alongside the skipped and excluded counts, and names the shared replication slot in use.
 
 If **no** table is eligible, the catalog fails to load with an `ERROR` status rather than registering an empty catalog. The error names the excluded and skipped counts and the fix. Because discovery happens at startup, an empty result is treated as a configuration problem: either every table lacks a usable CDC key, or the `include`/`exclude` patterns matched nothing.
 


### PR DESCRIPTION
## Summary

The catalog-level CDC acceleration section said only that the shared replication slot is "derived once from the catalog `name`". `spiceai/spiceai#12026` gave that derivation user-visible semantics worth documenting: the name is now a pure function of the catalog name with no instance component, which is what makes restart reuse work and what makes a second concurrent instance a hard failure rather than a silent split of the change stream.

Added a **Shared replication slot** subsection to `website/docs/components/catalogs/postgres.md` covering the name format, the two consequences of instance-independence (restart/reschedule reuse; one instance per catalog), and the bounded wait that distinguishes the runtime's own crash-restart from a genuinely competing consumer. Also linked the intro sentence to it and noted that the startup summary names the slot.

Verified against `origin/trunk`, not the PR description:

- Name format `spice_catalog_{sanitized_catalog}_{hash}`: `catalog_slot_name` (`crates/data_components/src/postgres_replication/config.rs:422`), `CATALOG_SLOT_PREFIX = "spice_catalog_"`.
- 63-byte limit and the truncate-plus-hash-of-the-**full**-name rationale: `CATALOG_SLOT_NAME_PORTION_MAX = PG_IDENTIFIER_MAX_BYTES - prefix - 1 - DATASET_HASH_LEN`, and `xxh3_short_hash_prefix(catalog_name, …)` hashing the untruncated name.
- No instance component, and no slot identity persisted by Spice: the function takes only `catalog_name`; contrast with the per-dataset `default_slot_name`. Covered by the `catalog_slot_name_is_deterministic_and_instance_independent` / `..._omits_the_instance_suffix` tests.
- absent → create / present-but-inactive → reuse / active → fail: the three arms of `ensure_catalog_slot_available` (`crates/runtime/src/catalogconnector/postgres_accelerated.rs:416`), backed by `replication_slot_status` reading `active`/`active_pid` from `pg_catalog.pg_replication_slots`.
- Wait budget numbers: `SLOT_RELEASE_GRACE = 5s`, `SLOT_WAIT_BUDGET_WHEN_TIMEOUT_DISABLED = 90s`, `SLOT_WAIT_BUDGET_CAP = 3min`, `SLOT_POLL_INTERVAL = 1s` (`postgres_accelerated.rs:337-345`), sized from the server's `wal_sender_timeout` via `wal_sender_timeout_ms` (`connector-postgres-common/src/lib.rs:328`).
- The error naming the slot and the holding consumer: the `SlotInUse` display string.
- The summary line naming the slot: `summary_message` (`postgres_accelerated.rs:234`).

## Source PRs

- spiceai/spiceai#12026 — feat(catalog): deterministic instance-independent replication slot + fail-loud + restart recovery (#11850)

## Versioned-docs propagation

**Addition** — vNext only. Catalog-level CDC acceleration itself is vNext-only (documented in #1949/#1958/#1977) and does not appear in any `website/versioned_docs/version-*/` snapshot; `grep -rl "Catalog-Level CDC Acceleration" website/versioned_docs/` returns nothing.

## Test plan

- [x] `cd website && npm run build` passes (the new `#shared-replication-slot` anchor resolves)
- [x] Versioned-docs propagation checked (addition → vNext only; feature absent from every snapshot)
- [x] Files updated: 1 (matches the diff)