### PR TITLE
docs(cli): list the 14 missing Spicepod manifest-editing commands

### DIFF
--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -19,34 +19,61 @@ spice [command] [--help]
 | ---------------------------------- | ---------------------------------------------------------------------- |
 | acceleration                       | Manage dataset acceleration features                                   |
 | [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                          |
+| catalog                            | Add or configure catalog entries in `spicepod.yaml`                    |
 | [catalogs](reference/catalogs)     | List [catalogs](../components/catalogs) loaded by the Spice runtime |
 | [chat](reference/chat)             | Chat with an LLM                                                       |
 | [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
 | [connect](reference/connect)       | Enroll this host with Spice Cloud (Cloud Connect)                      |
-| [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
+| [dataset](reference/dataset)       | Add or configure dataset entries in `spicepod.yaml`                    |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
+| embedding                          | Add or configure embedding entries in `spicepod.yaml`                  |
+| extension                          | Add or configure entries under `extensions:` in `spicepod.yaml`        |
 | [feedback](reference/feedback)     | Open the Spice.ai community Slack to share feedback                    |
+| function                           | Add or configure function entries in `spicepod.yaml`                   |
 | help                               | Help about any command                                                 |
 | [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                     |
 | [install](reference/install)       | Install or reinstall the Spice.ai runtime                              |
 | [login](reference/login)           | Login to Spice.ai or configure credentials for data sources            |
+| management                         | Configure the `management:` section of `spicepod.yaml`                 |
+| metadata                           | Add or configure key/value entries under `metadata:` in `spicepod.yaml` |
+| model                              | Add or configure model entries in `spicepod.yaml`                      |
 | [models](reference/models)         | Lists models loaded by the Spice runtime                               |
 | [nsql](reference/nsql)             | Text-to-SQL REPL - translate natural language to SQL                   |
 | [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                            |
 | [query](reference/query)           | Submit an async query or start an interactive async query REPL         |
 | [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                          |
+| reranker                           | Add or configure reranker entries in `spicepod.yaml`                   |
 | [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary          |
+| runtime                            | Configure the `runtime:` section of `spicepod.yaml`                    |
 | [search](reference/search)         | Search datasets with embeddings                                        |
+| secret                             | Add or configure secret entries in `spicepod.yaml`                     |
+| snapshots                          | Configure the `snapshots:` section of `spicepod.yaml`                  |
 | [sql](reference/sql)               | Start an interactive SQL query session against the Spice runtime       |
 | [spiced](reference/spiced)         | Spice runtime binary — direct invocation reference                     |
 | [status](reference/status)         | Spice runtime status                                                   |
+| tool                               | Add or configure tool entries in `spicepod.yaml`                       |
 | [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
 | [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest or specified version   |
 | [validate](reference/validate)     | Validate a spicepod.yaml without starting the runtime                  |
 | [version](reference/version)       | Spice CLI version                                                      |
+| view                               | Add or configure view entries in `spicepod.yaml`                       |
+| worker                             | Add or configure worker entries in `spicepod.yaml`                     |
 | workers                            | Lists workers loaded by the Spice runtime                              |
+
+### Spicepod manifest editors
+
+`catalog`, `dataset`, `embedding`, `function`, `model`, `reranker`, `secret`, `tool`, `view`, and `worker` all edit the matching list section of `spicepod.yaml` and share the same two subcommands and body flags:
+
+```shell
+spice <component> add <name> [body flags]        # add a new entry; fails if it already exists
+spice <component> configure <name> [body flags]  # add or update an entry in place
+```
+
+`runtime`, `management`, and `snapshots` edit singleton sections, so they expose only `configure`. `extension` edits the `extensions:` map (`add` and `configure`), and `metadata` edits the `metadata:` map (`add`, `configure`, and `set <KEY> <VALUE>`).
+
+See [`spice dataset`](reference/dataset) for the shared body-flag reference. The other list editors accept the same flags, plus the type-specific ones: `--sql` / `--sql-ref` for views, `--cron` for workers, and `--body` / `--body-ref` for functions. Run `spice <command> --help` for the per-command help.
 
 ### Command Flags
 

--- a/website/versioned_docs/version-2.0.x/cli/reference/index.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/index.md
@@ -19,34 +19,61 @@ spice [command] [--help]
 | ---------------------------------- | ---------------------------------------------------------------------- |
 | acceleration                       | Manage dataset acceleration features                                   |
 | [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                          |
+| catalog                            | Add or configure catalog entries in `spicepod.yaml`                    |
 | [catalogs](reference/catalogs)     | List [catalogs](../components/catalogs) loaded by the Spice runtime |
 | [chat](reference/chat)             | Chat with an LLM                                                       |
 | [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
 | [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
-| [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
+| [dataset](reference/dataset)       | Add or configure dataset entries in `spicepod.yaml`                    |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
+| embedding                          | Add or configure embedding entries in `spicepod.yaml`                  |
+| extension                          | Add or configure entries under `extensions:` in `spicepod.yaml`        |
 | [feedback](reference/feedback)     | Open the Spice.ai community Slack to share feedback                    |
+| function                           | Add or configure function entries in `spicepod.yaml`                   |
 | help                               | Help about any command                                                 |
 | [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                     |
 | [install](reference/install)       | Install or reinstall the Spice.ai runtime                              |
 | [login](reference/login)           | Login to Spice.ai or configure credentials for data sources            |
+| management                         | Configure the `management:` section of `spicepod.yaml`                 |
+| metadata                           | Add or configure key/value entries under `metadata:` in `spicepod.yaml` |
+| model                              | Add or configure model entries in `spicepod.yaml`                      |
 | [models](reference/models)         | Lists models loaded by the Spice runtime                               |
 | [nsql](reference/nsql)             | Text-to-SQL REPL - translate natural language to SQL                   |
 | [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                            |
 | [query](reference/query)           | Submit an async query or start an interactive async query REPL         |
 | [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                          |
+| reranker                           | Add or configure reranker entries in `spicepod.yaml`                   |
 | [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary          |
+| runtime                            | Configure the `runtime:` section of `spicepod.yaml`                    |
 | [search](reference/search)         | Search datasets with embeddings                                        |
+| secret                             | Add or configure secret entries in `spicepod.yaml`                     |
+| snapshots                          | Configure the `snapshots:` section of `spicepod.yaml`                  |
 | [sql](reference/sql)               | Start an interactive SQL query session against the Spice runtime       |
 | [spiced](reference/spiced)         | Spice runtime binary — direct invocation reference                     |
 | [status](reference/status)         | Spice runtime status                                                   |
+| tool                               | Add or configure tool entries in `spicepod.yaml`                       |
 | [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
 | [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest or specified version   |
 | [validate](reference/validate)     | Validate a spicepod.yaml without starting the runtime                  |
 | [version](reference/version)       | Spice CLI version                                                      |
+| view                               | Add or configure view entries in `spicepod.yaml`                       |
+| worker                             | Add or configure worker entries in `spicepod.yaml`                     |
 | workers                            | Lists workers loaded by the Spice runtime                              |
+
+### Spicepod manifest editors
+
+`catalog`, `dataset`, `embedding`, `function`, `model`, `reranker`, `secret`, `tool`, `view`, and `worker` all edit the matching list section of `spicepod.yaml` and share the same two subcommands and body flags:
+
+```shell
+spice <component> add <name> [body flags]        # add a new entry; fails if it already exists
+spice <component> configure <name> [body flags]  # add or update an entry in place
+```
+
+`runtime`, `management`, and `snapshots` edit singleton sections, so they expose only `configure`. `extension` edits the `extensions:` map (`add` and `configure`), and `metadata` edits the `metadata:` map (`add`, `configure`, and `set <KEY> <VALUE>`).
+
+See [`spice dataset`](reference/dataset) for the shared body-flag reference. The other list editors accept the same flags, plus the type-specific ones: `--sql` / `--sql-ref` for views, `--cron` for workers, and `--body` / `--body-ref` for functions. Run `spice <command> --help` for the per-command help.
 
 ### Command Flags
 

--- a/website/versioned_docs/version-2.1.x/cli/reference/index.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/index.md
@@ -19,34 +19,61 @@ spice [command] [--help]
 | ---------------------------------- | ---------------------------------------------------------------------- |
 | acceleration                       | Manage dataset acceleration features                                   |
 | [add](reference/add)               | Add Spicepod - adds a Spicepod to the project                          |
+| catalog                            | Add or configure catalog entries in `spicepod.yaml`                    |
 | [catalogs](reference/catalogs)     | List [catalogs](../components/catalogs) loaded by the Spice runtime |
 | [chat](reference/chat)             | Chat with an LLM                                                       |
 | [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
 | cloud                              | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
 | [connect](reference/connect)       | Connect to a Spice.ai Cloud Platform app                               |
-| [dataset](reference/dataset)       | Dataset operations (configure datasets)                                |
+| [dataset](reference/dataset)       | Add or configure dataset entries in `spicepod.yaml`                    |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
+| embedding                          | Add or configure embedding entries in `spicepod.yaml`                  |
+| extension                          | Add or configure entries under `extensions:` in `spicepod.yaml`        |
 | [feedback](reference/feedback)     | Open the Spice.ai community Slack to share feedback                    |
+| function                           | Add or configure function entries in `spicepod.yaml`                   |
 | help                               | Help about any command                                                 |
 | [init](reference/init)             | Initialize Spice app - creates a new spicepod.yaml                     |
 | [install](reference/install)       | Install or reinstall the Spice.ai runtime                              |
 | [login](reference/login)           | Login to Spice.ai or configure credentials for data sources            |
+| management                         | Configure the `management:` section of `spicepod.yaml`                 |
+| metadata                           | Add or configure key/value entries under `metadata:` in `spicepod.yaml` |
+| model                              | Add or configure model entries in `spicepod.yaml`                      |
 | [models](reference/models)         | Lists models loaded by the Spice runtime                               |
 | [nsql](reference/nsql)             | Text-to-SQL REPL - translate natural language to SQL                   |
 | [pods](reference/pods)             | Lists Spicepods loaded by the Spice runtime                            |
 | [query](reference/query)           | Submit an async query or start an interactive async query REPL         |
 | [refresh](reference/refresh)       | Refresh a dataset loaded by the Spice runtime                          |
+| reranker                           | Add or configure reranker entries in `spicepod.yaml`                   |
 | [run](reference/run)               | Run Spice - starts the Spice runtime, installing if necessary          |
+| runtime                            | Configure the `runtime:` section of `spicepod.yaml`                    |
 | [search](reference/search)         | Search datasets with embeddings                                        |
+| secret                             | Add or configure secret entries in `spicepod.yaml`                     |
+| snapshots                          | Configure the `snapshots:` section of `spicepod.yaml`                  |
 | [sql](reference/sql)               | Start an interactive SQL query session against the Spice runtime       |
 | [spiced](reference/spiced)         | Spice runtime binary — direct invocation reference                     |
 | [status](reference/status)         | Spice runtime status                                                   |
+| tool                               | Add or configure tool entries in `spicepod.yaml`                       |
 | [trace](reference/trace)           | Return traces for operations that occurred in Spice                    |
 | [upgrade](reference/upgrade)       | Upgrades the Spice CLI and runtime to the latest or specified version   |
 | [validate](reference/validate)     | Validate a spicepod.yaml without starting the runtime                  |
 | [version](reference/version)       | Spice CLI version                                                      |
+| view                               | Add or configure view entries in `spicepod.yaml`                       |
+| worker                             | Add or configure worker entries in `spicepod.yaml`                     |
 | workers                            | Lists workers loaded by the Spice runtime                              |
+
+### Spicepod manifest editors
+
+`catalog`, `dataset`, `embedding`, `function`, `model`, `reranker`, `secret`, `tool`, `view`, and `worker` all edit the matching list section of `spicepod.yaml` and share the same two subcommands and body flags:
+
+```shell
+spice <component> add <name> [body flags]        # add a new entry; fails if it already exists
+spice <component> configure <name> [body flags]  # add or update an entry in place
+```
+
+`runtime`, `management`, and `snapshots` edit singleton sections, so they expose only `configure`. `extension` edits the `extensions:` map (`add` and `configure`), and `metadata` edits the `metadata:` map (`add`, `configure`, and `set <KEY> <VALUE>`).
+
+See [`spice dataset`](reference/dataset) for the shared body-flag reference. The other list editors accept the same flags, plus the type-specific ones: `--sql` / `--sql-ref` for views, `--cron` for workers, and `--body` / `--body-ref` for functions. Run `spice <command> --help` for the per-command help.
 
 ### Command Flags
 


### PR DESCRIPTION
## Summary

The **Full Command Reference** table in the CLI reference lists 30 commands. `spice --help` has 41. The 14 missing ones are the Spicepod manifest editors added by spiceai/spiceai#10815 (merged 2026-05-18, first released in **v2.0.0**) — undocumented for nearly three months:

`catalog`, `model`, `view`, `embedding`, `reranker`, `tool`, `worker`, `function`, `secret`, `runtime`, `management`, `snapshots`, `extension`, `metadata`

## What changed

- Added a row for each, using the command's clap `about` string verbatim (`bin/spice/src/main.rs` doc comments + `bin/spice/src/commands/component.rs:465,518`).
- Corrected the `dataset` row from "Dataset operations (configure datasets)" to "Add or configure dataset entries in `spicepod.yaml`", matching `DatasetArgs`' `about`.
- Added a short **Spicepod manifest editors** section covering the shared shape, verified against the clap types:
  - The 10 list editors (`catalog`, `dataset`, `embedding`, `function`, `model`, `reranker`, `secret`, `tool`, `view`, `worker`) are `ComponentArgs`/`DatasetArgs` → `add` + `configure`.
  - `runtime`, `management`, `snapshots` are `SingletonArgs` → `SingletonCommand` has only `Configure`.
  - `extension` is `ExtensionArgs` → `Add` + `Configure`.
  - `metadata` is `MetadataArgs` → `Add` + `Configure` + `Set`.
  - Type-specific flags (`--sql`/`--sql-ref`, `--cron`, `--body`/`--body-ref`) named where they apply.

## Version scope

The `Commands` enum is byte-identical at `v2.0.1`, `v2.1.4`, and `trunk`, and none of these commands exist at `v1.11.6` — so vNext + `version-2.0.x` + `version-2.1.x` only (3 files). The versioned snapshots keep their own `connect` description (from #2026), which is unrelated to this change.

## Source ref

- spiceai/spiceai @ `trunk` — [`bin/spice/src/main.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/main.rs) (`enum Commands`), [`bin/spice/src/commands/component.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/component.rs)
- Source PR: spiceai/spiceai#10815 — Improve Spice CLI manifest editing and direct command modes

## Related

- spiceai/docs#2066 documents the `spice dataset add` subcommand and the shared body flags this section links to.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (vNext + 2.0.x + 2.1.x; 1.x correctly excluded)
- [x] Files updated: 3 (matches the diff)