### PR TITLE
docs(catalogs): correct acceleration claim, document `exclude` and catalog refresh

### DIFF
--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -18,7 +18,9 @@ In Spice, datasets are organized hierarchically with catalogs, schemas, and tabl
 
 Creating schemas and tables within the `spice` catalog is configured by the `name` field in the dataset configuration. A name with a period (`.`) will create a schema, i.e. a dataset defined with `name: foo.bar` would have a full path of `spice.foo.bar`. If the name does not contain a period, the dataset will be created in the `public` schema of the `spice` catalog. For example, a dataset defined with `name: foo` would have a full path of `spice.public.foo`. Attempting to create a dataset with a name that contains a catalog name will result in an error. Adding catalogs to Spice is done via Catalog Connectors.
 
-Catalog Connectors connect to external catalog providers and make their tables available for federated SQL query in Spice. Configuring accelerations for tables in catalogs is only supported for the Spice Cayenne catalog. Creating accelerations in external catalogs is not supported. The schema hierarchy of the external catalog is preserved in Spice.
+Catalog Connectors connect to external catalog providers and make their tables available for federated SQL query in Spice. The schema hierarchy of the external catalog is preserved in Spice.
+
+Accelerating a catalog as a whole is supported by the [PostgreSQL Catalog Connector](./postgres.md), which CDC-accelerates every discovered table from a single replication slot — see [Catalog-Level CDC Acceleration](./postgres.md#catalog-level-cdc-acceleration). For every other Catalog Connector, an `acceleration` block on the catalog is a configuration error rather than a silent no-op. To accelerate an individual table from one of those catalogs, define it as a [dataset](../../reference/spicepod/datasets.md) with its own `acceleration` block.
 
 Supported Catalog Connectors include:
 
@@ -54,6 +56,26 @@ catalogs:
     include:
       - 'tpch.*' # Include only the "tpch" tables.
 ```
+
+### `exclude`
+
+Use the `exclude` field to omit tables that would otherwise be included. It uses the same `schema.table` glob syntax as `include`, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
+Example:
+
+```yaml
+catalogs:
+  - from: pg
+    name: my_pg
+    include:
+      - 'public.*' # Consider every table in the "public" schema...
+    exclude:
+      - 'public.*_audit' # ...except the audit tables.
+```
+
+:::warning
+`exclude` is currently only honored by the [PostgreSQL Catalog Connector](./postgres.md). Other Catalog Connectors accept the field without error but ignore it, so an `exclude` pattern set on them has no effect — use `include` to scope those catalogs.
+:::
 
 import DocCardList from '@theme/DocCardList';
 

--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -39,6 +39,26 @@ The `name` field specifies the name of the catalog in Spice. Tables from the Pos
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against `schema.table` using the same glob syntax as `include`, and multiple `exclude` patterns are OR'ed together.
+
+`exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
+```yaml
+catalogs:
+  - from: pg
+    name: my_pg
+    include:
+      - 'public.*' # Consider every table in the "public" schema...
+    exclude:
+      - 'public.*_audit' # ...except the audit tables.
+    params:
+      pg_connection_string: postgresql://${secrets:PG_USER}:${secrets:PG_PASS}@localhost:5432/my_database
+```
+
+Excluded tables are filtered out before their schema is read, so narrow patterns also reduce the metadata load each refresh places on the source — see [Catalog Refresh](#catalog-refresh). A common use is to keep tables that cannot be CDC-accelerated out of an accelerated catalog's scope, which also suppresses their skip warnings — see [Table eligibility](#table-eligibility).
+
 ## `params`
 
 Connection can be configured using a connection string or individual parameters.
@@ -147,6 +167,31 @@ The PostgreSQL Catalog Connector automatically discovers foreign key relationshi
 
 No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
 
+## Catalog Refresh
+
+The catalog is discovered once when the runtime starts, and then re-discovered every **60 seconds**. This interval is not currently configurable.
+
+Each cycle re-runs discovery from scratch, so schema changes at the source are picked up without restarting Spice: newly created tables and schemas appear, dropped ones disappear, and column additions, removals, and type changes are reflected when the table's schema is re-read. A source DDL change therefore becomes visible in Spice within roughly one refresh interval — up to about 60 seconds, plus the time the refresh itself takes.
+
+### Source metadata load
+
+Because every cycle re-discovers the catalog, the metadata load on the source database scales with catalog size rather than with query volume. Each refresh issues:
+
+- One query to enumerate non-system schemas.
+- Per schema: one query for its relations (`pg_catalog.pg_class`), one for foreign-key constraints, and one for table and column comments.
+- Per selected table: one lookup to read its columns and build its Arrow schema.
+
+Use `include`/`exclude` to narrow the catalog on large databases. Filtered-out tables are skipped before their per-table schema lookup, so tighter patterns directly reduce the per-cycle query count. Note that `include`/`exclude` filter tables, not schemas — every non-system schema is still enumerated, so the per-schema queries are unaffected.
+
+### Refresh failures
+
+Failure is handled differently at initial load than on a later refresh cycle:
+
+- **Initial discovery** — the catalog does not register, its status is set to `Error`, and the load is retried with a fibonacci backoff until it succeeds. Two problems are treated as permanent misconfiguration and are _not_ retried: no eligible tables for an accelerated catalog, and a replication slot already actively held by another consumer.
+- **Later refresh cycles** — a failure is logged at `ERROR` and the catalog keeps serving its last-known-good state until a subsequent cycle succeeds. The schema map is replaced atomically at the end of a cycle, so queries never observe a partially-refreshed catalog.
+
+Failures isolated to a single schema are handled per-schema rather than failing the whole cycle — see [Limitations](#limitations).
+
 ## Catalog-Level CDC Acceleration
 
 A PostgreSQL catalog can be accelerated as a whole. Adding an `acceleration` block bootstraps and CDC-accelerates every discovered table (subject to `include`/`exclude`) with no per-table dataset configuration. All accelerated tables share a single replication slot and publication — derived deterministically from the catalog `name`, see [Shared replication slot](#shared-replication-slot) — so the source's write-ahead log (WAL) is decoded once for the entire catalog instead of once per table.
@@ -226,7 +271,7 @@ They are gauges rather than counters because each refresh re-plans the whole nam
 
 :::warning
 
-- **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
+- **`include`/`exclude` filter tables, not schemas.** Both are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
 - **Partial discovery failures.** If discovery of a schema's tables fails, that schema is skipped with a warning rather than aborting the whole catalog load. On refresh, a transient per-schema failure falls back to the last-known-good state for that schema, so intermittent errors do not cause catalog flapping; a schema is only dropped for a cycle if it has never refreshed successfully. Total connectivity loss (a failed `list_schemas`) still fails hard.
 - **Amazon Redshift.** Redshift is supported over the PostgreSQL wire protocol, but its `pg_catalog` coverage is partial and it does not enforce foreign keys, so table/column comment and foreign-key metadata are often unavailable. Discovery degrades gracefully (tables are still registered).
 - **Read-only; per-table acceleration not configurable.** Catalog tables are read-only, and per-table `acceleration` blocks cannot be set on individually discovered tables. Catalog-wide CDC acceleration _is_ available for PostgreSQL — see [Catalog-Level CDC Acceleration](#catalog-level-cdc-acceleration).


### PR DESCRIPTION
## Summary

Part of #2002 — addresses the three **accuracy/completeness gaps** in that issue. Does **not** add the Deployment Guide, which remains blocked (see [Not included](#not-included-still-open-on-2002) below), so this PR intentionally does not auto-close the issue.

Every claim below was verified against `spiceai/spiceai` at `trunk` (`b356739149`).

### 1. `catalogs/index.md` acceleration claim was wrong on both counts

The page said:

> Configuring accelerations for tables in catalogs is only supported for the Spice Cayenne catalog. Creating accelerations in external catalogs is not supported.

- The **Cayenne catalog connector page was deleted** in #1750, and `b18ad3a4` removed it from the connectors table — but this prose reference was left behind, pointing at a page that no longer exists. On `trunk` the `cayenne` catalog connector is registered only behind the `spicebench` feature, so it is not a user-facing catalog at all.
- "Creating accelerations in external catalogs is not supported" is **no longer true** — the PostgreSQL catalog supports catalog-wide CDC acceleration, which this same page's `pg` row and the PostgreSQL page both document.

Replaced with an accurate statement: `pg` supports catalog-level acceleration; for every other connector an `acceleration` block is a **configuration error**, not a silent no-op ([`component/catalog.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/component/catalog.rs) — `CatalogAccelerationUnsupportedProvider`).

### 2. `exclude` was used but never documented

`exclude` is a real top-level catalog field ([`spicepod/src/component/catalog.rs:48`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/catalog.rs)) referenced four times on the PostgreSQL page but documented nowhere in `components/`. Added sections to both the overview and the PostgreSQL page covering:

- `schema.table` glob matching, patterns OR'ed together.
- Precedence — `included && !excluded`, so `exclude` wins ([`postgres/provider.rs` `is_table_selected`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/postgres/provider.rs)).
- **A footgun worth calling out**: only the `pg` connector honors `exclude`. The other 11 public catalog connectors accept the field (it's on the shared spec) and silently ignore it. Documented as a warning so users don't set it on Iceberg and expect filtering.

`reference/spicepod/catalogs.md` already documented `exclude` correctly; the new wording is aligned with it rather than diverging.

### 3. Catalog refresh was undocumented

Nothing told the reader the catalog re-discovers at all. Added a `Catalog Refresh` section:

- **Cadence: a fixed 60 seconds**, not configurable. `init/catalog.rs:184` passes `None` to `get_catalog_provider`, and `start_refresh` resolves `None` to `Duration::from_mins(1)` ([`data_components/src/lib.rs:481-482`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/lib.rs)). Per the issue's non-goals, the not-yet-shipped refresh-interval **field is not documented** — only the cadence that ships today.
- **DDL visibility latency** — up to ~60s plus refresh duration.
- **Source metadata load** — the per-cycle query shape (1 schema enumeration; 3 queries per schema; 1 column lookup per selected table), and that `include`/`exclude` cut the per-table lookups but not the per-schema queries.
- **Failure behavior**, split by phase because it genuinely differs: initial discovery retries with fibonacci backoff (`max_retries(None)`) and is permanent only for the two configuration classes, whereas later cycles log at `ERROR` and retain last-known-good with an atomic map swap. Written explicitly so it doesn't read as contradicting the existing "total connectivity loss still fails hard" limitation, which describes initial load.

## Changes

- `website/docs/components/catalogs/index.md` — corrected the acceleration paragraph; added an `exclude` section.
- `website/docs/components/catalogs/postgres.md` — added `exclude` and `Catalog Refresh` sections; generalized the `include`-filters-tables limitation to cover `exclude`.

## Version scope

**vNext-only.** Neither `exclude` nor catalog `acceleration` exists on the `Catalog` spec at `v2.0.1` or `v2.1.1`, so the "acceleration in external catalogs is not supported" wording is still **accurate** in `versioned_docs/version-2.0.x` and `version-2.1.x` and is deliberately left alone. Documenting `exclude` there would describe a field those releases reject.

## Not included (still open on #2002)

The Deployment Guide is not in this PR — it is blocked on work outside this repo:

- The acceptance criterion requires the least-privilege role SQL be **verified against a live PostgreSQL instance**, not written from first principles.
- It must document the **refresh-interval field**, which has not shipped.
- The **Redshift support-level decision** determines what the guide can claim.
- The tested **PostgreSQL version range** for the Stable claim is undecided.
- Restructuring `postgres.md` into a directory changes its URL and needs a redirect decision.

The `pg` status-table flip is likewise gated on sign-off (the table currently reads `Alpha`, while the issue describes a Beta → RC → Stable path — worth reconciling separately).

## Test plan

- [x] `cd website && npm run build` passes locally (no broken links, no undefined frontmatter tags)
- [x] All new anchor links resolve (`#catalog-refresh`, `#table-eligibility`, `#catalog-level-cdc-acceleration`, `#limitations`)
- [x] Every factual claim traced to source on `spiceai/spiceai@b356739149`
- [x] Versioned-docs propagation deliberately scoped out — verified the old wording is still correct for v2.0.x/v2.1.x
