### PR TITLE
docs(troubleshooting): make the sandbox container approachable for Kubernetes newcomers

### DIFF
--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -267,10 +267,14 @@ explain select * from taxi_trips;
 
 If you try to open a shell in a Spice container the way you would with most images, it fails:
 
+**On your machine:**
+
 ```console
 $ kubectl exec -it my-spicepod -- bash
 error: exec: "bash": executable file not found in $PATH
 ```
+
+The error comes from *inside* the container: `kubectl` reached the pod successfully, then found no `bash` there to execute.
 
 This is expected, not a broken container. The sections below explain why, and give three ways to debug depending on what you need to look at.
 
@@ -296,21 +300,44 @@ This is deliberate: an image with no shell and no packages has a far smaller att
 
 Start with the SQL REPL if the question is about data or queries. Reach for an ephemeral container when the question is about the environment — config files, mounted volumes, DNS, or connectivity.
 
+### Where commands run
+
+Debugging a container means moving between machines, and the same command can behave differently — or fail — depending on where it is typed. Three contexts appear below, and **every command block states which one it belongs to**:
+
+| Context                        | Where it actually executes                                                                                                                              | How you get there                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **Your machine**               | Your own workstation or CI runner — wherever `kubectl` and `docker` are installed. These commands talk *to* the cluster or Docker daemon, not inside it. | The default; no extra step               |
+| **Inside the Spice container** | The sandbox container running `spiced`. No shell here, so only `spiced` itself, or a mounted binary such as `busybox`, can be run.                       | `kubectl exec` / `docker exec`           |
+| **Inside the debug container** | A *separate* temporary container in the same pod, with its own filesystem and its own tools. Spice's files are **not** at their usual paths here.        | `kubectl debug` drops you straight in    |
+
+Two consequences that catch people out:
+
+- `kubectl` and `docker` commands are typed on **your machine**, but the part after `--` (or after the container name) executes **inside the container**. In `kubectl exec -it my-pod -- spiced --repl`, `kubectl` runs locally while `spiced --repl` runs in the container — which is why `localhost` in that command means the container's own localhost, not your machine's.
+- `kubectl debug` does **not** put you inside the Spice container. It puts you in a new debug container beside it. That is why inspecting Spice's files from there needs the `/proc/1/root` prefix described below.
+
 ### SQL REPL
 
-The REPL needs no shell, because `spiced` is itself the binary being executed. It connects to the runtime's Flight endpoint at `http://localhost:50051`, so run it *inside* the pod or container to attach to the runtime already running there:
+The REPL needs no shell, because `spiced` is itself the binary being executed.
+
+**On your machine** — the `spiced --repl` part after the container name executes **inside the Spice container**:
 
 ```console
+# Docker
 docker exec -it <container_id> spiced --repl
-```
 
-Or from `kubectl`:
-
-```console
+# Kubernetes
 kubectl exec -it <pod_name> -- spiced --repl
 ```
 
+Because `spiced --repl` runs inside the container, it connects to that container's own `http://localhost:50051` Flight endpoint — attaching to the runtime already serving there. The interactive SQL prompt that follows is therefore executing queries **inside the deployment**, not locally.
+
 This is the quickest way to check whether a dataset loaded, inspect a schema, or reproduce a slow query from inside the deployment.
+
+:::note
+
+Running `spiced --repl` on **your machine** instead is a different thing entirely: it would try to reach a runtime on your own `localhost:50051`. To query a remote runtime from your workstation without `kubectl exec`, use `spice sql --endpoint <url>` (it accepts `http://`, `https://`, `grpc://`, and `grpc+tls://`), pointing at an address the runtime is reachable on — for example one published by `kubectl port-forward`.
+
+:::
 
 ### Debug Kubernetes Pods with Ephemeral Containers
 
