### PR TITLE
docs(duckdb): on_full_refresh shipped in v2.1.2 — propagate to version-2.1.x

### DIFF
--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/deployment.md
@@ -30,7 +30,9 @@ Use `mode: file` for any dataset larger than a few hundred MB or where restart s
 
 ### Checkpointing
 
-The DuckDB accelerator enables `PRAGMA enable_checkpoint_on_shutdown` at connection setup. Graceful shutdown writes a clean checkpoint, making restart near-instantaneous. Ungraceful shutdowns leave a WAL to replay, slowing the first subsequent startup.
+The DuckDB accelerator enables `PRAGMA enable_checkpoint_on_shutdown` once per DuckDB instance, when the instance is set up. Graceful shutdown writes a clean checkpoint, making restart near-instantaneous. Ungraceful shutdowns leave a WAL to replay, slowing the first subsequent startup.
+
+Full-refresh bulk loads bypass the WAL, so DuckDB's WAL-growth-based automatic checkpoint never fires on a repeatedly full-refreshed acceleration and the freed blocks are never returned to the free list. Set [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) to `replace_file` or `checkpoint_file` to reclaim that space on every refresh.
 
 ### Spill Directory
 
@@ -38,7 +40,7 @@ Large queries (sort, aggregate, join) can spill to disk. The spill directory is 
 
 ### Vacuum
 
-DuckDB does not require explicit `VACUUM`; its storage layout compacts on checkpoint. No Spice-level vacuum automation is provided.
+DuckDB does not require explicit `VACUUM`; its storage layout compacts on checkpoint. For file-mode accelerations on `refresh_mode: full`, the [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) parameter is the Spice-level control over that reclamation: `replace_file` rebuilds and atomically swaps in a compact file on every refresh, `checkpoint_file` checkpoints the live file in place, and the default `reuse_file` reclaims nothing.
 
 ## Capacity & Sizing
 
