### PR TITLE
docs(monitoring): Datadog distributions for histogram percentiles

### DIFF
--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -47,10 +47,10 @@ Spice exports latency and size metrics — `query_duration_ms`, `flight_request_
 p99:spiceai.flight_request_duration_ms{method:do_get} by {command}
 ```
 
-| Option                               | Default | Why Spice needs it                                                                                                                                                                                      |
-| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                                                                                          |
-| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries.                                                                 |
+| Option                               | Default | Why Spice needs it                                                                                                                      |
+| ------------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                          |
+| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries. |
 
 :::caution Percentile aggregations must be enabled on the metric
 Submitting a distribution is not sufficient on its own. Datadog computes `p50`/`p90`/`p95`/`p99` for a distribution metric only once **percentile aggregations** are enabled for that metric on the Metrics Summary page — see [Enabling advanced query functionality](https://docs.datadoghq.com/metrics/distributions/#enabling-advanced-query-functionality). Until then a `p99:` query returns no data and the widget renders empty rather than reporting an error.
@@ -84,6 +84,18 @@ ad.datadoghq.com/spiceai.checks: |
 ```
 
 `collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
+
+## Instance Identity
+
+The `service_instance_id` tag identifies which Spice instance a metric came from. It is a normalization Spice asks operators to configure, not a tag the Datadog Agent supplies: Datadog's [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version`, and while the Agent adds Kubernetes dimensions such as `pod_name`, `kube_namespace`, and `kube_cluster_name` automatically, none of them exist on a host, VM, or Docker deployment. Tagging `service_instance_id` in the Agent configuration gives every deployment shape one consistent instance identity.
+
+The Spice dashboard relies on it in two places: the `instance` template variable filters on it, and every per-instance panel groups by it. Set it in both configurations above — to the pod name under Kubernetes (`%%kube_pod_name%%`), and to the hostname or another stable per-process identifier elsewhere.
+
+:::caution Panels collapse silently without this tag
+Datadog does not error on a missing tag. A dashboard imported without `service_instance_id` renders one `N/A` series per panel carrying the sum across every replica — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing. There is no query-level fallback from one tag to another, so this has to be fixed in the Agent configuration.
+:::
+
+Panels backed by the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, since those metrics come from the Kubernetes check and never carry `service_instance_id`.
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -94,8 +94,6 @@ The Spice dashboard identifies each running instance by a `service_instance_id` 
 | Kubernetes          | `%%kube_pod_name%%`                                |
 | Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
-This mirrors how Datadog integrations identify systems that run several members alongside each other, where `host` cannot tell them apart: the [RabbitMQ dashboard](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/assets/dashboards/rabbitmq_dashboard.json) groups by `rabbitmq_node`, and the [Vault dashboard](https://github.com/DataDog/integrations-core/blob/master/vault/assets/dashboards/vault_overview.json) by `vault_cluster`.
-
 :::caution Panels collapse silently without this tag
 Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -19,18 +19,46 @@ init_config:
 
 instances:
   - openmetrics_endpoint: http://localhost:9090/metrics # Spice metrics endpoint
-    namespace: spice
+    namespace: spiceai
     metrics:
       - .*
+    collect_histogram_buckets: true # Required for percentile queries, see below
+    histogram_buckets_as_distributions: true # Required for percentile queries, see below
+    max_returned_metrics: 3000 # Default is 2000, which Spice can exceed
     tags:
       - service_instance_id:<unique-id> # e.g. hostname; required by the Spice dashboard filter
 ```
 
 1. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent) to start collecting Spice metrics.
 1. Refer to [Prometheus and OpenMetrics metrics collection from a host](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/) for all available configuration options and supported parameters.
-1. Open Datadog Metrics Explorer and type `spice` to confirm Spice telemetry information is successfully collected.
+1. Open Datadog Metrics Explorer and type `spiceai` to confirm Spice telemetry information is successfully collected.
 
 <img width="800" src="/img/datadog/spice_datadog_metrics_explorer.png"/>
+
+:::note The `namespace` sets the metric prefix
+Every scraped metric is prefixed with the configured `namespace`, so `query_duration_ms` is stored as `spiceai.query_duration_ms`. Keep this value consistent with the prefix used by the queries in the Spice dashboard JSON, and with [`runtime.telemetry.metric_prefix`](#namespace-spice-metrics-with-a-prefix) if the same deployment also pushes metrics over OTLP.
+:::
+
+### Histogram Percentiles (Distributions)
+
+Spice exports latency and size metrics — `query_duration_ms`, `flight_request_duration_ms`, `http_requests_duration_ms`, `dataset_acceleration_refresh_duration_ms`, and others — as Prometheus histograms. Configuring the Agent to submit those buckets as [Datadog distributions](https://docs.datadoghq.com/integrations/guide/prometheus-metrics/?tab=latestversion#histogram) makes percentiles queryable over the selected time window:
+
+```text
+p99:spiceai.flight_request_duration_ms{method:do_get} by {command}
+```
+
+| Option                               | Default | Why Spice needs it                                                                                                                                                                                      |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                                                                                          |
+| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries.                                                                 |
+
+:::caution Percentile aggregations must be enabled on the metric
+Submitting a distribution is not sufficient on its own. Datadog computes `p50`/`p90`/`p95`/`p99` for a distribution metric only once **percentile aggregations** are enabled for that metric on the Metrics Summary page — see [Enabling advanced query functionality](https://docs.datadoghq.com/metrics/distributions/#enabling-advanced-query-functionality). Until then a `p99:` query returns no data and the widget renders empty rather than reporting an error.
+:::
+
+:::note Why not the `_summary` metrics
+The metrics endpoint also exposes a `<metric>_summary` family carrying `quantile` tags, derived from each histogram at scrape time. The underlying histogram is cumulative, so those quantiles describe the **entire lifetime of the process** rather than the queried time window: they flatten the longer a pod stays up and will not surface a latency regression. Prefer distributions for any percentile that needs to track a time window.
+:::
 
 ## Kubernetes (Operator / Autodiscovery)
 
@@ -43,14 +71,19 @@ ad.datadoghq.com/spiceai.checks: |
       "instances": [
         {
           "openmetrics_endpoint": "http://%%host%%:9090/metrics",
-          "namespace": "spice",
+          "namespace": "spiceai",
           "metrics": [".*"],
+          "collect_histogram_buckets": true,
+          "histogram_buckets_as_distributions": true,
+          "max_returned_metrics": 3000,
           "tags": ["service_instance_id:%%kube_pod_name%%"]
         }
       ]
     }
   }
 ```
+
+`collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -94,6 +94,8 @@ The Spice dashboard identifies each running instance by a `service_instance_id` 
 | Kubernetes          | `%%kube_pod_name%%`                                |
 | Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
+This mirrors how Datadog integrations identify systems that run several members alongside each other, where `host` cannot tell them apart: the [RabbitMQ dashboard](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/assets/dashboards/rabbitmq_dashboard.json) groups by `rabbitmq_node`, and the [Vault dashboard](https://github.com/DataDog/integrations-core/blob/master/vault/assets/dashboards/vault_overview.json) by `vault_cluster`.
+
 :::caution Panels collapse silently without this tag
 Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::

--- a/website/docs/monitoring/datadog/index.md
+++ b/website/docs/monitoring/datadog/index.md
@@ -83,19 +83,22 @@ ad.datadoghq.com/spiceai.checks: |
   }
 ```
 
-`collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
+`collect_histogram_buckets` and `histogram_buckets_as_distributions` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions). `max_returned_metrics` raises the check's default limit of 2000, which Spice can exceed.
 
 ## Instance Identity
 
-The `service_instance_id` tag identifies which Spice instance a metric came from. It is a normalization Spice asks operators to configure, not a tag the Datadog Agent supplies: Datadog's [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version`, and while the Agent adds Kubernetes dimensions such as `pod_name`, `kube_namespace`, and `kube_cluster_name` automatically, none of them exist on a host, VM, or Docker deployment. Tagging `service_instance_id` in the Agent configuration gives every deployment shape one consistent instance identity.
+The Spice dashboard identifies each running instance by a `service_instance_id` tag: the `instance` filter selects on it, and every per-instance panel groups by it. The Agent supplies no instance-level tag of its own — its [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version` — so set it explicitly, as in both examples above:
 
-The Spice dashboard relies on it in two places: the `instance` template variable filters on it, and every per-instance panel groups by it. Set it in both configurations above — to the pod name under Kubernetes (`%%kube_pod_name%%`), and to the hostname or another stable per-process identifier elsewhere.
+| Deployment          | Value                                              |
+| ------------------- | -------------------------------------------------- |
+| Kubernetes          | `%%kube_pod_name%%`                                |
+| Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
 :::caution Panels collapse silently without this tag
-Datadog does not error on a missing tag. A dashboard imported without `service_instance_id` renders one `N/A` series per panel carrying the sum across every replica — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing. There is no query-level fallback from one tag to another, so this has to be fixed in the Agent configuration.
+Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::
 
-Panels backed by the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, since those metrics come from the Kubernetes check and never carry `service_instance_id`.
+Panels from the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, as those metrics never carry `service_instance_id`.
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -47,10 +47,10 @@ Spice exports latency and size metrics — `query_duration_ms`, `flight_request_
 p99:spiceai.flight_request_duration_ms{method:do_get} by {command}
 ```
 
-| Option                               | Default | Why Spice needs it                                                                                                                                                                                      |
-| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                                                                                          |
-| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries.                                                                 |
+| Option                               | Default | Why Spice needs it                                                                                                                      |
+| ------------------------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                          |
+| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries. |
 
 :::caution Percentile aggregations must be enabled on the metric
 Submitting a distribution is not sufficient on its own. Datadog computes `p50`/`p90`/`p95`/`p99` for a distribution metric only once **percentile aggregations** are enabled for that metric on the Metrics Summary page — see [Enabling advanced query functionality](https://docs.datadoghq.com/metrics/distributions/#enabling-advanced-query-functionality). Until then a `p99:` query returns no data and the widget renders empty rather than reporting an error.
@@ -84,6 +84,18 @@ ad.datadoghq.com/spiceai.checks: |
 ```
 
 `collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
+
+## Instance Identity
+
+The `service_instance_id` tag identifies which Spice instance a metric came from. It is a normalization Spice asks operators to configure, not a tag the Datadog Agent supplies: Datadog's [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version`, and while the Agent adds Kubernetes dimensions such as `pod_name`, `kube_namespace`, and `kube_cluster_name` automatically, none of them exist on a host, VM, or Docker deployment. Tagging `service_instance_id` in the Agent configuration gives every deployment shape one consistent instance identity.
+
+The Spice dashboard relies on it in two places: the `instance` template variable filters on it, and every per-instance panel groups by it. Set it in both configurations above — to the pod name under Kubernetes (`%%kube_pod_name%%`), and to the hostname or another stable per-process identifier elsewhere.
+
+:::caution Panels collapse silently without this tag
+Datadog does not error on a missing tag. A dashboard imported without `service_instance_id` renders one `N/A` series per panel carrying the sum across every replica — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing. There is no query-level fallback from one tag to another, so this has to be fixed in the Agent configuration.
+:::
+
+Panels backed by the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, since those metrics come from the Kubernetes check and never carry `service_instance_id`.
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -94,8 +94,6 @@ The Spice dashboard identifies each running instance by a `service_instance_id` 
 | Kubernetes          | `%%kube_pod_name%%`                                |
 | Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
-This mirrors how Datadog integrations identify systems that run several members alongside each other, where `host` cannot tell them apart: the [RabbitMQ dashboard](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/assets/dashboards/rabbitmq_dashboard.json) groups by `rabbitmq_node`, and the [Vault dashboard](https://github.com/DataDog/integrations-core/blob/master/vault/assets/dashboards/vault_overview.json) by `vault_cluster`.
-
 :::caution Panels collapse silently without this tag
 Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -19,18 +19,46 @@ init_config:
 
 instances:
   - openmetrics_endpoint: http://localhost:9090/metrics # Spice metrics endpoint
-    namespace: spice
+    namespace: spiceai
     metrics:
       - .*
+    collect_histogram_buckets: true # Required for percentile queries, see below
+    histogram_buckets_as_distributions: true # Required for percentile queries, see below
+    max_returned_metrics: 3000 # Default is 2000, which Spice can exceed
     tags:
       - service_instance_id:<unique-id> # e.g. hostname; required by the Spice dashboard filter
 ```
 
 1. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent) to start collecting Spice metrics.
 1. Refer to [Prometheus and OpenMetrics metrics collection from a host](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/) for all available configuration options and supported parameters.
-1. Open Datadog Metrics Explorer and type `spice` to confirm Spice telemetry information is successfully collected.
+1. Open Datadog Metrics Explorer and type `spiceai` to confirm Spice telemetry information is successfully collected.
 
 <img width="800" src="/img/datadog/spice_datadog_metrics_explorer.png"/>
+
+:::note The `namespace` sets the metric prefix
+Every scraped metric is prefixed with the configured `namespace`, so `query_duration_ms` is stored as `spiceai.query_duration_ms`. Keep this value consistent with the prefix used by the queries in the Spice dashboard JSON, and with [`runtime.telemetry.metric_prefix`](#namespace-spice-metrics-with-a-prefix) if the same deployment also pushes metrics over OTLP.
+:::
+
+### Histogram Percentiles (Distributions)
+
+Spice exports latency and size metrics — `query_duration_ms`, `flight_request_duration_ms`, `http_requests_duration_ms`, `dataset_acceleration_refresh_duration_ms`, and others — as Prometheus histograms. Configuring the Agent to submit those buckets as [Datadog distributions](https://docs.datadoghq.com/integrations/guide/prometheus-metrics/?tab=latestversion#histogram) makes percentiles queryable over the selected time window:
+
+```text
+p99:spiceai.flight_request_duration_ms{method:do_get} by {command}
+```
+
+| Option                               | Default | Why Spice needs it                                                                                                                                                                                      |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collect_histogram_buckets`          | `true`  | Sends the `_bucket` series that percentiles are computed from.                                                                                                                                          |
+| `histogram_buckets_as_distributions` | `false` | Submits those buckets as a Datadog distribution rather than a set of counters. Required for `p50:`, `p90:`, `p95:`, and `p99:` queries.                                                                 |
+
+:::caution Percentile aggregations must be enabled on the metric
+Submitting a distribution is not sufficient on its own. Datadog computes `p50`/`p90`/`p95`/`p99` for a distribution metric only once **percentile aggregations** are enabled for that metric on the Metrics Summary page — see [Enabling advanced query functionality](https://docs.datadoghq.com/metrics/distributions/#enabling-advanced-query-functionality). Until then a `p99:` query returns no data and the widget renders empty rather than reporting an error.
+:::
+
+:::note Why not the `_summary` metrics
+The metrics endpoint also exposes a `<metric>_summary` family carrying `quantile` tags, derived from each histogram at scrape time. The underlying histogram is cumulative, so those quantiles describe the **entire lifetime of the process** rather than the queried time window: they flatten the longer a pod stays up and will not surface a latency regression. Prefer distributions for any percentile that needs to track a time window.
+:::
 
 ## Kubernetes (Operator / Autodiscovery)
 
@@ -43,14 +71,19 @@ ad.datadoghq.com/spiceai.checks: |
       "instances": [
         {
           "openmetrics_endpoint": "http://%%host%%:9090/metrics",
-          "namespace": "spice",
+          "namespace": "spiceai",
           "metrics": [".*"],
+          "collect_histogram_buckets": true,
+          "histogram_buckets_as_distributions": true,
+          "max_returned_metrics": 3000,
           "tags": ["service_instance_id:%%kube_pod_name%%"]
         }
       ]
     }
   }
 ```
+
+`collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
 
 ## Import the Spice Datadog Dashboard
 

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -94,6 +94,8 @@ The Spice dashboard identifies each running instance by a `service_instance_id` 
 | Kubernetes          | `%%kube_pod_name%%`                                |
 | Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
+This mirrors how Datadog integrations identify systems that run several members alongside each other, where `host` cannot tell them apart: the [RabbitMQ dashboard](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/assets/dashboards/rabbitmq_dashboard.json) groups by `rabbitmq_node`, and the [Vault dashboard](https://github.com/DataDog/integrations-core/blob/master/vault/assets/dashboards/vault_overview.json) by `vault_cluster`.
+
 :::caution Panels collapse silently without this tag
 Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::

--- a/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/datadog/index.md
@@ -83,19 +83,22 @@ ad.datadoghq.com/spiceai.checks: |
   }
 ```
 
-`collect_histogram_buckets`, `histogram_buckets_as_distributions`, and `max_returned_metrics` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions).
+`collect_histogram_buckets` and `histogram_buckets_as_distributions` serve the same purpose here as in the host configuration — see [Histogram Percentiles (Distributions)](#histogram-percentiles-distributions). `max_returned_metrics` raises the check's default limit of 2000, which Spice can exceed.
 
 ## Instance Identity
 
-The `service_instance_id` tag identifies which Spice instance a metric came from. It is a normalization Spice asks operators to configure, not a tag the Datadog Agent supplies: Datadog's [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version`, and while the Agent adds Kubernetes dimensions such as `pod_name`, `kube_namespace`, and `kube_cluster_name` automatically, none of them exist on a host, VM, or Docker deployment. Tagging `service_instance_id` in the Agent configuration gives every deployment shape one consistent instance identity.
+The Spice dashboard identifies each running instance by a `service_instance_id` tag: the `instance` filter selects on it, and every per-instance panel groups by it. The Agent supplies no instance-level tag of its own — its [unified service tags](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/) are `env`, `service`, and `version` — so set it explicitly, as in both examples above:
 
-The Spice dashboard relies on it in two places: the `instance` template variable filters on it, and every per-instance panel groups by it. Set it in both configurations above — to the pod name under Kubernetes (`%%kube_pod_name%%`), and to the hostname or another stable per-process identifier elsewhere.
+| Deployment          | Value                                              |
+| ------------------- | -------------------------------------------------- |
+| Kubernetes          | `%%kube_pod_name%%`                                |
+| Host, VM, or Docker | Hostname, or another stable per-process identifier |
 
 :::caution Panels collapse silently without this tag
-Datadog does not error on a missing tag. A dashboard imported without `service_instance_id` renders one `N/A` series per panel carrying the sum across every replica — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing. There is no query-level fallback from one tag to another, so this has to be fixed in the Agent configuration.
+Datadog does not error on a missing tag. Without `service_instance_id`, each panel renders a single `N/A` series summing every instance — a 12-replica deployment reports 12 times its real dataset count rather than showing nothing.
 :::
 
-Panels backed by the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, since those metrics come from the Kubernetes check and never carry `service_instance_id`.
+Panels from the Kubernetes integration (CPU, memory, and PVC utilization) group by `pod_name` instead, as those metrics never carry `service_instance_id`.
 
 ## Import the Spice Datadog Dashboard
 


### PR DESCRIPTION
Percentiles were only available from the `*_summary` metrics, which are derived from the cumulative histogram and therefore cover the whole process lifetime rather than the selected time window.

- Enable `collect_histogram_buckets` and `histogram_buckets_as_distributions` in the host and Kubernetes scrape configs, so `p50`/`p90`/`p95`/`p99` can be queried over the dashboard time window.
- Raise `max_returned_metrics` above the default of 2000, which histogram buckets and per-dataset tags can exceed.
- Use the `spiceai` namespace consistently, matching `runtime.telemetry.metric_prefix` on the OTLP path.

Adds a short "Histogram Percentiles (Distributions)" section covering the options and the requirement to enable percentile aggregations on the metric in Datadog.

Also adds an "Instance Identity" section. The dashboard's `instance` filter and every per-instance panel group by `service_instance_id`, but the Agent supplies no instance-level tag of its own — its unified service tags are `env`, `service`, and `version` — and a missing tag does not error, it renders one `N/A` series per panel summing every instance. That requirement was previously implied only by a comment in a config sample.

`service_instance_id` follows the pattern Datadog integrations already use for systems that run several members alongside each other, where `host` cannot separate them: [RabbitMQ](https://github.com/DataDog/integrations-core/blob/master/rabbitmq/assets/dashboards/rabbitmq_dashboard.json) groups by `rabbitmq_node`, [Vault](https://github.com/DataDog/integrations-core/blob/master/vault/assets/dashboards/vault_overview.json) by `vault_cluster`. 

Applied to `website/docs` and `website/versioned_docs/version-2.1.x`.