### PR TITLE
docs(memory): sizing model, coordinated budget, and how to validate it

### DIFF
--- a/website/docs/deployment/kubernetes/index.md
+++ b/website/docs/deployment/kubernetes/index.md
@@ -63,7 +63,9 @@ Prefer `runtime.cpu.cores` over `resources.limits.cpu` for bounding Spice. A CPU
 
 Unlike CPU, memory is enforced by the kernel: a pod that exceeds `resources.limits.memory` is OOM-killed rather than throttled. Size the limit for the whole process, not just for query execution.
 
-A pod's memory divides into a **baseline** that is present at idle and scales with the number of configured datasets, and a **working set** that scales with data volume and concurrency. The runtime derives `runtime.query.memory_limit` from the pod's cgroup limit with the per-dataset baseline already subtracted, so the common case needs no configuration — leave it unset and set `resources.limits.memory` instead.
+A pod's memory divides into a **baseline** that scales with the number of configured datasets, and a **working set** that scales with data volume, per-query cost, and concurrency. The runtime derives `runtime.query.memory_limit` from the pod's cgroup limit with the per-dataset baseline already subtracted, so the common case needs no configuration — leave it unset and set `resources.limits.memory` instead.
+
+Note that much of the baseline is bounded buffers that grow toward their limits as traffic drives them there, so a pod's memory shortly after startup understates what it will settle at. Size the limit from a sustained run, not from a fresh pod.
 
 | Situation                                             | What to set                                                                                     |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |

