### PR TITLE
docs(cli): document the global flags and the missing per-command flags

### DIFF
--- a/website/docs/cli/reference/catalogs.md
+++ b/website/docs/cli/reference/catalogs.md
@@ -20,6 +20,7 @@ List [catalogs](../../components/catalogs) currently loaded by the Spice runtime
 #### Flags
 
 - `--tls-root-certificate-file` The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 
 ### Example
 

--- a/website/docs/cli/reference/chat.md
+++ b/website/docs/cli/reference/chat.md
@@ -33,6 +33,7 @@ spice chat [flags] [<message>]
 - `--temperature <float>` Model temperature used for chat request.
 - `--endpoint <endpoint>` Specifies the remote Spice instance HTTP endpoint (e.g., `http://localhost:8090`).
 - `--headers <KEY:VALUE>` Custom HTTP headers in format `Key:Value` (can be specified multiple times).
+- `--output <format>`, `-o` Output format: `table` (default) or `json`.
 
 ## Examples
 

--- a/website/docs/cli/reference/datasets.md
+++ b/website/docs/cli/reference/datasets.md
@@ -16,6 +16,7 @@ spice datasets [flags]
 #### Flags
 
 - `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   help for datasets
 
 ### Examples:

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -43,13 +43,22 @@ spice [command] [--help]
 | [spiced](reference/spiced)         | Spice runtime binary — direct invocation reference                     |
 | [status](reference/status)         | Spice runtime status                                                   |
 | [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
-| [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest release               |
+| [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest or specified version   |
 | [validate](reference/validate)     | Validate a spicepod.yaml without starting the runtime                  |
 | [version](reference/version)       | Spice CLI version                                                      |
 | workers                            | Lists workers loaded by the Spice runtime                              |
 
 ### Command Flags
 
-All commands have a help flag **--help** or **-h** to print its usage documentation:
+The following flags are global — they are accepted by every command:
 
-- **--help** | **-h** : Print the help message
+| Flag                            | Description                                                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `-h`, `--help`                  | Print the help message.                                                                                                              |
+| `-v`, `--verbose`               | Increase log verbosity. `-v` for debug, `-vv` for trace.                                                                             |
+| `--machine`                     | Machine-readable mode for LLMs and automation: prefer JSON output where supported, and always emit structured JSON errors. Alias: `--programmatic`. |
+| `--api-key <key>`               | API key used to authenticate with the runtime or the Spice.ai Cloud Platform. Also read from the `SPICE_API_KEY` environment variable. |
+| `--cloud`                       | Target the Spice.ai Cloud Platform instead of a local runtime. Requires `--api-key`.                                                  |
+| `--cloud-region <region>`       | Spice.ai Cloud Platform runtime endpoint region, used with `--cloud`. Defaults to `us-east-1`.                                        |
+| `--http-endpoint <endpoint>`    | HTTP endpoint of the Spice runtime to talk to. Defaults to `http://127.0.0.1:8090`.                                                  |
+| `--tls-root-certificate-file <file>` | Path to a PEM root certificate used to verify the runtime's TLS server certificate.                                              |

--- a/website/docs/cli/reference/models.md
+++ b/website/docs/cli/reference/models.md
@@ -16,6 +16,7 @@ spice models [flags]
 #### Flags
 
 - `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   help for models
 
 ### Examples

--- a/website/docs/cli/reference/pods.md
+++ b/website/docs/cli/reference/pods.md
@@ -15,6 +15,7 @@ spice pods [flags]
 #### Flags
 
 - `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   help for pods
 
 ### Examples

--- a/website/docs/cli/reference/refresh.md
+++ b/website/docs/cli/reference/refresh.md
@@ -20,6 +20,8 @@ spice refresh [dataset] [flags]
 - `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
 - `--refresh-sql`  SQL used to refresh the dataset, see [Refresh SQL docs](../../features/data-acceleration/data-refresh#refresh-sql).
 - `--refresh-mode`  Refresh mode to use, see [Refresh Modes docs](../../features/data-acceleration/data-refresh#refresh-modes).
+- `--refresh-jitter-max`  Maximum [jitter](../../features/data-acceleration/data-refresh#refresh-jitter) applied to the refresh, as a [duration](../../reference/duration) (e.g. `1m`).
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   Print this help message
 
 ### Examples

--- a/website/docs/cli/reference/sql.md
+++ b/website/docs/cli/reference/sql.md
@@ -23,6 +23,7 @@ spice sql [flags]
 - `--client-tls-key-file <file>` The path to the client private key file for mTLS authentication. Must be used together with `--client-tls-certificate-file`.
 - `--headers <KEY:VALUE>` Custom HTTP headers in format `Key:Value` (can be specified multiple times).
 - `-x`, `--expanded` Start the REPL in expanded view, rendering each column on its own line per record. Useful for wide tables. Can be toggled at runtime with the `.expanded` meta-command.
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help` Print this help message.
 
 #### REPL Meta-commands

--- a/website/docs/cli/reference/status.md
+++ b/website/docs/cli/reference/status.md
@@ -15,6 +15,7 @@ spice status [flags]
 #### Flags
 
 - `--tls-root-certificate-file`   The path to the root certificate file used to verify the Spice.ai runtime server certificate
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   help for status
 
 ### Examples

