### PR TITLE
docs(s3_vectors): add the IAM actions the engine actually calls

### DIFF
--- a/website/docs/components/vectors/s3_vectors.md
+++ b/website/docs/components/vectors/s3_vectors.md
@@ -295,7 +295,10 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes",
+                "s3vectors:DeleteVectors"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -327,8 +330,11 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 
 | Permission                     | Purpose                                                                                 |
 | ------------------------------ | --------------------------------------------------------------------------------------- |
+| `s3vectors:DeleteVectors`      | Required. Used to remove vectors when rows are deleted from the dataset.                |
 | `s3vectors:GetIndex`           | Required. Used to verify if the index already exists or needs to be created.            |
 | `s3vectors:GetVectorBucket`    | Required. Used to verify if the vector bucket already exists or needs to be created.    |
+| `s3vectors:GetVectors`         | Required. Used to read vector data when the `*_embeddings` column is projected.         |
+| `s3vectors:ListIndexes`        | Required when using index partitioning or spill writes, to enumerate physical indexes.  |
 | `s3vectors:ListVectors`        | Required. Used to populate the `*_embeddings` column on vector tables in Spice.         |
 | `s3vectors:PutVectors`         | Required. Used to populate the vector index with Spice-computed embeddings.             |
 | `s3vectors:QueryVectors`       | Required. Used to query for vectors using the `vector_search` table function.           |

--- a/website/versioned_docs/version-1.10.x/components/vectors/s3_vectors.md
+++ b/website/versioned_docs/version-1.10.x/components/vectors/s3_vectors.md
@@ -294,7 +294,9 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -328,6 +330,8 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 |------------|---------|
 | `s3vectors:GetIndex` | Required. Used to verify if the index already exists or needs to be created. |
 | `s3vectors:GetVectorBucket` | Required. Used to verify if the vector bucket already exists or needs to be created. |
+| `s3vectors:GetVectors` | Required. Used to read vector data when the `*_embeddings` column is projected. |
+| `s3vectors:ListIndexes` | Required when using index partitioning, to enumerate the physical indexes. |
 | `s3vectors:ListVectors` | Required. Used to populate the `*_embeddings` column on vector tables in Spice. |
 | `s3vectors:PutVectors` | Required. Used to populate the vector index with Spice-computed embeddings. |
 | `s3vectors:QueryVectors` | Required. Used to query for vectors using the `vector_search` table function. |

--- a/website/versioned_docs/version-1.11.x/components/vectors/s3_vectors.md
+++ b/website/versioned_docs/version-1.11.x/components/vectors/s3_vectors.md
@@ -294,7 +294,9 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -328,6 +330,8 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 | ------------------------------ | --------------------------------------------------------------------------------------- |
 | `s3vectors:GetIndex`           | Required. Used to verify if the index already exists or needs to be created.            |
 | `s3vectors:GetVectorBucket`    | Required. Used to verify if the vector bucket already exists or needs to be created.    |
+| `s3vectors:GetVectors`         | Required. Used to read vector data when the `*_embeddings` column is projected.         |
+| `s3vectors:ListIndexes`        | Required when using index partitioning or spill writes, to enumerate physical indexes.  |
 | `s3vectors:ListVectors`        | Required. Used to populate the `*_embeddings` column on vector tables in Spice.         |
 | `s3vectors:PutVectors`         | Required. Used to populate the vector index with Spice-computed embeddings.             |
 | `s3vectors:QueryVectors`       | Required. Used to query for vectors using the `vector_search` table function.           |

--- a/website/versioned_docs/version-1.9.x/components/vectors/s3_vectors.md
+++ b/website/versioned_docs/version-1.9.x/components/vectors/s3_vectors.md
@@ -294,7 +294,9 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -328,6 +330,8 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 |------------|---------|
 | `s3vectors:GetIndex` | Required. Used to verify if the index already exists or needs to be created. |
 | `s3vectors:GetVectorBucket` | Required. Used to verify if the vector bucket already exists or needs to be created. |
+| `s3vectors:GetVectors` | Required. Used to read vector data when the `*_embeddings` column is projected. |
+| `s3vectors:ListIndexes` | Required when using index partitioning, to enumerate the physical indexes. |
 | `s3vectors:ListVectors` | Required. Used to populate the `*_embeddings` column on vector tables in Spice. |
 | `s3vectors:PutVectors` | Required. Used to populate the vector index with Spice-computed embeddings. |
 | `s3vectors:QueryVectors` | Required. Used to query for vectors using the `vector_search` table function. |

--- a/website/versioned_docs/version-2.0.x/components/vectors/s3_vectors.md
+++ b/website/versioned_docs/version-2.0.x/components/vectors/s3_vectors.md
@@ -294,7 +294,9 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -328,6 +330,8 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 | ------------------------------ | --------------------------------------------------------------------------------------- |
 | `s3vectors:GetIndex`           | Required. Used to verify if the index already exists or needs to be created.            |
 | `s3vectors:GetVectorBucket`    | Required. Used to verify if the vector bucket already exists or needs to be created.    |