@@ -97,3 +99,4 @@ DuckDB acceleration operations participate in [task history](../../../reference/
 | Query uses table scan when an index exists             | `duckdb_index_scan_percentage` / `duckdb_index_scan_max_count` too low.     | Tune thresholds; `EXPLAIN` to confirm.                                                                       |
 | Indexes disappear after refresh                        | `on_refresh_sort_columns` triggers `CREATE OR REPLACE`.       | Re-create indexes post-refresh, or avoid sort-column refreshes until the underlying behavior is updated.    |
 | `IO Error: Could not set lock on file`                 | Another process holds a write lock.                           | Ensure single-writer semantics; verify no other Spice instance is using the same file.                      |
+| DuckDB file grows on every refresh                     | `refresh_mode: full` bulk loads bypass the WAL, so no automatic checkpoint reclaims the previous copy of the data. | Set [`on_full_refresh`](./index.md#bounding-acceleration-file-growth) to `replace_file` (or `checkpoint_file` for a lighter, in-place checkpoint). |

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/duckdb/index.md
@@ -46,6 +46,7 @@ DuckDB acceleration supports the following optional parameters under `accelerati
 - `duckdb_partitioned_write_flush_threshold_rows` (integer, default: `122880`): The number of rows buffered per partition before flushing data to acceleration storage. Only applicable when using `partition_mode: tables`. Using a larger value can improve write performance but requires more memory.
 - `partitioned_write_buffer` (string, default: `memory`): Specifies the buffering mechanism used when writing partitioned data. Only applicable when using `partition_mode: tables`. Set to `parquet` to buffer writes through Parquet files instead of in-memory buffers.
 - `on_refresh_sort_columns` (string, default: none): Sorts data after each refresh by the specified columns, improving DuckDB [zone map](https://duckdb.org/2025/05/14/sorting-for-fast-selective-queries) (min/max) statistics for query pruning and significantly faster lookup queries. Format: `column1 ASC, column2 DESC` or `column1, column2` (defaults to ASC). Specified columns must exist in the dataset schema, and sort direction must be `ASC` or `DESC`.
+- `on_full_refresh` (string, default: `reuse_file`): How a full refresh writes into a file-mode acceleration, and whether the space held by the previous copy of the data is reclaimed. One of `reuse_file`, `replace_file`, or `checkpoint_file` — see [Bounding acceleration file growth](#bounding-acceleration-file-growth). `replace_file` and `checkpoint_file` require `mode: file`; configuring either with `mode: memory` is rejected at load time.
 - `optimizer_duckdb_aggregate_pushdown` (string, default: `disabled`): Enables aggregate pushdown optimization to execute supported aggregate queries directly in DuckDB. Set to `enabled` to push down aggregations for improved query performance on supported functions like `count`, `sum`, `avg`, `min`, and `max`. Requires `query_federation` to be `disabled`.
 
 Refer to the [datasets configuration reference](../../reference/spicepod/datasets#acceleration) for additional supported fields.
@@ -63,6 +64,55 @@ datasets:
         duckdb_file: /my/chosen/location/duckdb.db
         duckdb_memory_limit: '2GB'
 ```
+
+## Bounding Acceleration File Growth
+
+A full refresh (`refresh_mode: full`) bulk-loads a fresh copy of the data into the DuckDB file. Bulk loads write row groups directly to the database file and send only block pointers to the WAL, so DuckDB's WAL-growth-based automatic checkpoint never fires — and the blocks freed by dropping the previous copy of the table are only returned to the free list at a checkpoint. On a repeatedly full-refreshed file-mode acceleration, the DuckDB file therefore **grows without bound** even though the data it holds does not.
+
+Set the `on_full_refresh` parameter to reclaim that space after each refresh:
+
+| `on_full_refresh`  | Behavior                                                                                                | Query impact                                                                                          | File size                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `reuse_file`       | Default. Keeps writing into the current database file. No space is reclaimed.                            | None.                                                                                                  | Grows with every refresh.                        |
+| `replace_file`     | Writes a new database file, checkpoints it, and atomically replaces the live file with it.                | Readers are never interrupted; writers pause briefly during the replacement.                            | Reclaimed on every refresh; the file can shrink. |
+| `checkpoint_file`  | Keeps the current file and checkpoints it after each refresh commits.                                     | A checkpoint that has to escalate stalls queries on that file for a bounded window (see below).          | Plateaus near the working set, but never shrinks below the file's high-water mark. |
+
+Both `replace_file` and `checkpoint_file` require file-mode acceleration. Configuring either alongside `mode: memory` is rejected at load time.
+
+```yaml
+datasets:
+  - from: spice.ai:path.to.my_dataset
+    name: my_dataset
+    acceleration:
+      engine: duckdb
+      mode: file
+      refresh_mode: full
+      params:
+        duckdb_file: /data/shared.duckdb
+        on_full_refresh: replace_file # default: reuse_file
+```
+
+### `replace_file`
+
+A full refresh streams into a fresh staging database file while the live file keeps serving queries, then:
+
+1. copies every other object sharing the file into the staging file — other datasets' tables, views, and indexes, the `spice_sys_*` metadata tables (dataset checkpoints, CDC offsets), and HNSW indexes,
+2. checkpoints and cleanly closes the staging file, so it is compact and WAL-free, and
+3. atomically renames it over the configured path and repoints the shared connection pool at it.
+
+In-flight queries drain against the old file through their already-open descriptors and new queries see the new file, so readers never block; only writers pause, for the duration of the copy-and-replace window. Because the replacement always produces a checkpointed file, [acceleration snapshots](../../features/data-acceleration/snapshots) taken from it are exact.
+
+Several datasets can share one DuckDB file: replacements serialize on a per-file write gate and each one carries the other datasets' current data forward. A dataset accelerated into a *different* DuckDB file that reads this one needs no special handling — its attachment re-resolves when the file underneath it is replaced.
+
+If the process is interrupted mid-replacement, the leftover files are cleaned up on the next startup: incomplete staging files are deleted, and the newest completed replacement is adopted when the configured file itself is missing.
+
+`replace_file` cannot be combined with `refresh_mode: snapshot` on the same DuckDB file — whether on the same dataset or on another dataset sharing the file — and the combination is rejected at load time. Both mechanisms replace the file out-of-band on their own schedules, so refreshes would fail intermittently as each retires the other's file. Give one of them its own `duckdb_file`, or set `on_full_refresh: reuse_file`.
+
+### `checkpoint_file`
+
+After each full-refresh overwrite commits, the runtime runs `CHECKPOINT` on the live database. A plain `CHECKPOINT` fails fast while other transactions are open, in which case it escalates to `FORCE CHECKPOINT`, which waits for the in-flight transactions to finish while blocking new ones from starting — a stall bounded by the slowest in-flight query plus the checkpoint write itself, paid only when the escalation is needed. A checkpoint that fails is logged and never fails the refresh; the refreshed data is already durably committed.
+
+This is lighter than `replace_file` — there is no staging copy of cohabiting objects — at the cost of that stall, and of the file plateauing at its high-water mark instead of shrinking. Prefer `replace_file` where in-flight queries must not be interrupted.
 
 ## Limitations
 


### PR DESCRIPTION
## Summary

`v2.1.2` backported the DuckDB `on_full_refresh` parameter, but the `version-2.1.x` docs snapshot never received it — the parameter, its three values, and the file-growth behavior it controls are documented **only** in vNext (docs #2004). Readers on the current 2.1 release see no `on_full_refresh` at all, so the released runtime accepts a parameter its own docs do not mention.

The same snapshot also still says the shutdown-checkpoint pragma is applied "at connection setup"; `v2.1.2` moved it to per-instance setup.

**What the 2.1.x docs said vs. what v2.1.2 does:**

| Claim in `version-2.1.x` | v2.1.2 behavior |
| --- | --- |
| `on_full_refresh` absent from the parameter list and the page | `ParameterSpec::runtime("on_full_refresh")` accepts `reuse_file` (default), `replace_file`, `checkpoint_file`; any other value is rejected at load time |
| No mention that a repeatedly full-refreshed file-mode acceleration grows without bound | Full-refresh bulk loads bypass the WAL, so the automatic checkpoint never fires and freed blocks are not returned to the free list |
| "No Spice-level vacuum automation is provided." | `on_full_refresh` **is** the Spice-level reclamation control for `refresh_mode: full` |
| `PRAGMA enable_checkpoint_on_shutdown` applied "at connection setup" | `with_instance_setup_query(...)` — once per DuckDB instance, at instance setup |

## What changed

Propagated the vNext `on_full_refresh` content (byte-identical to `website/docs/`) into `version-2.1.x`:

- `index.md` — the `on_full_refresh` parameter row and the **Bounding Acceleration File Growth** section (comparison table, YAML example, `replace_file` and `checkpoint_file` subsections).
- `deployment.md` — connection-setup → instance-setup correction, the full-refresh/WAL note under Checkpointing, the Vacuum paragraph, and a troubleshooting row for a file that grows on every refresh.

**Deliberately not propagated** (trunk-only, must stay out of the 2.1.x snapshot):

- the coordinated DuckDB/query memory budget (spiceai#11985) — not in `v2.1.2`
- the `partition_by` removal (spiceai#11808) — partitioning still ships in `v2.1.2`, and its params remain documented in this snapshot
- the "datasets 10 GB or larger → Cayenne" recommendation (docs #2000) — Cayenne is still RC in the 2.1 line

## Verification

Source: `spiceai/spiceai` at tag **`v2.1.2`**.

- [`crates/runtime/src/dataaccelerator/duckdb.rs:587`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/runtime/src/dataaccelerator/duckdb.rs#L587) — `ParameterSpec::runtime("on_full_refresh")` (unprefixed, matching the documented key).
- Same file `:738-776` — the match on `reuse_file` / `replace_file` / `checkpoint_file`, the `mode: memory` rejection, the invalid-value error, and `checkpoint_on_write` translation.
- Same file `:298-356` — `replace_file` rejected alongside `refresh_mode: snapshot` on a shared DuckDB file.
- Same file `:221,244` — `with_instance_setup_query("PRAGMA enable_checkpoint_on_shutdown")` (it was `with_connection_setup_query` at `v2.1.1`).
- `CHECKPOINT` → `FORCE CHECKPOINT` escalation: `core/src/duckdb/write.rs` `checkpoint_after_write` in `datafusion-table-providers` rev `1b83cbf` — the **same** rev is pinned on `v2.1.2` and `trunk`, so the documented stall semantics hold identically.

Source PRs: spiceai/spiceai#12135, spiceai/spiceai#12139 (both in the `v2.1.1..v2.1.2` range).

## Cross-page / cross-version grep

```
$ grep -rln "on_full_refresh" website/
website/releases/v2.1.2.md
website/docs/components/data-accelerators/duckdb/index.md
website/docs/components/data-accelerators/duckdb/deployment.md
```

Zero hits under `versioned_docs/` before this change. `version-2.0.x` and older are correctly untouched — the parameter does not exist in those releases (it landed in the `v2.1.1..v2.1.2` range). `duckdb/{index,deployment}.md` are the only page types carrying the claim; `reference/performance-tuning.md` and `reference/spicepod/datasets.md` do not mention it.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks`/`onBrokenAnchors`/`onInlineTags` all `throw`) — 3750 documents, `Generated static files in "build"`.
- [x] Versioned-docs propagation checked (grep-count gate above)
- [x] Files updated: 2 (matches the diff)