### PR TITLE
docs(tools): the sampling tools are not in the auto group since v2.0

### DIFF
--- a/website/docs/components/tools/index.md
+++ b/website/docs/components/tools/index.md
@@ -19,14 +19,18 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `sql`                     | Execute SQL queries on the runtime. Write statements (`INSERT`/`UPDATE`/`DELETE`/DDL) are accepted only when the request is authenticated with a ReadWrite API key and the target dataset is configured `access: read_write`; otherwise the tool runs as read-only. | `auto`        |
 | `table_schema`            | Get the schema of a specific SQL table.                           | `auto`        |
 | `search`                  | Searches a configured dataset based on an input query.            | `auto`        |
-| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `auto`        |
-| `random_sample`           | Sample random rows from a table.                                  | `auto`        |
-| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
+| `get_readiness`           | Report the readiness state of every runtime component (datasets, accelerators, models, embeddings, catalogs). | `auto`        |
+| `get_current_datetime`    | Return the current UTC date and time as an ISO 8601 timestamp.    | `auto`        |
+| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `all`         |
+| `random_sample`           | Sample random rows from a table.                                  | `all`         |
+| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `all`         |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
 | ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Deprecated)               | -             |
 
 [websearch]: tools/websearch
+
+The `auto` group is a subset of `all`: the sampling tools (`sample_distinct_columns`, `random_sample`, `top_n_sample`) are provided only by the `all` (and `nsql`) groups, or by naming them individually.
 
 ### Tool Groups
 
@@ -48,6 +52,8 @@ models:
 | `all`             | All built-in and Spicepod-configured tools, provided directly to the LLM.                                                                           |
 | `search_registry` | Use searchable tool registry discovery via `tool_search` and `tool_invoke` meta-tools. Requires an embedding model (see `tool_embedding_model`).    |
 | `memory`          | Memory tools for storing and retrieving information across conversations.                                                                            |
+| `nsql`            | Built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, and the sampling tools.                     |
+| `disabled`        | Provide no tools to the LLM.                                                                                                                        |
 | [`MCP`][mcp]      | Tools provided from an MCP server. Can be run within Spice, or connected to over HTTP(s) SSE                                                        |
 
 [mcp]: tools/mcp

--- a/website/docs/features/large-language-models/tools.md
+++ b/website/docs/features/large-language-models/tools.md
@@ -24,6 +24,8 @@ The `tools` parameter on a model controls how tools are provided to the LLM:
 | `auto` | Automatically choose between direct tools and searchable registry discovery. When the number of available tools exceeds 20 and an embedding model is available, `auto` switches to registry-based discovery; otherwise it uses direct tools. |
 | `all` | Provide all built-in and Spicepod-configured tools directly to the LLM. |
 | `search_registry` | Use searchable registry discovery. The LLM receives `tool_search` and `tool_invoke` meta-tools instead of individual tool definitions. Requires an embedding model (see `tool_embedding_model`). |
+| `nsql` | Provide only the built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, `random_sample`, `sample_distinct_columns`, and `top_n_sample`. |
+| `disabled` | Provide no tools to the LLM. |
 | `<tool1>, <tool2>, ...` | Provide only the named tools directly. |
 
 ### Example: Specifying Tools for a Model

--- a/website/versioned_docs/version-2.0.x/components/tools/index.md
+++ b/website/versioned_docs/version-2.0.x/components/tools/index.md
@@ -19,14 +19,18 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `sql`                     | Execute SQL queries on the runtime. Write statements (`INSERT`/`UPDATE`/`DELETE`/DDL) are accepted only when the request is authenticated with a ReadWrite API key and the target dataset is configured `access: read_write`; otherwise the tool runs as read-only. | `auto`        |
 | `table_schema`            | Get the schema of a specific SQL table.                           | `auto`        |
 | `search`                  | Searches a configured dataset based on an input query.            | `auto`        |
-| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `auto`        |
-| `random_sample`           | Sample random rows from a table.                                  | `auto`        |
-| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
+| `get_readiness`           | Report the readiness state of every runtime component (datasets, accelerators, models, embeddings, catalogs). | `auto`        |
+| `get_current_datetime`    | Return the current UTC date and time as an ISO 8601 timestamp.    | `auto`        |
+| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `all`         |
+| `random_sample`           | Sample random rows from a table.                                  | `all`         |
+| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `all`         |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
 | ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Deprecated)               | -             |
 
 [websearch]: tools/websearch
