### PR TITLE
docs(memory): document how a query memory-pool refusal surfaces (503, ResourcesExhausted)

### DIFF
--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -193,6 +193,19 @@ DataFusion supports spilling for several operators, but the following operations
 
 Queries using these operators that exceed memory limits may fail. Monitor query patterns and allocate sufficient memory for workloads that rely on these operators.
 
+### How a Memory Refusal Surfaces
+
+When the query memory pool cannot satisfy a reservation, the query is refused rather than the process being allowed to grow past `runtime.query.memory_limit`. The refusal is reported as a capacity condition, not a client error, so retry middleware and load balancers can treat it as retriable:
+
+| Surface | Reported as |
+| ------- | ----------- |
+| HTTP (`/v1/sql`) | `503 Service Unavailable`, with the pool's message (including its top memory consumers) as the response body. Earlier releases answered this condition with `400 Bad Request`. |
+| Flight and Flight SQL | gRPC status `RESOURCE_EXHAUSTED` |
+| `query_failures` metric | `err_code="ResourcesExhausted"` |
+| Runtime log | Logged at `warn` level (`Query refused, out of memory: …`), so a runtime refusing queries is visible at the default `INFO` verbosity |
+
+A sustained rate of these means the deployment needs more memory, fewer concurrent queries, or fewer partitions — not that the client's SQL is malformed. Note that `/health` is served by a separate Tokio runtime and stays green while queries are being refused, so alert on `query_failures{err_code="ResourcesExhausted"}` rather than relying on health checks.
+
 ## Predicate Pushdown and Memory Reduction
 
 Predicate pushdown reduces memory consumption by filtering data early in the query execution pipeline. Rather than reading all data and filtering afterward, Spice pushes filter predicates to the data source, reducing the volume of data materialized in memory.


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12289` changes how a query memory-pool refusal is reported, and the docs never described the failure surface at all — the "Spill Limitations" section only said such queries "may fail."

Verified against `origin/trunk`:

- **`503`, not `400`.** `SqlErrorKind::ResourcesExhausted => StatusCode::SERVICE_UNAVAILABLE` (`crates/runtime/src/http/v1/mod.rs:465`), reached via `SqlErrorKind::of_datafusion_error` / `of_query_error` when `ErrorCode::from(e) == ErrorCode::ResourcesExhausted` (`:407`). The funnel is `sql_error_response`, the only place a query error is mapped to a status; `/v1/sql` routes to `v1::query::post` (`http/routes.rs:331`), which goes through `sql_to_http_response`. A malformed query still gets `400` and a read-only rejection still gets `403`.
- **`err_code="ResourcesExhausted"`.** New `ErrorCode::ResourcesExhausted` variant matched from `DataFusionError::ResourcesExhausted` (`datafusion/query/error_code.rs:70`); the label is `err.to_string()` (`datafusion/query/tracker.rs:141`) and `Display` writes exactly `ResourcesExhausted` (`error_code.rs:42`), so the string in the table is copied, not paraphrased. Previously this fell through the catch-all to `InternalError` — the same label a genuine runtime bug gets.
- **Flight was already correct** and is documented for contrast, not as a change: `DataFusionError::ResourcesExhausted(source) => Status::resource_exhausted(source)` (`crates/runtime/src/flight/mod.rs:748`).
- **`warn` level.** `sql_error_response` logs `"Query refused, out of memory: {logged}"` at `warn!` for this kind only; everything else stays `debug!` (`http/v1/mod.rs:448-455`). The quoted log text is taken from that literal.
- **`/health` staying green** is documented in the same function's doc comment (it is served by a separate Tokio runtime), which is why the guidance points at the metric instead.

Scope: `website/docs/` only. The `503` status and the `err_code` value are unreleased, so no `versioned_docs` snapshot should describe them (`grep -rn ResourcesExhausted website/versioned_docs/` → 0 hits).

**Not changed, deliberately:** `website/docs/api/HTTP/post-sql.StatusCodes.json` (and its `.api.mdx`) still list only `200`/`400`/`500`. Those files are generated from `website/public/openapi.json`, and spiceai/spiceai#12289 did not add a `503` response to the endpoint's OpenAPI annotation — so hand-editing the generated output would be reverted by the next `gen-api-docs` run. The upstream annotation is the right fix site.

## Source PRs

- spiceai/spiceai#12289 — fix(runtime): report a memory-pool refusal as ResourcesExhausted and answer it with 503 (fixes #12282, #12283)

## Doc pages changed

- `website/docs/reference/memory.md` — new "How a Memory Refusal Surfaces" subsection under DataFusion Query Memory Management

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — vNext only (unreleased behavior change)
- [x] Files updated: 1 (matches the diff)
