### PR TITLE
docs(turso): indexes are supported under MVCC since v2.0.0

### DIFF
--- a/website/docs/components/data-accelerators/turso.md
+++ b/website/docs/components/data-accelerators/turso.md
@@ -120,11 +120,11 @@ Multi-Version Concurrency Control (MVCC) is automatically enabled for all Turso-
 When MVCC is active:
 
 - Concurrent reads and writes perform better
-- Indexes are not yet supported (a warning is logged if indexes are configured)
+- Standard (`enabled`) and unique (`unique`) indexes are created and enforced normally
 
 ### Indexes
 
-Turso supports index creation for improved query performance (when MVCC is disabled):
+Turso supports index creation for improved query performance:
 
 ```yaml
 datasets:
@@ -150,7 +150,6 @@ Turso supports query federation, where queries can span multiple data sources. T
 ## Limitations
 
 - **Remote databases not supported**: Only local Turso databases (file-based or in-memory) are supported as accelerators. Remote Turso databases using `turso_url` and `turso_auth_token` are not supported in this accelerator context. Remote Turso support will be available when Turso is implemented as a data connector.
-- **Indexes with MVCC**: Indexes are not yet supported when MVCC is enabled.
 - **Arrow Interval types**: Not supported, as SQLite/libSQL doesn't have a native interval type.
 - **Complex List types**: Only Arrow `List` types of primitive data types are supported; lists with structs are not supported.
 - **Dictionary and Map types**: Not supported.

--- a/website/docs/features/data-acceleration/indexes.md
+++ b/website/docs/features/data-acceleration/indexes.md
@@ -41,7 +41,7 @@ There are two types of indexes that can be specified in a Spicepod:
 
 :::warning[Limitations]
 
-Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso) (when MVCC is disabled), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
+Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
 
 For Arrow acceleration, see [Hash Index](./hash-index) (experimental, v1.11.0-rc.2+) for O(1) point lookups on primary key columns.
 

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/turso.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/turso.md
@@ -120,11 +120,11 @@ Multi-Version Concurrency Control (MVCC) is automatically enabled for all Turso-
 When MVCC is active:
 
 - Concurrent reads and writes perform better
-- Indexes are not yet supported (a warning is logged if indexes are configured)
+- Standard (`enabled`) and unique (`unique`) indexes are created and enforced normally
 
 ### Indexes
 
-Turso supports index creation for improved query performance (when MVCC is disabled):
+Turso supports index creation for improved query performance:
 
 ```yaml
 datasets:
@@ -150,7 +150,6 @@ Turso supports query federation, where queries can span multiple data sources. T
 ## Limitations
 
 - **Remote databases not supported**: Only local Turso databases (file-based or in-memory) are supported as accelerators. Remote Turso databases using `turso_url` and `turso_auth_token` are not supported in this accelerator context. Remote Turso support will be available when Turso is implemented as a data connector.
-- **Indexes with MVCC**: Indexes are not yet supported when MVCC is enabled.
 - **Arrow Interval types**: Not supported, as SQLite/libSQL doesn't have a native interval type.
 - **Complex List types**: Only Arrow `List` types of primitive data types are supported; lists with structs are not supported.
 - **Dictionary and Map types**: Not supported.

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/indexes.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/indexes.md
@@ -41,7 +41,7 @@ There are two types of indexes that can be specified in a Spicepod:
 
 :::warning[Limitations]
 
-Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso) (when MVCC is disabled), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
+Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
 
 For Arrow acceleration, see [Hash Index](./hash-index) (experimental, v1.11.0-rc.2+) for O(1) point lookups on primary key columns.
 

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/turso.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/turso.md
@@ -120,11 +120,11 @@ Multi-Version Concurrency Control (MVCC) is automatically enabled for all Turso-
 When MVCC is active:
 
 - Concurrent reads and writes perform better
-- Indexes are not yet supported (a warning is logged if indexes are configured)
+- Standard (`enabled`) and unique (`unique`) indexes are created and enforced normally
 
 ### Indexes
 
