### PR TITLE
docs(task_history): document captured_context

### DIFF
--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -431,6 +431,7 @@ runtime:
 | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `enabled`                  | Yes      | Defaults to `true`.                                                                                                                                          |
 | `captured_output`          | Yes      | Specifies the level of output captured by the task history table. Defaults to `none`.                                                                        |
+| `captured_context`         | Yes      | Controls how much of the `input` and `captured_output` payload is stored for AI and search tasks. Options: `truncated` (default), `redacted`, or `full`. Values are case-sensitive. |
 | `captured_plan`            | Yes      | Controls SQL query plan capture. Options: `none` (default), `explain`, or `explain analyze`. Query plans are captured asynchronously after query completion. |
 | `min_sql_duration`         | Yes      | Minimum query execution duration before a plan is captured. Only queries exceeding this threshold are captured. Example: `5s`.                               |
 | `min_plan_duration`        | Yes      | Minimum plan execution duration before a plan is captured. This threshold applies to the execution time of the `EXPLAIN` operation itself. Example: `10s`.   |

--- a/website/docs/reference/task_history.md
+++ b/website/docs/reference/task_history.md
@@ -27,10 +27,33 @@ runtime:
 
 - **`enabled`**: Enable or disable task history. Defaults to `true`.
 - **`captured_output`**: Level of output captured. Defaults to `none`.
