### PR TITLE
docs(imap): document date-filter pushdown and projection-aware body fetch (vNext)

### DIFF
--- a/website/docs/components/data-connectors/imap.md
+++ b/website/docs/components/data-connectors/imap.md
@@ -58,6 +58,32 @@ With an acceleration enabled, the `content` field will be populated with the com
 
 :::
 
+## Query performance
+
+Filters on the `date` column are pushed down to the IMAP server as a `SEARCH` command, so a query or refresh transfers only the matching messages instead of the whole mailbox.
+
+- **Supported filter shapes.** A comparison of `date` against a timestamp or date literal (`>`, `>=`, `<`, `<=`, `=`, with the column on either side) and conjunctions (`AND`) of those. Lower bounds become `SENTSINCE`, upper bounds `SENTBEFORE`.
+- **Everything else scans the full mailbox.** A filter on any other column, a disjunction (`OR`), `!=`, or a non-temporal literal contributes no `SEARCH` criteria, and the connector fetches every message and filters locally, exactly as before.
+- **Server-side matching is a superset.** IMAP `SEARCH` compares the calendar day of the `Date:` header, disregarding time and timezone ([RFC 3501 §6.4.4](https://www.rfc-editor.org/rfc/rfc3501#section-6.4.4)), so each bound is widened by a day and Spice re-applies the predicate exactly on the returned rows. Results are identical to an unpushed scan; only the bytes transferred change.
+- **Very large match sets fall back to a full fetch.** When the set of matching messages is too large to express compactly as an IMAP identifier set, the connector fetches the whole mailbox instead. The filters are applied above the scan either way, so results are unaffected.
+
+To make an [acceleration](../../features/data-acceleration/) refresh incremental rather than re-reading the mailbox each cycle, set `time_column: date` so that `refresh_mode: append` and [`refresh_data_window`](../../reference/spicepod/datasets#accelerationrefresh_data_window) generate a `date` predicate for the connector to push down:
+
+```yaml
+datasets:
+  - from: imap:jsmith@example.com
+    name: emails
+    time_column: date
+    params:
+      imap_password: ${secrets:IMAP_PASSWORD}
+    acceleration:
+      enabled: true
+      refresh_mode: append
+      refresh_check_interval: 10m
+```
+
+Scans also only request the raw message body when it is needed to populate `content` — that is, when acceleration is enabled (see [Retrieving email body contents](#retrieving-email-body-contents)). A dataset without acceleration transfers envelopes only, and never the MIME parts and attachments of every message. Every body section is requested with `.PEEK`, so querying a dataset never marks messages as read (`\Seen`) on the server.
+
 ## Configuration
 
 ### `from`


### PR DESCRIPTION
## Summary

Two merged PRs changed what an IMAP scan asks the server for. Neither is documented, and the first one is the difference between an acceleration refresh costing the whole mailbox every cycle and costing only new mail — the reported case was 6m19s of fetch for ~1,100 messages, paid in full on every refresh.

- **`spiceai/spiceai#12039`** — `ImapTableProvider` now implements `supports_filters_pushdown` and translates `date` predicates into IMAP `SEARCH` criteria (`SENTSINCE` / `SENTBEFORE`), addressing the matches by UID. Previously every predicate was applied in a `FilterExec` above the scan while `scan()` fetched `1:N` unconditionally — which silently defeated both mechanisms meant to bound refresh cost, since `refresh_mode: append` and `refresh_data_window` each express themselves as exactly such a `date` filter.
- **`spiceai/spiceai#12060`** — the fetch attribute list is now derived from whether `content` needs filling: `(ENVELOPE BODY.PEEK[])` when it does, `(ENVELOPE)` when it does not. An unaccelerated dataset no longer transfers every MIME part and attachment of every message only to discard them.

Adds a **Query performance** section to `website/docs/components/data-connectors/imap.md` covering the supported filter shapes, why pushdown is `Inexact` (IMAP `SEARCH` compares the `Date:` header's calendar day disregarding timezone, so bounds are widened by a day and Spice re-applies the predicate exactly), the full-mailbox fallbacks, and the `time_column: date` configuration that makes an append refresh incremental — plus the body-fetch behavior and the `.PEEK` guarantee that a scan never sets `\Seen`.

Verified against `origin/trunk`, not the merged diffs:

- Filter shapes and operators from `search_criteria` / `collect_date_keys` in `crates/data-connectors/connector-imap/src/imap/search.rs` — `date` vs. a timestamp/date literal in either operand order for `>`, `>=`, `<`, `<=`, `=`, plus `AND` conjunctions; `OR`, `!=`, other columns, and non-temporal literals contribute no criteria.
- The one-day widening and its rationale from `SKEW_DAYS` and the RFC 3501 §6.4.4 citation in the same file.
- The `Inexact` / `Unsupported` verdicts from `supports_filters_pushdown` in `imap/provider.rs`.
- The attribute lists from `fetch_query(fetch_content)` in `imap/provider.rs`, and `fetch_content = dataset.is_accelerated()` from `read_provider` in `connector-imap/src/lib.rs` — which is why the section ties the raw-message fetch to acceleration being enabled, matching what the **Retrieving email body contents** section already says, rather than to the `content` column's presence.

vNext only: `git grep -c supports_filters_pushdown v2.1.1 -- crates/data-connectors/connector-imap/src/` returns no hits, so neither change is in a released version and no `versioned_docs/` snapshot should describe them.

## Source PRs

- spiceai/spiceai#12039 — fix(imap): narrow scans with IMAP SEARCH instead of refetching the mailbox (fixes #11548)
- spiceai/spiceai#12060 — fix(imap): fetch the raw message only when a scan reads content (fixes #12045)

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / anchors / undefined tags). The gate caught a broken anchor on the first run — `datasets#refresh_data_window` does not exist; the heading is `## acceleration.refresh_data_window`, so the link now uses `#accelerationrefresh_data_window`, matching the convention used elsewhere in `website/docs/`
- [x] Both added links verified to resolve to the intended page and anchor (`../../features/data-acceleration/`, `../../reference/spicepod/datasets#accelerationrefresh_data_window`, in-page `#retrieving-email-body-contents`)
- [x] Versioned-docs propagation checked — vNext-only addition (feature absent at `v2.1.1`)
- [x] Files updated: 1