### PR TITLE
docs(distributions): make install-nas and make build-runtime do not exist

### DIFF
--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -48,7 +48,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | --- | --- | --- | --- | --- |
 | Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
 | Data-only | `latest-data` | Nightly only | ✅ | ✅ |
-| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| NFS connector | — | Local build only | ❌ | ✅ |
 | Metal (macOS) | — | Local build only | ✅ | ✅ |
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
@@ -160,24 +160,27 @@ CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Ent
 CUDA_COMPUTE_CAP=89 make install-cuda
 ```
 
-## NAS Distribution
+## NFS Distribution
 
-The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+The NFS (Network File System) distribution adds support for the NFS data connector, enabling federated queries against data stored on NFS exports.
 
 :::note
-The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+The SMB data connector is **not** part of this variant — `smb` is in the default `spiced` feature set, so SMB shares are queryable from the standard distribution. Only the NFS connector is feature-gated.
+:::
+
+:::note
+The NFS connector is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
 :::
 
 **Included Features:**
 
 - All default features
-- SMB data connector
 - NFS data connector
 
 **Local Build:**
 
 ```bash
-make install-nas
+make install-nfs
 ```
 
 ## Allocator Variants
@@ -206,7 +209,7 @@ Uses the system's default allocator (glibc malloc on Linux).
 
 ## Platform Support
 
-| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| Platform                      | Default | Data            | NFS             | Metal | CUDA             |
 | ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
 | Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
 | Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
@@ -224,7 +227,7 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 | --------------------------------------- | ------------------------ |
 | General purpose with AI capabilities    | Default                  |
 | Data federation only, minimal footprint | Data (nightly)           |
-| Network attached storage (SMB/NFS)      | NAS                      |
+| NFS exports                             | NFS                      |
 | macOS with GPU acceleration             | Metal                    |
 | Linux with NVIDIA GPU                   | CUDA                     |
 | Memory allocation benchmarking          | Allocator variants       |
@@ -258,8 +261,8 @@ make install-odbc
 Custom distributions with specific feature combinations can be built:
 
 ```bash
-# Build with specific features
-SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build-runtime
+# Build with specific features (replaces the default feature set)
+SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build
 
 # Build with non-default features added to defaults
 SPICED_NON_DEFAULT_FEATURES="odbc" make install

--- a/website/versioned_docs/version-1.11.x/reference/distributions.md
+++ b/website/versioned_docs/version-1.11.x/reference/distributions.md
@@ -48,7 +48,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | --- | --- | --- | --- | --- |
 | Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
 | Data-only | `latest-data` | Nightly only | ✅ | ✅ |
-| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| NFS connector | — | Local build only | ❌ | ✅ |
 | Metal (macOS) | — | Local build only | ✅ | ✅ |
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
@@ -160,24 +160,27 @@ CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Ent
 CUDA_COMPUTE_CAP=89 make install-cuda
 ```
 
-## NAS Distribution
+## NFS Distribution
 
-The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+The NFS (Network File System) distribution adds support for the NFS data connector, enabling federated queries against data stored on NFS exports.
 
 :::note
-The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+The SMB data connector is **not** part of this variant — `smb` is in the default `spiced` feature set, so SMB shares are queryable from the standard distribution. Only the NFS connector is feature-gated.
+:::
+
+:::note
+The NFS connector is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
 :::
 
 **Included Features:**
 
 - All default features
-- SMB data connector
 - NFS data connector
 
 **Local Build:**
 
 ```bash
-make install-nas
+make install SPICED_NON_DEFAULT_FEATURES="nfs"
 ```
 
 ## Allocator Variants
@@ -206,7 +209,7 @@ Uses the system's default allocator (glibc malloc on Linux).
 
 ## Platform Support
 
-| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| Platform                      | Default | Data            | NFS             | Metal | CUDA             |
 | ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
 | Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
 | Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
@@ -224,7 +227,7 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 | --------------------------------------- | ------------------------ |
 | General purpose with AI capabilities    | Default                  |
 | Data federation only, minimal footprint | Data (nightly)           |
-| Network attached storage (SMB/NFS)      | NAS                      |
+| NFS exports                             | NFS                      |
 | macOS with GPU acceleration             | Metal                    |
 | Linux with NVIDIA GPU                   | CUDA                     |
 | Memory allocation benchmarking          | Allocator variants       |

--- a/website/versioned_docs/version-2.0.x/reference/distributions.md
+++ b/website/versioned_docs/version-2.0.x/reference/distributions.md
@@ -48,7 +48,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | --- | --- | --- | --- | --- |
 | Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
 | Data-only | `latest-data` | Nightly only | ✅ | ✅ |
-| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| NFS connector | — | Local build only | ❌ | ✅ |
 | Metal (macOS) | — | Local build only | ✅ | ✅ |
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
@@ -160,24 +160,27 @@ CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Ent
 CUDA_COMPUTE_CAP=89 make install-cuda
 ```
 
