### PR TITLE
docs(spicepod embeddings): complete the embeddings `from` prefix list

### DIFF
--- a/website/docs/reference/spicepod/embeddings.md
+++ b/website/docs/reference/spicepod/embeddings.md
@@ -28,7 +28,12 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `google` - Google AI models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/embeddings.md
@@ -28,7 +28,11 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/embeddings.md
@@ -28,7 +28,12 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `google` - Google AI models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 

--- a/website/versioned_docs/version-1.5.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.5.x/reference/spicepod/embeddings.md
@@ -28,7 +28,10 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
 
 Follows the same convention as [`models.from`](./models.md#from).
 

--- a/website/versioned_docs/version-1.6.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.6.x/reference/spicepod/embeddings.md
@@ -28,7 +28,11 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models.md#from).
 

--- a/website/versioned_docs/version-1.7.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.7.x/reference/spicepod/embeddings.md
@@ -28,7 +28,11 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 

--- a/website/versioned_docs/version-1.8.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.8.x/reference/spicepod/embeddings.md
@@ -28,7 +28,11 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models.md#from).
 

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/embeddings.md
@@ -28,7 +28,11 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models.md#from).
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/embeddings.md
@@ -28,7 +28,12 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `google` - Google AI models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/embeddings.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/embeddings.md
@@ -28,7 +28,12 @@ The `from` field specifies the source of the embedding model. It supports the fo
 
 - `huggingface:huggingface.co` - Models from Hugging Face
 - `file:` - Local file paths
-- `openai` - OpenAI models
+- `openai` - OpenAI (or OpenAI-compatible) models
+- `azure` - Azure OpenAI models
+- `databricks` - Databricks-hosted models
+- `bedrock` - Amazon Bedrock models
+- `google` - Google AI models
+- `model2vec` - Model2Vec static embedding models
 
 Follows the same convention as [`models.from`](./models#from).
 


### PR DESCRIPTION
## Summary

The **Embeddings** spicepod reference (`reference/spicepod/embeddings.md`) says `from` "supports the following prefixes" and then lists three:

```
- `huggingface:huggingface.co` - Models from Hugging Face
- `file:` - Local file paths
- `openai` - OpenAI models
```

`EmbeddingPrefix::try_from` accepts **eight**:

```rust
pub enum EmbeddingPrefix {
    OpenAi, Azure, Google, HuggingFace, File, Databricks, Bedrock, Model2Vec,
}
```

So `azure`, `google`, `databricks`, `bedrock`, and `model2vec` were all missing — even though each has its own provider page under `components/embeddings/` (`Azure OpenAI Embedding Models`, `Google AI Embedding Models`, `Databricks Model Provider`, `Amazon Bedrock Model Provider`, `Model2Vec Embedding Models`). The reference page was the only surface implying they are unsupported. Also softened `openai` to "OpenAI (or OpenAI-compatible)" to match that provider page's own title.

## Version scope — the list differs by release

The prefix set grew over time, so this is **not** a flat sweep. I read the enum at each doc version's latest release tag and scoped each snapshot to what that release actually accepted:

| Release tag | Prefixes | Snapshot(s) |
| --- | --- | --- |
| `v1.5.2` | 6 — no `google`, no `model2vec` | `1.5.x` |
| `v1.6.1` … `v1.10.4` | 7 — no `google` | `1.6.x` – `1.10.x` |
| `v1.11.6`, `v2.0.1`, `v2.1.1` | 8 | `1.11.x`, `2.0.x`, `2.1.x`, vNext |

`google` landed for `1.11.x`; `model2vec` for `1.6.x`. Older snapshots keep the smaller, correct list rather than being over-corrected to the vNext set.

## Verified against

`spiceai/spiceai` — [`crates/spicepod/src/component/embeddings.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/embeddings.rs) (`enum EmbeddingPrefix` + its `TryFrom<&str>` impl), read at `trunk` (`1676acca7d`) and at tags `v1.5.2`, `v1.6.1`, `v1.7.3`, `v1.8.3`, `v1.9.2`, `v1.10.4`, `v1.11.6`, `v2.0.1`, `v2.1.1`.

## Noted, not changed

The `Embeddings` struct also carries a `datasets: Vec<String>` field, and this page's own example uses `datasets:` — but the reference page never documents it, and I could not trace any runtime consumer reading it (every `.datasets` read I found is `Model.datasets`, the model component's table allowlist). Rather than document behavior I can't verify, I've left it alone and flagged it here for someone with more context to confirm or file.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation: `grep -rln '^- \`openai\` - OpenAI models$' docs/ versioned_docs/` → **0 remaining hits**
- [x] Files updated: 10 (1 unversioned + 9 versioned — matches the diff)