### PR TITLE
docs(datasets): document check_availability_interval and the availability Error status

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -315,10 +315,10 @@ datasets:
 
 ## `check_availability`
 
-Spice monitors the availability of non-accelerated datasets and emits metrics if a dataset becomes unavailable. Note that this monitoring process may trigger the startup of compute resources (for example, Databricks or Snowflake), potentially incurring additional costs. To disable availability monitoring, configure the `check_availability` parameter to `disabled`.
+Spice can monitor whether the source backing a non-accelerated dataset is still reachable, marking the dataset `Error` while it is not. Availability monitoring is **opt-in**: it runs only for datasets that set [`check_availability_interval`](#check_availability_interval). Note that probing may trigger the startup of compute resources (for example, Databricks or Snowflake), potentially incurring additional costs.
 
-- `auto`: Automatically check the availability monitor of the dataset. This is the default value. Accelerated datasets are not monitored.
-- `disabled`: Disable the availability monitor for the dataset.
+- `auto`: Monitor the dataset when it is not accelerated and `check_availability_interval` is set. This is the default value. Accelerated datasets are never monitored.
+- `disabled`: Never monitor the dataset, even with `check_availability_interval` set.
 
 ```yaml
 datasets:
@@ -327,6 +327,24 @@ datasets:
     check_availability: disabled
     params: ...
 ```
+
+## `check_availability_interval`
+
+Optional. How often the runtime probes the source backing this dataset to confirm it is still reachable. Accepts a duration string (for example `60s`, `5m`). There is no default — leave it unset and the dataset is not monitored at all.
+
+```yaml
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    check_availability_interval: 60s
+    params: ...
+```
+
+Only non-accelerated datasets with `check_availability: auto` are monitored. Setting the interval on an accelerated dataset logs a warning and has no effect, because an accelerated dataset keeps serving from its accelerator even when the source is unavailable. An unparseable duration fails dataset load rather than silently disabling the check.
+
+A recent successful query counts as proof that the source is reachable: when a dataset was queried successfully more recently than its own interval, that query stands in for the probe, so actively-queried datasets are not probed redundantly. This uses [task history](../task_history), and looks back at most one hour regardless of the configured interval; datasets with a longer interval are probed directly.
+
+Availability monitoring is not supported for Iceberg datasets and is skipped for them (see [spiceai/spiceai#6994](https://github.com/spiceai/spiceai/issues/6994)).
 
 The monitoring works by executing a query that selects one row and all columns from the dataset. i.e.:
 
@@ -346,7 +364,9 @@ FROM
 LIMIT 1;
 ```
 
-If the monitoring query fails a warning is emitted in the logs, an error is propagated to the `task_history` table and the `dataset_unavailable_time_ms` metric is incremented for the failing dataset.
+If the monitoring query fails, a warning is emitted in the logs, an error is propagated to the `task_history` table, the `dataset_unavailable_time_ms` metric is recorded for the failing dataset, and the dataset's status becomes `Error` — visible via `GET /v1/datasets?status=true`. A later successful probe restores the dataset to `Ready`.
+
+The status transition applies only to a dataset that is otherwise `Ready` (or already in `Error` from a previous failed probe); transient lifecycle states such as `Initializing` and `Refreshing` are left to the load and refresh paths that own them, and a recovery only restores `Ready` for a dataset the availability monitor itself put into `Error`.
 
 ## Deferred dataset initialization
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12079` changed dataset availability monitoring in two user-visible ways, neither of which the docs reflected:

1. Monitoring is now **opt-in** behind a new top-level dataset field, `check_availability_interval`. The old hardcoded 60-second cadence was removed, so a dataset that does not set an interval is not probed at all. The `check_availability` section said "Spice monitors the availability of non-accelerated datasets", which now over-promises — `check_availability: auto` on its own monitors nothing.
2. A failed probe now marks the dataset `Error` (surfaced by `GET /v1/datasets?status=true`) and restores `Ready` on recovery. Previously it only logged, wrote to `task_history`, and recorded a metric.

Changes to `website/docs/reference/spicepod/datasets.md`:

- `## check_availability`: reworded to say monitoring is opt-in via the interval, and that `auto` means "monitored when not accelerated **and** an interval is set". `disabled` now says it wins even with an interval set.
- New `## check_availability_interval` section: duration string, no default, non-accelerated + `auto` only (an interval on an accelerated dataset warns and is ignored), unparseable duration fails dataset load, the recent-successful-query stand-in for a probe (task-history-backed, one-hour lookback cap), and the Iceberg exclusion.
- The failure paragraph now includes the `Error` status transition and recovery, plus the guard that only `Ready`/already-`Error` datasets are transitioned — transient `Initializing`/`Refreshing` states are left alone.

## Source PRs

- spiceai/spiceai#12079 — feat(datasets): mark non-accelerated datasets Error when their source is unavailable

## Verification notes

Read off `origin/trunk` (`7bc4175f`), not the source PR description — **the PR body's "default `60s`" is not what shipped.** That number was the old `DATASETS_AVAILABILITY_CHECK_INTERVAL_SECONDS` constant the same PR deleted; the field's own docstring in `crates/spicepod/src/component/dataset.rs:240-247` says monitoring is opt-in, and `datasets_health_monitor.rs:169` returns early with "no check_availability_interval configured" when it is unset. Documenting the stated default would have been wrong.

- Field shape: `pub check_availability_interval: Option<String>` — a **top-level dataset field**, not a `params` key. Parsed with `fundu::parse_duration` in `crates/runtime/src/component/dataset/builder.rs:117`; a parse failure returns `UnableToParseFieldAsDuration` and fails dataset construction.
- Accelerated-dataset warning: `builder.rs:134-140`.
- Status transitions and the `Ready`/`Error`-only guard: `datasets_health_monitor.rs:412-470`.
- Recent-query stand-in: `datasets_health_monitor.rs:332-361`, with `MAX_RECENT_QUERY_LOOKBACK = 1 hour` (`:57`), gated on task history being enabled.
- Iceberg skip: `datasets_health_monitor.rs` (`IcebergTableProvider` arm, spiceai/spiceai#6994).
- Metric name `dataset_unavailable_time_ms` re-confirmed against its registration literal, `runtime-metrics/src/datasets/mod.rs:23` (`.f64_gauge("dataset_unavailable_time_ms")`) — a runtime-global metric, so the exported name is verbatim and unchanged.
- **Versioning**: vNext only. `version-2.1.x/reference/spicepod/datasets.md:322` still describes the always-on behavior, which is correct for v2.1.1 and earlier, so it is deliberately untouched.

## Test plan

- [x] `cd website && npm run build` passes (exit 0 — no broken links or undefined tags; validates the new `#check_availability_interval` anchor and the `../task_history` link)
- [x] Versioned-docs propagation checked — vNext-only behavioral change, see above
- [x] Files updated: 1 (matches the diff)