### PR TITLE
docs(runtime): document which runtime.* sections require a restart vs apply on reload

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -6,6 +6,34 @@ description: 'Runtime YAML reference'
 
 The `runtime` section specifies configuration settings for the Spice runtime.
 
+## Reload Behavior
+
+Editing a Spicepod on disk reloads it into the running process, but **most of `runtime.*` is consumed once when `spiced` starts and cannot be rebuilt in place**. A reload installs the new value in the app while the process keeps running the old one; `spiced` logs a warning naming each start-time-only section that changed and telling you to restart. Restart `spiced` to apply them.
+
+**Applied when `spiced` starts — a reload logs a warning and the previous value stays in effect:**
+
+`runtime.auth` · `runtime.caching` · `runtime.cors` · `runtime.cpu` · `runtime.dataset_load_parallelism` · `runtime.mcp` · `runtime.metrics` · `runtime.output_level` · `runtime.query` · `runtime.ready_state` · `runtime.scheduler` · `runtime.task_history` · `runtime.telemetry` · `runtime.tls` · `runtime.tracing`
+
+**Applied when `spiced` starts, except for components the same reload recreates** — a connector rebuilt by the reload reads the new value, while the process-wide use of it does not change until a restart:
+
+`runtime.flight` · `runtime.params` · `runtime.source_rate_control`
+
+**Applied on reload — no restart needed:**
+
+| Setting                                  | Why it applies                                             |
+| ---------------------------------------- | ------------------------------------------------------------ |
+| `runtime.shutdown_timeout`               | Read from the current app when the runtime shuts down.       |
+| `runtime.functions`                      | Reconciled by the function diff on each reload.              |
+| `runtime.caching.sql_results.cache_key_type` | Resolved per request from the live app.                  |
+| `runtime.query.timeout`                  | Resolved per request from the live app.                      |
+| `runtime.telemetry.user_agent_collection` | Resolved per request from the live app.                     |
+
+The three per-request settings sit inside otherwise start-time-only sections. Changing one of them alone takes effect on the next request and is not reported as requiring a restart; changing any *other* key in the same section is.
+
+:::note
+`runtime.tls` certificate and CA **files** are separately hot-reloadable without a restart — see [Certificate Hot-Reload](#certificate-hot-reload). Inline PEM material is loaded once at startup.
+:::
+
 ## `runtime.auth`
 
 ### `runtime.auth.api-key`
@@ -464,7 +492,7 @@ Three configuration surfaces set the same value. Precedence, highest first:
 
 A surface set to `auto` still takes precedence over the surfaces below it; it simply resolves to detection.
 
-Applied at startup only. The thread pools it sizes cannot be resized afterwards, so changing `runtime.cpu` and reloading the spicepod logs a warning that a restart is required rather than taking effect.
+Applied at startup only. The thread pools it sizes cannot be resized afterwards, so changing `runtime.cpu` and reloading the spicepod logs a warning that a restart is required rather than taking effect. It is one of several start-time-only sections — see [Reload Behavior](#reload-behavior).
 
 #### Detection
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12874` made a Spicepod reload **name every start-time-only `runtime.*` section it changed** and say a restart is required. Before it, a reload silently installed the new value in the app while the process kept running the old one — the file on disk and the behavior of the process diverged with no signal. Exactly one section reported it: `runtime.cpu`.

The docs mirrored that gap: `runtime.cpu` was the only setting documented as restart-only, which reads as though it is special. It is one of eighteen.

## Changes

`website/docs/reference/spicepod/runtime.md` gains a **Reload Behavior** section directly under the page intro, with three groups:

- **Applied when `spiced` starts** (15) — `runtime.auth`, `runtime.caching`, `runtime.cors`, `runtime.cpu`, `runtime.dataset_load_parallelism`, `runtime.mcp`, `runtime.metrics`, `runtime.output_level`, `runtime.query`, `runtime.ready_state`, `runtime.scheduler`, `runtime.task_history`, `runtime.telemetry`, `runtime.tls`, `runtime.tracing`.
- **Applied at start, except for components the same reload recreates** (3) — `runtime.flight`, `runtime.params`, `runtime.source_rate_control`. These get a distinct warning upstream because a connector rebuilt by the reload *does* read the new value, so "the previous value stays in effect" is not true everywhere.
- **Applied on reload, no restart** (5) — `runtime.shutdown_timeout`, `runtime.functions`, plus the three per-request settings that sit *inside* otherwise start-time-only sections: `runtime.caching.sql_results.cache_key_type`, `runtime.query.timeout`, `runtime.telemetry.user_agent_collection`. Changing one of those alone takes effect on the next request and is deliberately excluded from the comparison; changing any other key in the same section is not.

Also cross-linked from the existing `runtime.cpu` note, and added a `:::note` pointing to the existing [Certificate Hot-Reload](https://docs.spiceai.org/docs/next/reference/spicepod/runtime#certificate-hot-reload) mechanism so the `runtime.tls` row is not misread — TLS cert/CA *files* are separately hot-reloadable via `SIGHUP`; inline PEM is not.

The list is transcribed from `start_time_only_changes()` in `crates/runtime/src/init/pods_watcher.rs` on `origin/trunk` — the function destructures `SpicepodRuntime` exhaustively, so it is the authoritative enumeration, and the `StartTimeScope::{Process, ProcessAndRecreatedComponents}` split is what the two upstream warning strings distinguish. The per-request exclusions come from `start_time_caching`, `start_time_query`, and `start_time_telemetry` in the same file.

## Source PRs

- spiceai/spiceai#12874 — fix(runtime): report every start-time-only `runtime.*` section a reload changes

## Versioned-docs propagation

**vNext only**, deliberately — and this is a case where "the behavior predates the release" does *not* make it a back-portable correction:

- The claim "a reload names every start-time-only section it changed" is true only on vNext. On `v2.1.4` only `runtime.cpu` warns, so the section as written would be wrong in `version-2.1.x/`.
- `start_time_only_changes()` does not exist in `v2.1.4`, so there is no verified enumeration for that snapshot; publishing this list there would be an unverified claim.

`git tag --contains be8f679` is empty (latest tag `v2.1.4`, 2026-08-05).

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext only, rationale above
- [x] Files updated: 1
