### PR TITLE
docs(ftp): mark the FTP/SFTP username and password as required

### DIFF
--- a/website/docs/components/data-connectors/ftp.md
+++ b/website/docs/components/data-connectors/ftp.md
@@ -75,25 +75,25 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 
 #### FTP Parameters
 
-| Parameter Name              | Description                                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                      |
-| `ftp_user`                  | Username for FTP authentication.                                                                   |
-| `ftp_pass`                  | Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
-| `ftp_port`                  | FTP server port. Default: `21`.                                                                    |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                              |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.      |
+| Parameter Name              | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                |
+| `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
+| `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
+| `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                |
 
 #### SFTP Parameters
 
-| Parameter Name              | Description                                                                                          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                        |
-| `sftp_user`                 | Username for SFTP authentication.                                                                    |
-| `sftp_pass`                 | Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
-| `sftp_port`                 | SFTP server port. Default: `22`.                                                                     |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.        |
+| Parameter Name              | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                  |
+| `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
+| `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
+| `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                  |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/ftp.md
@@ -39,25 +39,25 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                          |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#supported-formats). |
-| `ftp_user`                  | Username for FTP authentication.                                                                                     |
-| `ftp_pass`                  | Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`.          |
-| `ftp_port`                  | FTP server port. Default: `21`.                                                                                      |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                                |
-| `hive_partitioning_enabled` | Enable Hive-style partitioning from folder structure. Default: `false`.                                              |
+| Parameter Name              | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#supported-formats).                           |
+| `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
+| `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
+| `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `hive_partitioning_enabled` | Enable Hive-style partitioning from folder structure. Default: `false`.                                      |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                          |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#supported-formats). |
-| `sftp_user`                 | Username for SFTP authentication.                                                                                    |
-| `sftp_pass`                 | Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`.        |
-| `sftp_port`                 | SFTP server port. Default: `22`.                                                                                     |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                                |
-| `hive_partitioning_enabled` | Enable Hive-style partitioning from folder structure. Default: `false`.                                              |
+| Parameter Name              | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#supported-formats).                             |
+| `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
+| `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
+| `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `hive_partitioning_enabled` | Enable Hive-style partitioning from folder structure. Default: `false`.                                        |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/ftp.md
@@ -75,25 +75,25 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 
 #### FTP Parameters
 
-| Parameter Name              | Description                                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                      |
-| `ftp_user`                  | Username for FTP authentication.                                                                   |
-| `ftp_pass`                  | Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
-| `ftp_port`                  | FTP server port. Default: `21`.                                                                    |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                              |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.      |
+| Parameter Name              | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                |
+| `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
+| `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
+| `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                |
 
 #### SFTP Parameters
 
-| Parameter Name              | Description                                                                                          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                        |
-| `sftp_user`                 | Username for SFTP authentication.                                                                    |
-| `sftp_pass`                 | Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
-| `sftp_port`                 | SFTP server port. Default: `22`.                                                                     |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.        |
+| Parameter Name              | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                  |
+| `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
+| `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
+| `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                  |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/ftp.md
@@ -58,25 +58,25 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                  |
-| `ftp_user`                  | The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                       |
-| `ftp_pass`                  | The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                            |
-| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                             |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                       |
+| `ftp_user`                  | Required. The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                  |
+| `ftp_pass`                  | Required. The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                                |
+| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                                  |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                |
-| `sftp_user`                 | The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                                    |
-| `sftp_pass`                 | The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                          |
-| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                           |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                     |
+| `sftp_user`                 | Required. The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                               |
+| `sftp_pass`                 | Required. The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                              |
+| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                                |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/ftp.md
@@ -58,25 +58,25 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                                                                                                              |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors#object-store-file-formats). |
-| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                       |
-| `ftp_user`                  | The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                            |
-| `ftp_pass`                  | The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                                 |
-| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                                  |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
+| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                              |
+| `ftp_user`                  | Required. The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                         |
+| `ftp_pass`                  | Required. The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                       |
+| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                         |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                      |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                                                                                                              |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors#object-store-file-formats). |
-| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                     |
-| `sftp_user`                 | The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                                         |
-| `sftp_pass`                 | The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                               |
-| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                                |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
+| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                            |
+| `sftp_user`                 | Required. The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                      |
+| `sftp_pass`                 | Required. The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                     |
+| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                       |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                      |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/ftp.md
@@ -58,25 +58,25 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors#object-store-file-formats). |
-| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                  |
-| `ftp_user`                  | The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                       |
-| `ftp_pass`                  | The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                            |
-| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                             |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                              |
+| `ftp_user`                  | Required. The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                         |
+| `ftp_pass`                  | Required. The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                       |
+| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                         |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                      |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors#object-store-file-formats). |
-| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                |
-| `sftp_user`                 | The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                                    |
-| `sftp_pass`                 | The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                          |
-| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                           |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                            |
+| `sftp_user`                 | Required. The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                      |
+| `sftp_pass`                 | Required. The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                     |
+| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                       |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                      |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/ftp.md
@@ -58,25 +58,25 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                  |
-| `ftp_user`                  | The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                       |
-| `ftp_pass`                  | The password for the FTP server. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                            |
-| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                             |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                       |
+| `ftp_user`                  | Required. The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                  |
+| `ftp_pass`                  | Required. The password for the FTP server. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                       |
+| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                                  |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                |
-| `sftp_user`                 | The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                                    |
-| `sftp_pass`                 | The password for the SFTP server. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                          |
-| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                           |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                     |
+| `sftp_user`                 | Required. The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                               |
+| `sftp_pass`                 | Required. The password for the SFTP server. Use the [secret replacement syntax](../secret-stores/index.md) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                     |
+| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                                |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 ## Examples
 

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/ftp.md
@@ -58,25 +58,25 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 
 #### FTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                  |
