### PR TITLE
docs(postgres catalog): rename semantics, the empty-catalog warning, and the current query shape

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -173,15 +173,24 @@ The catalog is discovered once when the runtime starts, and then re-discovered e
 
 Each cycle re-runs discovery from scratch, so schema changes at the source are picked up without restarting Spice: newly created tables and schemas appear, dropped ones disappear, and column additions, removals, and type changes are reflected when the table's schema is re-read. A source DDL change therefore becomes visible in Spice within roughly one refresh interval — up to about 60 seconds, plus the time the refresh itself takes.
 
+A **renamed** table (`ALTER TABLE … RENAME`) is seen as a removal plus an addition, because each cycle rebuilds the catalog from what the source reports rather than tracking identity across cycles. After the next refresh the old name no longer resolves and the new name is queryable, carrying the same rows. Nothing is preserved across the rename: a query that names the old table fails from the moment the refresh completes.
+
 ### Source metadata load
 
 Because every cycle re-discovers the catalog, the metadata load on the source database scales with catalog size rather than with query volume. Each refresh issues:
 
 - One query to enumerate non-system schemas.
-- Per schema: one query for its relations (`pg_catalog.pg_class`), one for foreign-key constraints, and one for table and column comments.
-- Per selected table: one lookup to read its columns and build its Arrow schema.
+- One query to identify the server, so PostgreSQL-compatible variants such as Amazon Redshift are handled correctly.
+- Per schema that `include` can reach: one query for its relations (`pg_catalog.pg_class`), one for foreign-key constraints, one for table and column comments, and one that reads the columns of every selected table in that schema at once.
 
-Use `include`/`exclude` to narrow the catalog on large databases. Filtered-out tables are skipped before their per-table schema lookup, so tighter patterns directly reduce the per-cycle query count. Note that `include`/`exclude` filter tables, not schemas — every non-system schema is still enumerated, so the per-schema queries are unaffected.
+Use `include`/`exclude` to narrow the catalog on large databases. Tighter patterns reduce the per-cycle query count in two ways:
+
+- A schema that no `include` pattern can match is skipped without being interrogated at all — it is still registered, empty, because that is what interrogating it would have produced.
+- Within a schema that is interrogated, only the selected tables have their columns read.
+
+As a measure of the effect, a database of 100 schemas × 10 tables where `include` selects a single schema is discovered in **6 queries per cycle**.
+
+The column lookup is a per-schema batch on PostgreSQL. On Amazon Redshift it falls back to one lookup per table, because Redshift's `SHOW COLUMNS` cannot describe several relations in a single statement.
 
 ### Refresh failures
 
