### PR TITLE
docs(s3_vectors): enumerate which metadata predicates push down

### DIFF
--- a/website/docs/components/vectors/s3_vectors.md
+++ b/website/docs/components/vectors/s3_vectors.md
@@ -141,6 +141,25 @@ columns:
 
 This ensures results respect constraints like time ranges during similarity search.
 
+### Which Predicates Push Down
+
+S3 Vectors accepts a restricted, MongoDB-style metadata filter, so only some predicates translate. A predicate is pushed into the S3 Vectors query when it references a `filterable` metadata column **on the left-hand side** and takes one of these shapes:
+
+| Predicate                     | Pushed down when                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| `=`, `!=`                     | The literal is a boolean, a string, or a finite number                                             |
+| `<`, `<=`, `>`, `>=`          | The literal is **numeric** — an integer, or a finite float                                          |
+| `IS NULL`, `IS NOT NULL`      | Always                                                                                             |
+| `IN (…)`                      | The list is non-empty and every element is a boolean, a string, or a finite number                  |
+| `AND`, `OR`                   | Every sub-expression is itself pushable                                                            |
+
+Anything else is evaluated by the Spice query engine after candidates come back, which is correct but reads more rows from the index. The cases that most often surprise:
+
+- **Range comparisons against strings are not pushed down.** `WHERE category > 'm'` is a valid SQL predicate, but S3 Vectors supports range operators only on numeric metadata, so it is filtered locally. Equality and `IN` on strings do push down.
+- **The column must be the left operand.** `WHERE rating > 4` pushes down; `WHERE 4 < rating` does not.
+- **`NaN` and infinite floats never push down**, nor do `NULL` literals — use `IS NULL` instead of `= NULL`.
+- **Columns that are not `filterable` metadata cannot be pushed at all**, including derived columns such as the similarity distance the index adds to results.
+
 ## Optimizations
 
 Store non-filterable columns as metadata to avoid joins:


### PR DESCRIPTION
## Summary

The "Handling Filters" section told readers to mark columns `filterable` so filters push into S3 Vectors queries, but never said which predicates actually translate. S3 Vectors accepts a restricted MongoDB-style metadata filter, and spiceai/spiceai#12250 narrowed the advertised set after finding the provider was claiming *exact* pushdown for predicates S3 then rejected — a valid `WHERE category > 'm'` failed the query rather than falling back.

Adds a "Which Predicates Push Down" subsection enumerating the pushable shapes, plus the four cases that surprise: string range comparisons are not pushable (only numeric metadata supports range operators), the column must be the left operand, `NaN`/infinite floats and `NULL` literals never push, and non-`filterable` columns (including the derived distance column) cannot push at all.

## Source PRs

- spiceai/spiceai#12250 — bug: S3 Vectors advertises unsupported metadata predicates as exact pushdown (fixes #12243)

## Verification notes

Each row derived item-by-item from `supports_filter_expr` in `crates/s3_vectors_metadata_filter/src/datafusion.rs` on `origin/trunk`, not from the merged diff:

- `Eq | NotEq` → `is_supported_primitive_literal`, i.e. `is_supported_primitive_scalar`: `Boolean(Some(_))`, `Utf8(Some(_))`, `LargeUtf8(Some(_))`, or a supported numeric.
- `Lt | LtEq | Gt | GtEq` → `is_supported_numeric_literal` only: `Int8…Int64`, `UInt8…UInt64`, and `Float32`/`Float64` gated on `value.is_finite()`. This is the #12250 narrowing.
- `IsNull | IsNotNull` → column reference only. `InList` → non-empty list, every element a supported primitive. `And | Or` → recurses into children.
- Every other expression returns `false` → `TableProviderFilterPushDown::Unsupported`, so DataFusion evaluates it locally.
- The left-operand rule is `supports_column_ref(columns, &binary.left)` — only the left side is checked against the column list, so a reversed comparison is not pushable. The `Some(_)` patterns are why a `NULL` literal never qualifies.
- The filterable-column list in `query_provider_supports_filters_pushdown` (`crates/data_components/src/s3_vectors/vector_table.rs`) is the schema filtered by `is_filterable_column`, and excludes the derived distance column.

vNext-only: no release tag contains 6234bdc9e. The `version-2.1.x` snapshot documents a release where string range predicates were still advertised as exact pushdown, so it is intentionally untouched rather than described with the corrected rules.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only
- [x] Files updated: 1
