### PR TITLE
docs(cli): document the missing `spice login --output` flag

### DIFF
--- a/website/docs/cli/reference/login.md
+++ b/website/docs/cli/reference/login.md
@@ -21,6 +21,11 @@ spice login [command] [flags]
 
 - `-h`, `--help` Print this help message
 - `-k`, `--key` string API key (for spice.ai)
+- `-o`, `--output` string Where to store the resulting credentials. One of `env` (default; appends to a local `.env` file), `json` (prints the credentials as JSON to stdout), or `keychain` (stores them in the platform keychain, e.g. macOS Keychain).
+
+:::note
+`--output` applies to `spice login` itself (the Spice.ai login, with or without `--key`). The provider subcommands below always write to `.env`.
+:::
 
 #### Available Commands
 

--- a/website/versioned_docs/version-2.0.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/login.md
@@ -21,6 +21,11 @@ spice login [command] [flags]
 
 - `-h`, `--help` Print this help message
 - `-k`, `--key` string API key (for spice.ai)
+- `-o`, `--output` string Where to store the resulting credentials. One of `env` (default; appends to a local `.env` file), `json` (prints the credentials as JSON to stdout), or `keychain` (stores them in the platform keychain, e.g. macOS Keychain).
+
+:::note
+`--output` applies to `spice login` itself (the Spice.ai login, with or without `--key`). The provider subcommands below always write to `.env`.
+:::
 
 #### Available Commands
 

--- a/website/versioned_docs/version-2.1.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/login.md
@@ -21,6 +21,11 @@ spice login [command] [flags]
 
 - `-h`, `--help` Print this help message
 - `-k`, `--key` string API key (for spice.ai)
+- `-o`, `--output` string Where to store the resulting credentials. One of `env` (default; appends to a local `.env` file), `json` (prints the credentials as JSON to stdout), or `keychain` (stores them in the platform keychain, e.g. macOS Keychain).
+
+:::note
+`--output` applies to `spice login` itself (the Spice.ai login, with or without `--key`). The provider subcommands below always write to `.env`.
+:::
 
 #### Available Commands
 


### PR DESCRIPTION
## Summary

The `spice login` CLI reference lists only two flags:

```
- `-h`, `--help` Print this help message
- `-k`, `--key` string API key (for spice.ai)
```

The command also accepts **`-o` / `--output`**, which selects the credential-storage backend. It has been undocumented since it shipped.

| | |
| --- | --- |
| Flag | `-o`, `--output` |
| Values | `env` \| `json` \| `keychain` |
| Default | `env` |

From [`bin/spice/src/commands/login/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/login/mod.rs):

```rust
/// Where to store the resulting credentials.
#[arg(long, short = 'o', default_value = "env")]
pub output: LoginOutput,

#[derive(Debug, Clone, Default, clap::ValueEnum)]
pub enum LoginOutput {
    /// Write credentials to .env file (default)
    #[default]
    Env,
    /// Print credentials as JSON to stdout
    Json,
    /// Store credentials in the platform keychain
    Keychain,
}
```

## Scope caveat (worth a reviewer's eye)

`--output` is only threaded into `save_credentials` by `login_spiceai` (the no-subcommand path). Every provider subcommand — `dremio`, `s3`, `postgres`, `snowflake`, `databricks`, `delta-lake`, `spark`, `sharepoint`, `abfs` — calls `merge_auth_config(...)` directly, which always writes `.env`. This PR documents that observed behavior with a `:::note`.

Note that the command's own `long_about` help text disagrees with the code here — it advertises `spice login postgres -o keychain` and `spice login databricks -o json | jq` as examples. If the intent is for `--output` to apply to provider subcommands too, that's a runtime fix in `spiceai/spiceai` and this note should be dropped afterwards; I've documented what the code currently does rather than what the help text claims. Happy to reword if reviewers prefer.

## Version scope

vNext + `2.1.x` + `2.0.x`. `--output` was added in [spiceai/spiceai#9541](https://github.com/spiceai/spiceai/pull/9541) (commit `b410cd4c67`, 2026-03-01); `git tag --contains` shows it first shipped in `v2.0.0`, and no `v1.x` tag contains it — so the `1.x` snapshots are correct as-is and are left untouched.

## Verified against

`spiceai/spiceai` @ `trunk` (`1676acca7d`) — `bin/spice/src/commands/login/mod.rs`, `bin/spice/src/commands/login/providers.rs`.

Also re-checked while here (no changes needed): the `Available Commands` list matches the `LoginCommands` enum exactly (9 subcommands, `delta-lake` correctly kebab-cased), and the `spice cloud login` section's `subscription` / `pat` / `api` methods, `--device` flag, and `SPICE_CLOUD_*` env-var table all match `bin/spice/src/commands/cloud/mod.rs`.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (3 files: vNext + 2.1.x + 2.0.x; 1.x intentionally excluded per the version scope above)
- [x] Files updated: 3 (matches the diff)