--- a/website/docs/deployment/kubernetes/index.md
+++ b/website/docs/deployment/kubernetes/index.md
@@ -59,6 +59,25 @@ The [Spice Cloud Platform](https://spice.ai) sets `SPICE_CPU_CORES=all` on hoste
 
 Prefer `runtime.cpu.cores` over `resources.limits.cpu` for bounding Spice. A CPU limit is a CFS quota and [throttles](https://home.robusta.dev/blog/stop-using-cpu-limits) even when the node has idle CPU; `runtime.cpu.cores` caps how much machine the runtime organizes itself around without capping how much CPU it may use. See [`runtime.cpu`](../reference/spicepod/runtime#runtimecpu) and [Resource Allocation](../reference/performance-tuning#resource-allocation).
 
+## Memory sizing
+
+Unlike CPU, memory is enforced by the kernel: a pod that exceeds `resources.limits.memory` is OOM-killed rather than throttled. Size the limit for the whole process, not just for query execution.
+
+A pod's memory divides into a **baseline** that is present at idle and scales with the number of configured datasets, and a **working set** that scales with data volume and concurrency. The runtime derives `runtime.query.memory_limit` from the pod's cgroup limit with the per-dataset baseline already subtracted, so the common case needs no configuration — leave it unset and set `resources.limits.memory` instead.
+
+| Situation                                             | What to set                                                                                     |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Standard deployment                                   | `resources.limits.memory` only; let the runtime derive the query pool                             |
+| Co-located accelerators managing their own pools       | `resources.limits.memory` plus an explicit `runtime.query.memory_limit` that leaves room for them |
+| Sizing a smaller staging or test environment          | Reduce data volume and concurrency; keep the dataset count and accelerator configuration          |
+
+Two Kubernetes-specific consequences:
+
+- **Do not scale the production memory limit down proportionally for a lower environment.** The baseline does not shrink with the data, so a proportionally smaller pod is not a smaller model of production — it is a different regime that predicts nothing about production behavior, and the limits tuned to fit it do not transfer back.
+- **A pod that plateaus just under its memory limit is sized too tightly**, even while healthy. It has no margin for a refresh spike or a burst of concurrency.
+
+Because instances are evicted, preempted, and replaced during rollouts, clients should retry a failed query against the Service before treating it as an outage. See [Managing Memory Usage](../reference/memory) for the full sizing model, the load-testing properties that make a memory validation trustworthy, and client resiliency guidance.
+
 ## Prerequisites
 
 - Access to a Kubernetes cluster (v1.25+ recommended).

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -23,7 +23,7 @@ Spice's memory footprint has two parts, and they behave differently:
 Total Memory = Baseline + Working Set
 ```
 
-- **Baseline** — memory the runtime needs to operate at all: process overhead, per-dataset accelerator caches, results caches, task history, serialization buffers, and allocator arenas. It is a function of **how many datasets are configured**, not how much data they hold, and it does not shrink when the data does.
+- **Baseline** — memory the runtime needs to operate at all: process overhead, per-dataset accelerator caches, results caches, task history, serialization buffers, and allocator arenas. It is driven by **how the deployment is configured** — dataset count above all — and by how much traffic it has served, rather than by how much data the datasets hold. It does not shrink when the data does.
 - **Working Set** — memory that scales with the work: query execution, refreshes, and concurrency. This is the part bounded by [`runtime.query.memory_limit`](#memory-limit-configuration).
 
 Two refinements matter when reading a memory graph or sizing from a measurement:
@@ -73,7 +73,7 @@ The baseline is the sum of a fixed process cost and a per-dataset cost. The per-
 | Cayenne PK keyset cache       | Each Cayenne CDC/upsert dataset             | 1/32 of total memory, clamped to 256 MiB–8 GiB, and additionally bounded by a process-wide ceiling across all datasets |
 | CDC coalesce buffer           | Each CDC dataset                            | 128 MiB (`cdc_max_coalesced_bytes`)                        |
 | Results caches                | Runtime                                     | 128 MiB each for SQL, search, and embedding results        |
-| Task history                  | Runtime (enabled by default)                | Unbounded by size; scales with task rate × `retention_period` (8h) |
+| Task history                  | Runtime (enabled by default)                | No byte cap — bounded by time instead; scales with task rate × `retention_period` (8h) |
 | Metastore and protocol buffers | Runtime                                    | Bounded, but reached only under sustained traffic          |
 
 The last two rows are the ones that make a short measurement misleading. **Task history is an in-memory accelerated table**, so its footprint is a product of how many tasks the deployment completes and how long records are kept, rather than a fixed allocation — a high-throughput deployment accumulates far more than a quiet one at the same configuration. Setting `captured_plan` or `captured_output` increases the size of every record substantially.

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -15,6 +15,25 @@ pagination_next: null
 
 Effective memory management is essential for maintaining optimal performance and stability in Spice deployments. This guide outlines recommendations and best practices for managing memory usage across different [Data Accelerators](../components/data-accelerators).
 
+## How Spice Uses Memory
+
+Spice's memory footprint has two parts, and they behave differently:
+
+```text
+Total Memory = Baseline + Working Set
+```
+
+- **Baseline** — memory the runtime reserves to operate at all: process overhead, per-dataset accelerator caches, results caches, and allocator arenas. It is a function of **how many datasets are configured**, not how much data they hold. It is present at idle and it does not shrink when the data does.
+- **Working Set** — memory that scales with the work: query execution, refreshes, and concurrency. This is the part bounded by [`runtime.query.memory_limit`](#memory-limit-configuration).
+
+Almost every surprising memory result comes from treating the total as a single quantity that scales with data volume. It does not. Sizing rules expressed as a multiple of dataset size — including the ones below — describe the **working set**, and apply on top of the baseline:
+
+```text
+Total Memory ≈ Baseline + (multiple × dataset size)
+```
+
+At production data volumes the working set dominates and the baseline is a rounding error. At small data volumes the reverse is true, which is why a deployment holding a few hundred megabytes of data can still need several gigabytes of RAM, and why cutting the data volume by 100x does not let you cut memory by 100x. See [Sizing a Non-Production Environment](#sizing-a-non-production-environment).
+
 ## General Memory Recommendations
 
 Memory requirements vary based on workload characteristics, dataset sizes, query complexity, and refresh modes.
@@ -26,11 +45,58 @@ Memory requirements vary based on workload characteristics, dataset sizes, query
 | Large datasets (`refresh_mode: append`)  | 1.5x dataset size | Memory for incremental data only                               |
 | Large datasets (`refresh_mode: changes`) | 1.5x dataset size | Depends on CDC event volume and frequency                      |
 
+The multiples are working-set figures. Add them to the baseline rather than using them as the total, and treat the 8 GB row as a floor that applies regardless of how small the data is.
+
 Memory requirements can be reduced by using file-based acceleration with [DuckDB](../components/data-accelerators/duckdb), [SQLite](../components/data-accelerators/sqlite), [Turso](../components/data-accelerators/turso), or [Spice Cayenne](../components/data-accelerators/cayenne), which store data on disk and support spilling.
 
 :::tip[Datasets 10 GB or larger]
 
 For any dataset of **10 GB or larger**, [Spice Cayenne](../components/data-accelerators/cayenne) is recommended over [DuckDB](../components/data-accelerators/duckdb), because of DuckDB's memory requirements. Cayenne typically needs **one-third to one-half** the memory of the DuckDB accelerator for the same dataset.
+
+:::
+
+### What Makes Up the Baseline
+
+The baseline is the sum of a fixed process cost and a per-dataset cost. The per-dataset allocations are sized as a fraction of total memory but **clamped to a floor**, so they stop shrinking once the environment is small:
+
+| Allocation                    | Applies to                                  | Default size                                              |
+| ----------------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| Runtime process overhead      | Always                                      | ~500 MB                                                    |
+| Cayenne segment cache         | Each Cayenne-accelerated dataset            | 1/128 of total memory, clamped to 256 MB–1 GB              |
+| Cayenne PK keyset cache       | Each Cayenne CDC/upsert dataset             | 1/32 of total memory, clamped to 256 MiB–8 GiB, and additionally bounded by a process-wide ceiling across all datasets |
+| CDC coalesce buffer           | Each CDC dataset                            | 128 MiB (`cdc_max_coalesced_bytes`)                        |
+| Results caches                | Runtime                                     | 128 MiB each for SQL, search, and embedding results        |
+
+Two consequences follow:
+
+- **The baseline scales with dataset count.** Ten Cayenne-accelerated datasets reserve at least 2.5 GB of segment cache between them whether each dataset holds a gigabyte or a megabyte.
+- **The baseline is a larger share of a smaller container.** The per-dataset floors are absolute, so halving the container's memory does not halve the baseline — it raises the baseline's share of the total.
+
+The runtime accounts for this when deriving its own defaults: the query memory limit is reduced by the per-dataset reservations so the pools plus the caches fit within the memory the process may use. Explicitly configured limits are honored as-is and are **not** reduced, so a hand-set `runtime.query.memory_limit` is the one case where the total can be over-committed. Per-dataset caps sized in isolation still add up, and the aggregate is what the kernel makes its OOM decision on.
+
+## Sizing a Non-Production Environment
+
+A common approach to staging is to take the production configuration and scale every number down by the ratio of data volume — a tenth of the data, a tenth of the memory. Because the baseline does not scale, this does not produce a smaller model of production. It produces a **different regime**, in which the baseline dominates, the working set is squeezed into whatever is left, and behavior no longer predicts what production will do.
+
+Consider a Spicepod with ten accelerated datasets, deployed at two container sizes. The per-dataset caches sit at their floor in both, so the baseline is the same number in each row:
+
+| Container memory | Baseline (overhead + 10 datasets) | Baseline share | Left for the working set |
+| ---------------- | --------------------------------- | -------------- | ------------------------ |
+| 4 GiB            | ~3 GB                             | ~76%           | ~1 GB                    |
+| 32 GiB           | ~3 GB                             | ~9%            | ~29 GB                   |
+
+The same Spicepod is memory-bound in the first row and comfortable in the second. Nothing about the first row's behavior — its headroom, its spill frequency, its latency profile — carries over to the second.
+
+**Guidance for lower environments:**
+
+- **Scale the working set, not the baseline.** Reduce data volume and concurrency; keep the dataset count and the accelerator configuration the same.
+- **Do not copy limit ratios between environments.** Whatever fraction of the container `runtime.query.memory_limit` occupies in a small environment, the correct production value is a *larger* fraction, not the same one — the baseline it has to leave room for stays roughly constant while the container grows around it. Derive each environment's limit from its own baseline rather than carrying a percentage across.
+- **Reduce dataset count if you must run small.** Removing datasets lowers the baseline; shrinking their contents does not.
+- **Treat a configuration tuned to fit an undersized environment as disposable.** Lowering per-dataset caches and buffers to fit a container that is smaller than the runtime's floors will make it run, but it tunes for a regime you will not operate in, and the values do not transfer to production.
+
+:::warning[Costs of tuning below the defaults]
+
+The default cache and buffer sizes are the sizes the rest of the system is tuned against. Lowering them to fit a constrained environment is supported, but expect higher and less predictable query latency, more frequent spilling, and performance characteristics that will not match production. Prefer validating at a representative size — see [Validating a Memory Configuration](#validating-a-memory-configuration).
 
 :::
 
@@ -70,14 +136,16 @@ Spice Cayenne is DataFusion query-native, meaning all query execution adheres to
 | Parameter                  | Scope                  | Default | Description                                                                                                                                  |
 | -------------------------- | ---------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cayenne_footer_cache_mb`  | `runtime.params`       | `50` (unset) | Size of the engine-global in-memory Vortex footer cache in megabytes, shared by all Cayenne datasets. Larger values improve query performance for repeated scans by caching file metadata. Optional; when unset, DataFusion's default file-metadata-cache limit of 50 MB applies. |
-| `cayenne_segment_cache_mb` | `acceleration.params`  | `256`   | Per-dataset size of the in-memory Vortex segment cache in megabytes. Caches decompressed data segments for improved query performance.        |
+| `cayenne_segment_cache_mb` | `acceleration.params`  | auto    | Per-dataset size of the in-memory Vortex segment cache in megabytes. Caches decompressed data segments for improved query performance. When unset, derived as 1/128 of total memory, clamped to 256 MB–1 GB. |
 
 **Memory Usage Guidelines:**
 
 - Base memory: ~500 MB for runtime overhead
 - Footer cache: unset by default (DataFusion's 50 MB file-metadata-cache limit applies); increase for datasets with many files
-- Segment cache: 256 MB default, increase for workloads with repeated scans on the same data
+- Segment cache: auto-derived per dataset with a 256 MB floor; increase for workloads with repeated scans on the same data
 - Query execution memory: Depends on query complexity and concurrency
+
+The segment cache is allocated **per Cayenne-accelerated dataset**, and its floor does not scale down with the container. Count it once per dataset when sizing — see [What Makes Up the Baseline](#what-makes-up-the-baseline).
 
 **Example Configuration:**
 
@@ -147,11 +215,11 @@ Refresh modes affect memory usage as follows:
 
 ## DataFusion Query Memory Management
 
-Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of the memory the process may use** (its cgroup memory limit when one binds — a container, a `systemd` unit's `MemoryMax=`, a capped parent slice, or a Kubernetes pod cgroup — otherwise total system memory; reduced to **70%** when Cayenne acceleration is active, to leave headroom for Cayenne's compaction memory pool and in-memory CDC tier). This can be tuned through the `runtime.query.memory_limit` configuration.
+Spice uses DataFusion as its query execution engine. By default, Spice limits query engine memory to **90% of the memory the process may use** (its cgroup memory limit when one binds — a container, a `systemd` unit's `MemoryMax=`, a capped parent slice, or a Kubernetes pod cgroup — otherwise total system memory; reduced to **70%** when Cayenne's in-memory CDC tier is reachable, to leave headroom for Cayenne's compaction memory pool and that tier). Either base is then reduced by the per-dataset cache reservations and floored at 50% — see [How the Runtime Partitions Memory](#how-the-runtime-partitions-memory). This can be tuned through the `runtime.query.memory_limit` configuration.
 
 ### Memory Limit Configuration
 
-The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of the memory the process may use — its cgroup memory limit when one binds, otherwise total system memory (70% when Cayenne acceleration is active). Once the memory limit is reached, supported query operations spill data to disk.
+The `runtime.query.memory_limit` parameter defines the maximum memory available for query execution. If not specified, it defaults to 90% of the memory the process may use — its cgroup memory limit when one binds, otherwise total system memory (70% when Cayenne's in-memory CDC tier is reachable), less the per-dataset cache reservations and floored at 50%. Once the memory limit is reached, supported query operations spill data to disk.
 
 ```yaml
 runtime:
@@ -161,6 +229,45 @@ runtime:
 ```
 
 Spice uses [Apache DataFusion](https://datafusion.apache.org/) as its query execution engine, which provides vectorized, multi-threaded query execution with automatic memory management. DataFusion's [GreedyMemoryPool](https://docs.rs/datafusion/latest/datafusion/execution/memory_pool/struct.GreedyMemoryPool.html) allows memory reservations on a first-come, first-served basis up to the configured limit, improving throughput for high-concurrency queries with many partitions.
+
+### How the Runtime Partitions Memory
+
+When the limit is left unset, the runtime divides the memory the process may use into a partition that is designed to sum to 100%. Which partition applies depends on whether Cayenne's in-memory CDC tier is reachable:
+
+| Slice                             | Standard deployment | Cayenne CDC active |
+| --------------------------------- | ------------------- | ------------------ |
+| Query memory pool                 | 90%                 | 70% base, less the compaction carve |
+| Compaction memory pool            | —                   | Carved from the query pool (20% of it by default) |
+| In-memory CDC tier                | —                   | 20%, clamped to between 1/32 and 1/5 of memory |
+| Headroom for off-pool allocations | 10%                 | 10%                |
+
+The headroom slice is what covers the per-dataset caches, encode buffers, and allocator overhead described below. When the projected per-dataset reservations exceed that headroom, the excess is carved out of the query pool so the total still fits — which is why the effective query pool on a dataset-heavy Spicepod is smaller than the headline percentage. The query pool is never reduced below **50%** of available memory; when that floor binds and the caches still do not fit, the runtime warns at startup that the configuration is unfittable (see [Check the Startup Budget Warnings First](#check-the-startup-budget-warnings-first)).
+
+### Tuning the Memory Limit Safely
+
+`runtime.query.memory_limit` is bounded on both sides when Cayenne CDC ingestion is active, and both failure modes are counterintuitive:
+
+- **Setting it too low does not necessarily reduce resident memory.** The in-memory CDC tier is sized from the memory left over after the pools, so lowering the query pool hands that memory to the tier, which may float up to a quarter of total memory to reclaim it. The memory moves rather than being released. On a deployment being throttled to reduce its footprint, this is the most common reason the graph does not come down.
+- **Setting it too high starves CDC ingestion.** A greedy explicit limit can squeeze the tier's remainder below its floor, at which point the tier degrades to a refuse-all state and ingestion falls back to its disk-based path. The runtime warns when this happens.
+
+Both are consequences of the partition being coordinated. The practical guidance is to **leave `runtime.query.memory_limit` unset and size the container instead**, which lets the runtime derive every slice together. Set it explicitly only when a co-resident accelerator manages its own pool, and treat the value as one input to a partition rather than as a ceiling on the process.
+
+### What the Memory Limit Does Not Cover
+
+`runtime.query.memory_limit` bounds the query execution pool. It is not a ceiling on the process. Memory allocated outside that pool includes:
+
+- Per-dataset accelerator caches (see [What Makes Up the Baseline](#what-makes-up-the-baseline))
+- Serialization and encode buffers for query results, Arrow IPC, and Flight responses
+- Embedded engine internals that manage their own memory, such as DuckDB's pool and SQLite's page cache
+- Results, search, and embedding caches
+- Allocator retention — pages the process has freed but not returned to the operating system
+
+The gap between the query limit and the container's memory limit is the headroom that absorbs all of the above. The defaults reserve 10% of the memory the process may use, or 30% when Cayenne acceleration is active. **That reservation is a percentage, but what it has to cover is largely fixed**, so it gets tighter as the container gets smaller: 10% of a 4 GiB container is roughly 400 MB of headroom for buffers and caches whose own floors do not shrink with it.
+
+This is the usual reason a container is OOM-killed despite having a memory limit configured. Two corollaries:
+
+- **Lowering `runtime.query.memory_limit` does not reduce off-pool memory.** It shrinks the part that was already bounded and was probably not the cause. If the process is killed while the pool gauges show plenty of unused reservation, the memory is off-pool and a lower limit will not recover it.
+- **Explicit limits are not reduced for you.** When the limit is left unset the runtime derives it with the per-dataset reservations already subtracted. Setting it explicitly opts out of that arithmetic, so an explicit value must leave room for the baseline itself. When an explicit limit is set alongside Cayenne acceleration, the runtime logs the projected off-pool reservation at startup (`Explicit query memory limit set; the projected per-table Cayenne cache reservation is OFF-pool and unaffected by this limit`) — check it against the container's memory limit.
 
 ### Spill-to-Disk
 
@@ -205,6 +312,40 @@ When the query memory pool cannot satisfy a reservation, the query is refused ra
 | Runtime log | Logged at `warn` level (`Query refused, out of memory: …`), so a runtime refusing queries is visible at the default `INFO` verbosity |
 
 A sustained rate of these means the deployment needs more memory, fewer concurrent queries, or fewer partitions — not that the client's SQL is malformed. Note that `/health` is served by a separate Tokio runtime and stays green while queries are being refused, so alert on `query_failures{err_code="ResourcesExhausted"}` rather than relying on health checks.
+
+### Bounding Peak Memory with Concurrency
+
+Concurrency is the multiplier on the working set: each executing plan holds its own reservations, so peak memory scales with how many run at once. Two settings control this, and **both derive their defaults from the CPU entitlement rather than from memory**:
+
+| Setting                                | Default                                     | Effect on memory                                          |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------------- |
+| `runtime.query.max_concurrent_queries` | 4 × the CPU entitlement's cores             | Caps how many plans execute at once; excess queries wait   |
+| `runtime.query.target_partitions`      | The CPU entitlement's cores                 | Caps per-plan fan-out and its per-partition reservations   |
+
+Because the defaults follow CPU, a pod that is CPU-rich and memory-poor admits far more concurrent work than its memory can support. A pod sized for 8 cores admits 32 concurrent queries by default; one running [`runtime.cpu.cores: all`](./spicepod/runtime#runtimecpucores) on a large node admits proportionally more. Neither default consults `runtime.query.memory_limit`.
+
+```yaml
+runtime:
+  query:
+    max_concurrent_queries: 8 # bound admission by memory, not by core count
+```
+
+Lowering `max_concurrent_queries` reduces peak memory and converts what would have been capacity refusals into queueing, at the cost of latency under burst. It is usually the better first move than lowering `runtime.query.memory_limit`, which shrinks the pool available to each query without reducing how many run — and which, on a CDC deployment, may not reduce resident memory at all (see [Tuning the Memory Limit Safely](#tuning-the-memory-limit-safely)).
+
+When load testing, note that **peak concurrency, not average throughput, sets the peak memory** — a test that averages the target rate but never bursts will under-report the peak.
+
+### Client-Side Resiliency
+
+No memory configuration produces a zero-failure system, and sizing for one is not the goal. In any distributed deployment a query can fail for reasons unrelated to how Spice is tuned — an instance is evicted or preempted, a node is reclaimed, a rolling upgrade replaces a pod, a network path drops. Clients need an error budget and a retry path regardless of memory sizing.
+
+Recommended client behavior:
+
+- **Retry a failed query against the cluster before treating it as an outage.** With more than one instance behind a load balancer, a retry usually lands on a healthy instance. Capacity refusals (`503` / `RESOURCE_EXHAUSTED`) and connection failures are both retriable.
+- **Bound the retry.** One or two attempts with a short backoff is normally enough; unbounded retries turn a capacity problem into an outage by adding load to a runtime that is already refusing work.
+- **Set an explicit client timeout** so a slow query cannot consume the caller's own request budget.
+- **Fall back to the underlying data source last, not first.** Where a fallback path to the source of truth exists, place it after the in-cluster retry, so a single unhealthy instance does not divert all traffic away from the accelerated path.
+
+Distinguish the two cases when alerting: an isolated failure that a retry resolves is expected operational noise, while a sustained rate of capacity refusals is a sizing signal — see the metric guidance above.
 
 ## Predicate Pushdown and Memory Reduction
 
@@ -340,16 +481,19 @@ TinyLFU maintains frequency information to admit only items likely to be accesse
 When sizing memory, account for cache allocations:
 
 ```text
-Total Memory = Runtime Overhead + Accelerator Memory + Query Memory Limit + Cache Memory
+Total Memory = Runtime Overhead + (Per-Dataset Accelerator Caches × dataset count) + Query Memory Limit + Cache Memory
 ```
 
-**Example calculation:**
+**Example calculation** — four Cayenne-accelerated datasets, none using CDC:
 
 - Runtime overhead: 500 MB
-- Spice Cayenne caches: 306 MB (50 MB footer + 256 MB segment)
-- Query memory limit: 4 GB
+- Footer cache: 50 MB (engine-global, shared by all Cayenne datasets)
+- Segment caches: 1 GB (256 MB × 4 datasets — per-dataset, not shared)
 - Results caches: 1 GB (512 MB SQL + 256 MB search + 256 MB embeddings)
-- **Total: ~6 GB minimum**
+- Query memory limit: 4 GB
+- **Total: ~6.5 GB minimum**
+
+Everything above the query memory limit in that list is baseline: it is reserved at idle and it grows with the dataset count. Adding four more datasets adds roughly another 1 GB before a single query runs. Datasets using `refresh_mode: changes` add a PK keyset cache and a coalesce buffer on top of this — see [What Makes Up the Baseline](#what-makes-up-the-baseline).
 
 ### Cache Performance Considerations
 
@@ -384,10 +528,13 @@ spec:
 
 **Recommendations:**
 
-- Set memory requests to at least 1.3x the configured `runtime.query.memory_limit` plus accelerator cache sizes
+- Set memory requests to at least 1.3x the configured `runtime.query.memory_limit` plus accelerator cache sizes, counting the per-dataset caches once **per dataset**
 - Set memory limits higher than requests to handle temporary spikes
 - Avoid setting CPU limits, as they can cause [throttling](https://home.robusta.dev/blog/stop-using-cpu-limits) even when CPU is available
 - Monitor actual usage with observability tools and adjust accordingly
+- Prefer leaving `runtime.query.memory_limit` unset so the runtime derives it from the pod's cgroup limit with the per-dataset reservations subtracted; set it explicitly only when co-locating accelerators that manage their own pools
+
+The pod's memory limit is what the kernel enforces, so it must cover the baseline and the query pool together. A pod whose `runtime.query.memory_limit` was chosen without accounting for the per-dataset baseline will be OOM-killed while the query pool still reports unused capacity.
 
 ## Monitoring and Profiling
 
@@ -408,6 +555,67 @@ When [Spice Cayenne](../components/data-accelerators/cayenne) acceleration is co
 The pool gauges describe what the memory accounting believes is reserved; `process_resident_memory_bytes` describes what the process actually holds. A large and growing gap between them is off-pool memory that `runtime.query.memory_limit` does not bound — lowering the query memory limit will not shrink it.
 
 See [Observability](../features/observability) for configuration details.
+
+### Reading a Memory Graph
+
+Resident memory that climbs and then stays high is the expected shape, not a leak. Caches fill toward their configured ceilings and are not evicted until they are full, buffers are retained rather than reallocated because reallocation is expensive, and memory allocators keep freed pages mapped instead of returning them to the operating system. **Memory returning to its startup value is not a goal, and a flat high plateau is not evidence of a problem.**
+
+What matters is *where* it plateaus and *whether* it plateaus:
+
+| Observed shape                                                     | Interpretation                                                                                        |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Rises, then flat well below the container limit                     | Healthy. Caches are warm and the deployment has headroom.                                              |
+| Rises, then flat just under the container limit                     | Sized too tightly. Working normally, but with no margin for a spike — the next burst is an OOM kill.    |
+| Rises steadily under constant load and never flattens               | Investigate. Compare against the pool gauges to determine whether the growth is inside or outside the pools. |
+| Flat, then a sharp step on a specific operation                     | A refresh, compaction, or large query. Size for the peak, not the steady state.                        |
+
+To tell a plateau from slow growth, hold the load constant and run long enough for the steady state to establish itself: caches full, at least one full refresh cycle per dataset, and any background compaction having run. Reaching that point can take hours to days depending on refresh cadence, and reading the graph before then will show a rise that has not yet finished.
+
+When growth does not flatten, the two gauges separate the causes: growth in `query_memory_pool_used_bytes` is query work inside the bounded pool, while growth in `process_resident_memory_bytes` with the pool gauges flat is off-pool memory, which `runtime.query.memory_limit` does not govern.
+
+## Validating a Memory Configuration
+
+Memory behavior cannot be extrapolated from an environment that is not representative. Because the baseline is fixed and the working set is not, a deployment that is healthy on small data tells you very little about the same deployment on production data — and a deployment that is unhealthy on small data may be revealing only that the environment is below the runtime's floors.
+
+Start with the startup check below — it is free and immediate — then validate under load.
+
+### Check the Startup Budget Warnings First
+
+The runtime computes its memory partition at startup, before any data is loaded, and warns when the configuration cannot fit. These warnings are emitted at `warn` level, so they appear at the default `INFO` verbosity, and they are the cheapest possible sizing check: **an unfittable configuration is detectable in the first seconds of a run rather than after days of load.**
+
+| Startup warning (leading phrase)                                            | Meaning                                                                                                                       | Action                                                                                     |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `Cayenne CDC cache reservation exceeds what the query pool can yield`          | The per-dataset caches do not fit beside the query pool even after the pool has been reduced to its floor. The startup commitment already exceeds available memory. | Add memory, reduce dataset count, or lower per-dataset cache parameters. Expect resident memory above the budgets until then. |
+| `Cayenne in-memory CDC ingestion has limited memory available`                | The query pool, compaction pool, and any co-resident DuckDB reservations leave little room for CDC ingestion.                     | Lower `runtime.query.memory_limit` or per-dataset `duckdb_memory_limit`. Ingestion will spill to disk more often until then. |
+| `Detected potential memory over-commit from DuckDB accelerators`              | Un-limited DuckDB instances would each default to ~80% of host RAM. The runtime capped them automatically.                       | Set explicit `duckdb_memory_limit` values rather than relying on the automatic split.       |
+| `The explicit DuckDB accelerator memory limits plus the query memory limit exceed the coordinated memory budget` | Explicitly configured limits over-commit memory. These are honored as-is and **not** reduced.                                    | Lower the explicit `duckdb_memory_limit` and/or `runtime.query.memory_limit` values.        |
+
+The first warning is the important one for a constrained environment: it fires precisely in the situation described in [Sizing a Non-Production Environment](#sizing-a-non-production-environment) — an environment small enough that the per-dataset floors no longer fit beside a working query pool. Treat it as a statement that the environment is undersized for the dataset count, not as a tuning prompt.
+
+Also check the derived limit itself. At `DEBUG` verbosity the runtime logs the arithmetic it used (`No query memory limit specified; ...`), including the reservation it subtracted, which is the fastest way to see what the baseline actually costs for a given Spicepod.
+
+### Representative Load Testing
+
+A load test predicts production only if it reproduces all four of these. Missing any one of them makes the result unreliable:
+
+| Property               | Why it matters                                                                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Data volume**        | Determines the working set and the scan sizes. Generate synthetic data to production scale if real data cannot be copied into the environment. |
+| **Concurrency**        | Simultaneous in-flight queries multiply per-query memory. Peak concurrency, not average throughput, sets the peak.                             |
+| **Duration**           | Caches, refresh cycles, and compaction only reach steady state after a sustained run. Short runs measure the warm-up, not the plateau.         |
+| **Query diversity**    | Varied predicates and filter values exercise real scan and cache behavior. A test that replays one query measures the results cache.           |
+
+Generating production-scale data into a dedicated source is usually less effort than it appears, and is the piece most often skipped — it is also the piece that makes the other three meaningful.
+
+### Shadow or Canary Deployment
+
+Where a load test is impractical, mirror production traffic to a canary instance that serves no user-facing responses. This gives genuine query distribution, concurrency, and data volume without exposing users to the result. Confirm that the shadow path cannot write to production systems or double-count downstream side effects before enabling it.
+
+### What Not to Do
+
+- **Do not size production by scaling a small environment's numbers up proportionally.** The baseline does not scale, so the ratios do not transfer. See [Sizing a Non-Production Environment](#sizing-a-non-production-environment).
+- **Do not tune caches and buffers downward to make an undersized environment stop failing, and then ship that configuration.** It validates a regime you will not run in, at the cost of latency and predictability.
+- **Do not draw conclusions from a run that has not reached steady state**, in either direction.
 
 ## Related Documentation
 

--- a/website/docs/reference/memory.md
+++ b/website/docs/reference/memory.md
@@ -23,8 +23,13 @@ Spice's memory footprint has two parts, and they behave differently:
 Total Memory = Baseline + Working Set
 ```
 
-- **Baseline** — memory the runtime reserves to operate at all: process overhead, per-dataset accelerator caches, results caches, and allocator arenas. It is a function of **how many datasets are configured**, not how much data they hold. It is present at idle and it does not shrink when the data does.
+- **Baseline** — memory the runtime needs to operate at all: process overhead, per-dataset accelerator caches, results caches, task history, serialization buffers, and allocator arenas. It is a function of **how many datasets are configured**, not how much data they hold, and it does not shrink when the data does.
 - **Working Set** — memory that scales with the work: query execution, refreshes, and concurrency. This is the part bounded by [`runtime.query.memory_limit`](#memory-limit-configuration).
+
+Two refinements matter when reading a memory graph or sizing from a measurement:
+
+- **The baseline is mostly bounded buffers that grow toward their bounds with use, not memory claimed up front.** The SQLite metastore's page cache, gRPC and HTTP serialization buffers, and the accelerator caches all have ceilings, but they reach them only as traffic drives them there. The baseline is therefore the **converged** footprint under sustained load, not what the process holds at first startup — a freshly started runtime under-reports it, sometimes by a lot.
+- **The working set scales with the data each query touches, not just with dataset size.** `SELECT 1` costs almost nothing, `SELECT *` materializes a result set, and a multi-way join with a sort can exceed the size of the data it reads. Whatever a single query costs is then multiplied by how many run concurrently.
 
 Almost every surprising memory result comes from treating the total as a single quantity that scales with data volume. It does not. Sizing rules expressed as a multiple of dataset size — including the ones below — describe the **working set**, and apply on top of the baseline:
 
@@ -33,6 +38,8 @@ Total Memory ≈ Baseline + (multiple × dataset size)
 ```
 
 At production data volumes the working set dominates and the baseline is a rounding error. At small data volumes the reverse is true, which is why a deployment holding a few hundred megabytes of data can still need several gigabytes of RAM, and why cutting the data volume by 100x does not let you cut memory by 100x. See [Sizing a Non-Production Environment](#sizing-a-non-production-environment).
+
+Because both terms understate themselves early — buffers have not yet grown, and a light query mix has not yet hit its peak — sizing from a short observation biases low in both directions at once. Size from a sustained run, and see [Validating a Memory Configuration](#validating-a-memory-configuration).
 
 ## General Memory Recommendations
 
@@ -66,6 +73,19 @@ The baseline is the sum of a fixed process cost and a per-dataset cost. The per-
 | Cayenne PK keyset cache       | Each Cayenne CDC/upsert dataset             | 1/32 of total memory, clamped to 256 MiB–8 GiB, and additionally bounded by a process-wide ceiling across all datasets |
 | CDC coalesce buffer           | Each CDC dataset                            | 128 MiB (`cdc_max_coalesced_bytes`)                        |
 | Results caches                | Runtime                                     | 128 MiB each for SQL, search, and embedding results        |
+| Task history                  | Runtime (enabled by default)                | Unbounded by size; scales with task rate × `retention_period` (8h) |
+| Metastore and protocol buffers | Runtime                                    | Bounded, but reached only under sustained traffic          |
+
+The last two rows are the ones that make a short measurement misleading. **Task history is an in-memory accelerated table**, so its footprint is a product of how many tasks the deployment completes and how long records are kept, rather than a fixed allocation — a high-throughput deployment accumulates far more than a quiet one at the same configuration. Setting `captured_plan` or `captured_output` increases the size of every record substantially.
+
+```yaml
+runtime:
+  task_history:
+    retention_period: 1h # default 8h; the main lever on its footprint
+    captured_plan: none  # capturing plans materially increases per-record size
+```
+
+Prefer shortening `retention_period` to disabling task history outright — it backs `runtime.task_history`, which is the primary tool for diagnosing the very problems this page describes. Disable it only if the deployment is memory-critical and its diagnostics are served another way.
 
 Two consequences follow:
 
@@ -330,7 +350,9 @@ runtime:
     max_concurrent_queries: 8 # bound admission by memory, not by core count
 ```
 
-Lowering `max_concurrent_queries` reduces peak memory and converts what would have been capacity refusals into queueing, at the cost of latency under burst. It is usually the better first move than lowering `runtime.query.memory_limit`, which shrinks the pool available to each query without reducing how many run — and which, on a CDC deployment, may not reduce resident memory at all (see [Tuning the Memory Limit Safely](#tuning-the-memory-limit-safely)).
+Lowering `max_concurrent_queries` reduces peak **memory** and converts what would have been capacity refusals into queueing. The trade-off is that peak **query time** rises: excess queries now wait for admission, and that wait counts toward end-to-end duration. Measure total query duration rather than execution time alone when tuning it.
+
+It is still usually the better first move than lowering `runtime.query.memory_limit`, which shrinks the pool available to each query without reducing how many run — and which, on a CDC deployment, may not reduce resident memory at all (see [Tuning the Memory Limit Safely](#tuning-the-memory-limit-safely)).
 
 When load testing, note that **peak concurrency, not average throughput, sets the peak memory** — a test that averages the target rate but never bursts will under-report the peak.
 
@@ -344,6 +366,7 @@ Recommended client behavior:
 - **Bound the retry.** One or two attempts with a short backoff is normally enough; unbounded retries turn a capacity problem into an outage by adding load to a runtime that is already refusing work.
 - **Set an explicit client timeout** so a slow query cannot consume the caller's own request budget.
 - **Fall back to the underlying data source last, not first.** Where a fallback path to the source of truth exists, place it after the in-cluster retry, so a single unhealthy instance does not divert all traffic away from the accelerated path.
+- **Consider a circuit breaker for sustained failure.** Retries handle isolated failures; they make a sustained one worse. After a threshold of consecutive failures, stop sending traffic for a cooldown, then probe with a fraction of it and restore full load only once the probes succeed. This is usually best implemented at the load balancer or service mesh rather than in each client, so the decision is shared across callers instead of being re-learned by each one.
 
 Distinguish the two cases when alerting: an isolated failure that a retry resolves is expected operational noise, while a sustained rate of capacity refusals is a sizing signal — see the metric guidance above.
 
@@ -493,7 +516,15 @@ Total Memory = Runtime Overhead + (Per-Dataset Accelerator Caches × dataset cou
 - Query memory limit: 4 GB
 - **Total: ~6.5 GB minimum**
 
-Everything above the query memory limit in that list is baseline: it is reserved at idle and it grows with the dataset count. Adding four more datasets adds roughly another 1 GB before a single query runs. Datasets using `refresh_mode: changes` add a PK keyset cache and a coalesce buffer on top of this — see [What Makes Up the Baseline](#what-makes-up-the-baseline).
+Everything above the query memory limit in that list is baseline, and it grows with the dataset count. Adding four more datasets adds roughly another 1 GB before a single query runs. Datasets using `refresh_mode: changes` add a PK keyset cache and a coalesce buffer on top of this — see [What Makes Up the Baseline](#what-makes-up-the-baseline).
+
+:::warning[This is a planning floor, not a prediction]
+
+A calculation like this sums the allocations that can be named and sized in advance, so it **under-estimates actual usage** and should never be used as the container's memory limit. It omits the buffers that grow with traffic, task history's throughput-dependent growth, allocator retention and fragmentation, and any transient peak above the steady state. The query memory limit in particular is a *ceiling* on the pool, not a reservation — actual usage moves within it.
+
+Treat the result as the minimum below which the deployment certainly will not fit, add headroom, and then replace the estimate with a measurement from a sustained representative run. See [Validating a Memory Configuration](#validating-a-memory-configuration).
+
+:::
 
 ### Cache Performance Considerations
 
@@ -559,6 +590,8 @@ See [Observability](../features/observability) for configuration details.
 ### Reading a Memory Graph
 
 Resident memory that climbs and then stays high is the expected shape, not a leak. Caches fill toward their configured ceilings and are not evicted until they are full, buffers are retained rather than reallocated because reallocation is expensive, and memory allocators keep freed pages mapped instead of returning them to the operating system. **Memory returning to its startup value is not a goal, and a flat high plateau is not evidence of a problem.**
+
+The last of those is a documented property of the allocators themselves, not a Spice-specific behavior. [jemalloc](https://jemalloc.net/jemalloc.3.html) retains freed pages and returns them only on a decay schedule (`dirty_decay_ms`, `muzzy_decay_ms`). glibc's allocator returns memory to the OS only when the free block at the top of the heap exceeds [`M_TRIM_THRESHOLD`](https://man7.org/linux/man-pages/man3/mallopt.3.html), so freed memory in the middle of the heap stays resident by design. Resident set size is consequently an upper bound on what the process is actively using — and, per the [cgroup v2 documentation](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files), it is nonetheless what the kernel charges against `memory.max` when deciding whether to OOM-kill.
 
 What matters is *where* it plateaus and *whether* it plateaus:
 
@@ -631,3 +664,6 @@ Where a load test is impractical, mirror production traffic to a canary instance
 - [DataFusion Memory Usage](https://datafusion.apache.org/user-guide/configs.html#runtime-configuration-settings) - DataFusion runtime memory configuration
 - [DataFusion Tuning Guide](https://datafusion.apache.org/user-guide/configs.html#tuning-guide) - Memory-limited query optimization
 - [DuckDB Memory Management](https://duckdb.org/docs/operations_manual/limits.html) - DuckDB memory limits documentation
+- [jemalloc](https://jemalloc.net/jemalloc.3.html) - Page retention and the `dirty_decay_ms` / `muzzy_decay_ms` decay schedule
+- [`mallopt`](https://man7.org/linux/man-pages/man3/mallopt.3.html) - glibc's `M_TRIM_THRESHOLD` and when freed memory is returned to the OS
+- [cgroup v2 memory interface](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) - What `memory.max` accounts for and how the OOM decision is made

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -407,7 +407,9 @@ When the goal is to reduce peak memory, prefer bounding concurrency over lowerin
 | Reduce per-plan fan-out and its reservations      | `runtime.query.target_partitions` (defaults to the CPU entitlement's cores)                   |
 | Change how much memory a single query may reserve | `runtime.query.memory_limit`                                                                  |
 
-Lowering `max_concurrent_queries` converts capacity refusals into queueing and reduces the peak directly. Lowering `memory_limit` shrinks the pool each query draws from without reducing how many run concurrently, and on a Cayenne CDC deployment it can leave resident memory unchanged because the in-memory CDC tier expands into the freed budget — see [Tuning the Memory Limit Safely](./memory#tuning-the-memory-limit-safely).
+Lowering `max_concurrent_queries` reduces peak **memory** usage directly, by bounding how many plans hold reservations at once. The trade-off is latency: excess queries wait for admission rather than being refused, so peak end-to-end query time rises with the time spent queueing. Tune it against the workload's tolerance for wait, and watch total query duration — not just execution time — when you change it.
+
+Lowering `memory_limit` shrinks the pool each query draws from without reducing how many run concurrently, and on a Cayenne CDC deployment it can leave resident memory unchanged because the in-memory CDC tier expands into the freed budget — see [Tuning the Memory Limit Safely](./memory#tuning-the-memory-limit-safely).
 
 ### Spill Compression
 

--- a/website/docs/reference/performance-tuning.md
+++ b/website/docs/reference/performance-tuning.md
@@ -395,6 +395,20 @@ If not specified, `memory_limit` defaults to 90% of the memory the process may u
 runtime memory_limit = Total Memory - Accelerator Memory - OS/Runtime Overhead (30%)
 ```
 
+Accelerator memory in that expression is **per dataset**, not per deployment: each accelerated dataset holds its own caches, sized as a fraction of total memory but clamped to a floor that does not shrink with the container. The limit therefore has to be derived for the dataset count, and the ratio that works in a small environment does not carry to a large one. See [How Spice Uses Memory](./memory#how-spice-uses-memory) and [Sizing a Non-Production Environment](./memory#sizing-a-non-production-environment).
+
+Note also that this limit bounds the query execution pool, not the process. Serialization buffers, accelerator caches, and allocator retention sit outside it, which is why lowering it does not always reduce resident memory — see [What the Memory Limit Does Not Cover](./memory#what-the-memory-limit-does-not-cover).
+
+When the goal is to reduce peak memory, prefer bounding concurrency over lowering this limit:
+
+| Intent                                          | Setting                                                                                     |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Reduce peak memory under burst                    | `runtime.query.max_concurrent_queries` (defaults to 4× the CPU entitlement's cores, not from memory) |
+| Reduce per-plan fan-out and its reservations      | `runtime.query.target_partitions` (defaults to the CPU entitlement's cores)                   |
+| Change how much memory a single query may reserve | `runtime.query.memory_limit`                                                                  |
+
+Lowering `max_concurrent_queries` converts capacity refusals into queueing and reduces the peak directly. Lowering `memory_limit` shrinks the pool each query draws from without reducing how many run concurrently, and on a Cayenne CDC deployment it can leave resident memory unchanged because the in-memory CDC tier expands into the freed budget — see [Tuning the Memory Limit Safely](./memory#tuning-the-memory-limit-safely).
+
 ### Spill Compression
 
 | Compression      | Disk Usage | CPU Overhead |

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -53,6 +53,19 @@ SELECT task, error_message FROM runtime.task_history WHERE error_message IS NOT 
 - **Check tools configuration**: Ensure `tools: auto` is set in the model params so the model can discover and query datasets.
 - **Use `spice trace ai_chat`**: Inspect the trace output to see which tools the model called and whether SQL queries succeeded or failed.
 
+### Container OOM-killed despite a configured memory limit
+
+`runtime.query.memory_limit` bounds the query execution pool, not the process. Accelerator caches, serialization buffers, embedded engine pools, and allocator retention sit outside it, so a process can be killed while the query pool still reports unused capacity.
+
+- **Compare the pools against actual memory**: if `process_resident_memory_bytes` is far above `query_memory_pool_used_bytes`, the memory is off-pool and lowering the query limit will not recover it.
+- **Count the per-dataset baseline**: accelerator caches are allocated per dataset with a floor that does not shrink with the container, so the idle footprint grows with dataset count regardless of data size.
+- **Check whether the limit was set explicitly**: when unset, the runtime derives the query limit with the per-dataset reservations subtracted. An explicit value opts out of that and must leave room for the baseline itself.
+- **Do not read a flat, high memory graph as a leak**: caches fill to their ceilings and allocators retain freed pages. What matters is whether it plateaus, and how far below the limit.
+- **Read the startup warnings before load testing**: the runtime warns at startup when the configured caches cannot fit beside the query pool, which detects an undersized deployment in seconds rather than days.
+- **Lowering the query limit is often the wrong lever**: bounding `runtime.query.max_concurrent_queries` reduces the peak directly, whereas lowering `runtime.query.memory_limit` shrinks each query's budget without reducing how many run at once.
+
+See [Managing Memory Usage](../reference/memory.md) for the sizing model and validation guidance.
+
 ### Port conflicts on startup
 
 If Spice fails to bind to its default ports (`8090` for HTTP, `50051` for Flight, `9090` for metrics), another process is already using that port. Override the ports:


### PR DESCRIPTION
## Why

The memory guide gave sizing rules as multiples of dataset size plus a minimum RAM figure, with no account of the fixed cost those multiples sit on top of. That reads as *memory scales with data*, which makes a proportionally downscaled staging environment look like a valid model of production. It is not one, and nothing in the docs warned anyone off it.

Prompted by a support conversation about a deployment being OOM-killed in a small container; the guidance here is written generally, and every number is checked against the shipped runtime.

## The reframing

`Total = Baseline + Working Set`. The **baseline is a function of dataset count, not data volume** — each Cayenne table holds a segment cache (1/128 of memory, clamped to 256 MB–1 GB), and a CDC table adds a PK keyset cache (1/32, clamped 256 MiB–8 GiB) and a coalesce buffer.

The clamps are the point: the per-dataset cost stops shrinking once the environment is small, so it is a rounding error at production volumes and the dominant term below them. A worked table shows the same ten-dataset Spicepod at ~76% baseline in 4 GiB and ~9% in 32 GiB. The existing multiples are relabelled as working-set figures rather than totals.

## Four things from the runtime the docs did not carry

Each of these changes what an operator should actually do:

- **`How the Runtime Partitions Memory`** — the 70/20/10 partition (pools / in-memory CDC tier / off-pool headroom), the compaction carve out of the query pool, and the 50% floor.
- **`Tuning the Memory Limit Safely`** — the limit is bounded on **both** sides when CDC is active, and both directions are counterintuitive. Lowering it need not reduce resident memory: the tier is sized from what is left after the pools and floats up to a quarter of memory to reclaim it, so the memory *moves* rather than releasing. Raising it squeezes the tier below its floor into a refuse-all gate and ingestion falls back to disk. Hence: leave it unset, size the container.
- **`Bounding Peak Memory with Concurrency`** — `max_concurrent_queries` defaults to 4× the CPU entitlement's cores and `target_partitions` to the cores; neither consults the memory limit. With the entitlement at twice the pod's CPU request, a `requests.cpu: 4` pod admits 32 concurrent queries however little memory it has. This is the better first lever for peak memory — it lowers the peak, where lowering `memory_limit` only shrinks each query's share of it.
- **`Check the Startup Budget Warnings First`** — the partition is computed before any data loads and warns when it cannot fit, at `warn` level. **An unfittable configuration is detectable in the first seconds of a run rather than after days of load**, so it belongs ahead of load testing. Four warnings tabulated with meaning and action. (The source comment on the first records a ~122 GiB host OOM-killed at SF-1000 whose only trace was that line.)

Also added: `Reading a Memory Graph` (a flat high plateau is caches at their ceilings and allocator retention, not a leak), `Validating a Memory Configuration` (the four properties that make a load test predictive — data volume, peak concurrency, duration to steady state, predicate diversity — plus shadow/canary), and `Client-Side Resiliency` (retry in-cluster before falling back; instance loss is independent of memory tuning).

## Accuracy fixes found on the way

- `cayenne_segment_cache_mb` was documented as a flat `256` default. It is auto-derived — 256 MB is the *floor*, and it reaches 1 GB above a 32 GiB host.
- The cache-sizing example counted accelerator caches once per deployment. They are per dataset; the example now uses four and says what a fifth costs.
- Two statements attributed the 70% base to "Cayenne acceleration is active". It is specifically the in-memory CDC tier being *reachable* — Cayenne bulk-only keeps the 90% base less the full reservation. Both now match the source, and agree with `performance-tuning.md`, which already had it right.

## Supporting pages

The levers are surfaced where the problem is actually hit: `performance-tuning` gets a which-knob-for-which-intent table, `deployment/kubernetes` gets a Memory sizing section beside the CPU one, `troubleshooting` gets an OOM-despite-a-configured-limit entry.

## Verification

`cd website && npm run build` passes — the config throws on broken links and anchors, so the build gates every cross-reference added here.

Constants checked against the shipped source: the 90/70/50 percentages, the 20% compaction carve, the tier's 1/5 ceiling, 1/32 floor and 1/4 float, the two cache clamps, the 128 MiB coalesce buffer, `QUERIES_PER_CORE = 4`, and `target_partitions = cores`.

## Reviewer notes

Two things worth a maintainer's eye:

1. The docs now state plainly that a **small-data deployment can still legitimately need multiple gigabytes**. That follows from the per-dataset floors and I believe it is correct, but it is the first place the docs say it outright.
2. The startup warnings are documented by their **leading phrases** so they are greppable. Log strings are not a stable API — if someone rewords one, these tables go stale silently. Happy to point at the metrics instead if that is preferred.

Trunk `website/docs/` only, so this lands as **Next** and flows into the next release; no versioned snapshots touched.
