### PR TITLE
docs(mysql cdc): document the replication-privilege pre-flight

### DIFF
--- a/website/docs/features/cdc/mysql-replication.md
+++ b/website/docs/features/cdc/mysql-replication.md
@@ -81,6 +81,23 @@ GRANT SELECT ON mydb.orders TO 'replicator'@'%';           -- snapshot + layout 
 GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator'@'%';
 ```
 
+`REPLICATION SLAVE` (streams the binlog) and `REPLICATION CLIENT` (reads its position) are **global-only** privileges in MySQL — they cannot be granted per-database, which is why they are granted `ON *.*`. On MariaDB 10.5+ the same two privileges are named `REPLICATION REPLICA` and `BINLOG MONITOR`; either spelling satisfies Spice, as does `ALL PRIVILEGES`.
+
+Spice pre-flights these grants via `SHOW GRANTS FOR CURRENT_USER()` before it validates the server settings above — an account without `REPLICATION CLIENT` can still read those settings, so checking them first would report a healthy server and defer the real problem to an opaque `Access denied` at stream start. A definitively missing privilege fails the dataset with the account name, the privileges it lacks, and a ready-to-paste `GRANT`:
+
+```text
+MySQL account replicator@% is missing privileges required for change data capture:
+REPLICATION SLAVE, REPLICATION CLIENT. Grant them with:
+GRANT REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'replicator'@'%';
+```
+
+The suggested `GRANT` includes `SELECT ON *.*` so it can be pasted as-is; narrow the `SELECT` to the replicated tables (as in the block above) if you prefer least privilege.
+
+Two cases deliberately do **not** fail the pre-flight:
+
+- **`SELECT` is not audited.** It is grantable at database, table, and column scope, and the check runs before the dataset's table is known — so a valid per-table grant would read as missing. A missing `SELECT` instead surfaces at snapshot time, named against the table that needs it.
+- **An inconclusive `SHOW GRANTS` defers to the server.** If the statement cannot be read, or lists a role grant (whose constituent privileges `SHOW GRANTS` does not expand), no conclusion is drawn and startup proceeds rather than blocking a dataset that would replicate correctly.
+
 ## Parameters
 
 Configure replication behavior with the following `params` on the MySQL dataset:


### PR DESCRIPTION
## Summary

spiceai/spiceai#12485 added a **CDC privilege pre-flight** to the MySQL binlog replication connector. The Prerequisites section already listed the required `GRANT`, but documented none of the surrounding behavior — so an operator hitting the new startup failure, or running MariaDB, had nothing to check the docs against.

Documents, on the [MySQL Binlog Replication](https://docs.spiceai.org/docs/features/cdc/mysql-replication) page:

- **Why the grant is `ON *.*`.** `REPLICATION SLAVE` and `REPLICATION CLIENT` are global-only privileges in MySQL — they cannot be granted per-database. The existing example granted them globally without saying why, which reads like over-granting.
- **MariaDB 10.5+ spellings.** `REPLICATION REPLICA` and `BINLOG MONITOR` are the renamed equivalents and `SHOW GRANTS` reports the new names; both are accepted, as is `ALL PRIVILEGES`.
- **The pre-flight runs first**, before the server-setting validation already documented in the table above it — an account without `REPLICATION CLIENT` can still read those settings, so checking them first would report a healthy server and defer the real problem to an opaque `Access denied` at stream start.
- **The error text**, quoted verbatim from the `MissingPrivileges` display string with the substitutions from the PR's own regression test.
- **The two non-failing cases**: `SELECT` is deliberately not audited (grantable at database/table/column scope, and the check runs before the dataset's table is known, so a valid per-table grant would read as missing — it surfaces at snapshot time instead); and an inconclusive `SHOW GRANTS` (unreadable, or an unexpanded role grant) defers to the server rather than blocking a dataset that would replicate fine.

### One addition beyond the source PR

The runtime's suggested `GRANT` ends with `SELECT ON *.*` so it pastes cleanly, but this page's own recommended grant is table-scoped (`SELECT ON mydb.orders`). An operator following the error message verbatim would silently widen `SELECT` from one table to the whole server, so the page notes the global `SELECT` is a paste convenience and can be narrowed. No code change implied — the message is fine; the docs just shouldn't let the discrepancy pass unremarked.

## Scope

**vNext only.** `features/cdc/mysql-replication.md` does not exist under any `versioned_docs/version-*/` snapshot (the CDC feature pages are new in vNext), and `grep -rn "REPLICATION SLAVE\|REPLICATION CLIENT" website/docs website/versioned_docs` returns exactly one hit — this file. The MySQL connector reference page defers to this page for source prerequisites, so it needs no change.

## Source PRs

- spiceai/spiceai#12485 — fix(mysql): pre-flight CDC replication privileges with an actionable error (fixes #11967)

## Verification

`check_privileges`, `REPLICATION_SLAVE_ALIASES`, `REPLICATION_CLIENT_ALIASES` and the `MissingPrivileges` display string all confirmed present on today's `origin/trunk` (`crates/data_components/src/mysql_replication/setup.rs`, `mod.rs`) — not read from the merged diff alone.

## Doc pages changed

- `website/docs/features/cdc/mysql-replication.md`

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — vNext-only, page absent from every snapshot (grep above)
- [x] Files updated: **1** (matches the diff)
