### PR TITLE
docs(task_history): the default retention period is 8h, not 30 minutes

### DIFF
--- a/website/docs/reference/task_history.md
+++ b/website/docs/reference/task_history.md
@@ -14,7 +14,7 @@ For configuration options, see the [`runtime.task_history` reference](./spicepod
 
 ## Configuration
 
-Task history is enabled by default with a 30-minute retention period. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
+Task history is enabled by default and retains records for 8 hours. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
 
 ```yaml
 runtime:

--- a/website/versioned_docs/version-1.11.x/reference/task_history.md
+++ b/website/versioned_docs/version-1.11.x/reference/task_history.md
@@ -14,7 +14,7 @@ For configuration options, see the [`runtime.task_history` reference](./spicepod
 
 ## Configuration
 
-Task history is enabled by default with a 30-minute retention period. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
+Task history is enabled by default and retains records for 8 hours. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
 
 ```yaml
 runtime:

--- a/website/versioned_docs/version-2.0.x/reference/task_history.md
+++ b/website/versioned_docs/version-2.0.x/reference/task_history.md
@@ -14,7 +14,7 @@ For configuration options, see the [`runtime.task_history` reference](./spicepod
 
 ## Configuration
 
-Task history is enabled by default with a 30-minute retention period. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
+Task history is enabled by default and retains records for 8 hours. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
 
 ```yaml
 runtime:

--- a/website/versioned_docs/version-2.1.x/reference/task_history.md
+++ b/website/versioned_docs/version-2.1.x/reference/task_history.md
@@ -14,7 +14,7 @@ For configuration options, see the [`runtime.task_history` reference](./spicepod
 
 ## Configuration
 
-Task history is enabled by default with a 30-minute retention period. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
+Task history is enabled by default and retains records for 8 hours. To adjust retention and other settings, configure the `runtime.task_history` section in `spicepod.yaml`:
 
 ```yaml
 runtime:


### PR DESCRIPTION
## Summary

The Task History reference opened with:

> Task history is enabled by default with a 30-minute retention period.

The same page's parameter list, eleven lines below, says `retention_period` *"Defaults to `8h`"* — and so does [`reference/spicepod/runtime.md`](https://github.com/spiceai/docs/blob/trunk/website/docs/reference/spicepod/runtime.md). The `8h` figure is the correct one; the intro was wrong and self-contradictory.

```rust
fn default_retention_period() -> Arc<str> {
    "8h".into()
}
```

`retention_period` has defaulted to `8h` since the field was introduced (`spiceai/spiceai#2784`), so no released version ever retained task history for 30 minutes — this is a plain correction, propagated to every snapshot that carries the sentence.

## What changed

Intro now reads "Task history is enabled by default and retains records for 8 hours." — one line, four files.

## Verified against

`spiceai/spiceai` at `trunk` (93114d6d), and re-checked at `v2.1.5`, `v2.0.1`, and `v1.11.2` — `default_retention_period()` returns `"8h"` in all of them.

- [`crates/spicepod/src/component/runtime.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/runtime.rs) — `TaskHistory` struct, `default_retention_period()` (~L678), `default_retention_check_interval()` = `15m`

## Test plan

- [x] `cd website && npm run build` passes
- [x] Claim-class sweep: `grep -rn "30-minute\|30 minute" website/docs website/versioned_docs` returns 0 task-history hits after the change; `reference/memory.md` independently documents `# default 8h` and was already correct
- [x] Versioned propagation: the sentence exists in vNext + 2.1.x + 2.0.x + 1.11.x (the 1.5.x–1.10.x snapshots have no Configuration section on this page) — Files updated: 4 (matches the diff)