### PR TITLE
ci: run Generate API Docs on Node 24 to match the site's engines (fixes #1996)

### DIFF
--- a/.github/workflows/updated_openapi.yml
+++ b/.github/workflows/updated_openapi.yml
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 0 # Ensure the full history is available
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Install dependencies
         working-directory: website


### PR DESCRIPTION
## Summary
Fixes #1996

The **Generate API Docs** job fails at `npm ci` on every PR that touches `website/public/openapi.json`, so the schema bot never regenerates or pushes the API `.mdx` files:

```
npm error Missing: yaml@2.9.0 from lock file
```

This is a Node/npm version mismatch, not lockfile drift. `website/package.json` declares `engines: node >=24.0`, and `website/package-lock.json` (`lockfileVersion: 3`) is written by npm 11. The job pinned `node-version: '20'`, whose npm 10 resolves the auto-installed `yaml@^2.4.2` peer of `postcss-load-config` (via `tailwindcss`) differently and reports it missing.

Verified on the current `trunk` lockfile with Node 24 / npm 11: `npm ci --dry-run` succeeds and `npm install` is a no-op — the lockfile is in sync; only the Node 20 job disagrees.

## Changes
- `.github/workflows/updated_openapi.yml`: `node-version: '20'` → `24`, `setup-node@v3` → `@v4`.

This matches `build_and_publish.yml` (Deploy), which already runs `setup-node@v4` with Node 24 and installs cleanly. The `@v4` bump also clears the `setup-node@v3` Node 20 runtime deprecation warning.

## Test plan
- [x] `npm ci --dry-run` succeeds locally against the unchanged `trunk` lockfile on Node 24 / npm 11
- [x] `cd website && npm run build` passes locally
- [ ] Next PR touching `website/public/openapi.json` runs Generate API Docs green