-## NAS Distribution
+## NFS Distribution
 
-The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+The NFS (Network File System) distribution adds support for the NFS data connector, enabling federated queries against data stored on NFS exports.
 
 :::note
-The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+The SMB data connector is **not** part of this variant — `smb` is in the default `spiced` feature set, so SMB shares are queryable from the standard distribution. Only the NFS connector is feature-gated.
+:::
+
+:::note
+The NFS connector is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
 :::
 
 **Included Features:**
 
 - All default features
-- SMB data connector
 - NFS data connector
 
 **Local Build:**
 
 ```bash
-make install-nas
+make install-nfs
 ```
 
 ## Allocator Variants
@@ -206,7 +209,7 @@ Uses the system's default allocator (glibc malloc on Linux).
 
 ## Platform Support
 
-| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| Platform                      | Default | Data            | NFS             | Metal | CUDA             |
 | ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
 | Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
 | Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
@@ -224,7 +227,7 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 | --------------------------------------- | ------------------------ |
 | General purpose with AI capabilities    | Default                  |
 | Data federation only, minimal footprint | Data (nightly)           |
-| Network attached storage (SMB/NFS)      | NAS                      |
+| NFS exports                             | NFS                      |
 | macOS with GPU acceleration             | Metal                    |
 | Linux with NVIDIA GPU                   | CUDA                     |
 | Memory allocation benchmarking          | Allocator variants       |
@@ -258,8 +261,8 @@ make install-odbc
 Custom distributions with specific feature combinations can be built:
 
 ```bash
-# Build with specific features
-SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build-runtime
+# Build with specific features (replaces the default feature set)
+SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build
 
 # Build with non-default features added to defaults
 SPICED_NON_DEFAULT_FEATURES="odbc" make install

--- a/website/versioned_docs/version-2.1.x/reference/distributions.md
+++ b/website/versioned_docs/version-2.1.x/reference/distributions.md
@@ -48,7 +48,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | --- | --- | --- | --- | --- |
 | Default (Data + AI) | `latest` | ✅ | ✅ | ✅ |
 | Data-only | `latest-data` | Nightly only | ✅ | ✅ |
-| NAS (SMB + NFS) | — | Local build only | ❌ | ✅ |
+| NFS connector | — | Local build only | ❌ | ✅ |
 | Metal (macOS) | — | Local build only | ✅ | ✅ |
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
@@ -160,24 +160,27 @@ CUDA distributions are available with the [Spice Cloud Platform and Spice.ai Ent
 CUDA_COMPUTE_CAP=89 make install-cuda
 ```
 
-## NAS Distribution
+## NFS Distribution
 
-The NAS (Network Attached Storage) distribution adds support for SMB and NFS data connectors, enabling federated queries against data stored on network file shares.
+The NFS (Network File System) distribution adds support for the NFS data connector, enabling federated queries against data stored on NFS exports.
 
 :::note