+- **`captured_context`**: How much of the AI and search task payload is stored. Defaults to `truncated`. See [Captured context](#captured-context).
 - **`retention_period`**: How long records are retained. Defaults to `8h`. Longer retention periods increase memory usage.
 - **`retention_check_interval`**: How often old records are checked for removal. Defaults to `15m`.
 
 For the full list of parameters, see the [`runtime.task_history` reference](./spicepod/runtime#runtimetask_history).
+
+## Captured Context
+
+Tasks that carry user or model content — `ai_chat`, `ai_completion`, `responses`, `text_embed`, `search`, `nsql`, `scheduled_worker`, and every `tool_use::*` task — store that content in the `input` and `captured_output` columns. `captured_context` controls how much of it is written:
+
+```yaml
+runtime:
+  task_history:
+    captured_context: redacted
+```
+
+| Value                 | Behavior                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `truncated` (default) | Payloads longer than 4096 characters are cut at that point and suffixed with `...[truncated]`. |
+| `redacted`            | The payload is replaced with `[redacted]`.                                                    |
+| `full`                | The payload is stored in full.                                                                |
+
+Values are case-sensitive; an unrecognized value fails at load. Other task types (for example `sql_query` and `accelerated_refresh`) are unaffected by this setting.
+
+:::note
+`captured_context` shapes prompt, tool, and search payloads only. Whether task output is recorded at all is controlled separately by `captured_output`, which defaults to `none`.
+:::
 
 ## Querying Task History
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/runtime.md
@@ -403,6 +403,7 @@ runtime:
 | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `enabled`                  | Yes      | Defaults to `true`.                                                                                                                                          |
 | `captured_output`          | Yes      | Specifies the level of output captured by the task history table. Defaults to `none`.                                                                        |
+| `captured_context`         | Yes      | Controls how much of the `input` and `captured_output` payload is stored for AI and search tasks. Options: `truncated` (default), `redacted`, or `full`. Values are case-sensitive. |
 | `captured_plan`            | Yes      | Controls SQL query plan capture. Options: `none` (default), `explain`, or `explain analyze`. Query plans are captured asynchronously after query completion. |
 | `min_sql_duration`         | Yes      | Minimum query execution duration before a plan is captured. Only queries exceeding this threshold are captured. Example: `5s`.                               |
 | `min_plan_duration`        | Yes      | Minimum plan execution duration before a plan is captured. This threshold applies to the execution time of the `EXPLAIN` operation itself. Example: `10s`.   |

--- a/website/versioned_docs/version-2.0.x/reference/task_history.md
+++ b/website/versioned_docs/version-2.0.x/reference/task_history.md
@@ -27,10 +27,33 @@ runtime:
 
 - **`enabled`**: Enable or disable task history. Defaults to `true`.
 - **`captured_output`**: Level of output captured. Defaults to `none`.
+- **`captured_context`**: How much of the AI and search task payload is stored. Defaults to `truncated`. See [Captured context](#captured-context).
 - **`retention_period`**: How long records are retained. Defaults to `8h`. Longer retention periods increase memory usage.
 - **`retention_check_interval`**: How often old records are checked for removal. Defaults to `15m`.
 
 For the full list of parameters, see the [`runtime.task_history` reference](./spicepod/runtime#runtimetask_history).
+
+## Captured Context
+
+Tasks that carry user or model content — `ai_chat`, `ai_completion`, `responses`, `text_embed`, `search`, `nsql`, `scheduled_worker`, and every `tool_use::*` task — store that content in the `input` and `captured_output` columns. `captured_context` controls how much of it is written:
+
+```yaml
+runtime:
+  task_history:
+    captured_context: redacted
+```
+
+| Value                 | Behavior                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `truncated` (default) | Payloads longer than 4096 characters are cut at that point and suffixed with `...[truncated]`. |
+| `redacted`            | The payload is replaced with `[redacted]`.                                                    |
+| `full`                | The payload is stored in full.                                                                |
+
+Values are case-sensitive; an unrecognized value fails at load. Other task types (for example `sql_query` and `accelerated_refresh`) are unaffected by this setting.
+
+:::note
+`captured_context` shapes prompt, tool, and search payloads only. Whether task output is recorded at all is controlled separately by `captured_output`, which defaults to `none`.
+:::
 
 ## Querying Task History
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/runtime.md
@@ -403,6 +403,7 @@ runtime:
 | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `enabled`                  | Yes      | Defaults to `true`.                                                                                                                                          |
 | `captured_output`          | Yes      | Specifies the level of output captured by the task history table. Defaults to `none`.                                                                        |
+| `captured_context`         | Yes      | Controls how much of the `input` and `captured_output` payload is stored for AI and search tasks. Options: `truncated` (default), `redacted`, or `full`. Values are case-sensitive. |
 | `captured_plan`            | Yes      | Controls SQL query plan capture. Options: `none` (default), `explain`, or `explain analyze`. Query plans are captured asynchronously after query completion. |
 | `min_sql_duration`         | Yes      | Minimum query execution duration before a plan is captured. Only queries exceeding this threshold are captured. Example: `5s`.                               |
 | `min_plan_duration`        | Yes      | Minimum plan execution duration before a plan is captured. This threshold applies to the execution time of the `EXPLAIN` operation itself. Example: `10s`.   |

--- a/website/versioned_docs/version-2.1.x/reference/task_history.md
+++ b/website/versioned_docs/version-2.1.x/reference/task_history.md
@@ -27,10 +27,33 @@ runtime:
 
 - **`enabled`**: Enable or disable task history. Defaults to `true`.
 - **`captured_output`**: Level of output captured. Defaults to `none`.
+- **`captured_context`**: How much of the AI and search task payload is stored. Defaults to `truncated`. See [Captured context](#captured-context).
 - **`retention_period`**: How long records are retained. Defaults to `8h`. Longer retention periods increase memory usage.
 - **`retention_check_interval`**: How often old records are checked for removal. Defaults to `15m`.
 
 For the full list of parameters, see the [`runtime.task_history` reference](./spicepod/runtime#runtimetask_history).
+
+## Captured Context
+
+Tasks that carry user or model content — `ai_chat`, `ai_completion`, `responses`, `text_embed`, `search`, `nsql`, `scheduled_worker`, and every `tool_use::*` task — store that content in the `input` and `captured_output` columns. `captured_context` controls how much of it is written:
+
+```yaml
+runtime:
+  task_history:
+    captured_context: redacted
+```
+
+| Value                 | Behavior                                                                                     |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `truncated` (default) | Payloads longer than 4096 characters are cut at that point and suffixed with `...[truncated]`. |
+| `redacted`            | The payload is replaced with `[redacted]`.                                                    |
+| `full`                | The payload is stored in full.                                                                |
+
+Values are case-sensitive; an unrecognized value fails at load. Other task types (for example `sql_query` and `accelerated_refresh`) are unaffected by this setting.
+
+:::note
+`captured_context` shapes prompt, tool, and search payloads only. Whether task output is recorded at all is controlled separately by `captured_output`, which defaults to `none`.
+:::
 
 ## Querying Task History
 


### PR DESCRIPTION
## Summary

`runtime.task_history.captured_context` is a real, load-bearing knob that was undocumented everywhere — `grep -rn "captured_context" website/` returned zero hits before this PR, on both the Task History reference and the `runtime.task_history` spicepod reference (which lists every other field of the struct).

It controls how much of the `input` / `captured_output` payload is persisted for tasks that carry user or model content, which makes it the privacy lever for prompt and tool payloads landing in `runtime.task_history`:

```rust
match captured_context {
    TaskHistoryCapturedContext::Redacted => Arc::clone(&REDACTED_TASK_HISTORY_VALUE_ARC),
    TaskHistoryCapturedContext::Truncated => Self::truncate_context_payload(value),
    TaskHistoryCapturedContext::Full => value,
}
```

Details verified from source rather than inferred:

- Applies to `ai_chat`, `ai_completion`, `responses`, `text_embed`, `search`, `nsql`, `scheduled_worker`, and any `tool_use::*` task (`is_context_task`); other tasks such as `sql_query` pass through untouched.
- Applies to **both** the `input` and `captured_output` columns (two `process_context_payload` call sites).
- `truncated` is the default and cuts at `TRUNCATED_TASK_HISTORY_CONTEXT_CHARS = 4096`, appending `...[truncated]`; `redacted` substitutes the literal `[redacted]`.
- Values are matched **case-sensitively** (`get_captured_context` has no `to_lowercase()`, unlike `captured_plan`), and an unrecognized value errors.

## What changed

- `reference/task_history.md`: new **Captured Context** section (values table + note distinguishing it from `captured_output`) and a bullet in the Configuration list.
- `reference/spicepod/runtime.md`: one `captured_context` row in the `runtime.task_history` parameter table.

## Version scoping

`captured_context` exists at `v2.0.1`, `v2.1.5`, and `trunk`, and is **absent** at `v1.11.6` — so this lands in vNext + 2.1.x + 2.0.x only, and the 1.x snapshots are left alone. The `is_context_task` list, the 4096-char constant, and the `[redacted]` literal are byte-identical across those three, so one wording is accurate for all of them.

## Verified against

`spiceai/spiceai` at `trunk` (93114d6d), re-checked at `v2.1.5` / `v2.0.1` / `v1.11.6`:

- [`crates/spicepod/src/component/runtime.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/runtime.rs) — `TaskHistory.captured_context`, `default_truncated()`, `get_captured_context()` (~L743)
- [`crates/runtime/src/task_history/otel_exporter.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/task_history/otel_exporter.rs) — `is_context_task` (~L179), `process_context_payload` (~L192), `truncate_context_payload` (~L208)

## Test plan

- [x] `cd website && npm run build` passes (the new `#captured-context` anchor resolves — `onBrokenAnchors` would otherwise throw)
- [x] Cross-page grep: `runtime.task_history` fields are documented on exactly these two page types per version; both updated
- [x] Files updated: 6 (matches the diff)