### PR TITLE
docs(postgres cdc): document shared-slot envelope coalescing and its member metrics

### DIFF
--- a/website/docs/components/data-connectors/postgres/deployment.md
+++ b/website/docs/components/data-connectors/postgres/deployment.md
@@ -99,6 +99,10 @@ The PostgreSQL connector exposes observable metrics for its replication pipeline
 | `replication_member_send_stalled_seconds_total` | ObservableCounter | Seconds the shared-slot pump spent blocked delivering changes into this dataset's channel. Shared slots only.                       |
 | `replication_member_send_wait_micros_total`     | ObservableCounter | Microseconds the shared-slot pump spent awaiting this dataset's delivery channel. Dedicated-slot datasets export `0`.                |
 | `replication_member_attached`                   | ObservableGauge   | `1` while this dataset is an attached member of its shared slot, `0` once detached. Shared slots only.                              |
+| `replication_member_envelopes_delivered_total`   | ObservableCounter | Change envelopes delivered to this dataset as distinct units of work. `replication_transactions_total` divided by this is the coalescing factor the apply loop sees. Shared slots only. |
+| `replication_member_envelope_eager_merges_total` | ObservableCounter | Committed transactions folded into an envelope the shared-slot pump was still holding back, before delivery. Shared slots only.       |
+| `replication_member_envelope_mailbox_merges_total` | ObservableCounter | Committed transactions folded into an envelope already sitting unclaimed in this dataset's delivery buffer — the back-pressure-driven half of coalescing. Shared slots only. |
+| `replication_member_mailbox_coalesce_limited_total` | ObservableCounter | Times a committed transaction could not be folded into the unclaimed buffer tail because a configured bound refused it. `0` means the bounds never bind. Shared slots only. |
 
 Metric instruments are exposed with the prefix `dataset_postgres_`. Each instrument carries a `name` attribute set to the dataset name; `replication_member_attached` also carries a `slot` attribute for grouping shared-slot members.
 

