### PR TITLE
docs(acceleration): append compares a day-granular time column inclusively

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -52,7 +52,7 @@ datasets:
 
 ### Append
 
-Using `refresh_mode: append` requires the use of a [`time_column` dataset parameter](../../reference/spicepod/datasets#time_column), specifying a column to compare the local acceleration against the remote source. Data will be incrementally refreshed where the `time_column` value in the remote source is greater-than (gt) the `max(time_column)` value in the local acceleration.
+Using `refresh_mode: append` requires the use of a [`time_column` dataset parameter](../../reference/spicepod/datasets#time_column), specifying a column to compare the local acceleration against the remote source. Data will be incrementally refreshed where the `time_column` value in the remote source is greater-than (gt) the `max(time_column)` value in the local acceleration. A date-typed `time_column` (`time_format: date`) is compared greater-than-or-equal (gte) against the start of that day instead, since every row of a day shares one value — see [Day-Granular Time Columns](./refresh-modes/append#day-granular-time-columns).
 
 E.g.
 

--- a/website/docs/features/data-acceleration/refresh-modes/append.md
+++ b/website/docs/features/data-acceleration/refresh-modes/append.md
@@ -17,7 +17,7 @@ Use `append` when:
 
 ## Configuration
 
-`append` mode requires a [`time_column`](../../../reference/spicepod/datasets#time_column) that identifies new rows by comparing the local maximum value to the source. Data is incrementally refreshed where `time_column` in the source is greater than `max(time_column)` in the acceleration.
+`append` mode requires a [`time_column`](../../../reference/spicepod/datasets#time_column) that identifies new rows by comparing the local maximum value to the source. Data is incrementally refreshed where `time_column` in the source is greater than `max(time_column)` in the acceleration — see [Day-Granular Time Columns](#day-granular-time-columns) for the one case where that comparison is inclusive instead.
 
 ```yaml
 datasets:
@@ -33,6 +33,16 @@ datasets:
 ## Late-Arriving Data
 
 To account for clock skew or late-arriving rows, configure an overlap window with [`acceleration.refresh_append_overlap`](../../../reference/spicepod/datasets#accelerationrefresh_append_overlap). Rows within the overlap are re-read on each refresh.
+
+## Day-Granular Time Columns
+
+A date-typed `time_column` (Arrow `Date32`, configured as [`time_format: date`](../../../reference/spicepod/datasets#time_format)) carries no time of day, so every row of a given day shares one value. A strictly-greater comparison against the accelerated maximum would exclude every row that arrives later for the day already loaded, on that refresh and on every one after it.
+
+For a day-granular time column the comparison is therefore **inclusive**, against the start of the high-water mark's day, and Spice's exact-row de-duplication drops the already-loaded rows that come back so nothing is appended twice. A `time_partition_column` of the same type is floored to that same day boundary, so the partition predicate does not exclude the day the new rows are in.
+
+The trade-off is that each refresh re-reads the boundary day from the source rather than nothing — the minimum needed to see that day's new rows at all. Sub-day time columns are unaffected and keep the strict comparison; if a single day is large, bound the re-read by using a sub-day `time_column`.
+
+`refresh_append_overlap` still subtracts its duration from the high-water mark, but on a day-granular column the resulting window is quantized to the day boundary, so an overlap shorter than a day re-reads the whole boundary day.
 
 ## Partition Pruning with `time_partition_column`
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12500` changes the append high-water-mark comparison for a day-granular time column, which the refresh docs describe as unconditionally strict.

A `Date32` `time_column` carries no time of day, so every row of a day casts to the same instant. Filtering the source strictly greater than `max(time_column)` therefore excluded every row that arrived later for the day already loaded — permanently, since the mark never moves past that day until the source does. `convert_high_water_mark` (`crates/util/src/timestamp_filter.rs`) now compares `>=` against the start of the mark's day when the column `is_day_granular`, and the same widening is applied to the de-duplication filter in `refresh_task.rs` so the re-fetched rows are dropped rather than appended twice. A `time_partition_column` literal is floored to the same day boundary, since a partition predicate built from a sub-day mark would otherwise exclude the very partition the new rows are in.

`Date64` is handled in code but unreachable today — `validate_time_format` rejects it for every `TimeFormat` — so the docs describe the live `Date32` / `time_format: date` case.

Documents the behavior, its cost (each refresh re-reads the boundary day), and its interaction with `refresh_append_overlap`, whose window is quantized to the day boundary on such a column.

vNext-only: `14888458` is in no release tag, so the versioned snapshots correctly describe the previous behavior.

## Source PRs

- spiceai/spiceai#12500 — fix(runtime): compare an append high-water mark inclusively on a day-granular time column

## Doc pages changed

- `website/docs/features/data-acceleration/refresh-modes/append.md` — new "Day-Granular Time Columns" section, plus a pointer from Configuration
- `website/docs/features/data-acceleration/data-refresh.md` — the `append` paragraph restated the strict `gt` rule unconditionally

## Test plan

- [x] `cd website && npm run build` passes (new cross-page anchor `#day-granular-time-columns` resolves)
- [x] Versioned-docs propagation checked — vNext-only (source commit in no release tag)
- [x] Files updated: 2
