### PR TITLE
docs(oracle): DATE maps to Timestamp(Second), not Date32

### DIFF
--- a/website/docs/components/data-connectors/oracle.md
+++ b/website/docs/components/data-connectors/oracle.md
@@ -106,7 +106,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 | `BINARY_FLOAT`                   | `Float32`                                                                        |
 | `BINARY_DOUBLE`                  | `Float64`                                                                        |
 | `BOOLEAN`                        | `Boolean`                                                                        |
-| `DATE`                           | `Date32`                                                                         |
+| `DATE`                           | `Timestamp(Second)`                                                              |
 | `TIMESTAMP`                      | `Timestamp(Second)` for precision=0, otherwise `Timestamp(Nanosecond)`           |
 | `TIMESTAMP WITH TIME ZONE`       | `Timestamp(Second, UTC)` for precision=0, otherwise `Timestamp(Nanosecond, UTC)` |
 | `TIMESTAMP WITH LOCAL TIME ZONE` | `Timestamp(Second, UTC)` for precision=0, otherwise `Timestamp(Nanosecond, UTC)` |
@@ -116,6 +116,7 @@ The table below shows the Oracle data types supported, along with the type mappi
 
 :::note
 
+- Oracle `DATE` is **not** a date-only type — it stores hour, minute, and second alongside the calendar date — so it maps to `Timestamp(Second)`, matching Oracle's 1-second resolution. Earlier versions mapped it to `Date32`, which silently truncated every value to midnight.
 - The Oracle `TIMESTAMP WITH LOCAL TIME ZONE` value is retrieved as a UTC time value.
 - `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, and `TIMESTAMP WITH LOCAL TIME ZONE` columns with non-zero precision are mapped to `Timestamp(Nanosecond)`. Timestamps outside the nanosecond range (approximately years 1677–2262) will return an error. This is an inherent limitation of Arrow's nanosecond timestamp representation.
 


### PR DESCRIPTION
## Summary

The Oracle connector's type table mapped `DATE` → `Date32`. Oracle's `DATE` is **not** a date-only type — it stores hour, minute and second alongside the calendar date — so the `Date32` read path silently truncated every value to midnight. spiceai/spiceai#12097 maps it to `Timestamp(Second, None)`, matching Oracle's 1-second resolution.

Verified against `origin/trunk` — `crates/data_components/src/oracle/convert.rs:90`:

```rust
"DATE" => Some(DataType::Timestamp(TimeUnit::Second, None)),
```

Confirmed as an explicit left-hand-side source-type match arm (not an RHS occurrence), with a dedicated regression test asserting the mapping at `convert.rs:486-495`.

## Version scope

**vNext only.**

```
$ git show v2.1.2:crates/data_components/src/oracle/convert.rs | grep '"DATE" =>'
86:        "DATE" => Some(DataType::Date32),
```

v2.1.2 and earlier really do map `DATE` to `Date32`, so `versioned_docs/version-*/` correctly document their own behavior and are deliberately not touched.

## Cross-page check

```
$ grep -rn --include="*.md" '`DATE`' website/docs/ | grep -i oracle
website/docs/components/data-connectors/oracle.md:109
```

One hit. `website/docs/components/catalogs/oracle.md` has no type-mapping section, and `website/docs/reference/datatypes/` carries no Oracle table — so this is a genuine single-page fix.

Filter pushdown is unchanged by the source PR (`is_datetime_related_expr` already treats both `Date32` and `Timestamp` as datetime-related), so the existing "no filter push-down for datetime columns" limitation at `oracle.md:27` remains accurate and is left as-is.

## Source PRs

- spiceai/spiceai#12097 — fix(oracle): map DATE to a timestamp so the time-of-day is not silently truncated (fixes #12096)

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — vNext-only, v2.1.2 confirmed still `Date32`
- [x] Files updated: 1 (matches the diff)
