### PR TITLE
docs(cli): document spice dataset add and the manifest body flags

### DIFF
--- a/website/docs/cli/reference/dataset.md
+++ b/website/docs/cli/reference/dataset.md
@@ -7,27 +7,56 @@ pagination_next: null
 
 ---
 
-Configure a Spice dataset.
+Add or configure dataset entries in `spicepod.yaml`.
 
 ### Usage
 
 ```shell
-spice dataset [command]
+spice dataset [command] [name] [flags]
 ```
 
 Available `command`s:
 
-- `configure`: Create/configure a dataset directly from the command-line, including customizing components such as whether to add acceleration to the connector.
+- `add`: Add a new dataset entry. Fails if a dataset with that name already exists.
+- `configure`: Add or update a dataset entry in place. Run with no name and no body flags to configure a dataset through interactive prompts instead.
 
 **Note**: In order to run `spice dataset configure`, there _must_ be a `spicepod.yaml` file in the root of your project directory. To create this file, see [`spice init`](./init).
 
 #### Flags
 
+Both `add` and `configure` accept the same body flags, shared with the other Spicepod manifest editors (`spice model`, `spice catalog`, `spice view`, and so on):
+
+- `--from <SOURCE>` Provider or URI for the dataset, e.g. `s3://bucket/key` or `databricks:catalog.schema.table`
+- `--ref <PATH>` Add a dataset reference (`ref:`) instead of an inline definition
+- `--description <TEXT>` Human-readable description
+- `--param <KEY=VALUE>` Add a `params:` entry. Repeatable. Values are stored as strings unless prefixed with `yaml:` (parsed as typed YAML) or `string:` (stored as a literal string after the prefix).
+- `--env <KEY=VALUE>` Add an `env:` entry. Repeatable. Values are always stored as strings — the `yaml:` and `string:` prefixes do not apply.
+- `--set <PATH=VALUE>` Set any schema field by dotted path, e.g. `--set acceleration.enabled=yaml:true`. Repeatable, with the same value-prefix rules as `--param`.
+- `--depends-on <NAME>` Append an entry to `dependsOn:`. Repeatable.
+- `--enable` Set `enabled: true`
+- `--disable` Set `enabled: false`
+- `--file <PATH>` Read the dataset body from a YAML or JSON file
+- `--stdin` Read the dataset body from stdin
+- `--manifest <PATH>` Edit a non-default Spicepod file
 - `-h`, `--help` Print this help message
 
-### Example
+### Examples
 
-When running `spice dataset configure`, Spice will prompt for four inputs:
+Add a Parquet dataset on S3:
+
+```shell
+>>> spice dataset add taxi_trips --from s3://my-bucket/trips.parquet --param file_format=parquet
+```
+
+Enable acceleration on an existing dataset:
+
+```shell
+>>> spice dataset configure taxi_trips --set acceleration.enabled=yaml:true
+```
+
+### Interactive example
+
+When running `spice dataset configure` with no name and no body flags, Spice will prompt for four inputs:
 
 1.  The name of the dataset, labelled by `(1)` below.
 2.  The description of the dataset, labelled by `(2)` below.

--- a/website/versioned_docs/version-2.0.x/cli/reference/dataset.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/dataset.md
@@ -7,27 +7,56 @@ pagination_next: null
 
 ---
 
-Configure a Spice dataset.
+Add or configure dataset entries in `spicepod.yaml`.
 
 ### Usage
 
 ```shell
-spice dataset [command]
+spice dataset [command] [name] [flags]
 ```
 
 Available `command`s:
 
-- `configure`: Create/configure a dataset directly from the command-line, including customizing components such as whether to add acceleration to the connector.
+- `add`: Add a new dataset entry. Fails if a dataset with that name already exists.
+- `configure`: Add or update a dataset entry in place. Run with no name and no body flags to configure a dataset through interactive prompts instead.
 
 **Note**: In order to run `spice dataset configure`, there _must_ be a `spicepod.yaml` file in the root of your project directory. To create this file, see [`spice init`](./init).
 
 #### Flags
 
+Both `add` and `configure` accept the same body flags, shared with the other Spicepod manifest editors (`spice model`, `spice catalog`, `spice view`, and so on):
+
+- `--from <SOURCE>` Provider or URI for the dataset, e.g. `s3://bucket/key` or `databricks:catalog.schema.table`
+- `--ref <PATH>` Add a dataset reference (`ref:`) instead of an inline definition
+- `--description <TEXT>` Human-readable description
+- `--param <KEY=VALUE>` Add a `params:` entry. Repeatable. Values are stored as strings unless prefixed with `yaml:` (parsed as typed YAML) or `string:` (stored as a literal string after the prefix).
+- `--env <KEY=VALUE>` Add an `env:` entry. Repeatable. Values are always stored as strings — the `yaml:` and `string:` prefixes do not apply.
+- `--set <PATH=VALUE>` Set any schema field by dotted path, e.g. `--set acceleration.enabled=yaml:true`. Repeatable, with the same value-prefix rules as `--param`.
+- `--depends-on <NAME>` Append an entry to `dependsOn:`. Repeatable.
+- `--enable` Set `enabled: true`
+- `--disable` Set `enabled: false`
+- `--file <PATH>` Read the dataset body from a YAML or JSON file
+- `--stdin` Read the dataset body from stdin
+- `--manifest <PATH>` Edit a non-default Spicepod file
 - `-h`, `--help` Print this help message
 
-### Example
+### Examples
 
