### PR TITLE
docs(embeddings): drop ONNX from the embedding formats (vNext)

### DIFF
--- a/website/docs/components/embeddings/huggingface/deployment.md
+++ b/website/docs/components/embeddings/huggingface/deployment.md
@@ -61,7 +61,7 @@ When `pooling` is unset, the loader defaults to `mean` and logs a warning. Set t
 
 Local file mode (HF-downloaded) requires:
 
-- Model weights (accepted formats: `.onnx`, `.gguf`, `.ggml`, `.safetensors`, `pytorch_model.bin`).
+- Model weights (accepted formats: `.gguf`, `.ggml`, `.safetensors`, `pytorch_model.bin`).
 - `config.json`
 - `tokenizer.json`
 

--- a/website/docs/components/embeddings/index.md
+++ b/website/docs/components/embeddings/index.md
@@ -19,16 +19,16 @@ Embeddings enable vector-based and similarity search, such as document retrieval
 
 Spice supports a variety of embedding model sources and formats:
 
-| Name                       | Description                             | Status            | ML Format(s) | LLM Format(s)\*                 |
-| -------------------------- | --------------------------------------- | ----------------- | ------------ | ------------------------------- |
-| [`file`][file]             | Local filesystem                        | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
-| [`huggingface`][hf]        | Models hosted on HuggingFace            | Release Candidate | ONNX         | GGUF, GGML, SafeTensor          |
-| [`openai`][openai]         | OpenAI (or compatible) LLM endpoint     | Release Candidate | -            | OpenAI-compatible HTTP endpoint |
-| [`azure`][azure]           | Azure OpenAI                            | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`google`][google]         | Google AI embedding models              | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`databricks`][databricks] | Models deployed to Databricks Mosaic AI | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`bedrock`][bedrock]       | Models deployed on Amazon Bedrock       | Alpha             | -            | OpenAI-compatible HTTP endpoint |
-| [`model2vec`][model2vec]   | Model2Vec static word embeddings        | Alpha             | -            | Model2Vec format                |
+| Name                       | Description                             | Status            | Format(s)                       |
+| -------------------------- | --------------------------------------- | ----------------- | ------------------------------- |
+| [`file`][file]             | Local filesystem                        | Release Candidate | GGUF, GGML, SafeTensor          |
+| [`huggingface`][hf]        | Models hosted on HuggingFace            | Release Candidate | GGUF, GGML, SafeTensor          |
+| [`openai`][openai]         | OpenAI (or compatible) LLM endpoint     | Release Candidate | OpenAI-compatible HTTP endpoint |
+| [`azure`][azure]           | Azure OpenAI                            | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`google`][google]         | Google AI embedding models              | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`databricks`][databricks] | Models deployed to Databricks Mosaic AI | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`bedrock`][bedrock]       | Models deployed on Amazon Bedrock       | Alpha             | OpenAI-compatible HTTP endpoint |
+| [`model2vec`][model2vec]   | Model2Vec static word embeddings        | Alpha             | Model2Vec format                |
 
 [file]: embeddings/local
 [hf]: embeddings/huggingface

--- a/website/docs/components/embeddings/local/deployment.md
+++ b/website/docs/components/embeddings/local/deployment.md
@@ -55,7 +55,7 @@ When `pooling` is unset, the loader defaults to `mean` and logs a warning. Set t
 
 Local embedding requires all of the following in the model directory:
 
-- Model weights (accepted formats: `.onnx`, `.gguf`, `.ggml`, `.safetensors`, `pytorch_model.bin`).
+- Model weights (accepted formats: `.gguf`, `.ggml`, `.safetensors`, `pytorch_model.bin`).
 - `config.json`
 - `tokenizer.json`
 

--- a/website/docs/features/data-ingestion/index.md
+++ b/website/docs/features/data-ingestion/index.md
@@ -151,7 +151,7 @@ datasets:
 
 Spice.ai OSS includes built-in data ingestion support for collecting the latest data from edge nodes for use in subsequent queries. This feature eliminates the need for additional ETL pipelines and improves the speed of the feedback loop.
 
-For example, consider CPU usage anomaly detection. When CPU metrics are sent to the Spice OpenTelemetry endpoint, the loaded machine learning model can use the most recent observations for inferencing and provide recommendations to the edge node. This process occurs quickly on the edge itself, within milliseconds, and without generating network traffic.
+For example, consider CPU usage anomaly detection. When CPU metrics are sent to the Spice OpenTelemetry endpoint, they are immediately queryable alongside accelerated data, so an application can compare the most recent observations against historical baselines and act on the edge node. This process occurs quickly on the edge itself, within milliseconds, and without generating network traffic.
 
 Additionally, Spice will periodically replicate the data to the data connector for further use.
 


### PR DESCRIPTION
## Problem

ONNX inference was removed from the runtime in vNext (spiceai#11684) — there is no ONNX runtime left in the build at all: `Cargo.lock` on `trunk` contains **zero** `ort` / `tract-onnx` / `tract-core` entries, and the only text-embeddings backend resolved is `text-embeddings-backend-candle` (no ORT backend). The embeddings docs still advertise ONNX:

- The embedding-provider table has an "ML Format(s)" column listing `ONNX` for the `file` and `huggingface` sources. Every other row is `-`, so the whole column now describes a capability that no longer exists.
- Both local-embedding deployment guides list `.onnx` as an accepted model-weight format, so a reader would ship ONNX weights that cannot load.

Separately, the data-ingestion page's edge example still describes "the loaded machine learning model" performing inference on OTel observations — the ONNX inference path that removal deleted.

## Changes (vNext only)

- `components/embeddings/index.md`: dropped the now-empty "ML Format(s)" column and renamed the remaining "LLM Format(s)" column to `Format(s)`. Its cell values are carried over verbatim — the `GGUF, GGML, SafeTensor` entries were not re-verified here, so flag them if that list is also stale. (Also dropped the `\*` footnote marker, which had no footnote on the page.)
- `components/embeddings/local/deployment.md`, `components/embeddings/huggingface/deployment.md`: removed `.onnx` from the accepted weight formats.
- `features/data-ingestion/index.md`: reframed the anomaly-detection example around querying fresh ingested data instead of ONNX inference.

Not propagated to `versioned_docs/`: `ort`/`tract` are present in `Cargo.lock` at v2.0.1 and v2.1.1, so the ONNX claims are correct in the versioned snapshots.

## Verified against

`spiceai/spiceai` @ `origin/trunk` (7bc4175f59):

- `Cargo.lock` — `grep -cE '^name = "(ort|tract-onnx|tract-core)"'` → `0` on trunk, `2` at both `v2.0.1` and `v2.1.1`.
- `Cargo.lock` — the only TEI backend crates present are `text-embeddings-backend`, `-backend-candle`, `-backend-core`, `-core`.
- [`crates/llms/src/embeddings/candle/`](https://github.com/spiceai/spiceai/tree/trunk/crates/llms/src/embeddings/candle) — the local/HF embedding loaders go through `TeiEmbed` (candle + safetensors); no ONNX path.
- [`features/machine-learning-models`](https://spiceai.org/docs/next/features/machine-learning-models) already records the removal; these pages were missed by the earlier sweeps (docs #1914, #1981).

`npm run build` passes locally.