@@ -319,6 +346,8 @@ An [ephemeral container](https://kubernetes.io/docs/concepts/workloads/pods/ephe
 This is the recommended way to debug Spice on Kubernetes.
 
 #### 1. Find the pod and container names
+
+**On your machine:**
 
 ```bash
 # List pods in the namespace
@@ -332,6 +361,8 @@ The Helm chart names the Spice container `spiceai`. Run the second command rathe
 
 #### 2. Start the debug container
 
+**On your machine:**
+
 ```bash
 kubectl debug -it my-spicepod-name \
   -n my-spicepod-ns \
@@ -340,18 +371,22 @@ kubectl debug -it my-spicepod-name \
   --profile=sysadmin
 ```
 
+This command returns with an interactive prompt, and **from here on you are inside the debug container** — a different filesystem from both your machine and the Spice container.
+
 What each flag does:
 
 | Flag                 | Meaning                                                                                                                                                                        |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `-it`                | Attach an interactive terminal, as with `kubectl exec -it`.                                                                                                                     |
-| `--image`            | The image providing the debugging tools. `ubuntu:24.04` gives a familiar shell and `apt`; any image with the tools you need works.                                              |
+| `--image`            | The image providing the debugging tools, and therefore the only source of tools available once inside. `ubuntu:24.04` gives a familiar shell and `apt` to install more; any image works. |
 | `--target`           | The container in the pod to attach to, from step 1. This is what makes the Spice process and its filesystem visible — omit it and you get an isolated container that sees nothing of the runtime. |
 | `--profile=sysadmin` | Applies the `sysadmin` [static debugging profile](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#static-profile), which grants the elevated capabilities needed to inspect another container's files and processes. |
 
 #### 3. Inspect the runtime
 
-The debug container has **its own** filesystem — from `ubuntu:24.04`, not from Spice — so `/app` is empty and Spice's files are not where you might expect. Because `--target` shares the process namespace, `spiced` is visible as PID 1, and Linux exposes any process's root filesystem at `/proc/<pid>/root`. So everything belonging to Spice is reachable under **`/proc/1/root`**:
+The debug container has **its own** filesystem — from `ubuntu:24.04`, not from Spice — so `/app` here is empty, and Spice's files are not where you might expect. Because `--target` shares the process namespace, `spiced` is visible as PID 1, and Linux exposes any process's root filesystem at `/proc/<pid>/root`. So everything belonging to Spice is reachable under **`/proc/1/root`**:
+
+**Inside the debug container** (reading the Spice container's files):
 
 ```bash
 # The Spicepod definition the runtime actually loaded
@@ -364,9 +399,29 @@ ls -l /proc/1/root/app
 cat /proc/1/cmdline | tr '\0' ' '
 ```
 
-Standard networking tools also work here, and reflect the runtime's own network view — useful for confirming a data source is reachable from inside the cluster.
+The `/proc/1/root` prefix is what makes the difference: `ls /app` reads the *debug* container's empty directory, while `ls /proc/1/root/app` reads the *Spice* container's real working directory. Dropping the prefix is the most common source of confusion — it does not error, it just shows you the wrong container's filesystem.
 
-When finished, exit the shell.
+Networking is the exception to that rule. All containers in a pod share a single network namespace, so network tools run **inside the debug container** already see exactly what the runtime sees — no `/proc/1/root` prefix applies, and none is needed.
+
+Note that the tools available are whatever the `--image` you chose provides, not what Spice provides. `ubuntu:24.04` is a minimal image, so install what you need first — this is safe, because it modifies only the throwaway debug container:
+
+**Inside the debug container:**
+
+```bash
+# Install network tools into the debug container (not into Spice)
+apt update && apt install -y curl dnsutils iproute2
+
+# Resolve and reach a data source exactly as the runtime would
+dig my-postgres.my-namespace.svc.cluster.local
+curl -v telnet://my-postgres.my-namespace.svc.cluster.local:5432
+
+# The runtime's own listening sockets: HTTP 8090, metrics 9090, Flight 50051
+ss -ltnp
+```
+
+Images purpose-built for network debugging, such as `nicolaka/netshoot`, bundle these tools and skip the install step.
+
+When finished, type `exit` to leave the debug container and return to **your machine**.
 
 :::note
 
@@ -382,6 +437,8 @@ This technique is for Docker. On Kubernetes, use an [ephemeral container](#debug
 
 Note that the volume must be mounted when the container is **created**, so this requires starting a new container rather than attaching to a running one.
 
+**On your machine** (the Docker host) — all four commands:
+
 ```bash
 # Create a volume for the busybox binary
 docker volume create busybox
@@ -392,11 +449,15 @@ docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
 docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:latest
 
-# Exec into the container
+# Exec into the container — the shell that follows runs INSIDE the Spice container
 docker exec -it spiceai-debug /busy/busybox sh
 ```
 
-A shell with standard Linux tools is now available through the `busybox` binary. Because the tools are not on `PATH`, each command must be prefixed with `/busy/busybox`:
+That last command hands you a shell **inside the Spice container** itself — unlike `kubectl debug`, there is no separate debug container here, so paths such as `/app` are already Spice's own and need no `/proc/1/root` prefix.
+
+Because the busybox tools are not on `PATH`, every command in that shell must be prefixed with `/busy/busybox`:
+
+**Inside the Spice container:**
 
 ```bash
 /busy/busybox ls -l /app

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -265,11 +265,40 @@ explain select * from taxi_trips;
 
 ## Debugging Sandbox Container
 
-The Spice sandbox container is a minimal container that doesn't include standard Linux tools like `bash`. This can make it difficult to debug issues in the container itself.
+If you try to open a shell in a Spice container the way you would with most images, it fails:
+
+```console
+$ kubectl exec -it my-spicepod -- bash
+error: exec: "bash": executable file not found in $PATH
+```
+
+This is expected, not a broken container. The sections below explain why, and give three ways to debug depending on what you need to look at.
+
+### Why there is no shell
+
+The published Spice image is built `FROM scratch` — an empty base image with no Linux userspace at all. It contains only:
+
+- the `spiced` binary
+- the shared libraries `spiced` links against
+- CA certificates and timezone data
+
+There is no `bash`, no `sh`, not even `ls`, and no package manager — so nothing can be installed into a running container either. `spiced` also runs as the unprivileged user `65534` (`nobody`), whose login shell is set to `/usr/sbin/nologin`.
+
+This is deliberate: an image with no shell and no packages has a far smaller attack surface and far fewer CVEs to patch. The trade-off is that debugging needs the techniques below instead of `kubectl exec ... -- bash`. For background on how this image is built, see the [Docker Sandbox Guide](../deployment/docker/sandbox).
+
+### Choosing an approach
+
+| What you need to do                                            | Use                                                                        | Requirements                                                     |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Run SQL queries against the running runtime                    | [SQL REPL](#sql-repl)                                                      | None — works out of the box                                      |
+| Inspect files, processes, or the network of a Kubernetes pod    | [Ephemeral container](#debug-kubernetes-pods-with-ephemeral-containers)     | Kubernetes v1.25+, and permission to create ephemeral containers |
+| Get an interactive shell against a local Docker container      | [busybox shell](#debugging-with-a-shell)                                   | Docker, and the container started with an extra volume           |
+
+Start with the SQL REPL if the question is about data or queries. Reach for an ephemeral container when the question is about the environment — config files, mounted volumes, DNS, or connectivity.
 
 ### SQL REPL
 
-It's possible to run the SQL REPL from the container to debug SQL queries:
+The REPL needs no shell, because `spiced` is itself the binary being executed. It connects to the runtime's Flight endpoint at `http://localhost:50051`, so run it *inside* the pod or container to attach to the runtime already running there:
 
 ```console
 docker exec -it <container_id> spiced --repl
@@ -281,34 +310,77 @@ Or from `kubectl`:
 kubectl exec -it <pod_name> -- spiced --repl
 ```
 
+This is the quickest way to check whether a dataset loaded, inspect a schema, or reproduce a slow query from inside the deployment.
+
 ### Debug Kubernetes Pods with Ephemeral Containers
 
-Attach an [ephemeral container](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) to inspect a running Spice pod without restarting it. The helper container shares the runtime container's namespaces, so diagnostics reflect the live workload.
+An [ephemeral container](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) is a temporary extra container that Kubernetes adds to a pod that is already running. Because it brings its own image, it can supply all the tools the Spice image lacks — while the Spice process keeps running untouched. The pod is **not** restarted and no configuration is changed.
 
-1. List pods in the relevant namespace: `kubectl get pods -n <namespace>`
-2. Start the debugger:
+This is the recommended way to debug Spice on Kubernetes.
 
-   ```bash
-   kubectl debug -it my-spicepod-name \
-     -n my-spicepod-ns \
-     --image=ubuntu:24.04 \
-     --target=spiceai \
-     --profile=sysadmin
-   ```
+#### 1. Find the pod and container names
 
-   `--target` names the container inside the pod; Helm installs the Spice container as `spiceai` by default. `--profile` applies a [static debugging profile](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#static-profile); the `sysadmin` preset adds root-level capabilities. With `--profile=sysadmin` and `--target=spiceai`, the Spice filesystem mounts at `/proc/1/root` inside the debugger for direct inspection.
+```bash
+# List pods in the namespace
+kubectl get pods -n <namespace>
 
-3. Run the required commands and exit. For example, review the deployed Spicepod definition:
+# List the container names inside the pod
+kubectl get pod <pod_name> -n <namespace> -o jsonpath='{.spec.containers[*].name}'
+```
 
-   ```bash
-   cat /proc/1/root/app/spicepod.yaml
-   ```
+The Helm chart names the Spice container `spiceai`. Run the second command rather than assuming, since a custom manifest may name it something else.
 
-Ephemeral containers require Kubernetes v1.25+.
+#### 2. Start the debug container
+
+```bash
+kubectl debug -it my-spicepod-name \
+  -n my-spicepod-ns \
+  --image=ubuntu:24.04 \
+  --target=spiceai \
+  --profile=sysadmin
+```
+
+What each flag does:
+
+| Flag                 | Meaning                                                                                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-it`                | Attach an interactive terminal, as with `kubectl exec -it`.                                                                                                                     |
+| `--image`            | The image providing the debugging tools. `ubuntu:24.04` gives a familiar shell and `apt`; any image with the tools you need works.                                              |
+| `--target`           | The container in the pod to attach to, from step 1. This is what makes the Spice process and its filesystem visible — omit it and you get an isolated container that sees nothing of the runtime. |
+| `--profile=sysadmin` | Applies the `sysadmin` [static debugging profile](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#static-profile), which grants the elevated capabilities needed to inspect another container's files and processes. |
+
+#### 3. Inspect the runtime
+
+The debug container has **its own** filesystem — from `ubuntu:24.04`, not from Spice — so `/app` is empty and Spice's files are not where you might expect. Because `--target` shares the process namespace, `spiced` is visible as PID 1, and Linux exposes any process's root filesystem at `/proc/<pid>/root`. So everything belonging to Spice is reachable under **`/proc/1/root`**:
+
+```bash
+# The Spicepod definition the runtime actually loaded
+cat /proc/1/root/app/spicepod.yaml
+
+# The runtime's working directory, including acceleration files
+ls -l /proc/1/root/app
+
+# Confirm which process is PID 1 and how it was invoked
+cat /proc/1/cmdline | tr '\0' ' '
+```
+
+Standard networking tools also work here, and reflect the runtime's own network view — useful for confirming a data source is reachable from inside the cluster.
+
+When finished, exit the shell.
+
+:::note
+
+Ephemeral containers require Kubernetes v1.25 or later, and creating one requires permission on the `pods/ephemeralcontainers` subresource — a `Forbidden` error means the account lacks it, not that the command is wrong. An ephemeral container cannot be removed from a pod once added; it remains in the pod spec until the pod is replaced. Some hardened clusters also reject `--profile=sysadmin`; if so, try `--profile=general` (fewer capabilities, so cross-container file inspection may not work).
+
+:::
 
 ### Debugging with a shell
 
-To debug issues using a shell, mount a volume that has a statically compiled `busybox` binary, and exec into the container using the `busybox sh` command. Here is an example in Docker:
+For local Docker debugging, a shell can be added from outside the image. [busybox](https://busybox.net/) ships a single *statically compiled* binary containing dozens of standard tools — because it depends on no system libraries, it runs inside the sandbox image even though that image has no userspace of its own. Mounting it as a volume supplies a shell without rebuilding the image.
+
+This technique is for Docker. On Kubernetes, use an [ephemeral container](#debug-kubernetes-pods-with-ephemeral-containers) instead — it needs no volume and no restart.
+
+Note that the volume must be mounted when the container is **created**, so this requires starting a new container rather than attaching to a running one.
 
 ```bash
 # Create a volume for the busybox binary
@@ -318,11 +390,15 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:latest
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh
+```
 
-# At this point, a shell with standard Linux tools is available via the busybox binary.
-# However, commands must be prefixed with `/busy/busybox`, for example: `/busy/busybox ls -l /app`.
+A shell with standard Linux tools is now available through the `busybox` binary. Because the tools are not on `PATH`, each command must be prefixed with `/busy/busybox`:
+
+```bash
+/busy/busybox ls -l /app
+/busy/busybox cat /app/spicepod.yaml
 ```


### PR DESCRIPTION
## Summary

The **Debugging Sandbox Container** section assumed a lot of Kubernetes fluency. It opened with "The Spice sandbox container is a minimal container that doesn't include standard Linux tools like `bash`", then listed three techniques with no guidance on which to pick, and explained the ephemeral-container flow in a single dense paragraph. For someone new to Kubernetes or to debug containers, the unexplained parts were the ones that matter: what `--target` and `--profile=sysadmin` actually do, and why the Spice filesystem appears at the very unintuitive path `/proc/1/root`.

Rewrites the section (`website/docs/troubleshooting/index.md`) to be followable without prior debug-container experience:

- **Leads with the symptom.** A newcomer meets this section *after* `kubectl exec -it my-spicepod -- bash` has already failed, so the section now opens with that exact error and states plainly that it is expected, not a broken container.
- **New "Why there is no shell".** Explains the actual reason — the image is built `FROM scratch` and contains only the `spiced` binary, its shared libraries, and CA/timezone data, so there is no `sh`, no `ls`, and no package manager to install one; `spiced` runs as unprivileged `65534` (`nobody`) with `/usr/sbin/nologin`. Names the security trade-off so the constraint reads as intentional, and links to the Docker Sandbox Guide.
- **New "Choosing an approach" table** mapping *what you want to inspect* → technique → requirements, because the three subsections previously gave no basis for choosing.
- **Ephemeral containers, step by step.** Split into find-the-names / start / inspect. Adds `kubectl get pod <pod> -o jsonpath='{.spec.containers[*].name}'` so the `--target` value is looked up rather than guessed, a table explaining every `kubectl debug` flag, and an explanation of `/proc/1/root`: the debug container has its *own* filesystem from `--image`, and because `--target` shares the process namespace, `spiced` is PID 1 and Linux exposes any process's root at `/proc/<pid>/root`.
- **Failure modes for the debug flow itself**, which were absent: a `Forbidden` error means the account lacks `pods/ephemeralcontainers` permission rather than a malformed command; an ephemeral container cannot be removed once added; hardened clusters may reject `--profile=sysadmin`, with `--profile=general` as the fallback.
- **busybox section framed.** Explains *why* a statically compiled binary works in an image with no userspace, notes the volume must be mounted at container-creation time (so a running container cannot be attached this way), and points Kubernetes users to the ephemeral-container approach instead. Moved the "prefix every command with `/busy/busybox`" caveat out of a trailing code comment into visible prose with examples.

## Verification

Every technical claim was checked against `spiceai/spiceai` `origin/trunk` rather than carried over on trust:

- `FROM scratch` final stage, and the contents copied into it, from `Dockerfile` (the `sandbox-setup` stage installs only `ca-certificates libssl3 findutils tzdata`).
- `USER 65534:65534`, and the synthesized `/etc/passwd` entry giving `nobody` the shell `/usr/sbin/nologin`, from the same `Dockerfile`.
- `spiced --repl` from `bin/spiced/src/lib.rs` ("Starts a SQL REPL to interactively query against the runtime's Flight endpoint"), and its `http://localhost:50051` default from `ReplConfig` in `crates/repl/src/lib.rs` — which is why the doc now says to run it *inside* the pod to reach the runtime already there.
- The `spiceai` container name and `workingDir: /app` (so `/proc/1/root/app/spicepod.yaml` is right) from `deploy/chart/templates/deployment.yaml`, which also confirms `runAsUser/runAsGroup/fsGroup: 65534` and `runAsNonRoot: true`.

The `## Debugging Sandbox Container` heading text is unchanged, preserving the `#debugging-sandbox-container` anchor that `deployment/docker/sandbox.md` links to in vNext and in ten versioned snapshots. The three original subsection headings are also unchanged.

One incidental fix: the Docker example pinned `spiceai/spiceai:1.3.0` (the release where sandboxing landed, now long superseded) and is now `spiceai/spiceai:latest`, so the snippet is copy-pasteable.

**vNext only.** This is a clarity rewrite of current guidance, not a correction of a wrong claim, so it is not backported to the versioned snapshots.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / anchors / undefined tags)
- [x] All four added links verified against their targets: `#sql-repl`, `#debug-kubernetes-pods-with-ephemeral-containers`, `#debugging-with-a-shell`, and `../deployment/docker/sandbox`
- [x] Confirmed the linked `#debugging-sandbox-container` anchor is preserved (heading text untouched)
- [x] Files updated: 1
---

## Update: execution context made explicit

Follow-up commit `a627a64` addresses a gap in the first pass — the docs showed *what* to type but not *where* it runs, which matters because the same command behaves differently depending on the machine it is typed on:

- **New "Where commands run" table** defining the three contexts a reader moves between: **your machine** (where `kubectl`/`docker` are installed, talking *to* the cluster), **inside the Spice container** (no shell, so only `spiced` or a mounted binary), and **inside the debug container** (a separate container with its own filesystem and tools).
- **All 8 command blocks are now labeled** with the context they belong to — verified programmatically that no command block is unlabeled.
- **The two traps are called out explicitly:**
  - `kubectl`/`docker` run locally, but the part after `--` runs in the container — so `localhost:50051` in `kubectl exec -it my-pod -- spiced --repl` is the *container's* localhost, not the reader's. Added a note that running `spiced --repl` locally is a different thing, and that querying a remote runtime from a workstation is `spice sql --endpoint <url>` (verified against `SqlArgs` in `bin/spice/src/commands/sql.rs`; `--flight-endpoint` is deprecated there).
  - `kubectl debug` does **not** put you inside the Spice container, it puts you beside it — which is the actual reason `/proc/1/root` is needed. Made explicit that `ls /app` reads the *debug* container's empty dir while `ls /proc/1/root/app` reads Spice's real one, and that omitting the prefix silently shows the wrong container rather than erroring.
- **Networking documented as the exception:** pod containers share one network namespace, so `curl`/`dig`/`ss` in the debug container already see the runtime's view with no prefix. Ports cited (HTTP 8090, metrics 9090, Flight 50051) are from `deploy/chart/templates/deployment.yaml`.
- **Fixed a latent trap in my own first pass:** the networking examples assumed `curl`/`dig`/`ss` exist in `ubuntu:24.04`. They are not in that minimal base image, so a reader would have hit `command not found` immediately after being told the sandbox has no tools. The docs now state that available tools come from whichever `--image` was chosen, show the `apt install` step, and note that purpose-built images such as `nicolaka/netshoot` skip it. I could not verify image contents locally (no Docker in this environment), so the text avoids asserting what is preinstalled and shows the install instead.
- **busybox path clarified:** `docker exec ... /busy/busybox sh` lands you *inside the Spice container* — unlike `kubectl debug`, there is no separate container, so `/app` is already Spice's own and needs no prefix. That contrast was previously implicit.
