### PR TITLE
docs(databricks): every component sharing a SQL Warehouse must set the same max_concurrent_requests

### DIFF
--- a/website/docs/components/data-connectors/databricks/deployment.md
+++ b/website/docs/components/data-connectors/databricks/deployment.md
@@ -54,7 +54,9 @@ catalogs:
 
 When multiple datasets or catalog-discovery paths target the same SQL Warehouse (same `endpoint` + `sql_warehouse_id`), a single concurrency semaphore is shared across all of them. The `max_concurrent_requests` limit is enforced globally for that warehouse, not per dataset or per catalog.
 
-The `max_concurrent_requests` value only needs to be set on one dataset or catalog entry for a given warehouse — other components targeting the same warehouse that omit the parameter will share the same semaphore with the configured limit. If multiple components explicitly set `max_concurrent_requests`, the values must match; conflicting values are treated as a configuration error.
+Every dataset and catalog entry that targets the same warehouse must resolve to the **same** `max_concurrent_requests` value. A component that omits the parameter resolves to the default `8`, so setting a non-default limit on one entry and leaving it off another is itself a conflict — set the same value on every component that shares the warehouse.
+
+A mismatch fails at load with an error naming the requested and existing limits (`Conflicting Databricks SQL Warehouse concurrency limits for endpoint ... requested 4, existing 8`). A value of `0` or a non-numeric value is not applied: the runtime logs a warning and uses the default `8`.
 
 ### Permanent-Disable Behavior
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/databricks/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/databricks/deployment.md
@@ -54,7 +54,9 @@ catalogs:
 
 When multiple datasets or catalog-discovery paths target the same SQL Warehouse (same `endpoint` + `sql_warehouse_id`), a single concurrency semaphore is shared across all of them. The `max_concurrent_requests` limit is enforced globally for that warehouse, not per dataset or per catalog.
 
-The `max_concurrent_requests` value only needs to be set on one dataset or catalog entry for a given warehouse — other components targeting the same warehouse that omit the parameter will share the same semaphore with the configured limit. If multiple components explicitly set `max_concurrent_requests`, the values must match; conflicting values are treated as a configuration error.
+Every dataset and catalog entry that targets the same warehouse must resolve to the **same** `max_concurrent_requests` value. A component that omits the parameter resolves to the default `8`, so setting a non-default limit on one entry and leaving it off another is itself a conflict — set the same value on every component that shares the warehouse.
+
+A mismatch fails at load with an error naming the requested and existing limits (`Conflicting Databricks SQL Warehouse concurrency limits for endpoint ... requested 4, existing 8`). A value of `0` or a non-numeric value is not applied: the runtime logs a warning and uses the default `8`.
 
 ### Permanent-Disable Behavior
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/databricks/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/databricks/deployment.md
@@ -54,7 +54,9 @@ catalogs:
 
 When multiple datasets or catalog-discovery paths target the same SQL Warehouse (same `endpoint` + `sql_warehouse_id`), a single concurrency semaphore is shared across all of them. The `max_concurrent_requests` limit is enforced globally for that warehouse, not per dataset or per catalog.
 
-The `max_concurrent_requests` value only needs to be set on one dataset or catalog entry for a given warehouse — other components targeting the same warehouse that omit the parameter will share the same semaphore with the configured limit. If multiple components explicitly set `max_concurrent_requests`, the values must match; conflicting values are treated as a configuration error.
+Every dataset and catalog entry that targets the same warehouse must resolve to the **same** `max_concurrent_requests` value. A component that omits the parameter resolves to the default `8`, so setting a non-default limit on one entry and leaving it off another is itself a conflict — set the same value on every component that shares the warehouse.
+
+A mismatch fails at load with an error naming the requested and existing limits (`Conflicting Databricks SQL Warehouse concurrency limits for endpoint ... requested 4, existing 8`). A value of `0` or a non-numeric value is not applied: the runtime logs a warning and uses the default `8`.
 
 ### Permanent-Disable Behavior
 


### PR DESCRIPTION
## Summary

The Databricks deployment guide's **Shared Concurrency Semaphore** section said:

> The `max_concurrent_requests` value only needs to be set on one dataset or catalog entry for a given warehouse — other components targeting the same warehouse that omit the parameter will share the same semaphore with the configured limit.

That is not what the runtime does. `shared_request_semaphore()` keys a process-wide registry on `(endpoint, sql_warehouse_id)` and returns `ConflictingConcurrencyLimit` whenever a later component requests a limit different from the one already registered:

```rust
Entry::Occupied(entry) => {
    let (semaphore, existing) = entry.get();
    ensure!(*existing == max_concurrent_requests, ConflictingConcurrencyLimitSnafu { .. });
```

A component that *omits* `max_concurrent_requests` does not inherit the registered value — `build_sql_warehouse_config()` starts from `SqlWarehouseConfig::default()`, whose `max_concurrent_requests` is `SQL_WAREHOUSE_MAX_IN_FLIGHT_REQUESTS = 8`. So the documented pattern (set `4` on one dataset, omit it on the others) requests `8` for the second component and fails at load with the conflict error. The runtime's own error text says as much: *"Use the same max_concurrent_requests value for all datasets and catalogs that share this warehouse."*

Also documented the `0`/non-numeric handling while in the same paragraph: `build_sql_warehouse_config` logs a warning and keeps the default `8` rather than rejecting the config.

## What changed

Replaced the inheritance claim with the real requirement — every dataset and catalog entry that targets the same warehouse must resolve to the same value, and an omitted parameter resolves to `8`.

## Verified against

`spiceai/spiceai` at `trunk` (93114d6d), and re-checked at `v2.1.5` and `v2.0.1` — the conflict check and the default are identical in all three, so the correction applies to vNext, 2.1.x, and 2.0.x.

- [`crates/data_components/src/databricks/sql_warehouse.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/databricks/sql_warehouse.rs) — `shared_request_semaphore` (~L514), `ConflictingConcurrencyLimit` (~L251), `SQL_WAREHOUSE_MAX_IN_FLIGHT_REQUESTS = 8` (~L75)
- [`crates/runtime/src/catalogconnector/databricks.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/catalogconnector/databricks.rs) — `build_sql_warehouse_config` (~L560)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rn "max_concurrent_requests" website/ | grep -i databricks` — the claim exists only in the three `databricks/deployment.md` files (vNext + 2.1.x + 2.0.x); the connector `index.md`, catalog page, and FAQ carry only the default/`shared per SQL Warehouse` wording, which is correct
- [x] Files updated: 3 (matches the diff)