--- a/website/docs/cli/reference/trace.md
+++ b/website/docs/cli/reference/trace.md
@@ -44,6 +44,8 @@ These tasks are from the `task` column in the Spice SQL `runtime.task_history` t
 - `--api-key`  Specify the API key for authentication.
 - `--include-output`: Include, as an additional column, the captured output to each span (i.e. the `captured_output` column from `runtime.task_history`). Note: If captured outputs are not being stored, this will return an empty row.
 - `--include-input`: Include, as an additional column, the input to each span (i.e. the `input` column from `runtime.task_history`).
+- `--truncate [<length>]`  Truncate the `input` and `captured_output` columns to the given number of characters. Defaults to `80` characters when the flag is passed without a value; when omitted, the columns are not truncated.
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 
 The latest trace for the task will be used if neither `--trace-id` nor `--id` is specified.
 

--- a/website/docs/cli/reference/upgrade.md
+++ b/website/docs/cli/reference/upgrade.md
@@ -4,20 +4,37 @@ sidebar_label: "upgrade"
 pagination_prev: null
 pagination_next: null
 ---
-Upgrades the Spice CLI & Runtime to the latest release
+Upgrades the Spice CLI and runtime to the latest or specified version
 
 ### Usage
 
 ```shell
-spice upgrade [flags]
+spice upgrade [target_version] [flags]
 ```
+
+`target_version` - an optional release version to install, including the leading `v` (e.g. `v1.8.3`). A version without the leading `v` is rejected. When omitted, the latest release is used.
 
 #### Flags
 
+- `-f`, `--force`   Reinstall the CLI and runtime even when the target version is already installed
 - `-h`, `--help`   help for upgrade
 
 ### Examples
 
 ```shell
 spice upgrade
+```
+
+### Additional Examples
+
+Upgrade to a specific version:
+
+```shell
+spice upgrade v1.8.3
+```
+
+Reinstall the currently installed version:
+
+```shell
+spice upgrade --force
 ```

--- a/website/docs/cli/reference/version.md
+++ b/website/docs/cli/reference/version.md
@@ -14,6 +14,8 @@ spice version [flags]
 
 #### Flags
 
+- `--cli-only`   Show only the CLI version, skipping the runtime version lookup
+- `-o`, `--output <format>` Output format: `table` (default) or `json`.
 - `-h`, `--help`   help for version
 
 ### Sample output


### PR DESCRIPTION
## Problem

Several flags in the CLI reference are missing, and the `spice upgrade` page describes a command surface that no longer matches the binary.

**Global flags.** The reference index's "Command Flags" section says only that every command takes `--help`. The CLI actually declares seven `global = true` args in `bin/spice/src/main.rs` — `-v/--verbose`, `--machine`, `--api-key`, `--cloud`, `--cloud-region`, `--http-endpoint`, `--tls-root-certificate-file`. Several are already used in per-command examples (e.g. `spice chat --cloud --api-key ...`) without ever being defined.

**`-o`/`--output`.** Ten commands take `-o/--output <table|json>`, added in spiceai#9541 (2026-03) and, for `status`, in the Rust CLI rewrite. Only `query` and `search` document it. Missing from: `catalogs`, `chat`, `datasets`, `models`, `pods`, `refresh`, `sql`, `status`, `trace`, `version`.

**`spice upgrade`.** Documented as `spice upgrade [flags]` with `--help` as the only flag. `UpgradeArgs` has an optional `target_version` positional and `-f/--force`, and the command's own `about` is "Upgrades the Spice CLI and runtime to the latest **or specified** version".

**Other missing per-command flags:** `version --cli-only`, `refresh --refresh-jitter-max`, `trace --truncate`.

## Changes (vNext only)

- `cli/reference/index.md`: replaced the `--help`-only note with a table of all seven global flags plus `--help`, and corrected the `upgrade` row's description.
- `cli/reference/upgrade.md`: documented the `target_version` positional (including that a version without the leading `v` is rejected) and `-f/--force`; added examples for both.
- Added `-o/--output` to the ten pages that support it.
- Added `--cli-only` (`version`), `--refresh-jitter-max` (`refresh`), `--truncate` (`trace`).

Not propagated to `versioned_docs/`: `--output` arrived per command across different releases (`status` in v1.11.x, most others after v1.11.2), so the versioned snapshots diverge command-by-command and need their own pass rather than a copy of this one.

## Verified against

`spiceai/spiceai` @ `origin/trunk` (7bc4175f59), reading the `clap` derive attributes:

- [`bin/spice/src/main.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/main.rs) — `struct Cli`: the seven `global = true` args, `SPICE_API_KEY` env fallback, `--cloud` `requires = "cloud"` chain, `--http-endpoint` default `http://127.0.0.1:8090`, `DEFAULT_CLOUD_REGION = "us-east-1"`.
- [`bin/spice/src/commands/upgrade.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/upgrade.rs) — `target_version` positional, `#[arg(short, long)] force`, the leading-`v` validation, and `args.force ||` in both the CLI and runtime upgrade decisions.
- [`bin/spice/src/output/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/output/mod.rs) — `OutputFormat { Table (default, alias "text"), Json }`.
- `bin/spice/src/commands/{catalogs,chat,datasets,models,pods,refresh,sql,status,trace,version}.rs` — each declares `#[arg(long, short = 'o', default_value = "table")] output: OutputFormat`.
- `bin/spice/src/commands/version.rs` — `#[arg(long)] cli_only`; `refresh.rs` — `refresh_jitter_max`; `trace.rs` — `#[arg(long, default_missing_value = "80")] truncate`.

Note: `trace.md`'s existing `--api-key` entry is correct — it resolves to the global flag, not a `trace`-specific one.

`npm run build` passes locally.