@@ -191,6 +200,23 @@ Failure is handled differently at initial load than on a later refresh cycle:
 - **Later refresh cycles** — a failure is logged at `ERROR` and the catalog keeps serving its last-known-good state until a subsequent cycle succeeds. The schema map is replaced atomically at the end of a cycle, so queries never observe a partially-refreshed catalog.
 
 Failures isolated to a single schema are handled per-schema rather than failing the whole cycle — see [Limitations](#limitations).
+
+### When no tables are selected
+
+A federated catalog that selects no tables still loads and reports ready — it is a valid state, since a catalog can be configured before the tables it names exist. Because that is indistinguishable from success until a query fails with "table not found", the runtime logs a warning naming the catalog and the patterns that matched nothing:
+
+```
+PostgreSQL catalog pg registered no tables, so queries against it will not resolve any table.
+None of the tables in the 2 schema(s) it discovered matched include: ['public.orders'].
+Patterns match the qualified '<schema>.<table>' name, so an unqualified pattern such as
+'orders' never matches — write 'public.orders' (or 'public.*') instead.
+```
+
+The most common cause is an unqualified pattern: patterns are matched against `<schema>.<table>`, so `orders` never matches and `public.orders` does. If no `include`/`exclude` is configured at all, the warning instead points at the connecting role's `SELECT` and `USAGE` grants, since an empty catalog then means the role cannot see any table.
+
+The warning is logged when the catalog *becomes* empty rather than on every cycle, so a catalog that is legitimately empty for a while does not fill the log.
+
+An **accelerated** catalog treats this as a permanent misconfiguration instead: with no eligible tables it fails to register, with status `Error`, and is not retried. See [Table eligibility](#table-eligibility).
 
 ## Catalog-Level CDC Acceleration
 

--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -137,6 +137,13 @@ catalogs:
 
 The PostgreSQL Catalog Connector can also be used with Amazon Redshift:
 
+:::note
+
+Redshift is supported on a **best-effort** basis and is outside the connector's stability claim: the quality level stated in the table of Catalogs covers PostgreSQL. Redshift clusters are not part of the connector's test matrix, and the [Limitations](#limitations) below — datashare and external (Spectrum) objects not being discovered, and reduced metadata coverage — apply. Track [#12109](https://github.com/spiceai/spiceai/issues/12109) for progress.
+
+:::
+
+
 ```yaml
 catalogs:
   - from: pg

--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -212,7 +212,17 @@ Patterns match the qualified '<schema>.<table>' name, so an unqualified pattern 
 'orders' never matches — write 'public.orders' (or 'public.*') instead.
 ```
 
-The most common cause is an unqualified pattern: patterns are matched against `<schema>.<table>`, so `orders` never matches and `public.orders` does. If no `include`/`exclude` is configured at all, the warning instead points at the connecting role's `SELECT` and `USAGE` grants, since an empty catalog then means the role cannot see any table.
+The warning names the cause it can distinguish:
+
+- **Patterns matched nothing** (above). The most common reason is an unqualified pattern: patterns are matched against `<schema>.<table>`, so `orders` never matches and `public.orders` does.
+- **No patterns are configured**, in which case the warning points at the connecting role's `SELECT` and `USAGE` grants instead, since an empty catalog then means the role cannot see any table.
+- **Tables matched but none could be registered** — each failure is logged individually first, and the summary says so rather than blaming the configuration:
+
+  ```
+  PostgreSQL catalog pg registered no tables, so queries against it will not resolve any table.
+  3 table(s) matched, but none could be registered — the errors logged above this name the
+  tables that failed and why.
+  ```
 
 The warning is logged when the catalog *becomes* empty rather than on every cycle, so a catalog that is legitimately empty for a while does not fill the log.
 


### PR DESCRIPTION
Companion to spiceai/spiceai#12988, which closes spiceai/spiceai#12107. That task requires the catalog's refresh semantics to be documented; this is that half.

Everything here lands in the **Next (unreleased)** docs, which is where the behavior belongs — the query-shape changes are already on `trunk`, and the empty-catalog warning arrives with #12988.

## Corrections

Two statements in **Source metadata load** had drifted from the connector:

- "every non-system schema is still enumerated, so the per-schema queries are unaffected" — a schema that no `include` pattern can reach is now skipped without being interrogated at all. It is still *registered* (empty), which is why the matching `Limitations` bullet stays accurate, but its three metadata queries are no longer issued.
- "Per selected table: one lookup to read its columns" — a schema's columns are now read in a single query covering every selected table in it.

The section also omitted the server-identification query. It now lists all four per-schema queries, explains the two distinct ways `include`/`exclude` reduce per-cycle cost, and gives a concrete measure: 100 schemas × 10 tables with `include` selecting one schema is discovered in **6 queries per cycle**.

Redshift is called out where it differs: the column lookup falls back to one query per table there, because `SHOW COLUMNS` cannot describe several relations at once.

## Additions

**Rename semantics.** `ALTER TABLE … RENAME` reads as a removal plus an addition — each cycle rebuilds the catalog from what the source reports rather than tracking identity across cycles. The old name stops resolving the moment the refresh completes; the new name carries the same rows.

**When no tables are selected.** A federated catalog that selects nothing still loads and reports ready, which is indistinguishable from success until a query fails with "table not found". It now warns, naming the catalog and the patterns that matched nothing, and the docs explain the usual cause (an unqualified pattern — `orders` never matches, `public.orders` does), the different wording when no patterns are configured at all, and why it is logged on the transition to empty rather than every cycle. The contrast with the accelerated path, which treats this as a permanent misconfiguration and fails to register, is stated with a link.