+
+The `auto` group is a subset of `all`: the sampling tools (`sample_distinct_columns`, `random_sample`, `top_n_sample`) are provided only by the `all` (and `nsql`) groups, or by naming them individually.
 
 ### Tool Groups
 
@@ -48,6 +52,8 @@ models:
 | `all`             | All built-in and Spicepod-configured tools, provided directly to the LLM.                                                                           |
 | `search_registry` | Use searchable tool registry discovery via `tool_search` and `tool_invoke` meta-tools. Requires an embedding model (see `tool_embedding_model`).    |
 | `memory`          | Memory tools for storing and retrieving information across conversations.                                                                            |
+| `nsql`            | Built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, and the sampling tools.                     |
+| `disabled`        | Provide no tools to the LLM.                                                                                                                        |
 | [`MCP`][mcp]      | Tools provided from an MCP server. Can be run within Spice, or connected to over HTTP(s) SSE                                                        |
 
 [mcp]: tools/mcp

--- a/website/versioned_docs/version-2.0.x/features/large-language-models/tools.md
+++ b/website/versioned_docs/version-2.0.x/features/large-language-models/tools.md
@@ -24,6 +24,8 @@ The `tools` parameter on a model controls how tools are provided to the LLM:
 | `auto` | Automatically choose between direct tools and searchable registry discovery. When the number of available tools exceeds 20 and an embedding model is available, `auto` switches to registry-based discovery; otherwise it uses direct tools. |
 | `all` | Provide all built-in and Spicepod-configured tools directly to the LLM. |
 | `search_registry` | Use searchable registry discovery. The LLM receives `tool_search` and `tool_invoke` meta-tools instead of individual tool definitions. Requires an embedding model (see `tool_embedding_model`). |
+| `nsql` | Provide only the built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, `random_sample`, `sample_distinct_columns`, and `top_n_sample`. |
+| `disabled` | Provide no tools to the LLM. |
 | `<tool1>, <tool2>, ...` | Provide only the named tools directly. |
 
 ### Example: Specifying Tools for a Model