-When running `spice dataset configure`, Spice will prompt for four inputs:
+Add a Parquet dataset on S3:
+
+```shell
+>>> spice dataset add taxi_trips --from s3://my-bucket/trips.parquet --param file_format=parquet
+```
+
+Enable acceleration on an existing dataset:
+
+```shell
+>>> spice dataset configure taxi_trips --set acceleration.enabled=yaml:true
+```
+
+### Interactive example
+
+When running `spice dataset configure` with no name and no body flags, Spice will prompt for four inputs:
 
 1.  The name of the dataset, labelled by `(1)` below.
 2.  The description of the dataset, labelled by `(2)` below.

--- a/website/versioned_docs/version-2.1.x/cli/reference/dataset.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/dataset.md
@@ -7,27 +7,56 @@ pagination_next: null
 
 ---
 
-Configure a Spice dataset.
+Add or configure dataset entries in `spicepod.yaml`.
 
 ### Usage
 
 ```shell
-spice dataset [command]
+spice dataset [command] [name] [flags]
 ```
 
 Available `command`s:
 
-- `configure`: Create/configure a dataset directly from the command-line, including customizing components such as whether to add acceleration to the connector.
+- `add`: Add a new dataset entry. Fails if a dataset with that name already exists.
+- `configure`: Add or update a dataset entry in place. Run with no name and no body flags to configure a dataset through interactive prompts instead.
 
 **Note**: In order to run `spice dataset configure`, there _must_ be a `spicepod.yaml` file in the root of your project directory. To create this file, see [`spice init`](./init).
 
 #### Flags
 
+Both `add` and `configure` accept the same body flags, shared with the other Spicepod manifest editors (`spice model`, `spice catalog`, `spice view`, and so on):
+
+- `--from <SOURCE>` Provider or URI for the dataset, e.g. `s3://bucket/key` or `databricks:catalog.schema.table`
+- `--ref <PATH>` Add a dataset reference (`ref:`) instead of an inline definition
+- `--description <TEXT>` Human-readable description
+- `--param <KEY=VALUE>` Add a `params:` entry. Repeatable. Values are stored as strings unless prefixed with `yaml:` (parsed as typed YAML) or `string:` (stored as a literal string after the prefix).
+- `--env <KEY=VALUE>` Add an `env:` entry. Repeatable. Values are always stored as strings — the `yaml:` and `string:` prefixes do not apply.
+- `--set <PATH=VALUE>` Set any schema field by dotted path, e.g. `--set acceleration.enabled=yaml:true`. Repeatable, with the same value-prefix rules as `--param`.
+- `--depends-on <NAME>` Append an entry to `dependsOn:`. Repeatable.
+- `--enable` Set `enabled: true`
+- `--disable` Set `enabled: false`
+- `--file <PATH>` Read the dataset body from a YAML or JSON file
+- `--stdin` Read the dataset body from stdin
+- `--manifest <PATH>` Edit a non-default Spicepod file
 - `-h`, `--help` Print this help message
 
-### Example
+### Examples
 
-When running `spice dataset configure`, Spice will prompt for four inputs:
+Add a Parquet dataset on S3:
+
+```shell
+>>> spice dataset add taxi_trips --from s3://my-bucket/trips.parquet --param file_format=parquet
+```
+
+Enable acceleration on an existing dataset:
+
+```shell
+>>> spice dataset configure taxi_trips --set acceleration.enabled=yaml:true
+```
+
+### Interactive example
+
+When running `spice dataset configure` with no name and no body flags, Spice will prompt for four inputs:
 
 1.  The name of the dataset, labelled by `(1)` below.
 2.  The description of the dataset, labelled by `(2)` below.


### PR DESCRIPTION
## Summary

The `spice dataset` CLI reference has been stale since the CLI manifest-editing overhaul (spiceai/spiceai#10815, merged 2026-05-18, first released in **v2.0.0**).

**What the docs said**

- Available `command`s: only `configure`, described as purely interactive.
- Flags: only `-h`, `--help`.

**What the code does** (`bin/spice/src/commands/dataset.rs`, `bin/spice/src/commands/component.rs` @ `trunk`)

- `DatasetCommands` has **two** variants — `Add(ComponentAddArgs)` and `Configure(ComponentConfigureArgs)`.
- Both flatten `CommonComponentOptions`, so both accept `--manifest`, `--from`, `--ref`, `--file`, `--stdin`, `--description`, `--set`, `--param`, `--env`, `--depends-on`, `--enable`, `--disable`.
- `configure` only runs the interactive prompts when `has_manifest_edits()` is false — i.e. no name **and** no body flags. With a name or any body flag it edits `spicepod.yaml` in place.
- `add` fails when the dataset already exists (`"{} '{name}' already exists. Use \`spice {} configure {name}\` to update it."`, `component.rs:768`).

## What changed

- Documented the `add` subcommand and the interactive-only condition on `configure`.
- Documented the full body-flag set, with the `yaml:` / `string:` value prefixes for `--param` and `--set` (`parse_string_or_yaml_prefixed_value`, `component.rs:1115`).
- Called out that `--env` does **not** honour those prefixes — it goes through `parse_string_pair` and is always stored as a string (`component.rs:718`).
- Added two non-interactive examples; kept the existing interactive walkthrough under its own heading (verified still accurate against `configure_dataset()`).

## Version scope

The command enum is byte-identical at `v2.0.1`, `v2.1.4`, and `trunk`, and the feature is absent in `v1.11.6` — so this lands in vNext + `version-2.0.x` + `version-2.1.x` only (3 files). Older snapshots correctly document the pre-2.0 CLI.

## Source ref

- spiceai/spiceai @ `trunk` — [`bin/spice/src/commands/dataset.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/dataset.rs), [`bin/spice/src/commands/component.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/component.rs)
- Source PR: spiceai/spiceai#10815 — Improve Spice CLI manifest editing and direct command modes

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (vNext + 2.0.x + 2.1.x; 1.x correctly excluded)
- [x] Files updated: 3 (matches the diff)