### PR TITLE
docs(monitoring): Datadog service_instance_id and Grafana K8s metrics setup

### DIFF
--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -34,11 +34,7 @@ instances:
 
 ## Kubernetes (Operator / Autodiscovery)
 
-After the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) is running in the cluster (Operator or Helm), annotate Spice workloads so the Agent scrapes `/metrics` and tags series for the dashboard **instance** filter.
-
-The Spice Datadog dashboard filters on the tag **`service_instance_id`** (OpenTelemetry [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/resource/#service) in undotted form — Datadog template variable names cannot contain dots; see [Template variables](https://docs.datadoghq.com/dashboards/template_variables/#widgets)). Set the value to the pod name so Kubernetes resource panels (`pod_name:$instance.value`) stay aligned with Spice metrics.
-
-Add an Autodiscovery annotation on the Spice container (default container name in the Helm chart is `spiceai`):
+With the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) in the cluster, annotate the Spice container (`spiceai` in the Helm chart) so OpenMetrics scrapes include the `service_instance_id` tag used by the dashboard instance filter:
 
 ```yaml
 ad.datadoghq.com/spiceai.checks: |
@@ -55,12 +51,6 @@ ad.datadoghq.com/spiceai.checks: |
     }
   }
 ```
-
-Put the annotation on the Spice pod template (`spec.template.metadata.annotations` on the Deployment or StatefulSet), then roll the workload so pods pick it up.
-
-Confirm in Metrics Explorer that Spice metrics carry `service_instance_id:<pod-name>`. The dashboard instance dropdown lists those values after Datadog indexes the tag (often within a few minutes).
-
-Kubernetes CPU, memory, and volume panels use Datadog’s Kubernetes metrics (`k8s.pod.*`, `k8s.volume.*`). Those require the Agent’s Kubernetes / kubelet integrations (enabled by default for in-cluster Agents).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -18,10 +18,12 @@ Configure the Datadog Agent to scrape the Spice metrics endpoint:
 init_config:
 
 instances:
-  - prometheus_url: SPICE-METRICS-ENDPOINT>/metrics # for example http://localhost:9090/metrics
+  - openmetrics_endpoint: http://localhost:9090/metrics # Spice metrics endpoint
     namespace: spice
     metrics:
-      - '*'
+      - .*
+    tags:
+      - service_instance_id:<unique-id> # e.g. hostname; required by the Spice dashboard filter
 ```
 
 1. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent) to start collecting Spice metrics.
@@ -29,6 +31,36 @@ instances:
 1. Open Datadog Metrics Explorer and type `spice` to confirm Spice telemetry information is successfully collected.
 
 <img width="800" src="/img/datadog/spice_datadog_metrics_explorer.png"/>
+
+## Kubernetes (Operator / Autodiscovery)
+
+After the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) is running in the cluster (Operator or Helm), annotate Spice workloads so the Agent scrapes `/metrics` and tags series for the dashboard **instance** filter.
+
+The Spice Datadog dashboard filters on the tag **`service_instance_id`** (OpenTelemetry [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/resource/#service) in undotted form — Datadog template variable names cannot contain dots; see [Template variables](https://docs.datadoghq.com/dashboards/template_variables/#widgets)). Set the value to the pod name so Kubernetes resource panels (`pod_name:$instance.value`) stay aligned with Spice metrics.
+
+Add an Autodiscovery annotation on the Spice container (default container name in the Helm chart is `spiceai`):
+
+```yaml
+ad.datadoghq.com/spiceai.checks: |
+  {
+    "openmetrics": {
+      "instances": [
+        {
+          "openmetrics_endpoint": "http://%%host%%:9090/metrics",
+          "namespace": "spice",
+          "metrics": [".*"],
+          "tags": ["service_instance_id:%%kube_pod_name%%"]
+        }
+      ]
+    }
+  }
+```
+
+Put the annotation on the Spice pod template (`spec.template.metadata.annotations` on the Deployment or StatefulSet), then roll the workload so pods pick it up.
+
+Confirm in Metrics Explorer that Spice metrics carry `service_instance_id:<pod-name>`. The dashboard instance dropdown lists those values after Datadog indexes the tag (often within a few minutes).
+
+Kubernetes CPU, memory, and volume panels use Datadog’s Kubernetes metrics (`k8s.pod.*`, `k8s.volume.*`). Those require the Agent’s Kubernetes / kubelet integrations (enabled by default for in-cluster Agents).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/docs/monitoring/grafana/index.md
+++ b/website/docs/monitoring/grafana/index.md
@@ -20,44 +20,9 @@ Click "Load".
 
 ## Kubernetes
 
-### Scrape Spice metrics
+View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from Spice pods (`monitoring.podMonitor.enabled=true`).
 
-View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator (`monitoring.podMonitor.enabled=true`) to scrape metrics from Spice pods.
-
-### Kubernetes Resource Utilization panels
-
-The **Kubernetes Resource Utilization** section of the Grafana dashboard does **not** use Spice `/metrics`. It queries cluster metrics that must already be in Prometheus:
-
-| Panel | Metrics | Label used with `$instances` |
-| --- | --- | --- |
-| CPU / Memory | `k8s_pod_cpu_usage`, `k8s_pod_memory_working_set` | `k8s_pod_name` |
-| PVC storage | `k8s_volume_capacity`, `k8s_volume_available` | `k8s_pod_name` |
-
-The dashboard **Instances** variable is the Prometheus scrape `instance` label on Spice metrics. For those K8s panels to filter correctly, `instance` should match the pod name (same value as `k8s_pod_name`). Relabel the Spice PodMonitor/ServiceMonitor if your scrape target is `pod:port` or an IP.
-
-**Minimal setup**
-
-1. Prometheus scraping Spice (Helm PodMonitor or equivalent) — required for all Spice panels and the Instances filter.
-2. A source of the `k8s_pod_*` / `k8s_volume_*` metrics above, with label `k8s_pod_name`.
-
-A common approach is [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) plus an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet using the [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver, exporting Prometheus metrics **without** unit suffixes so names match the dashboard (`k8s_pod_cpu_usage`, not `k8s_pod_cpu_usage_seconds_total`).
-
-Example Collector install (contrib image; enable the kubelet metrics preset and a Prometheus exporter scraped by your Prometheus):
-
-```bash
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-helm repo update
-helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
-  --set mode=daemonset \
-  --set image.repository=otel/opentelemetry-collector-contrib \
-  --set presets.kubeletMetrics.enabled=true
-```
-
-Tune the chart values so kubeletstats includes the **volume** metric group (for PVC panels) and the Prometheus exporter omits unit suffixes. See the [kubeletstats receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) docs.
-
-:::note
-Without the cluster metrics in the table above, Spice application panels still work; only the Kubernetes Resource Utilization row stays empty. Some environments (for example Kind with local-path volumes) do not expose PVC stats from the kubelet, so disk panels may remain empty even when CPU and memory work.
-:::
+The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`), not Spice `/metrics`. A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
 
 ## Prometheus
 

