### PR TITLE
docs(spicepod tools): fix broken MCP example (mcp_endpoint is not a parameter)

### DIFF
--- a/website/docs/reference/spicepod/tools.md
+++ b/website/docs/reference/spicepod/tools.md
@@ -15,10 +15,8 @@ Example:
 ```yaml
 tools:
   - name: my_mcp_tool
-    from: mcp
+    from: mcp:http://localhost:8090/v1/mcp
     description: 'An MCP tool.'
-    params:
-      mcp_endpoint: http://localhost:3000/sse
 ```
 
 ### `name`
@@ -29,13 +27,20 @@ A unique identifier for this tool.
 
 Defines the source of the tool, or the specific built-in tool to customise. See [Available Tools](../../components/tools#available-tools) for a list of available tools.
 
+For [MCP tools](../../components/tools/mcp), the target is part of the `from` value itself, in the form `mcp:<target>`:
+
+- `mcp:<url>` connects to an MCP server over Streamable HTTP, e.g. `mcp:http://localhost:8090/v1/mcp`.
+- `mcp:<command>` runs a stdio-based MCP server as a subprocess, e.g. `mcp:npx`.
+
+A bare `from: mcp` (without a `:<target>` suffix) is rejected when the spicepod is loaded.
+
 ### `description`
 
 Optional. A textual description of the tool's function.
 
 ### `params`
 
-Optional. A map of key-value pairs for additional parameters specific to the tool.
+Optional. A map of key-value pairs for additional parameters specific to the tool. For MCP tools these are `mcp_args` (stdio), and `mcp_auth_token` / `mcp_headers` (Streamable HTTP) — see [MCP Tools](../../components/tools/mcp#params). The MCP server address is set via `from`, not via `params`.
 
 ### `env`
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/tools.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/tools.md
@@ -15,10 +15,8 @@ Example:
 ```yaml
 tools:
   - name: my_mcp_tool
-    from: mcp
+    from: mcp:http://localhost:8090/v1/mcp
     description: 'An MCP tool.'
-    params:
-      mcp_endpoint: http://localhost:3000/sse
 ```
 
 ### `name`
@@ -29,13 +27,20 @@ A unique identifier for this tool.
 
 Defines the source of the tool, or the specific built-in tool to customise. See [Available Tools](../../components/tools#available-tools) for a list of available tools.
 
+For [MCP tools](../../components/tools/mcp), the target is part of the `from` value itself, in the form `mcp:<target>`:
+
+- `mcp:<url>` connects to an MCP server over Streamable HTTP, e.g. `mcp:http://localhost:8090/v1/mcp`.
+- `mcp:<command>` runs a stdio-based MCP server as a subprocess, e.g. `mcp:npx`.
+
+A bare `from: mcp` (without a `:<target>` suffix) is rejected when the spicepod is loaded.
+
 ### `description`
 
 Optional. A textual description of the tool's function.
 
 ### `params`
 
-Optional. A map of key-value pairs for additional parameters specific to the tool.
+Optional. A map of key-value pairs for additional parameters specific to the tool. For MCP tools these are `mcp_args` (stdio), and `mcp_auth_token` / `mcp_headers` (Streamable HTTP) — see [MCP Tools](../../components/tools/mcp#params). The MCP server address is set via `from`, not via `params`.
 
 ### `env`
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/tools.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/tools.md
@@ -15,10 +15,8 @@ Example:
 ```yaml
 tools:
   - name: my_mcp_tool
-    from: mcp
+    from: mcp:http://localhost:8090/v1/mcp
     description: 'An MCP tool.'
-    params:
-      mcp_endpoint: http://localhost:3000/sse
 ```
 
 ### `name`
@@ -29,13 +27,20 @@ A unique identifier for this tool.
 
 Defines the source of the tool, or the specific built-in tool to customise. See [Available Tools](../../components/tools#available-tools) for a list of available tools.
 
+For [MCP tools](../../components/tools/mcp), the target is part of the `from` value itself, in the form `mcp:<target>`:
+
+- `mcp:<url>` connects to an MCP server over Streamable HTTP, e.g. `mcp:http://localhost:8090/v1/mcp`.
+- `mcp:<command>` runs a stdio-based MCP server as a subprocess, e.g. `mcp:npx`.
+
+A bare `from: mcp` (without a `:<target>` suffix) is rejected when the spicepod is loaded.
+
 ### `description`
 
 Optional. A textual description of the tool's function.
 
 ### `params`
 
-Optional. A map of key-value pairs for additional parameters specific to the tool.
+Optional. A map of key-value pairs for additional parameters specific to the tool. For MCP tools these are `mcp_args` (stdio), and `mcp_auth_token` / `mcp_headers` (Streamable HTTP) — see [MCP Tools](../../components/tools/mcp#params). The MCP server address is set via `from`, not via `params`.
 
 ### `env`
 


### PR DESCRIPTION
## Summary

The **Tools** spicepod reference (`reference/spicepod/tools.md`) leads with an MCP example that does not load:

```yaml
tools:
  - name: my_mcp_tool
    from: mcp
    description: 'An MCP tool.'
    params:
      mcp_endpoint: http://localhost:3000/sse
```

Three separate problems, all verified against source:

| Docs said | What the code does |
| --- | --- |
| `params.mcp_endpoint` sets the MCP server address | **`mcp_endpoint` is not a parameter.** It has never existed in `spiceai/spiceai` (`git log -S "mcp_endpoint"` across all refs returns nothing). `MCPConfig::from_type` reads only `mcp_args`, `mcp_auth_token` (`MCP_AUTH_TOKEN_PARAM`), and `mcp_headers` (`MCP_HEADERS_PARAM`) — an `mcp_endpoint` key is silently dropped. |
| `from: mcp` | **Rejected at load.** `McpToolFactory` does `let Some(("mcp", id)) = component.from.split_once(':')`, so a `from` with no `:` fails with `Invalid component `from` field. Expected: `mcp:<tool_id>``. The server address *is* the `from` target. |
| endpoint path `/sse` | **SSE transport is gone.** `MCPType` has only `StreamableHttp(url::Url)` and `Stdio(String)` variants. |

This is the tail of PR #1567 (*Update MCP transport from SSE to Streamable HTTP*, 2026-04-24), which corrected `components/tools/mcp.md` but missed the spicepod reference page — so the two pages have contradicted each other since: `components/tools/mcp.md` correctly documents `from: mcp:http://example.com/v1/mcp`, while the reference page still shows the pre-#1567 shape.

## What changed

- Replaced the example with a valid Streamable HTTP tool (`from: mcp:http://localhost:8090/v1/mcp`, no `params`).
- `### from` now documents the two `mcp:<target>` forms (URL → Streamable HTTP, command → stdio) and states that a bare `from: mcp` is rejected.
- `### params` now names the real MCP params (`mcp_args`, `mcp_auth_token`, `mcp_headers`) and points at `components/tools/mcp#params`, noting the address comes from `from`.

## Source refs

`spiceai/spiceai` @ `trunk` (`1676acca7d`), re-verified byte-identical at tags `v2.0.1` and `v2.1.1`:

- [`crates/runtime-tools/src/mcp/factory.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-tools/src/mcp/factory.rs) — `split_once(':')` on `component.from`
- [`crates/runtime-tools/src/mcp/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-tools/src/mcp/mod.rs) — `MCPType` variants; `MCPConfig::from_type` param reads

## Version scope

vNext + `2.1.x` + `2.0.x` — the three snapshots that carry this example (all byte-identical before the fix). The `1.x` snapshots use a `websearch` example instead and are unaffected.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: `grep -rn "mcp_endpoint\|from: mcp$" website/docs/ website/versioned_docs/` → **0 remaining hits**
- [x] Files updated: 3 (matches the diff)