-The NAS distribution is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
+The SMB data connector is **not** part of this variant — `smb` is in the default `spiced` feature set, so SMB shares are queryable from the standard distribution. Only the NFS connector is feature-gated.
+:::
+
+:::note
+The NFS connector is available with [Spice.ai Enterprise](https://spice.ai/pricing). Open source users can build locally for development and testing.
 :::
 
 **Included Features:**
 
 - All default features
-- SMB data connector
 - NFS data connector
 
 **Local Build:**
 
 ```bash
-make install-nas
+make install-nfs
 ```
 
 ## Allocator Variants
@@ -206,7 +209,7 @@ Uses the system's default allocator (glibc malloc on Linux).
 
 ## Platform Support
 
-| Platform                      | Default | Data            | NAS             | Metal | CUDA             |
+| Platform                      | Default | Data            | NFS             | Metal | CUDA             |
 | ----------------------------- | ------- | --------------- | --------------- | ----- | ---------------- |
 | Linux x86_64                  | ✅       | Nightly         | Enterprise only | ❌     | Cloud/Enterprise |
 | Linux aarch64                 | ✅       | Nightly         | Enterprise only | ❌     | ❌                |
@@ -224,7 +227,7 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 | --------------------------------------- | ------------------------ |
 | General purpose with AI capabilities    | Default                  |
 | Data federation only, minimal footprint | Data (nightly)           |
-| Network attached storage (SMB/NFS)      | NAS                      |
+| NFS exports                             | NFS                      |
 | macOS with GPU acceleration             | Metal                    |
 | Linux with NVIDIA GPU                   | CUDA                     |
 | Memory allocation benchmarking          | Allocator variants       |
@@ -258,8 +261,8 @@ make install-odbc
 Custom distributions with specific feature combinations can be built:
 
 ```bash
-# Build with specific features
-SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build-runtime
+# Build with specific features (replaces the default feature set)
+SPICED_CUSTOM_FEATURES="duckdb,postgres,sqlite,models" make build
 
 # Build with non-default features added to defaults
 SPICED_NON_DEFAULT_FEATURES="odbc" make install


### PR DESCRIPTION
## Summary

`reference/distributions.md` documents two `make` targets that do not exist and mis-scopes which connectors are feature-gated. All three claims are copy-paste-and-it-fails errors for a reader following the page.

### 1. `make install-nas` does not exist

The string `nas` appears nowhere in the Makefile at any release checked. The real invocation differs by version:

| Version | Correct command |
| --- | --- |
| trunk, v2.0.1, v2.1.4 | `make install-nfs` (`Makefile:433-435`) |
| v1.11.6 | no convenience target exists — `make install SPICED_NON_DEFAULT_FEATURES="nfs"` |

### 2. `make build-runtime` does not exist (trunk / 2.0.x / 2.1.x)

The build targets are `build` (`build: build-cli build-spiced`) and `install`. Both `SPICED_CUSTOM_FEATURES` and `SPICED_NON_DEFAULT_FEATURES` are consumed by `bin/spiced/Makefile`, which is reached through `build-spiced`, so the variables in the example are correct — only the target name was wrong.

`build-runtime` **did** exist at v1.11.6 (`Makefile:15-16`), so the 1.11.x snapshot is deliberately left unchanged on this point.

### 3. "NAS (SMB + NFS)" mis-scopes SMB

`smb` is in the `spiced` `default` feature set — and in `SPICED_DATA_FEATURES` — at v1.11.6, v2.0.1, v2.1.4 and trunk. SMB therefore ships in the standard open-source build and is not a locally-built NAS-only variant. Only `nfs` is feature-gated.

This also resolves a doc-vs-doc contradiction already present in the repo: `components/data-connectors/nfs.md` carries the Enterprise-edition callout, while `components/data-connectors/smb.md` correctly carries none.

The variant is renamed `NAS` → `NFS` in the availability table, the section heading and body, the platform-support table header, and the "Choosing a Distribution" table.

## What changed

| File | install-nas → | build-runtime → | SMB rescoped |
| --- | --- | --- | --- |
| `website/docs/…/distributions.md` | `make install-nfs` | `make build` | ✅ |
| `versioned_docs/version-2.1.x/…` | `make install-nfs` | `make build` | ✅ |
| `versioned_docs/version-2.0.x/…` | `make install-nfs` | `make build` | ✅ |
| `versioned_docs/version-1.11.x/…` | `make install SPICED_NON_DEFAULT_FEATURES="nfs"` | unchanged (target existed) | ✅ |

All four copies of the page were byte-identical before this change; `distributions.md` does not exist below 1.11.x.

Historical release notes under `website/releases/` also contain the old `NAS (SMB + NFS)` row and are intentionally left as-published.

## Verified source refs

- `spiceai/spiceai@origin/trunk` — [`Makefile`](https://github.com/spiceai/spiceai/blob/trunk/Makefile) (`install-nfs`, `build`, no `install-nas`/`build-runtime`)
- `spiceai/spiceai@origin/trunk` — [`bin/spiced/Cargo.toml`](https://github.com/spiceai/spiceai/blob/trunk/bin/spiced/Cargo.toml) (`default` feature set contains `smb`, not `nfs`)
- `spiceai/spiceai@origin/trunk` — [`bin/spiced/Makefile`](https://github.com/spiceai/spiceai/blob/trunk/bin/spiced/Makefile) (`SPICED_CUSTOM_FEATURES` / `SPICED_NON_DEFAULT_FEATURES` plumbing)
- Tags checked individually: `v1.11.6`, `v2.0.1`, `v2.1.4`

## Test plan

- [x] `npm run build` passes (exit 0, "Generated static files in build")
- [x] Versioned-docs propagation checked — residual grep: `install-nas` 0 files; `build-runtime` 0 in vNext/2.0.x/2.1.x and 1 in 1.11.x (intended); `NAS (SMB + NFS)` 0 in `docs/` + `versioned_docs/`
- [x] Files updated: 4 (matches the diff)
