### PR TITLE
docs(catalogs): add missing Limitations and Cookbook sections to v2.1.x pg catalog (fixes #2022)

### DIFF
--- a/website/versioned_docs/version-2.1.x/components/catalogs/postgres.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/postgres.md
@@ -109,6 +109,25 @@ The PostgreSQL Catalog Connector automatically discovers foreign key relationshi
 
 No configuration is required. If FK discovery fails for a schema (e.g., due to insufficient permissions on `information_schema`), tables are still registered without FK metadata and a warning is logged.
 
+## Limitations
+
+:::warning
+
+- **Base tables and standard views only.** The connector discovers `BASE TABLE` and `VIEW` relations. Materialized views and foreign tables are not currently discovered and will not appear in the catalog ([#11725](https://github.com/spiceai/spiceai/issues/11725)).
+- **Partitioned tables.** For declaratively-partitioned tables, both the partitioned parent and each child partition are registered as separate tables ([#11726](https://github.com/spiceai/spiceai/issues/11726)).
+- **`include` filters tables, not schemas.** The `include` patterns are matched against `schema.table`. All non-system schemas are still enumerated as (possibly empty) schemas even when no tables match.
+- **Unsupported column types.** Tables containing a column of a type that cannot be mapped are skipped entirely and a warning is logged. The `unsupported_type_action` behavior available on individual PostgreSQL datasets is not applied on the catalog path ([#11728](https://github.com/spiceai/spiceai/issues/11728)).
+- **Partial discovery failures.** If discovery of a schema's tables fails during the initial load, the catalog fails to register rather than loading the reachable schemas ([#11724](https://github.com/spiceai/spiceai/issues/11724)).
+- **Amazon Redshift — datashare and external tables are not discovered.** Discovery reads Redshift's _local_ catalog only (`information_schema.tables` and `information_schema.schemata`). Schemas and tables consumed from a datashare, and external schemas and tables (Redshift Spectrum), are absent from the local catalog — Redshift exposes them only through its `svv_all_schemas` / `svv_all_tables` views, which the Catalog Connector does not query. Those relations do not appear in the catalog; register them as individual datasets with the [Redshift Data Connector](../data-connectors/redshift) instead ([#12109](https://github.com/spiceai/spiceai/issues/12109)).
+- **Amazon Redshift — metadata coverage.** Redshift is supported over the PostgreSQL wire protocol, but its `pg_catalog` coverage is partial and it does not enforce foreign keys, so table/column comment and foreign-key metadata are often unavailable. Tables present in the local catalog are still registered.
+- **Read-only.** Catalog tables are read-only. Accelerations cannot be configured on tables discovered through an external catalog.
+
+:::
+
+## Cookbook
+
+There is a [cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/catalogs/postgres) demonstrating the PostgreSQL Catalog Connector with the TPC-H dataset.
+
 ## Secrets
 
 Spice integrates with multiple secret stores to help manage sensitive data securely. For detailed information on supported secret stores, refer to the [secret stores documentation](../secret-stores). Additionally, learn how to use referenced secrets in component parameters by visiting the [using referenced secrets guide](../secret-stores#using-secrets).


### PR DESCRIPTION
## Summary

Fixes #2022

`website/versioned_docs/version-2.1.x/components/catalogs/postgres.md` had **no `## Limitations` section and no `## Cookbook` section**, while both the unversioned (vNext) page and `version-2.0.x` had them. Readers on v2.1.x — the current release snapshot — got no known-limitations disclosure for the PostgreSQL Catalog Connector at all.

Cause is a propagation miss, the documented "freshly-cut snapshot arrives already-stale" case:

- `version-2.1.x` was cut **2026-07-08** (`Add versioned docs for v2.1`).
- #1909 (*docs(postgres catalog): add Limitations and Cookbook sections*) merged **2026-07-10**, two days later, touching only `website/docs/` and `website/versioned_docs/version-2.0.x/`.

## Every bullet verified at `v2.1.1` — not copied from either neighbour

The two existing lists differ substantially and neither is correct for v2.1.1, so each bullet was checked against `spiceai/spiceai` at tag `v2.1.1` (`crates/data_components/src/postgres/provider.rs`, reached via `crates/runtime/src/catalogconnector/postgres.rs`):

| Bullet | Evidence at `v2.1.1` |
|---|---|
| Base tables + standard views only | `list_tables` (L432) is `SELECT table_name FROM information_schema.tables WHERE table_schema = $1 AND table_type IN ('BASE TABLE', 'VIEW')` — matviews and foreign tables are not selected |
| Both partitioned parent and child partitions registered | No `pg_inherits` filtering anywhere in the v2.1.1 provider; `information_schema.tables` returns parent and children alike |
| `include` filters tables, not schemas | `refresh_schemas` (L116) inserts every non-system schema regardless of table matches; `is_table_included` matches `schema.table` |
| Unsupported column types skip the table | `build_table_providers_for_schema` `Err` arm (L516-523) logs `warn!` "…skipping" and drops the table; the catalog `PARAMETERS` list has no `unsupported_type_action` (and no `dataset_params`) at v2.1.1 |
| Initial-load discovery failure fails the whole catalog | `refresh_schemas` calls `schema_provider.refresh_tables(...).await?` — the `?` propagates, so one schema's `list_tables` failure aborts registration (FK and comment failures, by contrast, are caught and `warn!`ed) |
| Read-only, no per-table acceleration | Providers come from `Arc<dyn Read>`; the `Catalog` spec has no `acceleration` field at v2.1.1 |

**vNext's resolved limitations were deliberately not back-propagated** — materialized-view/foreign-table discovery, `has_table_privilege` filtering, partitioned-parent-only registration, resilient per-schema discovery with last-known-good fallback, and catalog-level CDC acceleration all landed after v2.1.1 (see #1945, #1949).

The Redshift bullets use the corrected wording from #2021, which applies at v2.1.1 too: discovery there reads only `information_schema.tables` / `information_schema.schemata`, with zero `svv_all_*` usage, so datashare and Redshift Spectrum relations are invisible to the catalog (spiceai/spiceai#12109). The Cookbook section is copied as-is; the recipe link is version-independent.

## Changes

- `website/versioned_docs/version-2.1.x/components/catalogs/postgres.md`

Files updated: **1** (matches the diff). Scoped to `version-2.1.x` by design — vNext and `version-2.0.x` already have both sections, and #2021 is handling the Redshift correction there.

## Test plan

- [x] `cd website && npm run build` passes locally (Docusaurus `onBrokenLinks: 'throw'` / `onInlineTags: 'throw'`)
- [x] Added `../data-connectors/redshift` link resolves — `version-2.1.x/components/data-connectors/redshift.md` exists
- [x] Blank lines around the `:::warning` admonition
- [x] Each limitation verified against `v2.1.1` source, per the table above
