### PR TITLE
docs(mssql): document availability group read-only routing

### DIFF
--- a/website/docs/components/data-connectors/mssql/index.md
+++ b/website/docs/components/data-connectors/mssql/index.md
@@ -74,7 +74,7 @@ The data connector supports the following `params`. Use the [secret replacement 
 
 | Parameter Name                   | Description                                                                                                                                                                                                                                                                                                                                                                 |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mssql_connection_string`        | The ADO connection string to use to connect to the server. This can be used instead of providing individual connection parameters.                                                                                                                                                                                                                                          |
+| `mssql_connection_string`        | The ADO connection string to use to connect to the server. This can be used instead of providing individual connection parameters, and is the only way to set `ApplicationIntent` — see [Availability groups and read-only routing](#availability-groups-and-read-only-routing).                                                                                             |
 | `mssql_host`                     | The hostname or IP address of the Microsoft SQL Server instance.                                                                                                                                                                                                                                                                                                            |
 | `mssql_port`                     | (Optional) The port of the Microsoft SQL Server instance. Default value is 1433.                                                                                                                                                                                                                                                                                            |
 | `mssql_database`                 | (Optional) The name of the database to connect to. The default database (`master`) will be used if not specified.                                                                                                                                                                                                                                                           |
@@ -97,6 +97,34 @@ datasets:
       mssql_encrypt: true
       mssql_trust_server_certificate: true
 ```
+
+## Availability groups and read-only routing
+
+When a dataset connects to an [Always On availability group](https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/always-on-availability-groups-sql-server) listener with read intent, the listener answers the login by naming the secondary replica the session belongs on instead of completing it. Spice follows that redirect automatically and re-dials the named replica, so a read-intent dataset lands on a readable secondary rather than the primary.
+
+Read intent is requested through the connection string, so it requires `mssql_connection_string` — the individual connection parameters (`mssql_host`, `mssql_username`, and so on) have no equivalent:
+
+```yaml
+datasets:
+  - from: mssql:SalesLT.Customer
+    name: customer
+    params:
+      mssql_connection_string: ${secrets:mssql_connection_string}
+```
+
+With a connection string of the form:
+
+```text
+Server=tcp:ag-listener.example.com,1433;Database=Sales;User ID=my_user;Password=my_password;ApplicationIntent=ReadOnly;Encrypt=true
+```
+
+`ApplicationIntent` is the only value that enables routing, and `ReadOnly` is matched exactly — other spellings are treated as read-write intent and are not routed.
+
+The redirect carries the settings the dataset supplied: only the host and port are replaced, so the routed replica is reached with the same credentials, database, encryption level and certificate-trust configuration.
+
+:::info
+Spice follows up to **3** redirects (4 connection attempts) before reporting the chain as broken. A routing list that points back at the listener redirects indefinitely, so exceeding the limit fails the connection with an error naming the last address it was routed to — check the availability group's read-only routing list when this happens.
+:::
 
 ## Performance
 


### PR DESCRIPTION
## Summary

The MSSQL connector now follows the read-only routing redirect a SQL Server Always On availability group answers a read-intent login with (spiceai/spiceai#12607). Previously the redirect was propagated as an error, `bb8` re-dialled the same listener on its backoff loop, and the caller saw only a 30-second `RunError::TimedOut` — so nothing on this page described read-intent connections at all.

The new **Availability groups and read-only routing** section documents:

- That the redirect is followed automatically and the session lands on the routed replica.
- **How to request read intent** — `ApplicationIntent=ReadOnly` in `mssql_connection_string`. There is no `mssql_application_intent` parameter: `PARAMETERS` in `crates/data-connectors/connector-mssql/src/lib.rs:75` has no such spec, and the individual-parameter path builds a `Config::default()` that never calls `Config::readonly`. Only the `Config::from_ado_string` branch reaches tiberius's `readonly()`, which matches the value exactly as `ReadOnly` (`src/client/config.rs:385`).
- That only host and port are replaced on the re-dial, so credentials, database, encryption and certificate trust are the ones the dataset supplied (`connect_with`, `crates/data_components/src/mssql/connection_manager.rs`).
- The **3-redirect bound** (`MAX_ROUTING_REDIRECTS: usize = 3`, 4 dials total per the crate's own test assertion `dialled == MAX_ROUTING_REDIRECTS + 1`) and that exhausting it reports the last address and points at the routing list.

The runtime's own error text for an exhausted chain links to `https://spiceai.org/docs/components/data-connectors/mssql`, which until now had nothing to say about routing.

The `mssql_connection_string` params row gains a pointer to the new section, since it is the only channel for `ApplicationIntent`.

## Version scope

vNext only. spiceai/spiceai#12607 merged 2026-08-07 and `git merge-base --is-ancestor 9f73b4bb v2.1.4` is false, so the 2.1.x and earlier snapshots correctly describe releases that do not follow the redirect.

## Source PRs

- spiceai/spiceai#12607 — fix(mssql): follow an availability group's read-only routing redirect (fixes #11453)

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags, including the new in-page anchor)
- [x] Versioned-docs propagation checked — vNext-only, source commit is not an ancestor of `v2.1.4`
- [x] Files updated: 1
