### PR TITLE
docs(postgres catalog): restore the Limitations section missing from version-2.1.x

### DIFF
--- a/website/versioned_docs/version-2.1.x/components/catalogs/postgres.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/postgres.md
@@ -109,6 +109,24 @@ The PostgreSQL Catalog Connector automatically discovers foreign key relationshi
 
 No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
 
+## Limitations
+
+:::warning
+
+- **Base tables and standard views only.** The connector discovers `BASE TABLE` and `VIEW` relations. Materialized views and foreign tables are not currently discovered and will not appear in the catalog ([#11725](https://github.com/spiceai/spiceai/issues/11725)).
+- **Partitioned tables.** For declaratively-partitioned tables, both the partitioned parent and each child partition are registered as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726)).
+- **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
+- **Unsupported column types.** Tables containing a column of a type that cannot be mapped are skipped entirely and a warning is logged. The `unsupported_type_action` behavior available on individual PostgreSQL datasets is not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728)).
+- **Partial discovery failures.** If discovery of a schema's tables fails during the initial load, the catalog fails to register rather than loading the reachable schemas ([#11724](https://github.com/spiceai/spiceai/issues/11724)).
+- **Amazon Redshift.** Redshift is supported over the PostgreSQL wire protocol, but its `pg_catalog` coverage is partial and it does not enforce foreign keys, so table/column comment and foreign-key metadata are often unavailable. Discovery degrades gracefully (tables are still registered).
+- **Read-only.** Catalog tables are read-only. Accelerations cannot be configured on tables discovered through an external catalog.
+
+:::
+
+## Cookbook
+
+There is a [cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/postgres) demonstrating the PostgreSQL Catalog Connector with the TPC-H dataset.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).


### PR DESCRIPTION
## Summary

`version-2.1.x/components/catalogs/postgres.md` documents **no limitations at all**, while `version-2.0.x` and vNext both do — and the seven limitations still apply to `v2.1.2`.

This is the "freshly-cut snapshot arrives already-stale" race, in its cleanest form:

- `version-2.1.x` was cut **2026-07-09** (docs #1903).
- docs #1909 — "add Limitations and Cookbook sections" — merged **2026-07-10**, one day later, touching `website/docs/` and `versioned_docs/version-2.0.x/` only. The brand-new 2.1.x snapshot was invisible to it.

So the released 2.1 docs silently dropped a section that the Alpha catalog release criteria explicitly require ("Documentation includes all known issues/limitations for the Catalog"). A reader on 2.1.x gets no warning that, for example, a declaratively-partitioned table registers its parent *and* every leaf partition as separate tables.

## What changed

Restored the `## Limitations` and `## Cookbook` sections to `version-2.1.x`, making that page identical to `version-2.0.x` (they were byte-identical apart from these 18 lines).

## Verification — every bullet re-checked at `v2.1.2`, not copied on faith

The whole point of the audit is that a 2.0.x-era limitation may have been fixed in 2.1. Each was read at the tag:

| Limitation | Evidence at `v2.1.2` | Still applies? |
| --- | --- | --- |
| Base tables and standard views only (matviews / foreign tables not discovered) — [#11725](https://github.com/spiceai/spiceai/issues/11725) | Table listing is `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type IN ('BASE TABLE', 'VIEW')` — [`data_components/src/postgres/provider.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/data_components/src/postgres/provider.rs) | Yes |
| Partitioned parent **and** each child partition registered — [#11726](https://github.com/spiceai/spiceai/issues/11726) | No `pg_inherits` `NOT EXISTS` exclusion at this tag. The fix (spiceai/spiceai#11798) is trunk-only — `git tag --contains` returns nothing, matching the scoping docs #1923 already established | Yes |
| `include` filters tables, not schemas | `is_table_included` matches `schema.table`; schema enumeration is a separate query filtered only by `SYSTEM_SCHEMAS` / `pg_temp` | Yes |
| Unsupported column types skip the whole table; `unsupported_type_action` not applied on the catalog path — [#11728](https://github.com/spiceai/spiceai/issues/11728) | `"Failed to create table provider for PostgreSQL table {schema_with_table}, skipping"` with a `warn!`; `unsupported_type_action` appears nowhere in the Postgres catalog path at this tag | Yes |
| Partial discovery failure fails the whole catalog load — [#11724](https://github.com/spiceai/spiceai/issues/11724) | `schema_provider.refresh_tables(&foreign_keys, &comments).await?` — the `?` propagates out of the per-schema loop | Yes |
| Amazon Redshift metadata caveats | Descriptive; unchanged behavior | Yes |
| Read-only; accelerations cannot be configured on catalog tables | The spicepod `Catalog` struct at `v2.1.2` has **no** `acceleration` field ([`crates/spicepod/src/component/catalog.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/spicepod/src/component/catalog.rs) — `from`, `name`, `description`, `metadata`, `access`, `include`, `params`, `dataset_params`, `depends_on`, `metrics`). Catalog-level CDC acceleration is vNext-only (docs #1949) | Yes |

Deliberately **not** back-ported into this snapshot, because neither exists at `v2.1.2`: the `exclude` field and the `Catalog Refresh` section (docs #2003) — the `Catalog` struct above has no `exclude`. vNext keeps its corrected, feature-complete version of the section.

## Cross-version scope

```
$ ls website/versioned_docs/version-1.11.x/components/catalogs/
databricks.md  glue.md  iceberg.md  index.md  spiceai.md  unity-catalog.md
```

The PostgreSQL catalog connector page exists only from 2.0.x onward, so `version-2.1.x` is the sole affected snapshot.

## Test plan

- [x] `cd website && npm run build` passes (`onBrokenLinks`/`onBrokenAnchors`/`onInlineTags` all `throw`) — 3750 documents, `Generated static files in "build"`.
- [x] Versioned-docs propagation checked (only 2.1.x is missing the section; 2.0.x and vNext already correct for their releases)
- [x] Files updated: 1 (matches the diff)