### PR TITLE
docs(cli): spice connect enrolls a host with Spice Cloud; pod-add form deprecated

### DIFF
--- a/website/docs/cli/reference/connect.md
+++ b/website/docs/cli/reference/connect.md
@@ -5,32 +5,79 @@ pagination_prev: null
 pagination_next: null
 ---
 
-Connect to an app on the Spice.ai Cloud Platform.
+Enroll this host with Spice Cloud for remote management (Cloud Connect).
 
-### Requirements
-
-- Authenticated to the Spice.ai Cloud Platform via [`login`](./login)
-
-**Notes**: Instead of pulling from Spicerack and integrating those Spicepods locally like `spice add`, `spice connect` enables connection to an app on the Spice.ai Cloud Platform without any local modifications or updates necessary.
+`spice connect <adoption-code>` **enrolls and exits**: the runtime identity is issued and persisted locally, the instance is registered with Spice Cloud, and nothing is left running. Start the managed runtime separately with [`spiced --cloud-connect`](./spiced#cloud-connect-flags). If the runtime is not installed, enrollment installs it first so that next step works immediately.
 
 ### Usage
 
 ```shell
-spice connect [app] [flags]
+spice connect [TARGET] [flags]
+spice connect status
+spice connect remove
 ```
 
-- `app`: The app slug in the Spice.ai Cloud Platform (i.e. `spiceai/tpch`).
+- `TARGET`: a Spice Cloud adoption code (`SPICE-ADOPT-XXXXX-XXXXX-XXXXX-XXXXX`, each segment five uppercase letters or digits), obtained from the Spice Cloud portal. With no argument, `spice connect` reports the current enrollment state, the same as `spice connect status`.
+
+#### Subcommands
+
+- `status` — Show the current enrollment state.
+- `remove` — Clear the local Cloud Connect identity from disk. A running `spiced` keeps its in-memory identity until it is restarted (a dropped stream just reconnects with the same identity), so restart `spiced` to stop remote management immediately.
 
 #### Flags
 
+- `--endpoint <URL>` The Spice Cloud enroll endpoint the adoption code is presented to. Default: `https://cloud.spice.ai`. The gateway (stream) address is issued by the enroll response and is not configured here.
+- `--dir <PATH>` Root this instance's state at `<PATH>/.spice`, so several instances on one host enroll independently. Defaults to the current directory. Applies to enrollment, `status`, and `remove`.
+- `--app-name <NAME>` Attach the instance to the existing Spice Cloud app of this name at enroll time, instead of attaching it later in the portal. When no such app exists the command fails **without consuming the adoption code** — pass `--create` to create it.
+- `--create` With `--app-name`: create the app when it does not exist, then attach the instance to it. An absent app without this flag is an error; apps are never created silently.
 - `-h`, `--help` Print this help message
+
+#### Environment variables
+
+For hosts provisioned without an interactive CLI invocation:
+
+| Variable                       | Equivalent to | Purpose                                                                                                                    |
+| ------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `SPICE_CONNECT_ADOPT_CODE`     | `TARGET`      | Adoption code to enroll with.                                                                                              |
+| `SPICE_CONNECT_ADOPT_APP_NAME` | `--app-name`  | Spice Cloud app to attach the instance to at enroll.                                                                       |
+| `SPICE_CONNECT_ADOPT_CREATE`   | `--create`    | Create the app named above when it does not exist.                                                                         |
+| `SPICE_CLOUD_ENDPOINT`         | `--endpoint`  | Enroll endpoint override.                                                                                                  |
+| `SPICE_CONFIG_DIR`             | —             | Overrides where per-instance state (identity and staged adoption code) is written, in full. Takes precedence over `--dir`. |
+
+Flags take precedence over their corresponding environment variables.
 
 ### Examples
 
-```shell
-> spice connect spiceai/quickstart
-```
+Enroll this host, then start the managed runtime:
 
 ```shell
-> spice connect spiceai/tpch
+> spice connect SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F
+> spiced --cloud-connect
+```
+
+Enroll a second instance on the same host, rooted at its own directory:
+
+```shell
+> spice connect SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F --dir /opt/edge-1
+```
+
+Attach the instance to a Spice Cloud app at enroll time, creating the app if it does not exist:
+
+```shell
+> spice connect SPICE-ADOPT-7K2PX-9XYZ2-A1B2C-D3E4F --app-name edge-fleet --create
+```
+
+Inspect, then clear, local enrollment state:
+
+```shell
+> spice connect status
+> spice connect remove
+```
+
+### Deprecated: adding a cloud-hosted Spicepod
+
+`spice connect <org>/<pod>` added a Spicepod hosted on the Spice.ai Cloud Platform, using Spice.ai Cloud authentication from [`login`](./login). It is **deprecated**, prints a warning, and will be removed in a future release — use [`spice add <org>/<pod>`](./add) instead:
+
+```shell
+> spice add spiceai/quickstart
 ```

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -24,7 +24,7 @@ spice [command] [--help]
 | [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
-| [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
+| [connect](reference/connect)       | Enroll this host with Spice Cloud (Cloud Connect)                      |
 | [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
 | [feedback](reference/feedback)     | Open the Spice.ai community Slack to share feedback                    |

--- a/website/docs/cli/reference/spiced.md
+++ b/website/docs/cli/reference/spiced.md
@@ -54,6 +54,10 @@ Used when running `spiced` as part of a [distributed cluster](../../features/dis
 - `--node-mtls-key-file <PATH>` — Private key file for the node certificate.
 - `--allow-insecure-connections` — Allow cluster communication without mTLS. Use only in development or testing environments.
 
+### Cloud Connect flags
+
+- `--cloud-connect` — Connect this runtime to Spice Cloud for remote management (Cloud Connect). Default: `false`. Requires an enrolled identity or a staged adoption code — see [`spice connect`](./connect). When the flag is omitted the client still activates if such adoption state exists, so instances enrolled before the flag existed keep connecting across an upgrade; a `spiced` with no adoption state never connects to the cloud.
+
 ### SQL REPL flags
 
 - `--repl` — Start a SQL REPL against the runtime's Flight endpoint instead of serving requests.


### PR DESCRIPTION
## Summary

`spice connect` no longer does what this page described. spiceai/spiceai#12143 split enrollment from running the runtime, and spiceai/spiceai#12153 renamed the `forget` subcommand:

- `spice connect <adoption-code>` **enrolls this host with Spice Cloud and exits** — identity issued and persisted locally, instance registered — and nothing is left running. `spiced --cloud-connect` starts the managed runtime as a separate step.
- New flags `--dir`, `--app-name`, `--create`, plus the `SPICE_CONNECT_ADOPT_CODE` / `_APP_NAME` / `_CREATE` environment variables for hosts provisioned without an interactive CLI invocation.
- `spice connect status` / `spice connect remove` (`remove` was `forget`; both were unreleased).
- `spice connect <org>/<pod>` — the only form this page documented — is **deprecated**, prints a warning, and forwards to `spice add`.

Verified against `origin/trunk` rather than the PR bodies: the flag/subcommand tokens come from the `clap` attributes in `bin/spice/src/commands/connect.rs`, the `--endpoint` default `https://cloud.spice.ai` from `DEFAULT_ENDPOINT` (`crates/runtime-cloud-connect/src/config.rs:26`), the env-var names from the `ADOPT_*_ENV` constants in the same file, and `--cloud-connect` from `bin/spiced/src/lib.rs:356`. `runtime-cloud-connect` is an unconditional dependency of `bin/spiced` (no feature gate), so this ships in the default OSS build and needs no Enterprise callout.

Scope note: this documents the **CLI surface** only. The Spice Cloud portal-side flow (minting an adoption code, managing enrolled instances) belongs in the Cloud Platform docs and is deliberately not described here.

## Source PRs

- spiceai/spiceai#12143 — Standalone instances: `spice connect` enroll-only split + connect surface
- spiceai/spiceai#12153 — refactor(cloud-connect): update the proto contract for evolvability and versioning (`forget` → `remove`)

## Versioning

**vNext only.** Both source PRs merged after `v2.1.2` was cut (`git tag --contains <merge-commit>` is empty for each), so `website/versioned_docs/version-*/cli/reference/connect.md` correctly keeps the old pod-add-only behavior.

## Test plan

- [x] `npm run build` passes (exit 0) — verifies the new `./spiced#cloud-connect-flags`, `./add`, and `./login` links and the added `### Cloud Connect flags` anchor
- [x] Versioned-docs propagation checked — vNext-only by the tag-containment check above
- [x] Files updated: 3 (`cli/reference/connect.md`, `cli/reference/index.md`, `cli/reference/spiced.md`)