--- a/website/docs/monitoring/grafana/index.md
+++ b/website/docs/monitoring/grafana/index.md
@@ -20,7 +20,44 @@ Click "Load".
 
 ## Kubernetes
 
-View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from the Spice instances in Kubernetes.
+### Scrape Spice metrics
+
+View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator (`monitoring.podMonitor.enabled=true`) to scrape metrics from Spice pods.
+
+### Kubernetes Resource Utilization panels
+
+The **Kubernetes Resource Utilization** section of the Grafana dashboard does **not** use Spice `/metrics`. It queries cluster metrics that must already be in Prometheus:
+
+| Panel | Metrics | Label used with `$instances` |
+| --- | --- | --- |
+| CPU / Memory | `k8s_pod_cpu_usage`, `k8s_pod_memory_working_set` | `k8s_pod_name` |
+| PVC storage | `k8s_volume_capacity`, `k8s_volume_available` | `k8s_pod_name` |
+
+The dashboard **Instances** variable is the Prometheus scrape `instance` label on Spice metrics. For those K8s panels to filter correctly, `instance` should match the pod name (same value as `k8s_pod_name`). Relabel the Spice PodMonitor/ServiceMonitor if your scrape target is `pod:port` or an IP.
+
+**Minimal setup**
+
+1. Prometheus scraping Spice (Helm PodMonitor or equivalent) — required for all Spice panels and the Instances filter.
+2. A source of the `k8s_pod_*` / `k8s_volume_*` metrics above, with label `k8s_pod_name`.
+
+A common approach is [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) plus an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet using the [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver, exporting Prometheus metrics **without** unit suffixes so names match the dashboard (`k8s_pod_cpu_usage`, not `k8s_pod_cpu_usage_seconds_total`).
+
+Example Collector install (contrib image; enable the kubelet metrics preset and a Prometheus exporter scraped by your Prometheus):
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
+  --set mode=daemonset \
+  --set image.repository=otel/opentelemetry-collector-contrib \
+  --set presets.kubeletMetrics.enabled=true
+```
+
+Tune the chart values so kubeletstats includes the **volume** metric group (for PVC panels) and the Prometheus exporter omits unit suffixes. See the [kubeletstats receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) docs.
+
+:::note
+Without the cluster metrics in the table above, Spice application panels still work; only the Kubernetes Resource Utilization row stays empty. Some environments (for example Kind with local-path volumes) do not expose PVC stats from the kubelet, so disk panels may remain empty even when CPU and memory work.
+:::
 
 ## Prometheus
 

--- a/website/docs/monitoring/grafana/index.md
+++ b/website/docs/monitoring/grafana/index.md
@@ -22,7 +22,7 @@ Click "Load".
 
 View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from Spice pods (`monitoring.podMonitor.enabled=true`).
 
-The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`), not Spice `/metrics`. A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
+The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`). A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
 
 ## Prometheus
 

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -34,11 +34,7 @@ instances:
 
 ## Kubernetes (Operator / Autodiscovery)
 
-After the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) is running in the cluster (Operator or Helm), annotate Spice workloads so the Agent scrapes `/metrics` and tags series for the dashboard **instance** filter.
-
-The Spice Datadog dashboard filters on the tag **`service_instance_id`** (OpenTelemetry [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/resource/#service) in undotted form — Datadog template variable names cannot contain dots; see [Template variables](https://docs.datadoghq.com/dashboards/template_variables/#widgets)). Set the value to the pod name so Kubernetes resource panels (`pod_name:$instance.value`) stay aligned with Spice metrics.
-
-Add an Autodiscovery annotation on the Spice container (default container name in the Helm chart is `spiceai`):
+With the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) in the cluster, annotate the Spice container (`spiceai` in the Helm chart) so OpenMetrics scrapes include the `service_instance_id` tag used by the dashboard instance filter:
 
 ```yaml
 ad.datadoghq.com/spiceai.checks: |
