### PR TITLE
docs(search): document English stemming for the built-in full-text engine

### DIFF
--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -26,6 +26,14 @@ Spice supports two full-text search engines:
 
 When no engine is specified, Tantivy is used automatically.
 
+### Text Analysis
+
+The built-in Tantivy engine indexes text with Tantivy's `en_stem` tokenizer: terms are lowercased and reduced to their English (Snowball) stem, with token positions retained so phrase queries keep working. Query terms are analyzed the same way, so a search for `running` also matches documents containing `run` and `runs`.
+
+Stemming is always on for the built-in engine and has no configuration parameter. It is English-only — text in other languages is still tokenized and lowercased, but not stemmed.
+
+The local warm index used with `engine: elasticsearch` is a Tantivy index and analyzes text the same way. Searches [served directly by Elasticsearch](#warm-tier) — multi-column datasets, a warm index that could not be built, or an `on_zero_results: use_source` fallback — are analyzed by Elasticsearch's own analyzer for that index instead.
+
 ## Enabling Full-Text Search
 
 To enable full-text search, configure your dataset columns within your dataset definition as follows:


### PR DESCRIPTION
## Summary

spiceai/spiceai#12220 changes how the built-in full-text engine analyzes text: the Tantivy index now uses the `en_stem` tokenizer (English Snowball stemming, lowercasing, `WithFreqsAndPositions` so phrase queries keep working) instead of Tantivy's default `TEXT` options. Tantivy's `QueryParser` is constructed with the index's tokenizer manager, so query terms are stemmed the same way — `running` now matches documents containing `run` and `runs`.

This is user-visible matching behavior with no configuration knob, and the Full-text Search page said nothing about analysis at all. Adds a short **Text Analysis** section under **Engines** covering:

- what the built-in engine does (stem + lowercase, positions retained), and that it applies at query time too;
- that it is always on, has no parameter, and is English-only;
- the Elasticsearch nuance — the local warm index is a Tantivy index and analyzes the same way, while searches served directly by Elasticsearch (multi-column datasets, a warm index that could not be built, or an `on_zero_results: use_source` fallback) use Elasticsearch's own analyzer.

## Source PRs

- spiceai/spiceai#12220 — fix(search): enable stemming by default for full-text search

## Doc pages changed (1)

- `website/docs/features/search/full-text.md` — vNext only

Scoped to vNext: `en_stem` is not present at `v2.1.2` (`git grep en_stem v2.1.2 -- crates/search/` → no hits), so no versioned snapshot needs it.

## Test plan

- [x] `cd website && npm run build` passes (the added `#warm-tier` link resolves to the `#### Warm tier` heading on the same page)
- [x] Versioned-docs propagation checked — addition, vNext only
- [x] Files updated: 1