-| `ftp_user`                  | The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                       |
-| `ftp_pass`                  | The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                            |
-| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                             |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `ftp_port`                  | Optional, specifies the port of the FTP server. Default is 21. E.g. `ftp_port: 21`                                                                                                                       |
+| `ftp_user`                  | Required. The username for the FTP server. E.g. `ftp_user: my-ftp-user`                                                                                                                                  |
+| `ftp_pass`                  | Required. The password for the FTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_ftp_pass}`.                                |
+| `client_timeout`            | Optional. Specifies timeout for FTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for FTP client.                                                                  |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 #### SFTP
 
-| Parameter Name              | Description                                                                                                                                                                                         |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parameter Name              | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `file_format`               | Specifies the data file format. Required if the format cannot be inferred by from the `from` path. See [Object Store File Formats](../../components/data-connectors/index.md#object-store-file-formats). |
-| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                |
-| `sftp_user`                 | The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                                    |
-| `sftp_pass`                 | The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                          |
-| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                           |
-| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                          |
+| `sftp_port`                 | Optional, specifies the port of the SFTP server. Default is 22. E.g. `sftp_port: 22`                                                                                                                     |
+| `sftp_user`                 | Required. The username for the SFTP server. E.g. `sftp_user: my-sftp-user`                                                                                                                               |
+| `sftp_pass`                 | Required. The password for the SFTP server. Use the [secret replacement syntax](../secret-stores) to load the password from a secret store, e.g. `${secrets:my_sftp_pass}`.                              |
+| `client_timeout`            | Optional. Specifies timeout for SFTP connection. E.g. `client_timeout: 30s`. When not set, no timeout will be configured for SFTP client.                                                                |
+| `hive_partitioning_enabled` | Optional. Enable partitioning using hive-style partitioning from the folder structure. Defaults to `false`                                                                                               |
 
 ## Examples
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/ftp.md
@@ -75,25 +75,25 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 
 #### FTP Parameters
 
-| Parameter Name              | Description                                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                      |
-| `ftp_user`                  | Username for FTP authentication.                                                                   |
-| `ftp_pass`                  | Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
-| `ftp_port`                  | FTP server port. Default: `21`.                                                                    |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                              |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.      |
+| Parameter Name              | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                |
+| `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
+| `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
+| `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                |
 
 #### SFTP Parameters
 
-| Parameter Name              | Description                                                                                          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                        |
-| `sftp_user`                 | Username for SFTP authentication.                                                                    |
-| `sftp_pass`                 | Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
-| `sftp_port`                 | SFTP server port. Default: `22`.                                                                     |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.        |
+| Parameter Name              | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                  |
+| `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
+| `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
+| `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                  |
 
 ## Examples
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/ftp.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/ftp.md
@@ -75,25 +75,25 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 
 #### FTP Parameters
 
-| Parameter Name              | Description                                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                      |
-| `ftp_user`                  | Username for FTP authentication.                                                                   |
-| `ftp_pass`                  | Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
-| `ftp_port`                  | FTP server port. Default: `21`.                                                                    |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                              |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.      |
+| Parameter Name              | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                |
+| `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
+| `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
+| `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                |
 
 #### SFTP Parameters
 
-| Parameter Name              | Description                                                                                          |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                        |
-| `sftp_user`                 | Username for SFTP authentication.                                                                    |
-| `sftp_pass`                 | Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
-| `sftp_port`                 | SFTP server port. Default: `22`.                                                                     |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                |
-| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.        |
+| Parameter Name              | Description                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `file_format`               | Required when connecting to a directory. See [File Formats](./#file-formats).                                  |
+| `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
+| `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
+| `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
+| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                  |
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The FTP/SFTP connector page lists `ftp_user` / `ftp_pass` and `sftp_user` / `sftp_pass` with no Required marker, while the rows around them **do** carry one (`file_format` — "Required when connecting to a directory"; `ftp_port` — "Default: `21`"; the older snapshots even say "Optional" explicitly on port/timeout/hive). By contrast the credential rows read as optional. They are not.

**What the code does:** both store constructors hard-error when either credential is missing:

```rust
let user = params.get("user").map(ToOwned::to_owned).ok_or_else(|| {
    DataFusionError::Configuration("No user provided for FTP".to_string())
})?;
let password = params.get("pass").map(ToOwned::to_owned).ok_or_else(|| {
    DataFusionError::Configuration("No password provided for FTP".to_string())
})?;
```

There is no anonymous-FTP path — a dataset without credentials fails to register.

## Version scoping

Flat correction. The same `ok_or_else` hard-error is present at `v1.5.0` (`crates/runtime/src/object_store_registry/mod.rs`), `v1.9.0` and `v2.0.0` (`crates/runtime-object-store/src/registry/mod.rs`), so every snapshot inherited the same omission — 1 unversioned + 9 versioned files, 4 rows each.

## Verified source refs

- `spiceai/spiceai` @ `trunk` — [`crates/runtime-object-store/src/registry/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-object-store/src/registry/mod.rs) — `prepare_ftp_object_store` and `prepare_sftp_object_store`

The rest of both tables was audited in the same pass and is accurate: `ftp_port` defaults to `21` and `sftp_port` to `22` (`params.get("port").map_or("21"…)` / `…("22"…)`), and `client_timeout` really does leave the client with no timeout when unset (`.map(fundu::parse_duration).transpose()` → `None`). SFTP is username/password only — there is no key-based auth path — so the FTP-vs-SFTP comparison table is correct as written.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — 4 rows updated in each of 10 files (40 total)
- [x] `npx prettier --write` run on the changed files to match `.prettierrc` (accounts for the table-alignment churn in the diff)
- [x] Files updated: 10 (1 unversioned + 9 versioned)