--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -240,6 +240,30 @@ Notes:
 - Each source table can back **at most one dataset per shared slot**. Pointing two datasets at the same `(schema, table)` through one slot is rejected — give the second dataset a different `pg_replication_slot` (or remove the param for a dedicated slot).
 - Sharing is per Spice instance. Across replicas, each replica must still use its own unique slot — see [Multi-replica deployments](#multi-replica-deployments).
 
+### Envelope coalescing
+
+Committed changes reach each member of a shared slot as **change envelopes**, not one unit of work per source transaction. A workload that commits constantly in small transactions would otherwise put an envelope per commit into each member's buffer, filling it long before the buffered rows are worth an apply — and while the shared pump is blocked delivering, it is not reading from the replication connection, so the back-pressure reaches the source walsender.
+
+The pump folds consecutive commits for the same member table together in two stages, both operating on raw pgoutput message chunks with no tuple decode:
+
+1. **Eager hold** — the throughput stage. The pump holds one unpublished envelope per member and folds later commits for that table into it, until the envelope reaches the row limit or the age limit elapses. The age is measured from the *first* commit the envelope absorbed, so a low-traffic table is never held indefinitely.
+2. **Mailbox tail fold** — the back-pressure stage. Publishing folds into the unclaimed tail of the member's buffer, with no age limit, so a member whose accelerator has stopped draining collapses envelopes instead of multiplying them.
+
+Folding never crosses a correctness boundary: changes destined for a different acknowledgement position, relation generation, or working schema are always kept in separate envelopes.
+
+The defaults need no tuning. They are process-wide operator escape hatches, set by environment variable rather than as dataset `params`:
+
+| Environment variable                                     | Default            | Maximum   | Effect                                                                                                        |
+| -------------------------------------------------------- | ------------------ | --------- | ------------------------------------------------------------------------------------------------------------- |
+| `SPICE_POSTGRES_CDC_MAX_ENVELOPE_AGE_MS`                 | `10`               | `60000`   | How long the pump may hold a member's envelope open. `0` publishes every commit straight through, disabling stage 1. |
+| `SPICE_POSTGRES_CDC_MAX_ROWS_PER_ENVELOPE`               | `8192`             | `1048576` | Rows at which a held envelope is published.                                                                    |
+| `SPICE_POSTGRES_CDC_MAX_BACKPRESSURE_ROWS_PER_ENVELOPE`  | `2048`             | `1048576` | Rows at which mailbox-tail folding seals an envelope.                                                          |
+| `SPICE_POSTGRES_CDC_MAX_MAILBOX_BYTES`                   | `33554432` (32 MiB) | 8 GiB    | Estimated Arrow bytes one member's buffer may hold across every buffered envelope.                             |
+
+A value that is unparseable or above the maximum logs a warning and the default is used instead.
+
+The two stage-2 bounds ship deliberately low, because mailbox folding absorbs back-pressure rather than adding throughput. Raise them only on evidence: `dataset_postgres_replication_member_mailbox_coalesce_limited_total` rising alongside `dataset_postgres_replication_member_envelope_mailbox_merges_total` means the bounds are binding while folding is still paying off, whereas a `dataset_postgres_replication_member_mailbox_coalesce_limited_total` that stays at `0` means the bounds never bind and there is nothing to tune. See [Metrics](#metrics).
+
 ## Multi-replica deployments
 
 Every Spice replica must have its own replication slot. Spice hashes the replica's identity into the default slot name:
@@ -333,6 +357,15 @@ Core freshness signals (auto-registered):
 | `dataset_postgres_replication_transactions_total` | Counter | Committed transactions applied.                                                                 |
 | `dataset_postgres_replication_inserts_total` / `dataset_postgres_replication_updates_total` / `dataset_postgres_replication_deletes_total` | Counter | Row-level events from WAL.                                      |
 | `dataset_postgres_replication_reconnects_total` | Counter | Number of times the stream reconnected after a transient failure.                            |
+
+Shared-slot delivery and coalescing (auto-registered; reported only for datasets on a shared, explicitly-named slot — see [Envelope coalescing](#envelope-coalescing)):
+
+| Metric                                                                     | Type    | Description                                                                                                                                                                             |
+|----------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `dataset_postgres_replication_member_envelopes_delivered_total`            | Counter | Change envelopes delivered to this dataset as distinct units of work. Divide `dataset_postgres_replication_transactions_total` by this for the coalescing factor the accelerator's apply loop actually sees. |
+| `dataset_postgres_replication_member_envelope_eager_merges_total`          | Counter | Committed transactions folded into an envelope the pump was still holding back, before it crossed into this dataset's buffer (stage 1).                                                   |
+| `dataset_postgres_replication_member_envelope_mailbox_merges_total`        | Counter | Committed transactions folded into an envelope already sitting unclaimed in this dataset's buffer (stage 2). Rising alongside a flat `dataset_postgres_replication_member_send_stalled_seconds_total` means back-pressure is being absorbed rather than stalling the slot. |
+| `dataset_postgres_replication_member_mailbox_coalesce_limited_total`       | Counter | Times a committed transaction could not be folded into the unclaimed buffer tail because a configured bound refused it, rather than because the changes were not foldable. `0` means the bounds never bind. |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

spiceai/spiceai#12147 changed how committed changes reach a member of a **shared** PostgreSQL replication slot: instead of one envelope per source transaction per relation, the pump folds consecutive commits for the same table together in two stages (an eager pump-side hold, then a fold into the unclaimed tail of the member's buffer when the sink stops draining). The docs described the per-member buffer only in terms of `pg_replication_member_channel_capacity`, with no mention that the unit being buffered is now a coalesced envelope, and none of the four new metrics were documented.

This adds:

- **`### Envelope coalescing`** under *Sharing one slot across datasets* — the two stages, the correctness boundaries folding never crosses (acknowledgement position, relation generation, working schema), and the four `SPICE_POSTGRES_CDC_*` environment variables with their defaults and maxima. These are process-wide operator escape hatches, **not** dataset `params` — the page says so explicitly, since a `params:` key for them would be silently dropped.
- **Four metric rows** to the CDC page's Metrics section and to the connector deployment guide's metrics table: `member_envelopes_delivered_total`, `member_envelope_eager_merges_total`, `member_envelope_mailbox_merges_total`, `member_mailbox_coalesce_limited_total`.

Verified against `origin/trunk`, not the PR body:

- Defaults/maxima from `crates/data_components/src/postgres_replication/shared.rs`: `DEFAULT_MAX_ENVELOPE_AGE` = 10 ms (max 60000), `DEFAULT_MAX_ROWS_PER_ENVELOPE` = 8192 (max 1048576), `DEFAULT_MAX_BACKPRESSURE_ROWS_PER_ENVELOPE` = 2048 (max 1048576), `DEFAULT_MAX_MAILBOX_BYTES` = 32 MiB (max 8 GiB); an unparseable or out-of-range value warns and falls back to the default (`env_u64_in_range` / `env_usize_in_range`).
- All four metrics are `MetricSpec::new(...).auto_register()` stems in `crates/data-connectors/connector-postgres/src/replication.rs`, all `ObservableCounterU64`. `PostgresMetricsProvider` reports `ComponentType::Dataset` + `component_name() == "postgres"`, so the exported names carry the `dataset_postgres_` prefix — spelled out in full per the convention from #1966.
- The coalescing-factor guidance uses `dataset_postgres_replication_transactions_total`. The upstream metric *description* references `replication_wal_transactions_total`, which is not a registered instrument — the real registration is `replication_transactions_total` (a source-side doc-comment nit, flagged upstream-side only).

## Source PRs

- spiceai/spiceai#12147 — perf(postgres): coalesce shared-slot CDC envelopes so a slow sink stops throttling the walsender

## Versioning

**vNext only.** #12147 merged after `v2.1.2` was cut (`git tag --contains f468644` is empty), so the `version-2.1.x` copies of both pages correctly describe the pre-coalescing behavior.

## Test plan

- [x] `cd website && npm run build` passes (exit 0) — validates the new `#envelope-coalescing` and `#metrics` anchors
- [x] Versioned-docs propagation checked — vNext-only by tag containment; `grep -rln pg_replication_member_channel_capacity website/docs website/versioned_docs` confirms the shared-slot surface is only these page types
- [x] Files updated: 2 (`features/cdc/postgres-replication.md`, `components/data-connectors/postgres/deployment.md`)