+| `s3vectors:GetVectors`         | Required. Used to read vector data when the `*_embeddings` column is projected.         |
+| `s3vectors:ListIndexes`        | Required when using index partitioning or spill writes, to enumerate physical indexes.  |
 | `s3vectors:ListVectors`        | Required. Used to populate the `*_embeddings` column on vector tables in Spice.         |
 | `s3vectors:PutVectors`         | Required. Used to populate the vector index with Spice-computed embeddings.             |
 | `s3vectors:QueryVectors`       | Required. Used to query for vectors using the `vector_search` table function.           |

--- a/website/versioned_docs/version-2.1.x/components/vectors/s3_vectors.md
+++ b/website/versioned_docs/version-2.1.x/components/vectors/s3_vectors.md
@@ -295,7 +295,9 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
                 "s3vectors:QueryVectors",
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors"
+                "s3vectors:ListVectors",
+                "s3vectors:GetVectors",
+                "s3vectors:ListIndexes"
             ],
             "Resource": [
                 "arn:aws:s3vectors:aws-region:123456789012:bucket/amzn-s3-demo-vector-bucket/index/*",
@@ -329,6 +331,8 @@ The IAM role or user needs the following minimum permissions to access S3 Vector
 | ------------------------------ | --------------------------------------------------------------------------------------- |
 | `s3vectors:GetIndex`           | Required. Used to verify if the index already exists or needs to be created.            |
 | `s3vectors:GetVectorBucket`    | Required. Used to verify if the vector bucket already exists or needs to be created.    |
+| `s3vectors:GetVectors`         | Required. Used to read vector data when the `*_embeddings` column is projected.         |
+| `s3vectors:ListIndexes`        | Required when using index partitioning or spill writes, to enumerate physical indexes.  |
 | `s3vectors:ListVectors`        | Required. Used to populate the `*_embeddings` column on vector tables in Spice.         |
 | `s3vectors:PutVectors`         | Required. Used to populate the vector index with Spice-computed embeddings.             |
 | `s3vectors:QueryVectors`       | Required. Used to query for vectors using the `vector_search` table function.           |


### PR DESCRIPTION
## Summary

The S3 Vectors engine page publishes a "minimum permissions" IAM policy, but it omits three actions the engine actually calls. A user who scopes an IAM policy to the documented set gets `AccessDenied` at runtime.

The page already contradicts itself on one of them: the IAM note above the policy names `s3vectors:GetVectors` as an example, and the `### metrics` table documents `s3_vectors_get_vectors_*`, `s3_vectors_list_indexes_*`, and `s3_vectors_delete_vectors_*` instruments — all for calls the policy doesn't grant.

### What the code does

| Action | Call site | Reached when |
| --- | --- | --- |
| `s3vectors:GetVectors` | `crates/data_components/src/s3_vectors/query_provider.rs` (`get_vectors_call`, guarded by `schema.column_with_name(S3_VECTOR_EMBEDDING_NAME)`) | a query projects the `*_embeddings` column |
| `s3vectors:ListIndexes` | `crates/data_components/src/s3_vectors/mod.rs` (`list_index_names`), called from `partition/mod.rs` and `spill/mod.rs`; it is also the only response the `s3_vectors_index_poll_interval` cache covers | `partition_by` or `s3_vectors_spill_writes` is configured |
| `s3vectors:DeleteVectors` | `crates/data_components/src/s3_vectors/vector_table.rs` (`delete_by_keys`) via `crates/search/src/index/s3_vectors/mod.rs` → retention, `refresh_mode: changes`, and `DELETE` | rows are deleted from the indexed dataset |

All three are `index`-scoped actions per the [AWS Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3vectors.html), so they join the existing index-scoped `AllowApplicationVectorAccess` statement rather than a new one.

## Version scoping

- `GetVectors` / `ListIndexes` — the production call paths exist from **v1.9** onward, so this fixes vNext plus `version-2.1.x`, `version-2.0.x`, `version-1.11.x`, `version-1.10.x`, `version-1.9.x`. The 1.6.x–1.8.x snapshots have no such call path and are intentionally left alone.
- `DeleteVectors` — wired up by spiceai/spiceai#11961 (merged 2026-07-31, after `v2.1.3`), so it is added to **vNext only**. Verified absent at `v2.1.3` (`git grep delete_by_keys v2.1.3 -- crates/search/src/index/s3_vectors/mod.rs` returns nothing).
- On 1.9.x/1.10.x the `ListIndexes` row says "index partitioning" only — `s3_vectors_spill_writes` did not exist until v1.11.

Verified against `spiceai/spiceai` at `origin/trunk` (`d1975a43a`) and tags `v2.1.3`, `v2.0.1`, `v1.11.6`, `v1.10.4`, `v1.9.2`.

## Test plan

- [x] Files updated: 6 (1 unversioned + 5 versioned) — matches the diff
- [x] Versioned-docs propagation scoped per release by verifying the call path at each tag; 1.6.x–1.8.x correctly excluded
- [x] Diff adds no links and no frontmatter tags (verified by grep over the added lines)
- [x] `cd website && npm run build` passes (`Generated static files in "build"`, exit 0)