--- a/website/versioned_docs/version-2.1.x/components/tools/index.md
+++ b/website/versioned_docs/version-2.1.x/components/tools/index.md
@@ -19,14 +19,18 @@ For details on tool specifications, see the [Tools Spicepod Reference](../refere
 | `sql`                     | Execute SQL queries on the runtime. Write statements (`INSERT`/`UPDATE`/`DELETE`/DDL) are accepted only when the request is authenticated with a ReadWrite API key and the target dataset is configured `access: read_write`; otherwise the tool runs as read-only. | `auto`        |
 | `table_schema`            | Get the schema of a specific SQL table.                           | `auto`        |
 | `search`                  | Searches a configured dataset based on an input query.            | `auto`        |
-| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `auto`        |
-| `random_sample`           | Sample random rows from a table.                                  | `auto`        |
-| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `auto`        |
+| `get_readiness`           | Report the readiness state of every runtime component (datasets, accelerators, models, embeddings, catalogs). | `auto`        |
+| `get_current_datetime`    | Return the current UTC date and time as an ISO 8601 timestamp.    | `auto`        |
+| `sample_distinct_columns` | Generate a synthetic sample of data with distinct values.         | `all`         |
+| `random_sample`           | Sample random rows from a table.                                  | `all`         |
+| `top_n_sample`            | Sample the top N rows from a table based on a specified ordering. | `all`         |
 | `memory:load`             | Retrieve all stored memories from the last time period.           | `memory`      |
 | `memory:store`            | Store information from LLM interaction(s) for future reference.   | `memory`      |
 | ~~[`websearch`][websearch]~~ | ~~Search the web for information.~~ (Deprecated)               | -             |
 
 [websearch]: tools/websearch
+
+The `auto` group is a subset of `all`: the sampling tools (`sample_distinct_columns`, `random_sample`, `top_n_sample`) are provided only by the `all` (and `nsql`) groups, or by naming them individually.
 
 ### Tool Groups
 
@@ -48,6 +52,8 @@ models:
 | `all`             | All built-in and Spicepod-configured tools, provided directly to the LLM.                                                                           |
 | `search_registry` | Use searchable tool registry discovery via `tool_search` and `tool_invoke` meta-tools. Requires an embedding model (see `tool_embedding_model`).    |
 | `memory`          | Memory tools for storing and retrieving information across conversations.                                                                            |
+| `nsql`            | Built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, and the sampling tools.                     |
+| `disabled`        | Provide no tools to the LLM.                                                                                                                        |
 | [`MCP`][mcp]      | Tools provided from an MCP server. Can be run within Spice, or connected to over HTTP(s) SSE                                                        |
 
 [mcp]: tools/mcp

--- a/website/versioned_docs/version-2.1.x/features/large-language-models/tools.md
+++ b/website/versioned_docs/version-2.1.x/features/large-language-models/tools.md
@@ -24,6 +24,8 @@ The `tools` parameter on a model controls how tools are provided to the LLM:
 | `auto` | Automatically choose between direct tools and searchable registry discovery. When the number of available tools exceeds 20 and an embedding model is available, `auto` switches to registry-based discovery; otherwise it uses direct tools. |
 | `all` | Provide all built-in and Spicepod-configured tools directly to the LLM. |
 | `search_registry` | Use searchable registry discovery. The LLM receives `tool_search` and `tool_invoke` meta-tools instead of individual tool definitions. Requires an embedding model (see `tool_embedding_model`). |
+| `nsql` | Provide only the built-in tools relevant to text-to-SQL: `table_schema`, `sql`, `list_datasets`, `get_current_datetime`, `random_sample`, `sample_distinct_columns`, and `top_n_sample`. |
+| `disabled` | Provide no tools to the LLM. |
 | `<tool1>, <tool2>, ...` | Provide only the named tools directly. |
 
 ### Example: Specifying Tools for a Model


### PR DESCRIPTION
## Summary

The **Available Tools** table marks `sample_distinct_columns`, `random_sample`, and `top_n_sample` with a **Default Group** of `auto`. That was true through v1.11.x, but v2.0.0 removed all three from `SpiceToolsOptions::Auto` — they are now provided only by `all` / `search_registry` / `nsql`, or by naming them individually.

A user setting `tools: auto` (the documented default mode) and expecting the sampling tools gets a model that silently cannot sample.

**What the code does** (`crates/runtime-tools/src/options.rs`, `SpiceToolsOptions::tools_by_name`):

```rust
SpiceToolsOptions::Auto => vec![
    "search", "table_schema", "sql", "list_datasets",
    "get_readiness", "get_current_datetime",
],
SpiceToolsOptions::All | SpiceToolsOptions::SearchRegistry => vec![
    "search", "table_schema", "sql", "list_datasets",
    "get_readiness", "get_current_datetime",
    "random_sample", "sample_distinct_columns", "top_n_sample",
],
```

The unit test `test_nested_tool_opts` asserts this directly:

```rust
assert!(!auto_tools.contains(&"random_sample"));
assert!(!auto_tools.contains(&"sample_distinct_columns"));
assert!(!auto_tools.contains(&"top_n_sample"));
```

## Changes

- **Default Group** for `sample_distinct_columns` / `random_sample` / `top_n_sample`: `auto` → `all`, plus a one-line note that `auto` is a subset of `all`.
- Added the two `auto` built-in tools the table never listed: `get_readiness` and `get_current_datetime` (descriptions taken from their constructors' default `description` strings).
- Added the `nsql` and `disabled` values — both accepted by `SpiceToolsOptions::from_str` — to the tool-groups table and to the **Tool Modes** table on the sibling Language Model Tools page.

## Version scoping

Version-specific change, not a typo — `auto` genuinely did include the sampling tools before v2.0. Verified per release tag:

| Tag | Sampling tools in `auto`? |
| --- | --- |
| v1.5.2 – v1.11.6 | yes — docs correct, left untouched |
| v2.0.1 | no |
| v2.1.2 | no |
| trunk | no |

So this fixes vNext + `version-2.0.x` + `version-2.1.x` only; the 1.x snapshots correctly document their own behavior.

## Cross-page coverage

```
$ grep -rln 'sample_distinct_columns' website/docs website/versioned_docs
website/docs/components/tools/index.md
website/versioned_docs/version-1.5.x/components/tools/index.md   ... (1.5-1.11: correct as-is)
website/versioned_docs/version-2.0.x/components/tools/index.md
website/versioned_docs/version-2.1.x/components/tools/index.md
```

Plus the `tools:` value enumeration on `features/large-language-models/tools.md` (same 3 versions).

## Source refs

- `spiceai/spiceai@trunk` — [`crates/runtime-tools/src/options.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-tools/src/options.rs)
- `crates/runtime/src/tools/builtin/catalog.rs` (`is_builtin_tool`), `crates/runtime-tools/src/builtin/get_current_datetime.rs`, `crates/runtime/src/tools/builtin/get_readiness.rs`

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (version-scoped: vNext + 2.0.x + 2.1.x; 1.5.x–1.11.x deliberately unchanged)
- [x] Files updated: 6
