### PR TITLE
docs(odbc): stop pointing at Docker images that have no ODBC support

### DIFF
--- a/website/docs/components/data-connectors/odbc.md
+++ b/website/docs/components/data-connectors/odbc.md
@@ -12,9 +12,9 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 :::warning
 
-Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
+In the open source edition, Spice must be [built with the `odbc` feature](#building-spice-with-odbc); [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions ship with ODBC support built in. Either way, the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
+The published open source `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, use an Enterprise distribution or [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -150,7 +150,7 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is built into [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions. It is not included in the open source released binaries or in the published `spiceai/spiceai` Docker images — to use ODBC with the open source build, [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
 To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 

--- a/website/docs/components/data-connectors/odbc.md
+++ b/website/docs/components/data-connectors/odbc.md
@@ -14,19 +14,7 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -162,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/odbc.md
@@ -10,19 +10,7 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -158,24 +146,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/odbc.md
@@ -10,19 +10,7 @@ ODBC (Open Database Connectivity) is a standard API for connecting applications 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -158,24 +146,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/odbc.md
@@ -10,18 +10,10 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai) — the default `spiceai/spiceai` images are built without the `odbc` feature:
 
 ```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 :::
@@ -158,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the default released binaries or in the default `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must be the `-odbc` variant — the default `spiceai/spiceai` images are built without the `odbc` feature.
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai/spiceai:latest-odbc
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/odbc.md
@@ -10,18 +10,10 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai) — the default `spiceai/spiceai` images are built without the `odbc` feature:
 
 ```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 :::
@@ -158,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the default released binaries or in the default `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must be the `-odbc` variant — the default `spiceai/spiceai` images are built without the `odbc` feature.
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai/spiceai:latest-odbc
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/odbc.md
@@ -10,18 +10,10 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai) — the default `spiceai/spiceai` images are built without the `odbc` feature:
 
 ```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 :::
@@ -158,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the default released binaries or in the default `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must be the `-odbc` variant — the default `spiceai/spiceai` images are built without the `odbc` feature.
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai/spiceai:latest-odbc
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/odbc.md
@@ -10,18 +10,10 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai) — the default `spiceai/spiceai` images are built without the `odbc` feature:
 
 ```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 :::
@@ -158,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the default released binaries or in the default `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+Alternatively, use the `-odbc` variant of the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker pull spiceai/spiceai:latest-odbc
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must be the `-odbc` variant — the default `spiceai/spiceai` images are built without the `odbc` feature.
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai/spiceai:latest-odbc
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/odbc.md
@@ -10,19 +10,7 @@ ODBC (Open Database Connectivity) is a standard API that allows applications to 
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -158,24 +146,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/odbc.md
@@ -12,9 +12,9 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 :::warning
 
-Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
+In the open source edition, Spice must be [built with the `odbc` feature](#building-spice-with-odbc); [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions ship with ODBC support built in. Either way, the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
+The published open source `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, use an Enterprise distribution or [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -150,7 +150,7 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is built into [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions. It is not included in the open source released binaries or in the published `spiceai/spiceai` Docker images — to use ODBC with the open source build, [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
 To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/odbc.md
@@ -14,19 +14,7 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -162,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/odbc.md
@@ -12,9 +12,9 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 :::warning
 
-Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
+In the open source edition, Spice must be [built with the `odbc` feature](#building-spice-with-odbc); [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions ship with ODBC support built in. Either way, the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
+The published open source `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, use an Enterprise distribution or [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -150,7 +150,7 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is built into [Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) distributions. It is not included in the open source released binaries or in the published `spiceai/spiceai` Docker images — to use ODBC with the open source build, [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
 To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/odbc.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/odbc.md
@@ -14,19 +14,7 @@ The ODBC Data Connector is available in the Spice [Enterprise edition](https://d
 
 Spice must be [built with the `odbc` feature](#building-spice-with-odbc), and the host/container must have a [valid ODBC configuration](https://www.unixodbc.org/odbcinst.html).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
-
-# Pull the latest official Spice image
-
-```bash
-docker pull spiceai/spiceai:latest
-```
-
-# Pull the official v0.20.0-beta Spice image
-
-```bash
-docker pull spiceai/spiceai:0.20.0-beta
-```
+The published `spiceai/spiceai` Docker images do **not** include ODBC support — they are built without the `odbc` feature and do not ship an ODBC Driver Manager. To run ODBC in a container, [bake your own image](#baking-an-image-with-odbc-support) from an ODBC-enabled build.
 
 :::
 
@@ -162,24 +150,22 @@ datasets:
 
 ## Building Spice with ODBC
 
-ODBC support is not included in the released binaries. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
+ODBC support is not included in the released binaries or in the published `spiceai/spiceai` Docker images. To use ODBC with Spice, you need to [checkout and compile the code](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING#building) with the `--features odbc` flag (`cargo build --release --features odbc`).
 
-Alternatively, use the official Spice Docker image. To use the official Spice Docker image from [DockerHub](https://hub.docker.com/r/spiceai/spiceai):
+To build a container image, pass the feature through to the repository `Dockerfile`, which also installs the `unixodbc` Driver Manager when the feature is enabled:
 
 ```bash
-# Pull the latest official Spice image
-docker pull spiceai/spiceai:latest
-
-# Pull the official v0.20.0-beta Spice image
-docker pull spiceai/spiceai:0.20.0-beta
+docker build --build-arg CARGO_FEATURES=release,models,odbc -t spiceai-odbc:local .
 ```
 
 ## Baking an image with ODBC Support
 
 There are many dozens of ODBC adapters; this recipe covers making a custom image and configuring it to work with Spice.
 
+The base image must already contain an ODBC-enabled `spiced` build — the published `spiceai/spiceai` images do not (see [Building Spice with ODBC](#building-spice-with-odbc)).
+
 ```Dockerfile
-FROM spiceai/spiceai:latest
+FROM spiceai-odbc:local
 
 RUN apt update \
     && apt install --yes libsqliteodbc --no-install-recommends \


### PR DESCRIPTION
## Summary

The ODBC Data Connector page offered the official Docker image as an alternative to building `spiced` with `--features odbc` — in two places, plus a "bake an image" recipe built `FROM spiceai/spiceai:latest`.

**What the docs said:** "Alternatively, use the official Spice Docker image", followed by `docker pull spiceai/spiceai:latest` and `docker pull spiceai/spiceai:0.20.0-beta`.

**What the code does:** the published images are built with `CARGO_FEATURES=release,models` (`.github/workflows/spiced_docker.yml`), and `odbc` is not in `spiced`'s `default` feature set (`bin/spiced/Cargo.toml`). `Dockerfile-release` only installs the `unixodbc` Driver Manager when `CARGO_FEATURES` contains `odbc`, which it does not for any published tag. A reader who followed this got an image with neither the connector nor a driver manager, and the bake recipe could never work from that base.

The only ODBC-enabled build in CI is the `spiced_odbc_*` artifact, explicitly commented "ODBC variant - for internal testing" and uploaded to MinIO — it is not published to DockerHub or GHCR.

## Version scoping

This is a version-specific change, not a flat correction. An `-odbc` image variant *was* published through **v1.8.x** (`variants=(... "odbc" ...)` → `spiceai/spiceai:latest-odbc`) and was removed in **v1.9.0**:

| Snapshot | `-odbc` image published? | Fix applied |
| --- | --- | --- |
| 1.5.x – 1.8.x | Yes | Point at the real `spiceai/spiceai:latest-odbc` tag (the `latest` / `0.20.0-beta` tags named there were the *default*, no-ODBC images) |
| 1.9.x – 2.1.x, vNext | No | Drop the Docker shortcut; document `docker build --build-arg CARGO_FEATURES=release,models,odbc` instead, and fix the bake recipe's base image |

Also removes the stale `spiceai/spiceai:0.20.0-beta` pull (current release line is v2.x) and the raw `#` markdown headings that were nested inside the `:::warning` admonition.

## Verified source refs

- `spiceai/spiceai` @ `trunk` — [`bin/spiced/Cargo.toml`](https://github.com/spiceai/spiceai/blob/trunk/bin/spiced/Cargo.toml) (`default` feature list omits `odbc`; `odbc = ["connector-odbc"]`)
- [`.github/workflows/spiced_docker.yml`](https://github.com/spiceai/spiceai/blob/trunk/.github/workflows/spiced_docker.yml) (`CARGO_FEATURES=release,models` for `default`; `release,models,cuda` for `cuda` — no ODBC variant)
- [`Dockerfile-release`](https://github.com/spiceai/spiceai/blob/trunk/Dockerfile-release) (`if echo "$CARGO_FEATURES" | grep -q "odbc"` gate on installing `unixodbc`)
- `spiceai/spiceai` @ `v1.8.0` — `.github/workflows/spiced_docker.yml` (`IMAGE_TAG=odbc`, published as `spiceai/spiceai:latest-odbc`); absent at `v1.9.0`

The rest of the page's `params` table was audited in the same pass and is accurate: `sql_dialect` (runtime-scoped, unprefixed; `mysql`/`postgresql`/`sqlite`/`athena`/`databricks`), `odbc_max_bytes_per_batch` = `512_000_000`, `odbc_max_num_rows_per_batch` = `4000`, and `odbc_max_text_size` / `odbc_max_binary_size` unset by default — all match `crates/data-connectors/connector-odbc/src/{lib,odbcconn}.rs`.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn "0.20.0-beta" website/docs website/versioned_docs` returns no hits in `odbc.md`
- [x] Anchors `#building-spice-with-odbc` and `#baking-an-image-with-odbc-support` resolve to existing headings
- [x] Files updated: 10 (1 unversioned + 9 versioned)