### PR TITLE
docs(search): document full-text index_store, index_directory, and persisted-index schema validation

### DIFF
--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -59,6 +59,34 @@ datasets:
 
 In this example, full-text search indexing is enabled on both the `title` and `body` columns using the default Tantivy engine. The `row_id` specifies a unique identifier for referencing search results and retrieving additional data.
 
+### Index Storage
+
+By default the built-in Tantivy index is held in memory and rebuilt on every start. Set `index_store: file` on a column to persist it to disk instead, so a restart reopens the existing index rather than re-indexing the dataset:
+
+```yaml
+columns:
+  - name: body
+    full_text_search:
+      enabled: true
+      index_store: file
+      # Optional. Defaults to `.spice/data/fts/<catalog>/<schema>/<table>/`
+      index_directory: ./my-index
+```
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `index_store` | `memory` | Where the index lives: `memory` (rebuilt on every start) or `file` (persisted on disk). If any indexed column of a dataset sets `file`, the dataset's index is persisted. |
+| `index_directory` | `.spice/data/fts/<catalog>/<schema>/<table>/` | Directory for a persisted index. Only applies with `index_store: file` — combining it with `index_store: memory` logs a warning and keeps the in-memory store. |
+
+#### Changing the configuration of a persisted index
+
+A persisted index records the schema it was built with, and that schema is what serves queries. On start, Spice compares the persisted schema against the current configuration:
+
+- **The index fails to open** — with an error naming the column, how its indexing changed, and the directory to delete so the index is rebuilt — when a configured column is absent from the persisted index, or when a column's value type, indexed flag, or tokenized/untokenized indexing differs. Searches, filters, and primary-key deletes over such a column cannot behave as configured, so this is reported rather than served. Adding a search column to a dataset with a persisted index therefore requires deleting the index directory.
+- **A warning is logged** when only the text analysis differs (for example an index built before [stemming](#text-analysis) became the default). Queries stay consistent with what the index actually holds; delete the directory to rebuild with the configured analysis.
+
+`index_store: memory` is never affected — it rebuilds from scratch on every start and so always matches the configuration.
+
 ## Using Elasticsearch as the FTS Engine
 
 To use Elasticsearch instead of the built-in Tantivy engine, add a dataset-level `full_text_search` block with `engine: elasticsearch` and the connection parameters:


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12275` makes a persisted full-text index validate its schema on reopen. Previously `FullTextDatabaseIndex::try_new` built the tantivy schema from the current configuration, then threw it away when the directory already existed (`open_in_dir` loads the schema recorded on disk) — so a newly configured search column was never indexed and searched over it silently matched nothing.

Documenting that behavior required documenting the store it applies to: **`index_store` and `index_directory` were not mentioned anywhere in the docs**, even though both are user-facing spicepod fields.

Verified against `origin/trunk`:

- `index_store` and `index_directory` are column-level `full_text_search` fields (`crates/spicepod/src/semantic.rs:287-291`); `IndexStore` is `#[serde(rename_all = "lowercase")]` with `Memory` as `#[default]` and `File` (`semantic.rs:301-308`), so the documented values are `memory` / `file` and the default is `memory`.
- **Any** column choosing `file` makes the dataset's index persistent: `indexes.iter().any(|(store, _)| *store == IndexStore::File)` (`crates/runtime-component/src/column.rs:103`).
- `index_store: memory` together with `index_directory` warns and keeps memory (`column.rs:46-49`) — documented rather than left to a log line.
- Default directory is `.spice/data/fts/<catalog>/<schema>/<table>/`, from `make_spice_data_sub_directory(["fts", …table])` (`crates/runtime/src/search/full_text/table.rs:67-81`).
- The error/warning split is copied from `ensure_persisted_schema_matches` (`crates/search/src/generation/text_search/index.rs:87-133`): **error** for a missing configured column (`PersistedIndexMissingColumnsSnafu`) or a changed `addressing_shape` — value type, `is_indexed`, tokenized-vs-untokenized (`PersistedIndexColumnChangedSnafu`); **warning only** when just the tokenizer differs, with queries staying consistent with the index until the directory is deleted.
- The tokenizer-only warning is the upgrade path for spiceai/spiceai#12220 (`en_stem` by default, documented in #2032): an index built before it keeps its old analysis and says so. The doc links that case to the [Text Analysis](https://docs.spiceai.org/docs/features/search/full-text#text-analysis) section.
- `index_store: memory` was never affected — it calls `create_in_ram` on every start.

Addition (new validation + previously-undocumented option) → `website/docs/` only; `grep -rn index_store website/versioned_docs/` → 0 hits.

## Source PRs

- spiceai/spiceai#12275 — fix(search): reject a persisted full-text index whose schema no longer matches the configuration (fixes #12274)
- Context: spiceai/spiceai#12220 (stemming by default) — the tokenizer-mismatch warning case

## Doc pages changed

- `website/docs/features/search/full-text.md` — new "Index Storage" section with the two fields and a "Changing the configuration of a persisted index" subsection

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — addition class, vNext only
- [x] Files updated: 1 (matches the diff)
