### PR TITLE
docs(reference): document the sub-second duration units and fractional values

### DIFF
--- a/website/docs/reference/duration/index.md
+++ b/website/docs/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.10.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.10.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.11.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.11.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.5.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.5.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.6.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.6.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.7.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.7.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.8.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.8.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-1.9.x/reference/duration/index.md
+++ b/website/versioned_docs/version-1.9.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-2.0.x/reference/duration/index.md
+++ b/website/versioned_docs/version-2.0.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```

--- a/website/versioned_docs/version-2.1.x/reference/duration/index.md
+++ b/website/versioned_docs/version-2.1.x/reference/duration/index.md
@@ -6,23 +6,32 @@ pagination_prev: 'reference/index'
 pagination_next: null
 ---
 
-Durations are represented as integers with a time unit suffix.
+Durations are represented as a number with a time unit suffix. A value without a suffix is interpreted as seconds, and fractional values (e.g. `1.5h`) are accepted.
 
 Supported time units are:
 
-| Time Unit | Identifier | Calculation |
-| --------: | ---------: | ----------: |
-|  `Second` |          s |        `1s` |
-|  `Minute` |          m |       `60s` |
-|    `Hour` |          h |       `60m` |
-|     `Day` |          d |       `24h` |
-|    `Week` |          w |        `7d` |
+| Time Unit     | Identifier | Calculation |
+| ------------: | ---------: | ----------: |
+| `Nanosecond`  |         ns |         `1` |
+| `Millisecond` |         ms |   `1000000` |
+|      `Second` |          s |        `1s` |
+|      `Minute` |          m |       `60s` |
+|        `Hour` |          h |       `60m` |
+|         `Day` |          d |       `24h` |
+|        `Week` |          w |        `7d` |
+
+Microseconds are also supported, spelled `Ms` (capital `M`, lowercase `s`).
+
+Month and year units are **not** supported — their length is ambiguous, so express longer intervals in weeks or days.
 
 ## Example
 
 ```example
 # 1 second
 1s
+
+# 250 milliseconds
+250ms
 
 # 3 minutes
 3m
@@ -39,4 +48,10 @@ Supported time units are:
 
 # 1 week
 1w
+
+# 90 minutes
+1.5h
+
+# 30 seconds (no suffix)
+30
 ```


### PR DESCRIPTION
## Problem

The Duration reference page claims durations are "integers with a time unit suffix" and lists only five units — `s`, `m`, `h`, `d`, `w`. Both duration parsers the runtime actually uses accept more than that:

| Docs said | What the parsers accept |
| --- | --- |
| Units: `s`, `m`, `h`, `d`, `w` | `ns`, microseconds, `ms`, `s`, `m`, `h`, `d`, `w` |
| "represented as integers" | Fractional values (`1.5h`) and exponent forms are accepted |
| (not mentioned) | A bare number with no suffix is interpreted as **seconds** |
| (not mentioned) | Month/year units are *not* accepted |

So `250ms` — used by real Spicepod duration fields — reads as unsupported, and a reader has no way to know `30` means 30 seconds.

## Changes

Added the sub-second units, the fractional/no-suffix rules, and an explicit note that month/year are unsupported. Microseconds are called out separately because the two parsers spell them differently (`Ms` in both; the `runtime`-field parser additionally accepts `us`), so the table documents only the spelling that is identical on both paths.

Propagated to all nine `versioned_docs` snapshots — the page is byte-identical in every version, and both parsers behave identically across them (see below).

## Verified against

`spiceai/spiceai` @ `origin/trunk` (7bc4175f59):

- [`crates/duration-parse/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/duration-parse/src/lib.rs) — `parse_time_unit()` unit table: `ns`, `us`, `Ms`, `ms`, `s`, `m`, `h`, `d`, `w`; "If no unit is found, defaults to seconds"; fraction + exponent handling. Used by `crates/spicepod` for `runtime.*` duration fields.
- `fundu` 2.0.1 `DurationParser::new()` — `get_current_time_units()` = `NanoSecond, MicroSecond, MilliSecond, Second, Minute, Hour, Day, Week` (no Month/Year); `parse("1")` → 1s; `parse("42.0e9ns")` accepted. `fundu::parse_duration` is what `crates/runtime-acceleration/src/acceleration.rs` uses for acceleration duration params (e.g. `refresh_check_interval`).
- `fundu` is pinned at **2.0.1** in `Cargo.lock` at every release tag from `v1.5.2` through `v2.1.1` and on trunk, so the accepted unit set is the same in every documented version.

`npm run build` passes locally. Post-stage grep confirms all 10 copies updated.
