### PR TITLE
docs(duckdb): document on_full_refresh for bounded acceleration file growth

### DIFF
--- a/website/docs/components/data-accelerators/duckdb/deployment.md
+++ b/website/docs/components/data-accelerators/duckdb/deployment.md
@@ -30,7 +30,9 @@ Use `mode: file` for any dataset larger than a few hundred MB or where restart s
 
 ### Checkpointing
 
-The DuckDB accelerator enables `PRAGMA enable_checkpoint_on_shutdown` at connection setup. Graceful shutdown writes a clean checkpoint, making restart near-instantaneous. Ungraceful shutdowns leave a WAL to replay, slowing the first subsequent startup.
+The DuckDB accelerator enables `PRAGMA enable_checkpoint_on_shutdown` once per DuckDB instance, when the instance is set up. Graceful shutdown writes a clean checkpoint, making restart near-instantaneous. Ungraceful shutdowns leave a WAL to replay, slowing the first subsequent startup.
+
+Full-refresh bulk loads bypass the WAL, so DuckDB's WAL-growth-based automatic checkpoint never fires on a repeatedly full-refreshed acceleration and the freed blocks are never returned to the free list. Set [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) to `replace_file` or `checkpoint_file` to reclaim that space on every refresh.
 
 ### Spill Directory
 
@@ -38,7 +40,7 @@ Large queries (sort, aggregate, join) can spill to disk. The spill directory is 
 
 ### Vacuum
 
-DuckDB does not require explicit `VACUUM`; its storage layout compacts on checkpoint. No Spice-level vacuum automation is provided.
+DuckDB does not require explicit `VACUUM`; its storage layout compacts on checkpoint. For file-mode accelerations on `refresh_mode: full`, the [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) parameter is the Spice-level control over that reclamation: `replace_file` rebuilds and atomically swaps in a compact file on every refresh, `checkpoint_file` checkpoints the live file in place, and the default `reuse_file` reclaims nothing.
 
 ## Capacity & Sizing
 
@@ -105,3 +107,4 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |
 | `IO Error: Could not set lock on file`                 | Another process holds a write lock.                           | Ensure single-writer semantics; verify no other Spice instance is using the same file.                      |
+| DuckDB file grows on every refresh                     | `refresh_mode: full` bulk loads bypass the WAL, so no automatic checkpoint reclaims the previous copy of the data. | Set [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) to `replace_file` (or `checkpoint_file` for a lighter, in-place checkpoint). |

