### PR TITLE
docs(ftp): client_timeout bounds the whole connection attempt, and defaults to 20s

### DIFF
--- a/website/docs/components/data-connectors/ftp.md
+++ b/website/docs/components/data-connectors/ftp.md
@@ -81,7 +81,7 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 | `ftp_user`                  | Required. Username for FTP authentication.                                                                   |
 | `ftp_pass`                  | Required. Password for FTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_ftp_pass}`. |
 | `ftp_port`                  | FTP server port. Default: `21`.                                                                              |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                        |
+| `client_timeout`            | Wall-clock bound for one connection attempt — TCP connect, server greeting and login together. E.g. `30s`, `1m`. Default: `20s`. |
 | `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                |
 
 #### SFTP Parameters
@@ -92,7 +92,7 @@ The dataset name used as the table name in SQL queries. Cannot be a [reserved ke
 | `sftp_user`                 | Required. Username for SFTP authentication.                                                                    |
 | `sftp_pass`                 | Required. Password for SFTP authentication. Use [secrets](../secret-stores) syntax: `${secrets:my_sftp_pass}`. |
 | `sftp_port`                 | SFTP server port. Default: `22`.                                                                               |
-| `client_timeout`            | Connection timeout duration. E.g. `30s`, `1m`. No timeout when unset.                                          |
+| `client_timeout`            | Wall-clock bound for one connection attempt — name resolution, TCP connect, SSH handshake and password authentication together. E.g. `30s`, `1m`. Default: `20s`. |
 | `hive_partitioning_enabled` | Enable [Hive-style partitioning](#hive-partitioning) from folder structure. Default: `false`.                  |
 
 ## Examples
@@ -152,6 +152,8 @@ datasets:
       sftp_pass: ${secrets:sftp_pass}
       client_timeout: 120s
 ```
+
+`client_timeout` bounds a connection attempt as a whole, not each stage of it, so a server that accepts the TCP connection and then stops responding — during the FTP greeting or login, or the SSH handshake or authentication — is abandoned once the bound expires rather than waiting indefinitely. When `client_timeout` is not set, a `20s` bound applies.
 
 ### Custom Port Configuration
 
@@ -261,7 +263,7 @@ For detailed information, refer to the [secret stores documentation](../secret-s
 
 ### Connection Timeouts
 
-If connections frequently timeout, increase the `client_timeout` value:
+Connection attempts are bounded at `20s` by default. If a server is reachable but slow to complete the greeting, login, or SSH handshake, raise `client_timeout`:
 
 ```yaml
 params:


### PR DESCRIPTION
## Summary

`client_timeout` on the FTP and SFTP connectors is documented as a generic "connection timeout duration" that applies "no timeout when unset". Neither half is true on `trunk` any more.

spiceai/spiceai#12655 bounded a connection attempt end to end and gave it a default:

- **FTP** — `connect_and_login` (`crates/runtime-object-store/src/store/ftp.rs`) puts TCP connect, the server greeting and `login` under a **single** deadline via `with_connect_deadline`, so a peer that accepts TCP and then stalls cannot spend the budget once per stage.
- **SFTP** — `resolve` charges name resolution against the same bound, `connect_within` connects within what is left, and `Session::set_timeout` re-arms the remainder before `handshake()` and again before `userauth_password()`.
- **Default when unset** — `DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(20)`, defined in both `store/ftp.rs:56` and `store/sftp.rs:50` and applied via `timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT)`. Previously an unset `client_timeout` really did mean unbounded, which is what the current wording describes.

Changes on the page:

- Both `client_timeout` rows now name what the bound covers per protocol and state `Default: 20s`.
- The "Connection with Timeout" example gains a sentence that the bound is for the attempt as a whole, not per stage.
- Troubleshooting → Connection Timeouts leads with the `20s` default instead of implying there is no bound to begin with.

## Version scope

vNext only. spiceai/spiceai#12655 merged 2026-08-08 and `git merge-base --is-ancestor 3426e2a8 v2.1.4` is false, so v2.1.x and earlier snapshots correctly keep "No timeout when unset" — that is the behavior those releases ship.

Not swept: `nfs.md` and `smb.md` carry the same "No timeout when unset" sentence, but they are backed by different object stores that #12655 did not touch (`store/nfs.rs`, `store/smb.rs`), so their rows are out of scope here.

## Source PRs

- spiceai/spiceai#12655 — fix(object-store): bound an FTP and SFTP connection attempt end to end (fixes #12647)

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext-only, source commit is not an ancestor of `v2.1.4`
- [x] Files updated: 1
