### PR TITLE
docs(models): pickle weight files are rejected by default; document `trust_pickle`

### DIFF
--- a/website/docs/components/models/filesystem/deployment.md
+++ b/website/docs/components/models/filesystem/deployment.md
@@ -37,7 +37,7 @@ Model loading happens once at startup. A missing or unreadable file fails the sp
 | GGUF           | `.gguf`                        | Quantized / unquantized; loaded via the mistral local loader.          |
 | GGML (legacy)  | `.ggml`                        | Legacy llama.cpp format.                                               |
 | Safetensors    | `.safetensors`                 | Native tensor format; preferred over `.bin` for safety.                 |
-| PyTorch        | `.bin` / `.pt` / `.pth`         | Legacy PyTorch checkpoints.                                             |
+| PyTorch        | `.bin` / `.pt` / `.pth` / `.ckpt` | Legacy pickle-based checkpoints. **Rejected by default** — these formats execute arbitrary code when loaded. Set [`trust_pickle: true`](index.md#params-optional) to load them from a fully trusted source. |
 
 ### Device Selection
 

--- a/website/docs/components/models/filesystem/index.md
+++ b/website/docs/components/models/filesystem/index.md
@@ -33,6 +33,7 @@ from: file:models/llms/llama3.2-1b-instruct/
 | `tools`         | Which [tools](../../features/large-language-models/tools) should be made available to the model. Set to `auto` to use all available tools.                      |
 | `system_prompt` | An additional system prompt used for all chat completions to this model.                                                                                        |
 | `chat_template` | Customizes the transformation of OpenAI chat messages into a character stream for the model. See [Overriding the Chat Template](#overriding-the-chat-template). |
+| `trust_pickle`  | Allow loading pickle-based weight files (`.bin`, `.pt`, `.pth`, `.ckpt`). These formats execute arbitrary code when loaded and are rejected by default. Accepts `true` or `false`; defaults to `false`. Set to `true` only when the weights come from a fully trusted source. |
 
 See [Large Language Models](../../features/large-language-models) for additional configuration options.
 

--- a/website/docs/reference/spicepod/models.md
+++ b/website/docs/reference/spicepod/models.md
@@ -87,7 +87,8 @@ Optional. A list of files associated with this model. Each file has:
 File types include:
 
 - `weights`: Model weights
-  - For LLMs: `.gguf`, `.ggml`, `.safetensors`, or `pytorch_model.bin` files
+  - For LLMs: `.gguf`, `.ggml`, or `.safetensors` files
+  - Pickle-based checkpoints (`.bin`, `.pt`, `.pth`, `.ckpt`) execute arbitrary code when loaded and are **rejected by default**. Set [`trust_pickle: true`](../../components/models/filesystem/index.md#params-optional) to load them from a fully trusted source.
   - These files contain the trained parameters of the model
 
 - `config`: Model configuration

--- a/website/versioned_docs/version-2.1.x/components/models/filesystem/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/models/filesystem/deployment.md
@@ -37,7 +37,7 @@ Model loading happens once at startup. A missing or unreadable file fails the sp
 | GGUF           | `.gguf`                        | Quantized / unquantized; loaded via the mistral local loader.          |
 | GGML (legacy)  | `.ggml`                        | Legacy llama.cpp format.                                               |
 | Safetensors    | `.safetensors`                 | Native tensor format; preferred over `.bin` for safety.                 |
-| PyTorch        | `.bin` / `.pt` / `.pth`         | Legacy PyTorch checkpoints.                                             |
+| PyTorch        | `.bin` / `.pt` / `.pth` / `.ckpt` | Legacy pickle-based checkpoints. **Rejected by default** — these formats execute arbitrary code when loaded. Set [`trust_pickle: true`](index.md#params-optional) to load them from a fully trusted source. |
 | ONNX           | `.onnx`                        | Supported via the tract runtime for classical ML models.               |
 
 ### Device Selection

--- a/website/versioned_docs/version-2.1.x/components/models/filesystem/index.md
+++ b/website/versioned_docs/version-2.1.x/components/models/filesystem/index.md
@@ -33,6 +33,7 @@ from: file:models/llms/llama3.2-1b-instruct/
 | `tools`         | Which [tools](../../features/large-language-models/tools) should be made available to the model. Set to `auto` to use all available tools.                      |
 | `system_prompt` | An additional system prompt used for all chat completions to this model.                                                                                        |
 | `chat_template` | Customizes the transformation of OpenAI chat messages into a character stream for the model. See [Overriding the Chat Template](#overriding-the-chat-template). |
+| `trust_pickle`  | Allow loading pickle-based weight files (`.bin`, `.pt`, `.pth`, `.ckpt`). These formats execute arbitrary code when loaded and are rejected by default. Accepts `true` or `false`; defaults to `false`. Set to `true` only when the weights come from a fully trusted source. |
 
 See [Large Language Models](../../features/large-language-models) for additional configuration options.
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/models.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/models.md
@@ -88,7 +88,8 @@ File types include:
 
 - `weights`: Model weights
   - For ML models: typically `.onnx` files
-  - For LLMs: `.gguf`, `.ggml`, `.safetensors`, or `pytorch_model.bin` files
+  - For LLMs: `.gguf`, `.ggml`, or `.safetensors` files
+  - Pickle-based checkpoints (`.bin`, `.pt`, `.pth`, `.ckpt`) execute arbitrary code when loaded and are **rejected by default**. Set [`trust_pickle: true`](../../components/models/filesystem/index.md#params-optional) to load them from a fully trusted source.
   - These files contain the trained parameters of the model
 
 - `config`: Model configuration


### PR DESCRIPTION
## Problem

The docs list pickle-based PyTorch checkpoints as an accepted model-weight format for locally-served LLMs, with no caveat:

- `components/models/filesystem/deployment.md` — a "Supported Formats" table row: `PyTorch | .bin / .pt / .pth | Legacy PyTorch checkpoints.`
- `reference/spicepod/models.md` — `weights` file type: "For LLMs: `.gguf`, `.ggml`, `.safetensors`, or `pytorch_model.bin` files".

The runtime **rejects** those files by default. `file`-source models run every declared weights path through `llms::chat::reject_unsafe_weight_formats`, which fails the load with `UnsafePickleWeight` for any `.bin` / `.pt` / `.pth` / `.ckpt` extension unless `trust_pickle` is set. A reader following the docs hits a hard load failure with no pointer to the opt-in.

The opt-in itself — `trust_pickle` — is undocumented in every version of the docs, even though it is a security-relevant parameter (these formats execute arbitrary code on load).

## Changes

- `components/models/filesystem/index.md`: added the `trust_pickle` parameter row (accepted values, `false` default, and why it exists).
- `components/models/filesystem/deployment.md`: marked the PyTorch row **rejected by default**, added the missing `.ckpt` extension, and linked the opt-in.
- `reference/spicepod/models.md`: removed `pytorch_model.bin` from the plain accepted-formats list and added the rejected-by-default note with the same link.

Propagated to `versioned_docs/version-2.1.x`, which has both the guard and the `trust_pickle` `ParameterSpec`.

Left alone, and worth a follow-up: **v2.0.x** enforces the same guard (`reject_unsafe_weight_formats` is called from `crates/runtime/src/model/chat.rs` at `v2.0.1`) but does **not** declare `trust_pickle` in `FILE_PARAMETERS` — that page's format claim is wrong too, but whether the opt-in is actually settable there needs confirmation before documenting it. Versions 1.9.x–1.11.x have no guard at all, so their text is correct.

## Verified against

`spiceai/spiceai` @ `origin/trunk` (7bc4175f59):

- [`crates/llms/src/chat/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/chat/mod.rs) — `PICKLE_WEIGHT_EXTENSIONS = ["bin", "pt", "pth", "ckpt"]`; `reject_unsafe_weight_formats()` returns `Error::UnsafePickleWeight` unless `trust_pickle`; tests `rejects_pickle_extensions_by_default` and `allows_safe_extensions`.
- [`crates/runtime/src/model/chat.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/chat.rs) — `file()` calls the guard with `parse_trust_pickle(params)`, which "Defaults to `false`".
- [`crates/runtime/src/model/params/file.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/params/file.rs) — `ParameterSpec::runtime("trust_pickle").one_of(&["true", "false"])`.
- The `huggingface` model source does not call the guard, so its pages are unchanged.

`npm run build` passes locally.
