### PR TITLE
docs(vectors): flag the Elasticsearch engine as Enterprise in the engines listing

### DIFF
--- a/website/docs/components/vectors/index.md
+++ b/website/docs/components/vectors/index.md
@@ -26,11 +26,11 @@ For the complete reference specification see [datasets](../reference/spicepod/da
 
 Supported Vector engines:
 
-| Name                             | Description                  |
-| -------------------------------- | ---------------------------- |
-| [`s3_vectors`][s3vectors]        | AWS S3 vectors               |
-| [`elasticsearch`][elasticsearch] | Elasticsearch                |
-| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension  |
+| Name                             | Description                         |
+| -------------------------------- | ----------------------------------- |
+| [`s3_vectors`][s3vectors]        | AWS S3 vectors                      |
+| [`elasticsearch`][elasticsearch] | Elasticsearch (Spice.ai Enterprise) |
+| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension         |
 
 [s3vectors]: /docs/components/vectors/s3_vectors.md
 [elasticsearch]: /docs/components/vectors/elasticsearch.md

--- a/website/versioned_docs/version-2.0.x/components/vectors/index.md
+++ b/website/versioned_docs/version-2.0.x/components/vectors/index.md
@@ -26,11 +26,11 @@ For the complete reference specification see [datasets](../reference/spicepod/da
 
 Supported Vector engines:
 
-| Name                             | Description                  |
-| -------------------------------- | ---------------------------- |
-| [`s3_vectors`][s3vectors]        | AWS S3 vectors               |
-| [`elasticsearch`][elasticsearch] | Elasticsearch                |
-| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension  |
+| Name                             | Description                         |
+| -------------------------------- | ----------------------------------- |
+| [`s3_vectors`][s3vectors]        | AWS S3 vectors                      |
+| [`elasticsearch`][elasticsearch] | Elasticsearch (Spice.ai Enterprise) |
+| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension         |
 
 [s3vectors]: /docs/components/vectors/s3_vectors.md
 [elasticsearch]: /docs/components/vectors/elasticsearch.md

--- a/website/versioned_docs/version-2.1.x/components/vectors/index.md
+++ b/website/versioned_docs/version-2.1.x/components/vectors/index.md
@@ -26,11 +26,11 @@ For the complete reference specification see [datasets](../reference/spicepod/da
 
 Supported Vector engines:
 
-| Name                             | Description                  |
-| -------------------------------- | ---------------------------- |
-| [`s3_vectors`][s3vectors]        | AWS S3 vectors               |
-| [`elasticsearch`][elasticsearch] | Elasticsearch                |
-| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension  |
+| Name                             | Description                         |
+| -------------------------------- | ----------------------------------- |
+| [`s3_vectors`][s3vectors]        | AWS S3 vectors                      |
+| [`elasticsearch`][elasticsearch] | Elasticsearch (Spice.ai Enterprise) |
+| [`duckdb`][duckdb]               | DuckDB VSS (HNSW) extension         |
 
 [s3vectors]: /docs/components/vectors/s3_vectors.md
 [elasticsearch]: /docs/components/vectors/elasticsearch.md


### PR DESCRIPTION
## Summary

The Elasticsearch vector engine is gated behind spiced's `elasticsearch` cargo feature, which is **not** in the default OSS feature set (`bin/spiced/Cargo.toml`), and the engine dispatch arm is `#[cfg(feature = "elasticsearch")]` (`crates/runtime/src/embeddings/index/table.rs`). Its dedicated page already carries the Enterprise edition callout, but the **Vector Engines listing table** labelled it plainly as "Elasticsearch", so a reader picking an engine from the index has no signal that it is unavailable in a stock OSS `spiced`.

This follows the existing convention in the data-connectors index, which appends "(Spice.ai Enterprise)" to the description cell (`odbc`, `elasticsearch`, `nfs`).

For contrast, both other engines listed are in the default build and correctly unlabelled: `runtime/s3_vectors` and `duckdb` are in the `default` feature list.

## Version scoping

The Elasticsearch vector engine page exists in vNext, `version-2.1.x`, and `version-2.0.x` — all three carry the Enterprise callout on the dedicated page and all three listing tables were missing the label, so all three are fixed. Earlier snapshots have no Elasticsearch vector engine page.

## Test plan

- [x] Files updated: 3 — matches the diff
- [x] `cd website && npm run build` passes (run over the audit tree carrying this change)
- [x] Diff adds no links and no frontmatter tags
