### PR TITLE
docs(pg catalog): document the replication-slot-capacity pre-flight check

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -220,6 +220,11 @@ Required — there is no catalog-level default. The only supported value is `cha
 ### Requirements
 
 - **Logical replication must be enabled.** Before accelerating any table, Spice validates the PostgreSQL prerequisites CDC requires — `wal_level = logical` and the replication privilege — and fails fast with a specific, actionable error if either is missing.
+- **A replication slot must be available.** A CDC-accelerated catalog needs one [shared replication slot](#shared-replication-slot). When that slot does not yet exist, Spice compares the server's in-use slot count against `max_replication_slots` before trying to create it, and fails the catalog to load if the server is already at its limit:
+
+  > Cannot start CDC catalog acceleration: PostgreSQL has no free replication slots (10 of 10 in use; `max_replication_slots` = 10). Drop an unused slot (inspect `pg_replication_slots`, then `SELECT pg_drop_replication_slot('<slot_name>');`), or raise `max_replication_slots` and restart PostgreSQL.
+
+  The check is skipped when the catalog's slot **already** exists, because reusing it consumes no additional capacity — so a restart or reschedule still succeeds on a server whose slots are otherwise full.
 
 ### Shared replication slot
 


### PR DESCRIPTION
## Summary

The PostgreSQL catalog page's **Requirements** section listed two CDC prerequisites Spice validates up front — `wal_level = logical` and the replication privilege. spiceai/spiceai#12114 adds a third: free **replication-slot capacity**. Without it documented, a reader hitting `max_replication_slots` sees a startup failure the requirements list does not account for.

Verified against `origin/trunk`:

- `ensure_replication_slot_capacity()` — `crates/data-connectors/connector-postgres-common/src/lib.rs:432` — compares the live `pg_replication_slots` count against `current_setting('max_replication_slots')`.
- Called from `AcceleratedCatalogProvider::ensure_catalog_slot_available` — `crates/runtime/src/catalogconnector/postgres_accelerated.rs:546` — **only when the slot is absent**, since a reused slot (restart / reschedule) consumes no capacity. The docs note that exemption, because it is what makes a restart on a full server still work.
- Error message quoted from `Error::ReplicationSlotsExhausted` — `connector-postgres-common/src/lib.rs:57-60`.

## Scope: catalog CDC only

`ensure_replication_slot_capacity` has exactly one call site, in the **catalog** provider:

```
$ git grep -n "ensure_replication_slot_capacity" origin/trunk -- crates/ | grep -v tests
crates/data-connectors/connector-postgres-common/src/lib.rs:432   # definition
crates/data_components/src/postgres/provider.rs:67                # re-export
crates/runtime/src/catalogconnector/postgres_accelerated.rs:546   # only call site
```

The per-dataset CDC path does **not** run this pre-flight, so `website/docs/features/cdc/postgres-replication.md` is deliberately left untouched rather than given a prerequisite it does not enforce.

## Version scope

**vNext only** — the pre-flight is new in #12114, merged after v2.1.2 was cut.

## Source PRs

- spiceai/spiceai#12114 — feat(catalog): pre-flight replication-slot-capacity check for PostgreSQL catalog CDC (#11850)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only
- [x] Files updated: 1 (matches the diff)
