### PR TITLE
docs(accelerators): recommend Spice Cayenne for datasets 10 GB and larger

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -25,7 +25,7 @@ Spice Cayenne uses Vortex as its storage format, providing significant performan
 
 Vortex is a Linux Foundation (LF AI & Data) project under Apache-2.0 license with neutral governance. For performance benchmarks, see [bench.vortex.dev](https://bench.vortex.dev/).
 
-While [DuckDB](duckdb) excels for datasets up to approximately 1TB, Spice Cayenne with Vortex is designed to scale beyond these limits.
+Spice Cayenne is recommended for any dataset of **10 GB or larger**. [DuckDB](duckdb) suits smaller datasets, but its memory requirements grow faster: Cayenne typically needs one-third to one-half the memory of the DuckDB accelerator for the same dataset, and scales beyond the limits at which a single DuckDB file becomes impractical.
 
 ## Architecture
 

--- a/website/docs/components/data-accelerators/duckdb/deployment.md
+++ b/website/docs/components/data-accelerators/duckdb/deployment.md
@@ -53,6 +53,12 @@ Datasets sharing a DuckDB instance share the pool. For write-heavy refresh plus 
 
 ### Memory
 
+:::tip[Datasets 10 GB or larger]
+
+For any dataset of **10 GB or larger**, deploy [Spice Cayenne](../cayenne/index.md) instead of DuckDB, because of DuckDB's memory requirements. Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset, which lowers the memory request a container needs to run the workload safely.
+
+:::
+
 DuckDB self-tunes its memory limit from **host** memory, not the cgroup limit, so in a container each instance's own default over-states what the process may use. When `duckdb_memory_limit` is unset, Spice caps each un-limited DuckDB instance from a cgroup-aware [coordinated memory budget](./index.md#coordinated-memory-budget) shared with the query pool, and warns when it does so.
 
 Set the `duckdb_memory_limit` acceleration parameter to replace that automatic split with a deliberate ceiling. Plan for the DuckDB working set plus ~2× for query execution headroom.

--- a/website/docs/components/data-accelerators/duckdb/index.md
+++ b/website/docs/components/data-accelerators/duckdb/index.md
@@ -80,6 +80,12 @@ Resource requirements depend on workload, dataset size, query complexity, and re
 
 ### Memory
 
+:::tip[Datasets 10 GB or larger]
+
+For any dataset of **10 GB or larger**, [Spice Cayenne](../cayenne/index.md) is recommended over DuckDB, because of DuckDB's memory requirements. Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset, and its query execution is governed by [`runtime.query.memory_limit`](../../../reference/spicepod/runtime#runtimequerymemory_limit) with spill-to-disk rather than a separate per-instance pool.
+
+:::
+
 DuckDB manages memory through streaming execution, intermediate spilling, and buffer management. Left to itself, each DuckDB instance (one per distinct DuckDB file, plus one shared instance for all `mode: memory` datasets) sizes its own `memory_limit` at roughly 80% of **host** RAM — independently of every other instance and of the Spice query engine. To control memory usage explicitly, set the `duckdb_memory_limit` parameter:
 
 ```yaml

--- a/website/docs/components/data-accelerators/index.md
+++ b/website/docs/components/data-accelerators/index.md
@@ -49,8 +49,8 @@ Select the appropriate accelerator based on dataset size, query patterns, and re
 | Use Case                                            | Recommended Accelerator | Rationale                                               |
 | --------------------------------------------------- | ----------------------- | ------------------------------------------------------- |
 | Small datasets (under 1 GB), maximum speed          | `arrow`                 | In-memory storage provides lowest latency               |
-| Medium datasets (1-100 GB), complex SQL             | `duckdb`                | Mature SQL support with memory management               |
-| Large datasets (100 GB - 1+ TB), scalable analytics | `cayenne`               | Vortex columnar format scales beyond single-file limits |
+| Small datasets (1-10 GB), complex SQL               | `duckdb`                | Mature SQL support with memory management               |
+| Datasets 10 GB and above (up to 1+ TB)              | `cayenne`               | Needs 1/3 to 1/2 the memory of `duckdb`; Vortex columnar format scales beyond single-file limits |
 | Point lookups on large datasets                     | `cayenne`               | Vortex provides 100x faster random access vs Parquet    |
 | Simple queries, low resource usage                  | `sqlite`                | Lightweight, minimal overhead                           |
 | Async operations, concurrent workloads              | `turso`                 | Native async support, modern connection pooling         |
@@ -58,19 +58,19 @@ Select the appropriate accelerator based on dataset size, query patterns, and re
 
 ### Spice Cayenne vs DuckDB
 
-Both [Spice Cayenne](data-accelerators/cayenne) and [DuckDB](data-accelerators/duckdb) support file-based acceleration, but differ in architecture and performance characteristics:
+Both [Spice Cayenne](data-accelerators/cayenne) and [DuckDB](data-accelerators/duckdb) support file-based acceleration, but differ in architecture and performance characteristics. **Spice Cayenne is recommended for any dataset of 10 GB or larger**, because of DuckDB's memory requirements: Cayenne typically needs one-third to one-half the memory of the DuckDB accelerator for the same dataset.
 
 **Choose Spice Cayenne when:**
 
-- Datasets exceed ~1 TB
+- Datasets are 10 GB or larger
+- Memory headroom is constrained, or the deployment must run in a smaller container
 - Multi-file data ingestion is required (e.g., partitioned S3 data)
-- Lower memory overhead is preferred
 - Workloads benefit from Vortex's [10-20x faster scans](https://bench.vortex.dev)
 - Point lookups and random access patterns are common ([100x faster than Parquet](https://bench.vortex.dev))
 
 **Choose DuckDB when:**
 
-- Datasets are under ~1 TB
+- Datasets are under 10 GB
 - Complex SQL features are required (window functions, CTEs)
 - Existing DuckDB tooling integration is beneficial
 - Explicit index control is required

--- a/website/docs/features/data-acceleration/index.md
+++ b/website/docs/features/data-acceleration/index.md
@@ -39,10 +39,10 @@ Consider a high-volume e-trading frontend application backed by an AWS RDS datab
 | Engine     | Best For                                           | Mode                                              |
 | ---------- | -------------------------------------------------- | ------------------------------------------------- |
 | `arrow`    | Read-heavy analytics, in-memory speed              | `memory`                                          |
-| `duckdb`   | Complex analytical queries, file-based persistence | `memory`, `file`, `file_create`, or `file_update` |
+| `duckdb`   | Complex analytical queries under 10 GB, file-based persistence | `memory`, `file`, `file_create`, or `file_update` |
 | `sqlite`   | OLTP-style point lookups, concurrent reads/writes  | `memory`, `file`, `file_create`, or `file_update` |
 | `postgres` | When a full SQL database is needed as accelerator  | External                                          |
-| `cayenne`  | Large datasets (1TB+), high-performance columnar   | `file`, `file_create`, or `file_update`           |
+| `cayenne`  | Datasets 10 GB and above, high-performance columnar | `file`, `file_create`, or `file_update`           |
 | `turso`    | Embedded libSQL, lightweight file-based caching    | `memory`, `file`, `file_create`, or `file_update` |
 
 ## Example

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -28,6 +28,12 @@ Memory requirements vary based on workload characteristics, dataset sizes, query
 
 Memory requirements can be reduced by using file-based acceleration with [DuckDB](../components/data-accelerators/duckdb), [SQLite](../components/data-accelerators/sqlite), [Turso](../components/data-accelerators/turso), or [Spice Cayenne](../components/data-accelerators/cayenne), which store data on disk and support spilling.
 
+:::tip[Datasets 10 GB or larger]
+
+For any dataset of **10 GB or larger**, [Spice Cayenne](../components/data-accelerators/cayenne) is recommended over [DuckDB](../components/data-accelerators/duckdb), because of DuckDB's memory requirements. Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset.
+
+:::
+
 ## Accelerator-Specific Memory Management
 
 Different acceleration engines have distinct memory characteristics and tuning options.
@@ -106,6 +112,7 @@ When `duckdb_memory_limit` is not set, Spice does not leave the instance on Duck
 
 **Memory Usage Guidelines:**
 
+- For datasets of **10 GB or larger**, prefer [Spice Cayenne](#spice-cayenne), which typically needs one-third to one-half the memory of DuckDB for the same dataset
 - Set `duckdb_memory_limit` to control memory per DuckDB instance, rather than relying on the automatic split
 - DuckDB indexes do not support spilling and may consume significant memory
 - Allocate at least 30% additional container/machine memory for the runtime process
@@ -249,8 +256,8 @@ For time-series data, sort by timestamp. For multi-tenant data, consider sorting
 | Accelerator   | Storage        | Query Memory Control         | Memory Spilling | Best For                                  |
 | ------------- | -------------- | ---------------------------- | --------------- | ----------------------------------------- |
 | Arrow         | Memory only    | `runtime.query.memory_limit` | Yes             | Small datasets, maximum speed             |
-| Spice Cayenne | Disk (Vortex)  | `runtime.query.memory_limit` | Yes             | Large datasets (1TB+), scalable analytics |
-| DuckDB        | Memory or Disk | `duckdb_memory_limit`        | Yes             | Medium datasets, complex queries          |
+| Spice Cayenne | Disk (Vortex)  | `runtime.query.memory_limit` | Yes             | Datasets 10 GB and above, scalable analytics; lowest memory footprint |
+| DuckDB        | Memory or Disk | `duckdb_memory_limit`        | Yes             | Datasets under 10 GB, complex queries     |
 | SQLite        | Memory or Disk | None                         | No              | Small-medium datasets, simple queries     |
 
 Spice Cayenne and Arrow both use DataFusion as the query execution engine and share the same `runtime.query.memory_limit` configuration. DuckDB manages its own memory pool separately via the `duckdb_memory_limit` parameter — though when that parameter is unset, the runtime sizes the two together rather than independently (see [Coordinated memory budget](../components/data-accelerators/duckdb#coordinated-memory-budget)).

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -23,8 +23,8 @@ Choose the appropriate [Data Accelerator](../components/data-accelerators) based
 | Scenario                                 | Recommended Accelerator    | Key Configuration                                                     |
 | ---------------------------------------- | -------------------------- | --------------------------------------------------------------------- |
 | Small datasets (under 1 GB), low latency | `arrow`                    | Default in-memory                                                     |
-| Medium datasets (1-100 GB), complex SQL  | `duckdb` with `mode: file` | Set `duckdb_memory_limit`                                             |
-| Large datasets (100 GB - 1+ TB)          | `cayenne`                  | Tune cache parameters                                                 |
+| Small datasets (1-10 GB), complex SQL    | `duckdb` with `mode: file` | Set `duckdb_memory_limit`                                             |
+| Datasets 10 GB and above (up to 1+ TB)   | `cayenne`                  | Tune cache parameters; needs 1/3 to 1/2 the memory of `duckdb`        |
 | Write-heavy workloads                    | `cayenne` with `zstd`      | Set `cayenne_compression_strategy: zstd`                              |
 | Point lookups, large datasets            | `cayenne`                  | Vortex provides [100x faster random access](https://bench.vortex.dev) |
 | Point lookups, small-medium datasets     | `arrow` with hash index    | Set a `primary_key` to auto-enable the hash index (experimental, v1.11.0-rc.2+) |
@@ -92,6 +92,12 @@ Choose `btrblocks` for read-heavy analytics workloads. Use `zstd` only when size
 ## DuckDB Performance Optimization
 
 [DuckDB](../components/data-accelerators/duckdb) provides mature SQL support with sophisticated query optimization.
+
+:::tip[Datasets 10 GB or larger]
+
+For any dataset of **10 GB or larger**, [Spice Cayenne](../components/data-accelerators/cayenne) is recommended over DuckDB, because of DuckDB's memory requirements. Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset. See [Spice Cayenne Performance Optimization](#spice-cayenne-performance-optimization).
+
+:::
 
 ### Memory Configuration
 


### PR DESCRIPTION
## Summary

Recommends **Spice Cayenne over DuckDB for any dataset of 10 GB or larger**, because of DuckDB's memory requirements — Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset.

This is maintainer-provided product guidance, not a claim derived from source: the 10 GB threshold and the 1/3–1/2 memory ratio come from the Spice team, and I have not invented supporting numbers around them. What I did verify from the docs is that the existing guidance said the *opposite* in several places and had to be realigned, or the new recommendation would have contradicted the pages a reader lands on next.

**Where the recommendation was added** (the surfaces named in the request):

- `components/data-accelerators/duckdb/index.md` — callout at the top of **Resource Considerations → Memory**
- `components/data-accelerators/duckdb/deployment.md` — callout at the top of **Capacity & Sizing → Memory**, framed around the container memory request
- `reference/memory.md` — callout under **General Memory Recommendations**, a guideline bullet in the **DuckDB** section, and the **Embedded Data Accelerator Comparison** table's "Best For" column
- `reference/performance-tuning.md` — callout under **DuckDB Performance Optimization** and the **Accelerator Selection** table

**Thresholds realigned so nothing contradicts it** (each of these previously pointed users to DuckDB at sizes now covered by the recommendation):

- `components/data-accelerators/index.md` — the **Choosing an Accelerator** table plus the **Spice Cayenne vs DuckDB** lists, which said "Choose Spice Cayenne when: datasets exceed ~1 TB" / "Choose DuckDB when: datasets are under ~1 TB"
- `components/data-accelerators/cayenne/index.md` — "While DuckDB excels for datasets up to approximately 1TB…"
- `features/data-acceleration/index.md` — the engine table's `duckdb` and `cayenne` "best for" cells (`cayenne` said "Large datasets (1TB+)")

The old `arrow` boundary (under 1 GB) is unchanged; the DuckDB band becomes 1–10 GB.

**vNext only — deliberately.** Cayenne is `Stable` only in `website/docs/`; it is still `Release Candidate` in both `versioned_docs/version-2.1.x/` and `version-2.0.x/` (verified in each snapshot's accelerator table). Recommending it as the default accelerator for production datasets in a release where the docs label it RC would contradict that page, so this guidance is not propagated to the versioned snapshots.

## Note for a follow-up (not bundled here)

`reference/performance-tuning.md` still carries a guideline bullet reading "DuckDB defaults to 80% of system memory per instance". On vNext that is stale — spiceai/spiceai#11985 added the cgroup-aware [coordinated memory budget](https://docs.spiceai.org/docs/components/data-accelerators/duckdb#coordinated-memory-budget), so an un-limited instance is capped rather than left at DuckDB's own ~80% default (docs #1986 fixed this on the DuckDB and memory pages but not here). It sits two lines from an edit in this PR, but it is a claim correction rather than guidance, so it belongs in its own `kind/bug` PR instead of being mixed in.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / anchors / undefined tags)
- [x] Added links and in-page anchors verified: `../cayenne/index.md`, `../../../reference/spicepod/runtime#runtimequerymemory_limit`, `#spice-cayenne-performance-optimization`, and `#spice-cayenne` (each confirmed against the target heading)
- [x] Contradiction sweep: `grep -rnE "1 ?TB|1-100 ?GB|100 ?GB|Medium datasets"` across `website/docs/` — every remaining hit is unrelated (SQLite sizing, refresh-mode memory multipliers, a pushdown example, and Cayenne's own "scales beyond 1TB" capability statement, which is not a DuckDB recommendation)
- [x] Versioned-docs propagation checked — vNext-only, per the RC-status reasoning above
- [x] Files updated: 7