--- a/website/docs/components/data-accelerators/duckdb/index.md
+++ b/website/docs/components/data-accelerators/duckdb/index.md
@@ -43,6 +43,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 - `duckdb_index_scan_percentage` (float, default: `0.001`): Sets the threshold percentage for performing an index scan instead of a table scan. An index scan is used when the number of matching rows is less than the maximum of `duckdb_index_scan_max_count` and `duckdb_index_scan_percentage` multiplied by total row count. Must be between `0.0` and `1.0`.
 - `duckdb_index_scan_max_count` (integer, default: `2048`): Sets the maximum row count threshold for performing an index scan instead of a table scan. An index scan is used when the number of matching rows is less than the maximum of `duckdb_index_scan_max_count` and `duckdb_index_scan_percentage` multiplied by total row count. Must be a non-negative integer.
 - `on_refresh_sort_columns` (string, default: none): Sorts data after each refresh by the specified columns, improving DuckDB [zone map](https://duckdb.org/2025/05/14/sorting-for-fast-selective-queries) (min/max) statistics for query pruning and significantly faster lookup queries. Format: `column1 ASC, column2 DESC` or `column1, column2` (defaults to ASC). Specified columns must exist in the dataset schema, and sort direction must be `ASC` or `DESC`.
+- `on_full_refresh` (string, default: `reuse_file`): How a full refresh writes into a file-mode acceleration, and whether the space held by the previous copy of the data is reclaimed. One of `reuse_file`, `replace_file`, or `checkpoint_file` — see [Bounding acceleration file growth](#bounding-acceleration-file-growth). `replace_file` and `checkpoint_file` require `mode: file`; configuring either with `mode: memory` is rejected at load time.
 - `optimizer_duckdb_aggregate_pushdown` (string, default: `disabled`): Enables aggregate pushdown optimization to execute supported aggregate queries directly in DuckDB. Set to `enabled` to push down aggregations for improved query performance on supported functions like `count`, `sum`, `avg`, `min`, and `max`. Requires `query_federation` to be `disabled`.
 
 Refer to the [datasets configuration reference](../../reference/spicepod/datasets#acceleration) for additional supported fields.
@@ -60,6 +61,55 @@ datasets:
         duckdb_file: /my/chosen/location/duckdb.db
         duckdb_memory_limit: '2GB'
 ```
+
+## Bounding Acceleration File Growth
+
+A full refresh (`refresh_mode: full`) bulk-loads a fresh copy of the data into the DuckDB file. Bulk loads write row groups directly to the database file and send only block pointers to the WAL, so DuckDB's WAL-growth-based automatic checkpoint never fires — and the blocks freed by dropping the previous copy of the table are only returned to the free list at a checkpoint. On a repeatedly full-refreshed file-mode acceleration, the DuckDB file therefore **grows without bound** even though the data it holds does not.
+
+Set the `on_full_refresh` parameter to reclaim that space after each refresh:
+
+| `on_full_refresh`  | Behavior                                                                                                | Query impact                                                                                          | File size                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `reuse_file`       | Default. Keeps writing into the current database file. No space is reclaimed.                            | None.                                                                                                  | Grows with every refresh.                        |
+| `replace_file`     | Writes a new database file, checkpoints it, and atomically replaces the live file with it.                | Readers are never interrupted; writers pause briefly during the replacement.                            | Reclaimed on every refresh; the file can shrink. |
+| `checkpoint_file`  | Keeps the current file and checkpoints it after each refresh commits.                                     | A checkpoint that has to escalate stalls queries on that file for a bounded window (see below).          | Plateaus near the working set, but never shrinks below the file's high-water mark. |
+
+Both `replace_file` and `checkpoint_file` require file-mode acceleration. Configuring either alongside `mode: memory` is rejected at load time.
+
+```yaml
+datasets:
+  - from: spice.ai:path.to.my_dataset
+    name: my_dataset
+    acceleration:
+      engine: duckdb
+      mode: file
+      refresh_mode: full
+      params:
+        duckdb_file: /data/shared.duckdb
+        on_full_refresh: replace_file # default: reuse_file
+```
+
+### `replace_file`
+
+A full refresh streams into a fresh staging database file while the live file keeps serving queries, then:
+
+1. copies every other object sharing the file into the staging file — other datasets' tables, views, and indexes, the `spice_sys_*` metadata tables (dataset checkpoints, CDC offsets), and HNSW indexes,
+2. checkpoints and cleanly closes the staging file, so it is compact and WAL-free, and
+3. atomically renames it over the configured path and repoints the shared connection pool at it.
+
+In-flight queries drain against the old file through their already-open descriptors and new queries see the new file, so readers never block; only writers pause, for the duration of the copy-and-replace window. Because the replacement always produces a checkpointed file, [acceleration snapshots](../../features/data-acceleration/snapshots) taken from it are exact.
+
+Several datasets can share one DuckDB file: replacements serialize on a per-file write gate and each one carries the other datasets' current data forward. A dataset accelerated into a *different* DuckDB file that reads this one needs no special handling — its attachment re-resolves when the file underneath it is replaced.
+
+If the process is interrupted mid-replacement, the leftover files are cleaned up on the next startup: incomplete staging files are deleted, and the newest completed replacement is adopted when the configured file itself is missing.
+
+`replace_file` cannot be combined with `refresh_mode: snapshot` on the same DuckDB file — whether on the same dataset or on another dataset sharing the file — and the combination is rejected at load time. Both mechanisms replace the file out-of-band on their own schedules, so refreshes would fail intermittently as each retires the other's file. Give one of them its own `duckdb_file`, or set `on_full_refresh: reuse_file`.
+
+### `checkpoint_file`
+
+After each full-refresh overwrite commits, the runtime runs `CHECKPOINT` on the live database. A plain `CHECKPOINT` fails fast while other transactions are open, in which case it escalates to `FORCE CHECKPOINT`, which waits for the in-flight transactions to finish while blocking new ones from starting — a stall bounded by the slowest in-flight query plus the checkpoint write itself, paid only when the escalation is needed. A checkpoint that fails is logged and never fails the refresh; the refreshed data is already durably committed.
+
+This is lighter than `replace_file` — there is no staging copy of cohabiting objects — at the cost of that stall, and of the file plateauing at its high-water mark instead of shrinking. Prefer `replace_file` where in-flight queries must not be interrupted.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

Documents the `on_full_refresh` DuckDB acceleration parameter, and the unbounded-file-growth problem it exists to solve.

A full refresh bulk-loads a fresh copy of the data; bulk loads write row groups straight to the database file and send only block pointers to the WAL, so DuckDB's WAL-growth-based automatic checkpoint never fires and the blocks freed by dropping the previous copy are never returned to the free list. The DuckDB file therefore grew without bound on a repeatedly full-refreshed file-mode acceleration, and nothing in the docs said so or offered a control.

`website/docs/components/data-accelerators/duckdb/index.md`

- New `on_full_refresh` row in **Configuration Parameters** (`ParameterSpec::runtime("on_full_refresh")` — no `duckdb_` prefix), noting that `replace_file` / `checkpoint_file` require `mode: file`.
- New **Bounding Acceleration File Growth** section: a comparison table of the three values, plus a subsection each for `replace_file` (staging file → copy cohabiting objects → checkpoint → atomic rename → repoint the pool; readers never block, writers pause during the replacement; boot recovery of an interrupted replacement; rejected alongside `refresh_mode: snapshot` on the same file) and `checkpoint_file` (`CHECKPOINT`, escalating to `FORCE CHECKPOINT`, which waits for in-flight transactions while blocking new ones; failures never fail the refresh).

`website/docs/components/data-accelerators/duckdb/deployment.md`

- **Checkpointing**: `PRAGMA enable_checkpoint_on_shutdown` is now applied once per DuckDB *instance* (#12135 moved instance-scoped pragmas from per-connection to instance setup queries) — the page said "at connection setup". Adds the full-refresh/WAL-bypass note and links to the new section.
- **Vacuum**: "No Spice-level vacuum automation is provided" was true before `on_full_refresh` and is not now; replaced with what each value does.
- **Troubleshooting**: new row for a DuckDB file that grows on every refresh.

## Source PRs

- spiceai/spiceai#12135 — feat(duckdb): `on_full_refresh: replace_file` — full refresh into a new database file, atomically replaced
- spiceai/spiceai#12139 — feat(duckdb): `on_full_refresh: checkpoint_file` to bound acceleration file growth

## Verification notes

- Values and validation read off `crates/runtime/src/dataaccelerator/duckdb.rs` on today's `trunk` (`7bc4175f`): the `PARAMETERS` entry, the `match cmd.options.remove("on_full_refresh")` arm (`reuse_file` / `replace_file` / `checkpoint_file`, file-mode `ensure!`, invalid-value error), and `validate_replace_file_peers` for the `refresh_mode: snapshot` rejection.
- The `FORCE CHECKPOINT` semantics are taken from the implementation (`checkpoint_after_write` in the pinned `datafusion-table-providers` rev `1b83cbf0`), which **waits** for in-flight transactions rather than aborting them. A stale doc comment on `DuckDBWriteSettings::checkpoint_on_write` in that same crate still says "aborts them" — it predates #12139; the docs follow the code path that runs.
- **Versioning**: vNext only. `on_full_refresh` is slated for v2.1.2, whose release notes are on `trunk` but which is not yet released (latest release is v2.1.1), so `versioned_docs/version-2.1.x/` correctly does not describe it. When v2.1.2 ships, this content should be propagated to `version-2.1.x/`.

## Test plan

- [x] `cd website && npm run build` passes (exit 0 — no broken links or undefined tags)
- [x] Versioned-docs propagation checked — vNext-only addition, see the note above
- [x] Cross-page grep for a stale "file growth" claim on other pages: no hits outside the two files changed
- [x] Files updated: 2 (matches the diff)