### PR TITLE
docs(mysql): invalid pool sizes fall back to 10/100 silently, not rejected at startup

### DIFF
--- a/website/docs/components/data-connectors/mysql/deployment.md
+++ b/website/docs/components/data-connectors/mysql/deployment.md
@@ -51,7 +51,7 @@ The connector uses a per-dataset connection pool with the following defaults:
 | `mysql_pool_min`            | `1`     | Minimum idle connections held by the pool.     |
 | `mysql_pool_max`            | `5`     | Maximum connections the pool will open.        |
 
-Invalid values (non-integers) are logged as a warning and silently replaced with the defaults. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients. `mysql_pool_min` must be less than or equal to `mysql_pool_max`; conflicting values are rejected at startup.
+Both values are parsed leniently, and an unusable value produces **no error and no log message**. A non-integer value is discarded and the pool falls back to the underlying `mysql_async` pool defaults — `10` for `mysql_pool_min` and `100` for `mysql_pool_max`, not the `1` and `5` above. A `mysql_pool_min` greater than `mysql_pool_max` (or a `mysql_pool_max` of `0`) is likewise **not** rejected at startup: the invalid pair is discarded and the same `10`/`100` defaults apply. Because a typo silently widens the pool instead of failing, double-check both values when tuning them. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients.
 
 ### Retry Behavior
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/mysql/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/mysql/deployment.md
@@ -51,7 +51,7 @@ The connector uses a per-dataset connection pool with the following defaults:
 | `mysql_pool_min`            | `1`     | Minimum idle connections held by the pool.     |
 | `mysql_pool_max`            | `5`     | Maximum connections the pool will open.        |
 
-Invalid values (non-integers) are logged as a warning and silently replaced with the defaults. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients. `mysql_pool_min` must be less than or equal to `mysql_pool_max`; conflicting values are rejected at startup.
+Both values are parsed leniently, and an unusable value produces **no error and no log message**. A non-integer value is discarded and the pool falls back to the underlying `mysql_async` pool defaults — `10` for `mysql_pool_min` and `100` for `mysql_pool_max`, not the `1` and `5` above. A `mysql_pool_min` greater than `mysql_pool_max` (or a `mysql_pool_max` of `0`) is likewise **not** rejected at startup: the invalid pair is discarded and the same `10`/`100` defaults apply. Because a typo silently widens the pool instead of failing, double-check both values when tuning them. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients.
 
 ### Retry Behavior
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/mysql/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/mysql/deployment.md
@@ -51,7 +51,7 @@ The connector uses a per-dataset connection pool with the following defaults:
 | `mysql_pool_min`            | `1`     | Minimum idle connections held by the pool.     |
 | `mysql_pool_max`            | `5`     | Maximum connections the pool will open.        |
 
-Invalid values (non-integers) are logged as a warning and silently replaced with the defaults. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients. `mysql_pool_min` must be less than or equal to `mysql_pool_max`; conflicting values are rejected at startup.
+Both values are parsed leniently, and an unusable value produces **no error and no log message**. A non-integer value is discarded and the pool falls back to the underlying `mysql_async` pool defaults — `10` for `mysql_pool_min` and `100` for `mysql_pool_max`, not the `1` and `5` above. A `mysql_pool_min` greater than `mysql_pool_max` (or a `mysql_pool_max` of `0`) is likewise **not** rejected at startup: the invalid pair is discarded and the same `10`/`100` defaults apply. Because a typo silently widens the pool instead of failing, double-check both values when tuning them. Size the pool to match the concurrent query and refresh load for the dataset; the upper bound should respect the MySQL server's `max_connections` budget shared across all Spice datasets and external clients.
 
 ### Retry Behavior
 


### PR DESCRIPTION
## Summary

The MySQL deployment guide's "Connection Pool Sizing" section asserted two runtime behaviors the pool code doesn't implement. Both are the "behavior verb without a code referent" class, and both mislead in the operationally dangerous direction — the reader is told a bad value will be caught, when in fact it silently produces a **20× wider pool**.

### 1. "Invalid values (non-integers) are logged as a warning and silently replaced with the defaults"

Nothing is logged — the parse is a bare `.unwrap_or(...)` with no `tracing` call anywhere in the block — and "the defaults" are not the `1`/`5` documented in the table directly above. Because `ParameterSpec::component("pool_min").default("1")` materializes into the secret map, `params.get("pool_min")` is always `Some`, so the `unwrap_or` fallback fires **only** on a parse failure, and it falls back to `mysql_async`'s constants, not Spice's:

```rust
let pool_min = params.get("pool_min").map(SecretBox::expose_secret)
    .unwrap_or_default()
    .parse::<usize>()
    .unwrap_or(DEFAULT_POOL_CONSTRAINTS.min());   // 10, not 1
let pool_max = /* … */.unwrap_or(DEFAULT_POOL_CONSTRAINTS.max());  // 100, not 5
```

So `mysql_pool_max: "ten"` yields a **100**-connection pool, silently — on a page that tells readers to size the server's `max_connections` budget from `mysql_pool_max`.

### 2. "`mysql_pool_min` must be less than or equal to `mysql_pool_max`; conflicting values are rejected at startup"

Nothing is rejected. `PoolConstraints::new` returns `None` when the pair is invalid, and the caller discards it with `.unwrap_or_default()` — which is again `10`/`100`:

```rust
PoolConstraints::new(pool_min, pool_max).unwrap_or_default()
```

```rust
// mysql_async: pub const fn new(min, max) -> Option<PoolConstraints>
if min <= max && max > 0 { Some(PoolConstraints { min, max }) } else { None }
// impl Default for PoolConstraints -> DEFAULT_POOL_CONSTRAINTS = { min: 10, max: 100 }
```

The prose now states the actual fallback values and that no error or log is emitted.

## Source refs

- Read-path pool: `core/src/sql/db_connection_pool/mysqlpool.rs:139-156` in [`spiceai/datafusion-table-providers`](https://github.com/spiceai/datafusion-table-providers) @ `1b83cbf` (the rev pinned by `spiceai/spiceai` @ `trunk` and `v2.1.2`)
- `DEFAULT_POOL_CONSTRAINTS`, `PoolConstraints::new`, `impl Default`: `mysql_async` 0.36.2 `src/opts/mod.rs:41`, `:1215`, `:1234`
- Spice-side defaults (`1` / `5`, correct and unchanged): `crates/data-connectors/connector-mysql/src/lib.rs:132`

The documented `1`/`5` defaults are **correct** and untouched — they're what a valid unset config yields (verified previously in #1453 / #1534 / #1625). This PR only corrects what happens on the *invalid*-value paths.

## Version scope

vNext + `version-2.1.x` + `version-2.0.x` — the only three snapshots carrying the claims (the sentences were introduced by #1524 and #1534, after `version-1.11.x` was cut). The pool code and `mysql_async` 0.36.2 are byte-identical at the `trunk`, `v2.1.2`, and `v2.0.1` revs, so the same correction applies to all three.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page/versioned grep: 0 remaining occurrences of either claim under `website/docs` and `website/versioned_docs`
- [x] Files updated: 3 (matches the diff)
- [x] Flip-flop guard: prior MySQL pool PRs (#1439, #1453, #1534, #1625) all corrected the *default values*, not these behavior sentences — no prior correction is being reversed