### PR TITLE
docs(turso): restore turso_mvcc to the v1.11.x accelerator reference

### DIFF
--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/turso.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/turso.md
@@ -60,6 +60,7 @@ datasets:
 Turso acceleration supports the following optional parameters under `acceleration.params`:
 
 - `turso_file` (string, default: `.spice/data/{dataset_name}.turso`): Path to the Turso database file. Only applies if `mode` is `file`. If the file does not exist, Spice creates it automatically.
+- `turso_mvcc` (string, default: `disabled`): Enable Multi-Version Concurrency Control (MVCC) for improved concurrent read/write performance. Values: `enabled`, `disabled`. Indexes are not created while MVCC is enabled.
 - `internal_timestamp_format` (string, default: `rfc3339`): Internal timestamp storage format. See [Timestamp Storage](#timestamp-storage) section. Values: `rfc3339`, `integer_millis`.
 
 ### Example Configuration
@@ -114,9 +115,16 @@ acceleration:
 
 ### MVCC Support
 
-Multi-Version Concurrency Control (MVCC) is automatically enabled for all Turso-accelerated datasets. The Turso accelerator sets `PRAGMA journal_mode = 'mvcc'` during connection pool initialization, enabling concurrent transactions via `BEGIN CONCURRENT`.
+Multi-Version Concurrency Control (MVCC) is **disabled by default** and can be enabled per dataset with the `turso_mvcc` acceleration parameter:
 
-When MVCC is active:
+```yaml
+acceleration:
+  engine: turso
+  params:
+    turso_mvcc: enabled
+```
+
+When MVCC is enabled:
 
 - Concurrent reads and writes perform better
 - Indexes are not yet supported (a warning is logged if indexes are configured)


### PR DESCRIPTION
## Summary

`turso_mvcc` is a **real parameter in v1.11.x** and was removed from that snapshot by mistake. #1675 verified the claim against `trunk` — where the param genuinely no longer exists — and applied the result to the `version-1.11.x` docs, which document a release that still has it. The same PR also copied vNext's "MVCC is automatically enabled" wording onto the v1.11.x page, where MVCC is in fact off by default.

Net effect on the published v1.11.x docs today: a real, documented knob is invisible, and the page tells readers MVCC is always on when it is opt-in.

## What the code does at v1.11.x

Verified against `spiceai/spiceai` at `v1.11.6` (the latest `v1.11.*` tag; all ten `v1.11.*` tags are identical here):

- `ParameterSpec::component("turso_mvcc").default("disabled").one_of(&["enabled", "disabled"])` — a declared accelerator parameter, `crates/runtime/src/dataaccelerator/turso.rs:374`.
- `parse_mvcc_enabled()` reads `acceleration.params.get("turso_mvcc")`, accepts `enabled`/`disabled`, errors on anything else, and returns `false` when the key is absent (`turso.rs:230-248`) — so it is fully wired end-to-end, not a declared-but-unmapped key.
- The value flows into `TursoConnectionPool::new(&db_path, mvcc_enabled)` → `Builder::with_mvcc(mvcc_enabled)` (`crates/data_components/src/turso.rs:410-426`). v1.11.x has **no** `PRAGMA journal_mode = 'mvcc'` call at all — that mechanism arrived later.
- Indexes are genuinely skipped with a warning under MVCC on this release (`turso.rs:627-633`), so the page's index caveats are correct here and are left as-is.

spiceai/spiceai#9120 ("Upgrade to Turso v0.4.4", 2026-01-30) deleted the parameter and switched MVCC to the unconditional PRAGMA. That landed after the v1.11 branch point, which is why trunk and v1.11.x disagree.

## Changes

Scoped to `website/versioned_docs/version-1.11.x/components/data-accelerators/turso.md` only:

- Restored the `turso_mvcc` row to Configuration Parameters (default `disabled`, values `enabled`/`disabled`), noting the index interaction that applies on this release.
- Rewrote MVCC Support to say MVCC is disabled by default and opt-in per dataset, with the `turso_mvcc: enabled` example.

## Not in scope

The vNext / 2.0.x / 2.1.x pages are correct that MVCC is unconditional there. The *index* claims on those pages are wrong for a different reason and are fixed separately in #2029; this PR deliberately leaves v1.11.x's index text alone because it matches v1.11.x's code.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rln "turso_mvcc" website/docs website/versioned_docs` → this file only; no other page type (index, deployment, spicepod reference) carries the param
- [x] Versioned scope: `turso_mvcc` exists in all `v1.11.*` tags and in none of `v2.0.0`, `v2.0.1`, `v2.1.0`, `v2.1.2`, or trunk — so v1.11.x is the only snapshot that should document it
- [x] Files updated: 1 (matches the diff)
- [x] Flip-flop guard: this reverses part of merged #1675; its cited evidence was trunk-only and does not hold for the release the file documents

Verified against `spiceai/spiceai` at `v1.11.6`.