### PR TITLE
docs(s3_vectors): an explicit index name is passed to AWS verbatim, so underscores fail

### DIFF
--- a/website/docs/components/vectors/s3_vectors.md
+++ b/website/docs/components/vectors/s3_vectors.md
@@ -42,8 +42,8 @@ embeddings:
 | `s3_vectors_aws_secret_access_key` | Optional. The secret access key for the S3 vectors index. If not specified, credentials will be loaded from the environment.                                                | -                                                                                    |
 | `s3_vectors_aws_session_token`     | Optional. Session token for the S3 vectors index.                                                                                                                           | -                                                                                    |
 | `s3_vectors_batch_write_rows`      | Optional. Number of rows each record batch is chunked into when writing vectors, to control memory usage during writes. Default `100000`. | `100000` |
-| `s3_vectors_bucket`                | The S3 vectors bucket to use. If `s3_vectors_index` is not specified, an index will be created based on the underlying embedding column. Incompatible with `s3_vectors_arn` | `a-bucket`                                                                           |
-| `s3_vectors_index`                 | The name of the s3 vectors index to use or create. Incompatible with `s3_vectors_arn`. Passed to AWS verbatim — see [Index Naming](#index-naming).                          | `index-of-important-embeddings`                                                      |
+| `s3_vectors_bucket`                | The S3 vectors bucket to use. If `s3_vectors_index` is not specified, an index will be created based on the underlying embedding column. Incompatible with `s3_vectors_arn`. Provided to AWS verbatim — see [Index Naming](#bucket-and-index-naming). | `a-bucket`                                                                           |
+| `s3_vectors_index`                 | The name of the s3 vectors index to use or create. Incompatible with `s3_vectors_arn`. Provided to AWS verbatim — see [Index Naming](#bucket-and-index-naming).                          | `index-of-important-embeddings`                                                      |
 | `s3_vectors_distance_metric`       | The distance metric to be used for similarity search. One of: `euclidean`, `cosine`. Default `cosine`.                                                                      | `euclidean`                                                                          |
 | `s3_vectors_index_poll_interval`   | The interval to poll for index updates to avoid excessive API calls. Minimum 5 seconds. Default is to poll on every scan.                                                   | `5m`                                                                                 |
 | `s3_vectors_spill_writes`          | Optional. When `true`, writes that exceed S3 Vectors rate limits spill to a separate physical index, which is also queried at read time. Ignored, with a warning, when `partition_by` is set. Default `false`. | `true` |
@@ -220,28 +220,11 @@ ORDER BY combined_score DESC
 LIMIT 5;
 ```
 
-## Index Naming
+## Bucket and Index Naming
 
-AWS S3 Vectors rejects an index name containing an underscore with `ValidationException: Invalid index name`. Spice normalizes the names it generates for you, but **not** the one you supply — so the same underscore is fine in one place and fatal in another:
+For S3 vector bucket and index names, AWS allows only lowercase letters, numbers, and hyphens. A name must also be 3 to 63 characters long. 
 
-| Where the name comes from                                    | What Spice does                                                                                    |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `s3_vectors_index` (explicit)                                | Passed to AWS **verbatim**. An underscore reaches S3 Vectors unchanged and the request fails.        |
-| Auto-derived (`s3_vectors_bucket` set, no `s3_vectors_index`) | Built as `<dataset>-<column>-<model>` with every `_` replaced by `-`, so it is always valid.          |
-| Partition prefix (`partition_by` set)                        | `_` and `.` are replaced by `-`, and the prefix is truncated to **45** characters before the partition suffix is appended. |
-
-Use hyphens in `s3_vectors_index`:
-
-```yaml
-vectors:
-  enabled: true
-  engine: s3_vectors
-  params:
-    s3_vectors_bucket: a-bucket
-    s3_vectors_index: my-index # not `my_index` — AWS rejects underscores
-```
-
-This is why a dataset named `taxi_trips` gets a working auto-derived index while an explicit `s3_vectors_index: taxi_trips` fails.
+When not provided, Spice normalizes the index names it generates, but it passes `s3_vectors_bucket` and an explicit `s3_vectors_index` to AWS unchanged. As a result, invalid names will be rejected.
 
 ## Index Partitioning
 S3 Vectors indexes can be partitioned using an arbitrary logical expression. This enables Spice to compose many actual vector indexes as one logical vector index, enabling elastic scalability for vector storage.
@@ -256,7 +239,7 @@ vectors:
     - 'bucket(50, PULocationID)'
 ```
 
-This example uses a `bucket` user-defined function (UDF) to hash the `PULocationID` column and split the associated vectors into one of 50 partitioned indexes. The runtime will use the `s3_vectors_index` parameter as a prefix and generate partition-specific names. The prefix is normalized (`_` and `.` become `-`) and truncated to 45 characters to leave room for the partition suffix within the S3 Vectors 63-character index-name limit — see [Index Naming](#index-naming).
+This example uses a `bucket` user-defined function (UDF) to hash the `PULocationID` column and split the associated vectors into one of 50 partitioned indexes. The runtime will use the `s3_vectors_index` parameter as a prefix and generate partition-specific names. The prefix is normalized (`_` and `.` become `-`) and truncated to 45 characters to leave room for the partition suffix within the S3 Vectors 63-character index-name limit — see [Index Naming](#bucket-and-index-naming).
 
 :::warning[Limitations]
 

--- a/website/docs/components/vectors/s3_vectors.md
+++ b/website/docs/components/vectors/s3_vectors.md
@@ -43,7 +43,7 @@ embeddings:
 | `s3_vectors_aws_session_token`     | Optional. Session token for the S3 vectors index.                                                                                                                           | -                                                                                    |
 | `s3_vectors_batch_write_rows`      | Optional. Number of rows each record batch is chunked into when writing vectors, to control memory usage during writes. Default `100000`. | `100000` |
 | `s3_vectors_bucket`                | The S3 vectors bucket to use. If `s3_vectors_index` is not specified, an index will be created based on the underlying embedding column. Incompatible with `s3_vectors_arn` | `a-bucket`                                                                           |
-| `s3_vectors_index`                 | The name of the s3 vectors index to use or create. Incompatible with `s3_vectors_arn`.                                                                                      | `index-of-important-embeddings`                                                      |
+| `s3_vectors_index`                 | The name of the s3 vectors index to use or create. Incompatible with `s3_vectors_arn`. Passed to AWS verbatim — see [Index Naming](#index-naming).                          | `index-of-important-embeddings`                                                      |
 | `s3_vectors_distance_metric`       | The distance metric to be used for similarity search. One of: `euclidean`, `cosine`. Default `cosine`.                                                                      | `euclidean`                                                                          |
 | `s3_vectors_index_poll_interval`   | The interval to poll for index updates to avoid excessive API calls. Minimum 5 seconds. Default is to poll on every scan.                                                   | `5m`                                                                                 |
 | `s3_vectors_spill_writes`          | Optional. When `true`, writes that exceed S3 Vectors rate limits spill to a separate physical index, which is also queried at read time. Ignored, with a warning, when `partition_by` is set. Default `false`. | `true` |
@@ -220,6 +220,29 @@ ORDER BY combined_score DESC
 LIMIT 5;
 ```
 
+## Index Naming
+
+AWS S3 Vectors rejects an index name containing an underscore with `ValidationException: Invalid index name`. Spice normalizes the names it generates for you, but **not** the one you supply — so the same underscore is fine in one place and fatal in another:
+
+| Where the name comes from                                    | What Spice does                                                                                    |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `s3_vectors_index` (explicit)                                | Passed to AWS **verbatim**. An underscore reaches S3 Vectors unchanged and the request fails.        |
+| Auto-derived (`s3_vectors_bucket` set, no `s3_vectors_index`) | Built as `<dataset>-<column>-<model>` with every `_` replaced by `-`, so it is always valid.          |
+| Partition prefix (`partition_by` set)                        | `_` and `.` are replaced by `-`, and the prefix is truncated to **45** characters before the partition suffix is appended. |
+
+Use hyphens in `s3_vectors_index`:
+
+```yaml
+vectors:
+  enabled: true
+  engine: s3_vectors
+  params:
+    s3_vectors_bucket: a-bucket
+    s3_vectors_index: my-index # not `my_index` — AWS rejects underscores
+```
+
+This is why a dataset named `taxi_trips` gets a working auto-derived index while an explicit `s3_vectors_index: taxi_trips` fails.
+
 ## Index Partitioning
 S3 Vectors indexes can be partitioned using an arbitrary logical expression. This enables Spice to compose many actual vector indexes as one logical vector index, enabling elastic scalability for vector storage.
 
@@ -233,7 +256,7 @@ vectors:
     - 'bucket(50, PULocationID)'
 ```
 
-This example uses a `bucket` user-defined function (UDF) to hash the `PULocationID` column and split the associated vectors into one of 50 partitioned indexes. The runtime will use the `s3_vectors_index` parameter as a prefix and generate partition-specific names.
+This example uses a `bucket` user-defined function (UDF) to hash the `PULocationID` column and split the associated vectors into one of 50 partitioned indexes. The runtime will use the `s3_vectors_index` parameter as a prefix and generate partition-specific names. The prefix is normalized (`_` and `.` become `-`) and truncated to 45 characters to leave room for the partition suffix within the S3 Vectors 63-character index-name limit — see [Index Naming](#index-naming).
 
 :::warning[Limitations]
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12892` renamed two S3 Vectors indexes in the MTEB test Spicepods (`miracl_en` → `miracl-en`, `trec_covid` → `trec-covid`) because **AWS S3 Vectors index names do not permit underscores** — the configurations were failing with `ValidationException: Invalid index name`.

That fixed the test fixtures, but the same trap is live for users and the docs said nothing about it. Tracing it on `origin/trunk` turned up an asymmetry worth documenting: **Spice normalizes the index names it generates, but passes an explicit `s3_vectors_index` to AWS verbatim.**

| Source of the name                                           | Behavior on `trunk`                                                                                      | Code |
| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---- |
| `s3_vectors_index` (explicit)                                | `index_name: index.to_string()` — verbatim, no sanitize, no validate                                       | `crates/runtime/src/embeddings/index/s3/mod.rs:213` |
| Auto-derived (bucket set, no index)                          | `format!("{ds_name}-{column}-{model}").replace('_', "-")` — always valid                                   | `crates/runtime/src/embeddings/index/s3/mod.rs:155` |
| Partition prefix (`partition_by` set)                        | `truncate(&sanitize_column(index_name), INDEX_NAME_MAX_LENGTH)`; `sanitize_column` = `s.replace(['_','.'], "-")`, `INDEX_NAME_MAX_LENGTH = 45` | `crates/data_components/src/s3_vectors/partition/mod.rs:27,98,236` |

So a dataset named `taxi_trips` gets a working auto-derived index, while an explicit `s3_vectors_index: taxi_trips` fails against AWS — the failure surfaces as an opaque AWS `ValidationException`, not a Spice error, which is exactly the shape that is hard to self-diagnose.

## Changes

`website/docs/components/vectors/s3_vectors.md`:

- New **Index Naming** section with the three-way table above, a corrected YAML example, and the one-line explanation of why auto-derived and explicit names behave differently.
- `s3_vectors_index` parameter row now says the value is passed to AWS verbatim and links to the new section.
- **Index Partitioning** section: the existing sentence "The runtime will use the `s3_vectors_index` parameter as a prefix and generate partition-specific names" now states the prefix is normalized and truncated to 45 characters, and why (headroom for the partition suffix inside the S3 Vectors 63-character limit — `_S3_VECTOR_INDEX_NAME_MAX_LENGTH = 63` in the same module).

Per the "third-party provider references" rule in `docs-pr-hygiene.md`, the *AWS-side* constraint is not a spiceai fact — it is stated here only as narrowly as the observed `ValidationException` in `spiceai/spiceai#12892` supports (underscores are rejected). The docs deliberately do not enumerate AWS's full naming grammar, which would be an unverified claim against a provider catalog that churns independently of Spice.

## Source PRs

- spiceai/spiceai#12892 — fix(search): Improve search benchmarking DX and fix some vector index names

## Versioned-docs propagation

**Addition** — vNext only. The verbatim pass-through is long-standing rather than newly shipped, but the 45-character partition truncation and `sanitize_column` are traced against `origin/trunk` only; I have not verified the same constants in `v2.1.4`, and publishing an unverified numeric limit into a frozen snapshot is the failure mode `docs-pr-hygiene.md` warns about. Worth a follow-up `docs-accuracy-review` pass to decide whether the naming section back-ports.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — vNext only, rationale above
- [x] Files updated: 1

<!-- CI note: the failing `enforce-pull-with-spice` run stamped at PR creation raced the assignee/label API calls; the newest run is the verdict. -->
