### PR TITLE
docs(cayenne): durable federated write-back is gated off pending atomic source delivery

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -745,11 +745,21 @@ COMMIT;
 - **Preconditions with `assert()`.** The `assert(<boolean expression>)` function evaluates its argument at execution time. If the expression is `false` or `NULL`, the transaction aborts with `assertion failed: gate expression was false or NULL`. Use it to enforce invariants (for example, a sufficient balance) as part of the transaction. Comparison gates such as `… >= cap` are NULL-safe.
 - **Return value.** On success, `/v1/sql` returns the final statement's result (for the canonical gate-plus-write shape, the last write's row-count summary), or `COMMIT` when the body produces no rows.
 
-**Durable federated write-back:** A Cayenne dataset configured with [`write_mode: write_back`](../../reference/spicepod/datasets#accelerationwrite_mode), `on_conflict`, and `refresh_mode: changes` (CDC) also participates in transactions. Its committed writes are staged to the accelerator and then reconciled asynchronously back to the federated source by a per-table write-back worker. `write_mode: write_back` requires `replication.enabled: true` as an explicit opt-in to asynchronous source durability.
+**Durable federated write-back:** A Cayenne dataset configured with [`write_mode: write_back`](../../reference/spicepod/datasets#accelerationwrite_mode), `on_conflict`, and `refresh_mode: changes` (CDC) stages its committed writes to the accelerator and then reconciles them asynchronously back to the federated source by a per-table write-back worker. `write_mode: write_back` requires `replication.enabled: true` as an explicit opt-in to asynchronous source durability.
+
+:::warning Durable write-back is not currently available
+Reconciling a row to the source is delivered as a separate `DELETE` followed by an `INSERT`. Because the accelerator is CDC-fed from that same source, the standalone `DELETE` echoes back over the changes stream and removes the committed row from the accelerator; if the follow-up `INSERT` then fails, the write is silently gone from both sides. Closing that window needs a source that can apply a delivered row in **one atomic step** — a single transaction covering both legs, or a native conditional upsert.
+
+No connector advertises that capability yet, so rather than accept a configuration that can lose a committed write, Spice now **rejects the dataset at registration**:
+
+> Failed to register dataset `<name>` (`<connector>`): durable write-back needs a source that can apply a delivered row in one atomic step, and the `<connector>` connector cannot yet.
+
+Remove `on_conflict` to keep writes on the accelerator, or choose a different [`acceleration.write_mode`](../../reference/spicepod/datasets#accelerationwrite_mode). Per-connector atomic delivery is planned; until it lands, this combination cannot be loaded.
+:::
 
 **Requirements and v1 limitations:**
 
-- Write targets must be **accelerator-only, non-partitioned Cayenne datasets** (or durable write-back Cayenne datasets, as described above). Other dataset modes route writes to the federated source — where the gate cannot govern them — and are rejected.
+- Write targets must be **accelerator-only, non-partitioned Cayenne datasets**. Other dataset modes route writes to the federated source — where the gate cannot govern them — and are rejected. Durable write-back datasets are not currently loadable (see the warning above).
 - Only **`INSERT` and `UPDATE`** writes are supported inside a transaction. `DELETE` and `MERGE` are rejected.
 - At most **one write per table** per transaction. Multiple tables may be written in the same transaction and are committed atomically together.
 - Reading a Cayenne table that is not a registered participant (for example, a partitioned table) fails the transaction closed.


### PR DESCRIPTION
## Summary

The Cayenne page documented **durable federated write-back** (`write_mode: write_back` + `on_conflict` + `refresh_mode: changes`) as a working configuration. On `trunk` it is now **rejected at dataset registration**, so a reader following the page cannot load the pod.

spiceai/spiceai#12051 found that delivery reconciles a committed accelerator row to the source as two separate source commits — `delete_from(pk)` then `insert(..., InsertOp::Append)`. Because the accelerator is CDC-fed from that same source and has no self-echo suppression, the standalone `DELETE` echoes back and erases the committed row from the accelerator; if the follow-up `INSERT` fails, the row is gone from both sides with nothing reported. The fix gates the configuration on the source connector advertising an atomic delivery primitive and fails registration otherwise.

Verified against `origin/trunk`:

- `Acceleration::resolves_to_durable_write_back()` — `crates/runtime-acceleration/src/acceleration.rs:463` — the exact four-condition config the page describes.
- Registration gate — `crates/runtime/src/init/dataset.rs:783-794`.
- `DataConnector::supports_durable_write_back_delivery()` defaults to `false` (`crates/runtime/src/dataconnector/mod.rs:672`) and **no connector overrides it to `true`** — the only other occurrences are the four forwarding wrappers (`deferred.rs`, `embeddings/connector.rs`, `search/full_text/connector.rs`, `search/full_text/elasticsearch.rs`) and tests. So the combination is currently unloadable for every source.
- Error string quoted verbatim from `crates/runtime/src/lib.rs:310`.

## Version scope

**vNext only.** `git show v2.1.2:crates/runtime/src/init/dataset.rs | grep -c supports_durable_write_back_delivery` → `0`; the gate landed after v2.1.2 was cut, so `versioned_docs/version-2.1.x/` and older correctly describe the pre-gate behavior.

## Cross-page check

```
$ grep -rn --include="*.md" "write_back" website/docs/
website/docs/components/data-connectors/postgres/index.md:226   # generic write_mode description
website/docs/components/data-accelerators/cayenne/index.md:748  # durable write-back  <-- fixed
website/docs/reference/spicepod/datasets.md:546                 # generic write_mode description
```

The other two hits describe `write_mode: write_back` generically. The gate fires **only** on the four-condition Cayenne combination (`resolves_to_durable_write_back`), so plain `write_back` without `on_conflict` is unaffected and those descriptions stay correct — left untouched deliberately rather than over-broadening the limitation.

## Source PRs

- spiceai/spiceai#12051 — fix(write-back): gate durable write-back on a safe source delivery primitive (fixes #11915)

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — vNext-only, gate absent from v2.1.2
- [x] Files updated: 1 (matches the diff)
