### PR TITLE
docs(embeddings): revision pinning works on huggingface, is rejected on model2vec

### DIFF
--- a/website/docs/components/embeddings/huggingface/deployment.md
+++ b/website/docs/components/embeddings/huggingface/deployment.md
@@ -31,6 +31,18 @@ The cache location honors the `HF_HUB_CACHE` environment variable. In containers
 
 Model weights are downloaded on first use into the HF Hub cache and reused on subsequent starts. Download retries follow the shared HTTP client's retry policy on transient failures.
 
+### Revision Pinning
+
+Append `:<revision>` to the repository id in `from:` to pin a branch, tag, or commit SHA — the same convention the `huggingface:` model source uses. The revision is split off the repository id and passed to the loader, so the pinned revision is what gets downloaded:
+
+```yaml
+embeddings:
+  - from: huggingface:huggingface.co/sentence-transformers/all-MiniLM-L6-v2:refs/pr/21
+    name: pinned_minilm
+```
+
+With no `:<revision>` suffix, the repository's default revision (`main`) is used. A trailing `:` with nothing after it is treated as no revision rather than as part of the repository name.
+
 ### TEI Queue Configuration
 
 The TEI pipeline has fixed queue parameters in the current release:
@@ -98,7 +110,6 @@ Embedding requests emit `text_embed` spans in [task history](../../../reference/
 
 - **TEI queue limits hardcoded**: `max_concurrent_requests` (512) and `max_batch_tokens` (16384) are not user-tunable in the current release.
 - **No auto-truncation for pooled embeds**: Inputs longer than `max_seq_length` fail unless truncated by the caller.
-- **Revision pinning caveat for embeddings**: Embeddings currently pass revision as `None` to the TEI loader; the effective revision is the default branch (`main`). Pin by mirroring a specific revision into the HF cache, or by pre-downloading and switching to a filesystem (`local`) embedding source.
 - **Single process loading**: Models load into the Spice process; no shared inference server across instances.
 
 ## Troubleshooting

--- a/website/docs/components/embeddings/model2vec.md
+++ b/website/docs/components/embeddings/model2vec.md
@@ -50,6 +50,17 @@ embeddings:
     name: local_model2vec
 ```
 
+## Revision Pinning Is Not Supported
+
+Unlike the [Hugging Face embedding source](./huggingface), `model2vec:` cannot load a pinned revision — the underlying loader takes no revision argument. A `from:` value shaped like `model2vec:org/model:revision` is rejected at load with an explicit error rather than being sent to the Hub, where the `:revision` suffix would become part of the repository name and fail as a `401 Unauthorized`:
+
+```
+The model 'org/model:revision' pins revision 'revision', but source 'model2vec' cannot load a pinned
+revision. Remove ':revision' to load the repository's default revision, and try again.
+```
+
+Load the repository's default revision instead, or pre-download the revision you want and reference it as a [local model](#local-models). Local paths are unaffected — a path that exists on disk is loaded as a path, even when it happens to look like a pinned repository id.
+
 ## Private Models
 
 Model2Vec supports private Hugging Face models with authentication:


### PR DESCRIPTION
## Summary

Revision pinning on embedding model sources, in both directions.

**Correction — Hugging Face.** The deployment guide's Known Limitations said "Embeddings currently pass revision as `None` to the TEI loader; the effective revision is the default branch (`main`)", and told readers to work around it by mirroring a revision into the HF cache or switching to a `local` source. That is no longer true: the HuggingFace embedding path now splits a pinned revision off the repository id and hands it to the loader. The stale bullet is removed and replaced with a "Revision Pinning" subsection documenting the `from: huggingface:huggingface.co/org/model:<revision>` syntax — the same convention the `huggingface:` *model* source already uses.

**New content — Model2Vec.** `model2vec:` still cannot pin a revision, and previously a pinned id reached the Hub as part of the *repository name* and surfaced as a bare `401 Unauthorized`. It is now rejected at load with an explicit unsupported-configuration error. Documented on the Model2Vec page, alongside the local-path escape hatch and the note that an existing local path is still loaded as a path even when it looks like a pinned repository id.

## Source PRs

- spiceai/spiceai#12446 — fix(models): pass the pinned revision to a HuggingFace embedding model (fixes #12430)
- spiceai/spiceai#12475 — fix(models): reject a pinned Model2Vec revision instead of 401ing on it (fixes #12445)

## Verification notes

- The HuggingFace claim was verified against `origin/trunk`, not the merged diff: `crates/runtime/src/model/embed.rs` calls `spicepod::component::model::split_hf_model_id(&id)` and passes the recovered `revision` into `TeiEmbed::from_hf(repo_id, revision, …)`, which forwards it to `download_hf_artifacts(model_id, revision, hf_token)` in `crates/llms/src/embeddings/candle/tei.rs`. Both ends of the wiring exist, so this is not a declaration-without-dispatch.
- The trailing-`:` behavior is the explicit `Some((repo_id, _)) => (repo_id, None)` arm in `split_hf_model_id`, not an assumption.
- The Model2Vec error text is quoted verbatim from the `#[snafu(display(...))]` on `EmbedError::RevisionPinningUnsupported` (`crates/llms/src/embeddings/mod.rs`) rather than paraphrased. The local-path carve-out is the `.filter(|_| !Path::new(&model_id).exists())` guard in the `model2vec` arm, which mirrors `from_pretrained`'s own path-before-repo precedence.
- Flip-flop guard: no prior merged docs PR touches HuggingFace embedding revision pinning, so this is not a reversal.
- vNext-only. Neither commit (20691bade, 6a749b0e2) is contained in any release tag, and the limitation was genuine in v2.0/v2.1 — so `versioned_docs/version-2.1.x` and `version-2.0.x` keep the bullet, which correctly describes those releases. This is deliberately *not* swept across snapshots.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only; the 2.0.x/2.1.x copies of the limitation are accurate for those releases and intentionally left in place
- [x] Files updated: 2