-Turso supports index creation for improved query performance (when MVCC is disabled):
+Turso supports index creation for improved query performance:
 
 ```yaml
 datasets:
@@ -150,7 +150,6 @@ Turso supports query federation, where queries can span multiple data sources. T
 ## Limitations
 
 - **Remote databases not supported**: Only local Turso databases (file-based or in-memory) are supported as accelerators. Remote Turso databases using `turso_url` and `turso_auth_token` are not supported in this accelerator context. Remote Turso support will be available when Turso is implemented as a data connector.
-- **Indexes with MVCC**: Indexes are not yet supported when MVCC is enabled.
 - **Arrow Interval types**: Not supported, as SQLite/libSQL doesn't have a native interval type.
 - **Complex List types**: Only Arrow `List` types of primitive data types are supported; lists with structs are not supported.
 - **Dictionary and Map types**: Not supported.

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/indexes.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/indexes.md
@@ -41,7 +41,7 @@ There are two types of indexes that can be specified in a Spicepod:
 
 :::warning[Limitations]
 
-Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso) (when MVCC is disabled), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
+Traditional indexes are not supported for the in-memory Arrow or [Spice Cayenne](../../components/data-accelerators/cayenne) acceleration engines. Use [DuckDB](../../components/data-accelerators/duckdb), [SQLite](../../components/data-accelerators/sqlite), [Turso](../../components/data-accelerators/turso), or [PostgreSQL](../../components/data-accelerators/postgres) as the acceleration engine to enable indexing.
 
 For Arrow acceleration, see [Hash Index](./hash-index) (experimental, v1.11.0-rc.2+) for O(1) point lookups on primary key columns.
 


### PR DESCRIPTION
## Summary

The Turso accelerator docs state that indexes do not work because MVCC is always on, and that a warning is logged when indexes are configured. Both claims are wrong for v2.0.0+ — they describe the pre-v2.0 code path and were never re-verified after MVCC became unconditional.

What the docs said (vNext, 2.0.x, 2.1.x — the three pages are byte-identical):

- `turso.md` → MVCC Support: "Indexes are not yet supported (a warning is logged if indexes are configured)"
- `turso.md` → Indexes: "Turso supports index creation for improved query performance **(when MVCC is disabled)**"
- `turso.md` → Limitations: "**Indexes with MVCC**: Indexes are not yet supported when MVCC is enabled."
- `indexes.md` → "Use DuckDB, SQLite, **Turso (when MVCC is disabled)**, or PostgreSQL … to enable indexing"

Since MVCC *is* unconditional on these versions (the same page says so, correctly), the pages as written say Turso indexes never work.

## What the code does

1. **MVCC cannot be disabled.** `TursoConnectionPool::new_with_timestamp_format` runs `conn.pragma_update("journal_mode", "'mvcc'")` unconditionally ([`crates/data_components/src/turso.rs:387`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/turso.rs#L387)); the accelerator exposes only `turso_file` and `internal_timestamp_format` ([`crates/runtime/src/dataaccelerator/turso.rs:447-452`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataaccelerator/turso.rs#L447-L452)). There is no knob to turn it off.
2. **Index creation is unconditional, and no warning exists.** The accelerator issues `CREATE {UNIQUE }INDEX IF NOT EXISTS …` for every configured index with no MVCC branch, and hard-errors on failure ([`crates/runtime/src/dataaccelerator/turso.rs:676-705`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataaccelerator/turso.rs#L676-L705)). The only `tracing::warn!` in the file is the unrelated `file_create` message at line 577 — the documented "warning is logged" string is not in source.
3. **Behavioral evidence.** Against the exact `turso` crate versions each snapshot ships (0.6.0 for v2.0.x, 0.6.1 for v2.1.x, 0.7.1 for trunk), with `PRAGMA journal_mode = 'mvcc'` set exactly as the pool sets it:

   ```
   journal_mode = Text("mvcc")
   CREATE INDEX ok: 1
   CREATE UNIQUE INDEX ok: 1
   dup insert REJECTED: UNIQUE constraint failed: t.(a, b) (19)
   index present: Text("idx_t_a")
   index present: Text("idx_t_ab")
   ```

   Identical output on all three versions: both index types are created, persist in `sqlite_schema`, and the unique constraint is enforced. Upstream `turso_core` gates only *custom index modules* (`CREATE INDEX … USING`) and `REINDEX` behind a non-MVCC check — plain `CREATE INDEX` is not gated.

## Where the stale text came from

Through v1.11.x, MVCC was opt-in via a real `turso_mvcc` param (default `disabled`) and index creation was genuinely skipped with a warning when it was on. spiceai/spiceai#9120 ("Upgrade to Turso v0.4.4", 2026-01-30) deleted the param and the skip-with-warning branch; the docs kept the old semantics. **v1.11.x is correctly left untouched by this PR** — its text still matches its code, and a separate issue on that snapshot is being fixed in its own PR.

## Changes

- Replaced the "indexes not yet supported / warning is logged" bullet with what actually happens: standard and unique indexes are created and enforced.
- Dropped the "(when MVCC is disabled)" qualifier from the Indexes section and from the `indexes.md` engine list.
- Removed the "Indexes with MVCC" Limitations row.

Applied to vNext, `version-2.0.x`, and `version-2.1.x` — every snapshot whose code has unconditional MVCC.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn "when MVCC is disabled\|Indexes with MVCC\|warning is logged if indexes" website/docs website/versioned_docs` returns only `version-1.11.x` hits, which are correct for that release
- [x] Files updated: 6 (matches the diff)
- [x] Flip-flop guard: `turso in:title` over merged docs PRs — #1443 and #1675 both corrected the *MVCC-is-always-on* half of this and left the index claims behind; this PR completes them rather than reversing either

Verified against `spiceai/spiceai` at `trunk` (10b0727a8), `v2.1.2`, and `v2.0.1`.