### PR TITLE
docs(mysql cdc): document the TableMap cross-check on layouts adopted under lag

### DIFF
--- a/website/docs/features/cdc/mysql-replication.md
+++ b/website/docs/features/cdc/mysql-replication.md
@@ -125,9 +125,17 @@ A detach logs an `ERROR` and flips that dataset's `dataset_mysql_replication_mem
 
 ## When the source layout changes
 
-Binlog row events are positional — each event carries column values in source-ordinal order, not by name — so the connector tracks the source table's column layout and refuses to apply events it can't line up against that layout. Compatible changes are adopted automatically: an additive `ALTER TABLE` is picked up from `information_schema` at the schema-change boundary and the stream continues without interruption.
+Binlog row events are positional — each event carries column values in source-ordinal order, not by name — so the connector tracks the source table's column layout and refuses to apply events it can't line up against that layout. Compatible changes are adopted automatically: an additive `ALTER TABLE` is picked up from `information_schema` at the schema-change boundary and the stream continues without interruption — subject to the cross-check in [Layout adopted under lag](#layout-adopted-under-lag).
 
 An **incompatible** change — one where the recorded position would replay row images against a layout that no longer matches (for example resuming after the source table's shape drifted while spiced was down, in a way the stream cannot reconcile with the events it still needs to replay) — cannot be applied without risking silent column misalignment. Rather than corrupt the accelerator, the connector stops and leaves the last known-good position in place. As with a purged position, `mysql_replication_invalid_checkpoint_behavior` controls the response: `error` (the default) surfaces an actionable error, and `restart` drops the position and re-snapshots the table from the current layout.
+
+### Layout adopted under lag
+
+A layout re-read from `information_schema` describes the source table **as it is now**, which under replication lag can already be a *later* DDL than the events still in flight. If the source applies a second `ALTER TABLE` with the same column count — a reorder (`MODIFY ... FIRST` / `AFTER`) or a rename swap — before Spice reaches the first one, the adopted layout maps ordinals the in-flight row images do not use. Column counts still agree, every name still resolves, and values still convert, so nothing would fail on its own.
+
+To catch this, every routed change is cross-checked against the column types the binlog's own `TableMap` event carries — the one description of the row image that travels *with* it. A disagreement is member-fatal: that dataset detaches with an error naming the column and its ordinal, and the rest of the shared binlog group keeps running. Recover by letting replication catch up before the next schema change, then re-bootstrapping the detached dataset with `mysql_replication_invalid_checkpoint_behavior: restart`.
+
+The comparison is deliberately coarse, because a false positive would break a healthy stream. It compares only type *classes*, and skips types whose wire encoding is ambiguous — `DATETIME`/`TIMESTAMP`/`TIME`, `TEXT`/`BLOB`, and `REAL` are not compared at all, and `CHAR`/`VARCHAR`/`BINARY`/`VARBINARY`/`ENUM`/`SET` are treated as a single class. What it does detect decisively is a reorder that moves columns of genuinely different types across each other (for example `INT` ↔ `VARCHAR`, `INT` ↔ `BIGINT`, or `DECIMAL` ↔ `INT`). Each detection increments `replication_schema_mismatch_errors_total`.
 
 ## Semantics and type notes
 
@@ -148,6 +156,8 @@ On `ALTER TABLE` against the replicated table, Spice re-fetches the table's layo
 - **Retyping a dataset column** keeps streaming while values remain convertible to the dataset's Arrow type; an unconvertible value stops the stream with a decode error.
 
 If the stream stopped across a DDL boundary with an un-checkpointed tail, the restart may be unable to decode pre-DDL events — re-bootstrap with `mysql_replication_invalid_checkpoint_behavior: restart`. Quiescing writes to the table around DDL avoids that case entirely.
+
+Issuing a second `ALTER TABLE` before replication has caught up on the first can also detach the dataset — see [Layout adopted under lag](#layout-adopted-under-lag).
 
 ## Metrics
 


### PR DESCRIPTION
## Summary

The MySQL CDC page said a compatible `ALTER TABLE` "is picked up from `information_schema` at the schema-change boundary and the stream continues without interruption." `spiceai/spiceai#12048` added a guard that can now detach a dataset in exactly that path, and the docs described only the un-guarded behavior.

The failure it closes is silent: a layout re-read from `information_schema` describes the table *now*, so under lag it can already reflect a *second* same-column-count `ALTER` (a `MODIFY ... FIRST/AFTER` reorder or a rename swap) that the in-flight row images predate. Counts agree, names resolve, types convert — values just land in the wrong columns, and the fingerprint then advances so a restart sees a "compatible" table.

Added a **Layout adopted under lag** subsection documenting the cross-check against the binlog `TableMap` event's own column types, the member-fatal detach and its recovery, and — importantly — the **limits** of the check, so readers don't treat it as full protection.

Verified against `origin/trunk`:

- The check and where it runs: `layout_event_mismatch` (`crates/data_components/src/mysql_replication/binlog.rs:464`), called on every routed `TableMap` in `shared.rs:1608`.
- Member-fatal, group survives: `routes.remove(&table_id)` + `member_fatal(...)` + `continue 'recv` at the call site — consistent with the detach semantics the page already documents.
- The recovery advice mirrors the error string the runtime actually emits (catch up, then `mysql_replication_invalid_checkpoint_behavior: restart`) rather than being invented.
- The coarseness caveats are the real skip/merge rules in `source_type_class` / `event_type_class`, not a paraphrase of the PR description: `DATETIME`/`TIMESTAMP`/`TIME`, `TEXT`/`BLOB` and `REAL` are not compared; `CHAR`/`VARCHAR`/`BINARY`/`VARBINARY`/`ENUM`/`SET` collapse to one class; unmapped or unrecognized types are skipped (`?` on both `source_type_class` and `event_type_class`).
- `replication_schema_mismatch_errors_total` is incremented by this path (`member.metrics.inc_schema_mismatch_error()`), and the stem is registered in `crates/data-connectors/connector-mysql/src/replication.rs:429` — the metrics table already lists it, so no row was added.

## Source PRs

- spiceai/spiceai#12048 — fix(mysql): verify an adopted layout against the event's own column types (fixes #11764)

## Versioned-docs propagation

**Addition** — vNext only. The guard shipped post-v2.1.1, and `grep -rln "When the source layout changes" website/versioned_docs/` returns nothing, so no snapshot carries this section.

## Notes

Open PR #1979 also edits this file (GTID resume), but in disjoint regions — the params table, the metrics table, and the GTID limitation bullet. This PR touches only the "When the source layout changes" and "Schema changes" prose, so the two are independent facts and should merge cleanly in either order.

## Test plan

- [x] `cd website && npm run build` passes (both new `#layout-adopted-under-lag` anchors resolve)
- [x] Versioned-docs propagation checked (addition → vNext only)
- [x] Files updated: 1 (matches the diff)