@@ -55,12 +51,6 @@ ad.datadoghq.com/spiceai.checks: |
     }
   }
 ```
-
-Put the annotation on the Spice pod template (`spec.template.metadata.annotations` on the Deployment or StatefulSet), then roll the workload so pods pick it up.
-
-Confirm in Metrics Explorer that Spice metrics carry `service_instance_id:<pod-name>`. The dashboard instance dropdown lists those values after Datadog indexes the tag (often within a few minutes).
-
-Kubernetes CPU, memory, and volume panels use Datadog’s Kubernetes metrics (`k8s.pod.*`, `k8s.volume.*`). Those require the Agent’s Kubernetes / kubelet integrations (enabled by default for in-cluster Agents).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -18,10 +18,12 @@ Configure the Datadog Agent to scrape the Spice metrics endpoint:
 init_config:
 
 instances:
-  - prometheus_url: SPICE-METRICS-ENDPOINT>/metrics # for example http://localhost:9090/metrics
+  - openmetrics_endpoint: http://localhost:9090/metrics # Spice metrics endpoint
     namespace: spice
     metrics:
-      - '*'
+      - .*
+    tags:
+      - service_instance_id:<unique-id> # e.g. hostname; required by the Spice dashboard filter
 ```
 
 1. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent) to start collecting Spice metrics.
