### PR TITLE
docs(models): correct the `spice.ai` model source for the LLM gateway (vNext)

### DIFF
--- a/website/docs/components/models/spiceai.md
+++ b/website/docs/components/models/spiceai.md
@@ -1,54 +1,56 @@
 ---
 title: 'Spice Cloud Platform'
-description: 'Instructions for using models hosted on the Spice Cloud Platform with Spice.'
+description: 'Instructions for using language models served by the Spice.ai Cloud Platform with Spice.'
 sidebar_label: 'Spice Cloud Platform'
 sidebar_position: 6
 ---
 
-To use a model hosted on the [Spice Cloud Platform](https://docs.spice.ai/building-blocks/spice-models), specify the `spice.ai` path in the `from` field.
+To use a large language model served by the Spice.ai Cloud Platform AI gateway — or by another Spice runtime — specify the `spice.ai` path in the `from` field and the associated `spiceai_api_key` parameter.
+
+| Param              | Description                                                                                                                                            | Default                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `spiceai_api_key`  | The API key for the Spice.ai Cloud Platform, or for the Spice runtime serving the model. **Required** when the endpoint is the Spice.ai Cloud Platform. | -                          |
+| `spiceai_endpoint` | The endpoint serving the model: the Spice.ai Cloud Platform, or another Spice runtime.                                                                  | `https://data.spiceai.io`  |
 
 Example:
 
 ```yaml
 models:
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats
-    name: drive_stats
-    datasets:
-      - drive_stats_inferencing
-```
-
-Specific model versions can be referenced using a version label or Training Run ID.
-
-```yaml
-models:
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats:latest # Label
-    name: drive_stats_a
-    datasets:
-      - drive_stats_inferencing
-
-  - from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf # Training Run ID
-    name: drive_stats_b
-    datasets:
-      - drive_stats_inferencing
+  - from: spice.ai:openai/gpt-4o
+    name: cloud_llm
+    params:
+      spiceai_api_key: ${secrets:SPICEAI_API_KEY}
 ```
 
 ## `from` Format
 
-The from key must conform to the following regex format:
+The `from` field is the source prefix — `spice.ai` or `spiceai` — followed by a `:` or `/` separator and the model identifier:
 
-```regex
-\A(?:spice\.ai\/)?(?<org>[\w\-]+)\/(?<app>[\w\-]+)(?:\/models)?\/(?<model>[\w\-]+):(?<version>[\w\d\-\.]+)\z
+- `spice.ai:openai/gpt-4o`
+- `spice.ai/openai/gpt-4o`
+- `spiceai:openai/gpt-4o`
+- `spiceai/openai/gpt-4o`
+
+All four forms resolve to the same model identifier, `openai/gpt-4o`. Both spellings of the prefix are accepted so that a `from` reads the same whether it names a model or a [dataset](../data-connectors/spiceai/index.md).
+
+Model identifiers take the form `<provider>/<model>` (for example `openai/gpt-4o` or `anthropic/claude-3-5-sonnet`); the identifiers available depend on what the endpoint serves. A `from` that names only the prefix (e.g. `from: spice.ai` or `from: spice.ai:`) carries no model identifier and fails to load.
+
+## Connecting to Another Spice Runtime
+
+Because the model is reached over an OpenAI-compatible HTTP API, `spiceai_endpoint` can point at another Spice runtime instead of the Cloud Platform. The endpoint is the root of the deployment — the OpenAI-compatible API is served under `/v1`, and an endpoint that already names `/v1` is used as-is.
+
+```yaml
+models:
+  - from: spice.ai:openai/gpt-4o
+    name: upstream_llm
+    params:
+      spiceai_endpoint: http://localhost:8090
 ```
 
-Examples:
+An API key is optional for a self-hosted Spice runtime, which may not have authentication enabled. The Spice.ai Cloud Platform always authenticates, so omitting `spiceai_api_key` when the endpoint resolves to the Cloud Platform is rejected at load time.
 
-- `spice.ai/lukekim/smart/models/drive_stats:latest`: Refers to the latest version of the drive_stats model in the smart application by the user or organization lukekim.
-- `spice.ai/lukekim/smart/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf`: Specifies a model with a unique training run ID.
+:::note
 
-### Specification
+The `spice.ai` model source serves large language models only. Support for loading and serving traditional machine learning (ONNX) models was removed in vNext — see [Machine Learning Models](../../features/machine-learning-models).
 
-1. **Prefix (Optional):** The value must start with `spice.ai/`.
-1. **Organization/User:** The name of the organization or user (`org`) hosting the model.
-1. **Application Name**: The name of the application (`app`) which the model belongs to.
-1. **Model Name:** The name of the model (`model`).
-1. **Version (Optional):** A colon (`:`) followed by the version identifier (`version`), which could be a semantic version, `latest` for the most recent version, or a specific training run ID.
+:::

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -166,10 +166,10 @@ A model defined inline.
 
 ```yaml
 models:
-  - from: spiceai/lukekim/smart/models/drive_stats:latest
-    name: drive_stats
-    datasets:
-      - drive_stats_inferencing
+  - from: spice.ai:openai/gpt-4o
+    name: cloud_llm
+    params:
+      spiceai_api_key: ${secrets:SPICEAI_API_KEY}
 ```
 
 ## `embeddings`

--- a/website/docs/reference/spicepod/models.md
+++ b/website/docs/reference/spicepod/models.md
@@ -60,8 +60,8 @@ The `<model_source>` prefix of the `from` field indicates where the model is sou
 
 The `<model_id>` suffix of the `from` field is a unique (per source) identifier for the model:
 
-- For Spice AI: Represents the full path to the model in the Spice AI repository. Supports a version suffix (default to `latest`).
-  - Example: `lukekim/smart/models/drive_stats:60cb80a2-d59b-45c4-9b68-0946303bdcaf`
+- For Spice AI: The identifier of a model served by the [Spice.ai Cloud Platform](../../components/models/spiceai.md) (or by another Spice runtime), in the form `<provider>/<model>`.
+  - Example: `spice.ai:openai/gpt-4o`
 - For Hugging Face: A repo_id and, optionally, revision hash or tag.
   - `Qwen/Qwen1.5-0.5B` (no revision)
   - `meta-llama/Meta-Llama-3-8B:cd892e8f4da1043d4b01d5ea182a2e8412bf658f` (with revision hash)


### PR DESCRIPTION
## Problem

The `spice.ai` model source page still documents the removed traditional-ML model flow: a `from: spice.ai/<org>/<app>/models/<model>` path, a `datasets:` list of "inferencing" datasets, and Training Run ID versions. That page has not been touched since docs #735.

On `trunk`, `ModelSource::SpiceAI` is wired **only** into the chat path (`crates/runtime/src/model/chat.rs`) — it is an LLM gateway to the Spice.ai Cloud Platform (or to another Spice runtime), reached over an OpenAI-compatible HTTP API. Nothing about the documented shape works:

| Docs said | What the code does |
| --- | --- |
| `from: spice.ai/taxi_tech_co/taxi_drives/models/drive_stats` | The model id is everything after the `spice.ai:` / `spice.ai/` prefix and is sent to the endpoint as an OpenAI model name (e.g. `openai/gpt-4o`) |
| `datasets: [drive_stats_inferencing]` for inference | `datasets` scopes the model's **tool** access (a table allowlist) — see `reference/spicepod/models.md` |
| Version label / Training Run ID suffix | No version resolution exists; the whole suffix is the model name |
| No parameters documented | `spiceai_api_key` (required when the endpoint is the Cloud Platform) and `spiceai_endpoint` (default `https://data.spiceai.io`) |

The `models` example in the Spicepod reference and the "For Spice AI" model-id bullet in the models reference carried the same removed shape.

## Changes (vNext only)

- Rewrote `components/models/spiceai.md` for the LLM gateway: the two parameters with their real defaults, the four accepted `from` spellings, the "connect to another Spice runtime" case, and the API-key requirement.
- `reference/spicepod/index.md`: replaced the inline `models` example.
- `reference/spicepod/models.md`: corrected the "For Spice AI" model-id description and example.

Not propagated to `versioned_docs/`: the ML model source was real through v2.1.1 (removed post-release by spiceai#11684), so the existing text is correct in every versioned snapshot. The LLM-gateway form is trunk-only — spiceai#12092 restored `spice.ai`/`spiceai` as a model source on 2026-07-27, after v2.1.1.

## Verified against

`spiceai/spiceai` @ `origin/trunk` (7bc4175f59):

- [`crates/runtime/src/model/chat.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/chat.rs) — `ModelSource::SpiceAI => spiceai(...)`; the missing-API-key check via `llms::spiceai::is_cloud_platform`, and `ModelNotProvided` for a bare prefix.
- [`crates/runtime/src/model/params/spiceai.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/params/spiceai.rs) — `api_key` (secret) and `endpoint`, defaulted from `llms::spiceai::DEFAULT_ENDPOINT`.
- [`crates/llms/src/spiceai/chat.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/spiceai/chat.rs) — `DEFAULT_ENDPOINT = "https://data.spiceai.io"`; `api_base()` appends `/v1` unless already present.
- [`crates/spicepod/src/component/model.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/model.rs) — `SPICEAI_PREFIXES = ["spice.ai", "spiceai"]`, `:`/`/` separators, id trimmed, bare prefix → no model id (`spiceai_source_accepts_both_spellings`, `spiceai_bare_prefix_reports_no_model_id`).

`npm run build` passes locally.
