### PR TITLE
docs(cli): spice add also takes a local path and an @version pin

### DIFF
--- a/website/docs/cli/reference/add.md
+++ b/website/docs/cli/reference/add.md
@@ -10,11 +10,19 @@ Add a Spicepod to the project.
 ### Usage
 
 ```shell
-spice add [spicerack slug] [flags]
+spice add [spicepod path] [flags]
 ```
 
-- `spicerack slug`: The slug to the Spicepod on [spicerack.org](https://spicerack.org).
+- `spicepod path`: Either a [spicerack.org](https://spicerack.org) slug (optionally pinned to a version with `@`), or a path to a Spicepod directory on the local filesystem.
 
+| Form                        | Example                       | Resolves to                                                     |
+| --------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| Spicerack slug              | `spiceai/quickstart`          | The latest published version of the Spicepod on spicerack.org.  |
+| Spicerack slug with version | `spiceai/quickstart@v1.0`     | The `v1.0` version of that Spicepod.                            |
+| Local directory             | `../shared/pods/analytics`    | A Spicepod directory copied from the local filesystem.          |
+| Local `file://` URL         | `file:///srv/pods/analytics`  | The same, written as a URL.                                     |
+
+A path is treated as local when it starts with `/`, `../`, or `file://`, or when it already exists on disk; anything else is fetched from spicerack.org.
 
 #### Flags
 
@@ -28,6 +36,20 @@ Adding a Spicepod from Spicerack (like `spiceai/quickstart`):
 ```shell
 > spice add spiceai/quickstart
 ```
+
+Pinning a published Spicepod to a version:
+
+```shell
+> spice add spiceai/quickstart@v1.0
+```
+
+Adding a Spicepod from a local directory:
+
+```shell
+> spice add ../shared/pods/analytics
+```
+
+A local Spicepod is copied into `spicepods/[pod-name]`, where `pod-name` is the source directory's name lowercased, and the root `spicepod.yaml` records the dependency as a path relative to the app directory rather than as a slug.
 
 **Directory Structure**: 
 The command makes two main modifications to the directory structure:

--- a/website/versioned_docs/version-2.0.x/cli/reference/add.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/add.md
@@ -10,11 +10,19 @@ Add a Spicepod to the project.
 ### Usage
 
 ```shell
-spice add [spicerack slug] [flags]
+spice add [spicepod path] [flags]
 ```
 
-- `spicerack slug`: The slug to the Spicepod on [spicerack.org](https://spicerack.org).
+- `spicepod path`: Either a [spicerack.org](https://spicerack.org) slug (optionally pinned to a version with `@`), or a path to a Spicepod directory on the local filesystem.
 
+| Form                        | Example                       | Resolves to                                                     |
+| --------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| Spicerack slug              | `spiceai/quickstart`          | The latest published version of the Spicepod on spicerack.org.  |
+| Spicerack slug with version | `spiceai/quickstart@v1.0`     | The `v1.0` version of that Spicepod.                            |
+| Local directory             | `../shared/pods/analytics`    | A Spicepod directory copied from the local filesystem.          |
+| Local `file://` URL         | `file:///srv/pods/analytics`  | The same, written as a URL.                                     |
+
+A path is treated as local when it starts with `/`, `../`, or `file://`, or when it already exists on disk; anything else is fetched from spicerack.org.
 
 #### Flags
 
@@ -28,6 +36,20 @@ Adding a Spicepod from Spicerack (like `spiceai/quickstart`):
 ```shell
 > spice add spiceai/quickstart
 ```
+
+Pinning a published Spicepod to a version:
+
+```shell
+> spice add spiceai/quickstart@v1.0
+```
+
+Adding a Spicepod from a local directory:
+
+```shell
+> spice add ../shared/pods/analytics
+```
+
+A local Spicepod is copied into `spicepods/[pod-name]`, where `pod-name` is the source directory's name lowercased, and the root `spicepod.yaml` records the dependency as a path relative to the app directory rather than as a slug.
 
 **Directory Structure**: 
 The command makes two main modifications to the directory structure:

--- a/website/versioned_docs/version-2.1.x/cli/reference/add.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/add.md
@@ -10,11 +10,19 @@ Add a Spicepod to the project.
 ### Usage
 
 ```shell
-spice add [spicerack slug] [flags]
+spice add [spicepod path] [flags]
 ```
 
-- `spicerack slug`: The slug to the Spicepod on [spicerack.org](https://spicerack.org).
+- `spicepod path`: Either a [spicerack.org](https://spicerack.org) slug (optionally pinned to a version with `@`), or a path to a Spicepod directory on the local filesystem.
 
+| Form                        | Example                       | Resolves to                                                     |
+| --------------------------- | ----------------------------- | --------------------------------------------------------------- |
+| Spicerack slug              | `spiceai/quickstart`          | The latest published version of the Spicepod on spicerack.org.  |
+| Spicerack slug with version | `spiceai/quickstart@v1.0`     | The `v1.0` version of that Spicepod.                            |
+| Local directory             | `../shared/pods/analytics`    | A Spicepod directory copied from the local filesystem.          |
+| Local `file://` URL         | `file:///srv/pods/analytics`  | The same, written as a URL.                                     |
+
+A path is treated as local when it starts with `/`, `../`, or `file://`, or when it already exists on disk; anything else is fetched from spicerack.org.
 
 #### Flags
 
@@ -28,6 +36,20 @@ Adding a Spicepod from Spicerack (like `spiceai/quickstart`):
 ```shell
 > spice add spiceai/quickstart
 ```
+
+Pinning a published Spicepod to a version:
+
+```shell
+> spice add spiceai/quickstart@v1.0
+```
+
+Adding a Spicepod from a local directory:
+
+```shell
+> spice add ../shared/pods/analytics
+```
+
+A local Spicepod is copied into `spicepods/[pod-name]`, where `pod-name` is the source directory's name lowercased, and the root `spicepod.yaml` records the dependency as a path relative to the app directory rather than as a slug.
 
 **Directory Structure**: 
 The command makes two main modifications to the directory structure:


### PR DESCRIPTION
## Summary

**What the docs said**

> `spice add [spicerack slug] [flags]`
> - `spicerack slug`: The slug to the Spicepod on spicerack.org.

**What the code does** — `spice add`'s single positional is `pod_path`, documented in clap as "Spicepod path (e.g. `spiceai/quickstart`, `./local/path`, or `spiceai/quickstart@v1.0`)" (`bin/spice/src/commands/add.rs:47`). `registry::get_pod` routes it:

- `registry::is_local_path` (`bin/spice/src/registry/mod.rs:128`) returns true when the argument starts with `/`, `../`, or `file://`, **or** already exists on disk → `LocalFileRegistry`, which copies the directory into `spicepods/<lowercased-dir-name>` (`local_file.rs:78,85,125`).
- Otherwise → `SpicerackRegistry`, which splits on the first `@` and requests `{base}/spicepods/{path}/{version}` when a version is present, `{base}/spicepods/{path}` otherwise (`spicerack.rs:119-130`).

A reader following the current page has no way to know either form exists.

## What changed

- Renamed the positional to `spicepod path` and added a table of the four accepted forms (slug, slug + `@version`, local directory, `file://` URL) with the exact routing rule.
- Added examples for the `@version` and local-directory forms.
- Noted that a local Spicepod is recorded in the root `spicepod.yaml` as a path **relative to the app directory**, not as a slug (`dependency_reference` → `get_relative_dependency_path`, `add.rs:155-162`) — the existing example only shows the slug form.

## Version scope

`is_local_path` and the `@version` split both arrived with the Rust CLI rewrite (spiceai/spiceai#9061). `git tag --contains` on that commit yields `v2.0` and `v2.1` only, so this lands in vNext + `version-2.0.x` + `version-2.1.x` (3 files). The 1.x snapshots document the Go CLI and are out of scope.

## Source ref

- spiceai/spiceai @ `trunk` — [`bin/spice/src/commands/add.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/add.rs), [`bin/spice/src/registry/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/registry/mod.rs), [`bin/spice/src/registry/spicerack.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/registry/spicerack.rs), [`bin/spice/src/registry/local_file.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/registry/local_file.rs)
- Source PR: spiceai/spiceai#9061 — Rewrite Go CLI in Rust

## Related

Same audit, same source area: spiceai/docs#2066 (`spice dataset add` + body flags), spiceai/docs#2067 (14 missing manifest-editing commands in the reference table).

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (vNext + 2.0.x + 2.1.x; 1.x correctly excluded)
- [x] Files updated: 3 (matches the diff)