@@ -29,6 +31,36 @@ instances:
 1. Open Datadog Metrics Explorer and type `spice` to confirm Spice telemetry information is successfully collected.
 
 <img width="800" src="/img/datadog/spice_datadog_metrics_explorer.png"/>
+
+## Kubernetes (Operator / Autodiscovery)
+
+After the [Datadog Agent](https://docs.datadoghq.com/containers/kubernetes/installation/) is running in the cluster (Operator or Helm), annotate Spice workloads so the Agent scrapes `/metrics` and tags series for the dashboard **instance** filter.
+
+The Spice Datadog dashboard filters on the tag **`service_instance_id`** (OpenTelemetry [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/resource/#service) in undotted form — Datadog template variable names cannot contain dots; see [Template variables](https://docs.datadoghq.com/dashboards/template_variables/#widgets)). Set the value to the pod name so Kubernetes resource panels (`pod_name:$instance.value`) stay aligned with Spice metrics.
+
+Add an Autodiscovery annotation on the Spice container (default container name in the Helm chart is `spiceai`):
+
+```yaml
+ad.datadoghq.com/spiceai.checks: |
+  {
+    "openmetrics": {
+      "instances": [
+        {
+          "openmetrics_endpoint": "http://%%host%%:9090/metrics",
+          "namespace": "spice",
+          "metrics": [".*"],
+          "tags": ["service_instance_id:%%kube_pod_name%%"]
+        }
+      ]
+    }
+  }
+```
+
+Put the annotation on the Spice pod template (`spec.template.metadata.annotations` on the Deployment or StatefulSet), then roll the workload so pods pick it up.
+
+Confirm in Metrics Explorer that Spice metrics carry `service_instance_id:<pod-name>`. The dashboard instance dropdown lists those values after Datadog indexes the tag (often within a few minutes).
+
+Kubernetes CPU, memory, and volume panels use Datadog’s Kubernetes metrics (`k8s.pod.*`, `k8s.volume.*`). Those require the Agent’s Kubernetes / kubelet integrations (enabled by default for in-cluster Agents).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
@@ -20,44 +20,9 @@ Click "Load".
 
 ## Kubernetes
 
-### Scrape Spice metrics
+View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from Spice pods (`monitoring.podMonitor.enabled=true`).
 
-View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator (`monitoring.podMonitor.enabled=true`) to scrape metrics from Spice pods.
-
-### Kubernetes Resource Utilization panels
-
-The **Kubernetes Resource Utilization** section of the Grafana dashboard does **not** use Spice `/metrics`. It queries cluster metrics that must already be in Prometheus:
-
-| Panel | Metrics | Label used with `$instances` |
-| --- | --- | --- |
-| CPU / Memory | `k8s_pod_cpu_usage`, `k8s_pod_memory_working_set` | `k8s_pod_name` |
-| PVC storage | `k8s_volume_capacity`, `k8s_volume_available` | `k8s_pod_name` |
-
-The dashboard **Instances** variable is the Prometheus scrape `instance` label on Spice metrics. For those K8s panels to filter correctly, `instance` should match the pod name (same value as `k8s_pod_name`). Relabel the Spice PodMonitor/ServiceMonitor if your scrape target is `pod:port` or an IP.
-
-**Minimal setup**
-
-1. Prometheus scraping Spice (Helm PodMonitor or equivalent) — required for all Spice panels and the Instances filter.
-2. A source of the `k8s_pod_*` / `k8s_volume_*` metrics above, with label `k8s_pod_name`.
-
-A common approach is [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) plus an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet using the [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver, exporting Prometheus metrics **without** unit suffixes so names match the dashboard (`k8s_pod_cpu_usage`, not `k8s_pod_cpu_usage_seconds_total`).
-
-Example Collector install (contrib image; enable the kubelet metrics preset and a Prometheus exporter scraped by your Prometheus):
-
-```bash
-helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-helm repo update
-helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
-  --set mode=daemonset \
-  --set image.repository=otel/opentelemetry-collector-contrib \
-  --set presets.kubeletMetrics.enabled=true
-```
-
-Tune the chart values so kubeletstats includes the **volume** metric group (for PVC panels) and the Prometheus exporter omits unit suffixes. See the [kubeletstats receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) docs.
-
-:::note
-Without the cluster metrics in the table above, Spice application panels still work; only the Kubernetes Resource Utilization row stays empty. Some environments (for example Kind with local-path volumes) do not expose PVC stats from the kubelet, so disk panels may remain empty even when CPU and memory work.
-:::
+The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`), not Spice `/metrics`. A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
 
 ## Prometheus
 

--- a/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
@@ -20,7 +20,44 @@ Click "Load".
 
 ## Kubernetes
 
-View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from the Spice instances in Kubernetes.
+### Scrape Spice metrics
+
+View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator (`monitoring.podMonitor.enabled=true`) to scrape metrics from Spice pods.
+
+### Kubernetes Resource Utilization panels
+
+The **Kubernetes Resource Utilization** section of the Grafana dashboard does **not** use Spice `/metrics`. It queries cluster metrics that must already be in Prometheus:
+
+| Panel | Metrics | Label used with `$instances` |
+| --- | --- | --- |
+| CPU / Memory | `k8s_pod_cpu_usage`, `k8s_pod_memory_working_set` | `k8s_pod_name` |
+| PVC storage | `k8s_volume_capacity`, `k8s_volume_available` | `k8s_pod_name` |
+
+The dashboard **Instances** variable is the Prometheus scrape `instance` label on Spice metrics. For those K8s panels to filter correctly, `instance` should match the pod name (same value as `k8s_pod_name`). Relabel the Spice PodMonitor/ServiceMonitor if your scrape target is `pod:port` or an IP.
+
+**Minimal setup**
+
+1. Prometheus scraping Spice (Helm PodMonitor or equivalent) — required for all Spice panels and the Instances filter.
+2. A source of the `k8s_pod_*` / `k8s_volume_*` metrics above, with label `k8s_pod_name`.
+
+A common approach is [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) plus an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) DaemonSet using the [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver, exporting Prometheus metrics **without** unit suffixes so names match the dashboard (`k8s_pod_cpu_usage`, not `k8s_pod_cpu_usage_seconds_total`).
+
+Example Collector install (contrib image; enable the kubelet metrics preset and a Prometheus exporter scraped by your Prometheus):
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+helm upgrade --install otel-collector open-telemetry/opentelemetry-collector \
+  --set mode=daemonset \
+  --set image.repository=otel/opentelemetry-collector-contrib \
+  --set presets.kubeletMetrics.enabled=true
+```
+
+Tune the chart values so kubeletstats includes the **volume** metric group (for PVC panels) and the Prometheus exporter omits unit suffixes. See the [kubeletstats receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) docs.
+
+:::note
+Without the cluster metrics in the table above, Spice application panels still work; only the Kubernetes Resource Utilization row stays empty. Some environments (for example Kind with local-path volumes) do not expose PVC stats from the kubelet, so disk panels may remain empty even when CPU and memory work.
+:::
 
 ## Prometheus
 

--- a/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/grafana/index.md
@@ -22,7 +22,7 @@ Click "Load".
 
 View the [Kubernetes](../../deployment/kubernetes/helm/index.md) deployment guide for configuring the Prometheus Operator to scrape metrics from Spice pods (`monitoring.podMonitor.enabled=true`).
 
-The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`), not Spice `/metrics`. A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
+The dashboard **Kubernetes Resource Utilization** panels need cluster metrics in Prometheus (`k8s_pod_cpu_usage`, `k8s_pod_memory_working_set`, `k8s_volume_capacity`, `k8s_volume_available` with label `k8s_pod_name`). A common source is an OpenTelemetry Collector [kubeletstats](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/kubeletstatsreceiver) receiver exporting those names (without unit suffixes). The scrape `instance` label should match the pod name so the Instances filter applies to those panels.
 
 ## Prometheus
 


### PR DESCRIPTION
## Summary
- Document Datadog OpenMetrics Autodiscovery tagging with `service_instance_id` (host + Kubernetes Operator) for the Spice dashboard instance filter
- Document Grafana **Kubernetes Resource Utilization** prerequisites (`k8s_pod_*` / `k8s_volume_*`, `k8s_pod_name`, OTel kubeletstats path)
