### PR TITLE
Update openapi.json for spiceai/spiceai#12686

### DIFF
--- a/website/public/openapi.json
+++ b/website/public/openapi.json
@@ -428,6 +428,89 @@
         }
       }
     },
+    "/v1/datasets/{name}/cdc": {
+      "post": {
+        "tags": [
+          "Datasets"
+        ],
+        "summary": "Ingest Debezium CDC changes",
+        "description": "Push Debezium change events (JSON or Avro) directly into an accelerated\ndataset configured with `from: cdc:…` and `refresh_mode: changes`. No Kafka\nis required — use this as a Debezium Server / Embedded Engine sink.",
+        "operationId": "post_dataset_cdc",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Dataset name (must match a `from: cdc:…` dataset)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Debezium change event(s) as JSON or Avro",
+          "content": {
+            "application/avro": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            },
+            "application/json": {
+              "schema": {}
+            },
+            "application/vnd.debezium+avro": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                }
+              }
+            },
+            "application/vnd.debezium+json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Changes applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CdcIngestResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid body or format"
+          },
+          "403": {
+            "description": "Write access required"
+          },
+          "404": {
+            "description": "Dataset not registered for CDC ingest"
+          },
+          "501": {
+            "description": "CDC ingest requires the debezium feature in this build"
+          },
+          "503": {
+            "description": "Change stream stopped (dataset unloaded or reloading)"
+          },
+          "504": {
+            "description": "Timed out waiting for capacity or apply"
+          }
+        }
+      }
+    },
     "/v1/embeddings": {
       "post": {
         "tags": [
@@ -2565,6 +2648,24 @@
           "name": {
             "type": "string",
             "description": "The name of the catalog"
+          }
+        }
+      },
+      "CdcIngestResponse": {
+        "type": "object",
+        "required": [
+          "applied",
+          "dataset"
+        ],
+        "properties": {
+          "applied": {
+            "type": "integer",
+            "description": "Number of change rows applied.",
+            "minimum": 0
+          },
+          "dataset": {
+            "type": "string",
+            "description": "Dataset that received the changes."
           }
         }
       },


### PR DESCRIPTION
## Summary
- Updates `website/public/openapi.json` to match spiceai/spiceai PR https://github.com/spiceai/spiceai/pull/12686
- Adds `POST /v1/datasets/{name}/cdc` for pushing Debezium CDC changes (JSON or Avro) directly into an accelerated dataset configured with `from: cdc:…` and `refresh_mode: changes`, without requiring Kafka — for use as a Debezium Server / Embedded Engine sink
- Adds the `CdcIngestResponse` schema
- No manual docs page edits — CI will regenerate the API reference pages from the spec

## Testing
- Verified the JSON diff against upstream is purely additive (one new path, one new schema, nothing else touched)