### PR TITLE
docs(cayenne): segment cache accesses and hits are counters, not gauges

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/deployment.md
+++ b/website/docs/components/data-accelerators/cayenne/deployment.md
@@ -144,12 +144,12 @@ The `cdc_path_*` phases are the mutually-exclusive terminal phase of a write —
 
 ### Segment Cache Metrics
 
-The segment cache is the per-dataset Vortex decompressed-segment cache (`cayenne_segment_cache_mb`). The `accesses` and `hits` instruments are cumulative.
+The segment cache is the per-dataset Vortex decompressed-segment cache (`cayenne_segment_cache_mb`). All five instruments are observable — sampled on every collection — and caches sharing a dataset label are aggregated into one series. `accesses` and `hits` are monotonic counters and keep counting across a cache being recreated, so query them with counter operations such as `rate()` or `increase()` (hit rate over a window = `rate(cayenne_segment_cache_hits[5m]) / rate(cayenne_segment_cache_accesses[5m])`).
 
 | Metric | Type | Unit | Description |
 | ------ | ---- | ---- | ----------- |
-| `cayenne_segment_cache_accesses` | Gauge | accesses | Cumulative Vortex segment cache `get()` calls. |
-| `cayenne_segment_cache_hits` | Gauge | hits | Cumulative Vortex segment cache hits. (Hit rate = `hits / accesses`.) |
+| `cayenne_segment_cache_accesses` | Counter | accesses | Cumulative Vortex segment cache `get()` calls. |
+| `cayenne_segment_cache_hits` | Counter | hits | Cumulative Vortex segment cache hits. |
 | `cayenne_segment_cache_entries` | Gauge | entries | Live Vortex segment cache entry count. |
 | `cayenne_segment_cache_weighted_bytes` | Gauge | By | Live Vortex segment cache size in bytes. |
 | `cayenne_segment_cache_capacity_bytes` | Gauge | By | Configured Vortex segment cache capacity in bytes. |

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/deployment.md
@@ -126,12 +126,12 @@ The `cdc_path_*` phases are mutually exclusive per write and measure end-to-end 
 
 ### Segment Cache Metrics
 
-The segment cache is the per-dataset Vortex decompressed-segment cache (`cayenne_segment_cache_mb`). The `accesses` and `hits` instruments are cumulative.
+The segment cache is the per-dataset Vortex decompressed-segment cache (`cayenne_segment_cache_mb`). Since v2.1.5 all five instruments are observable — sampled on every collection — and caches sharing a dataset label are aggregated into one series. `accesses` and `hits` are monotonic counters and keep counting across a cache being recreated, so query them with counter operations such as `rate()` or `increase()` (hit rate over a window = `rate(cayenne_segment_cache_hits[5m]) / rate(cayenne_segment_cache_accesses[5m])`).
 
 | Metric | Type | Unit | Description |
 | ------ | ---- | ---- | ----------- |
-| `cayenne_segment_cache_accesses` | Gauge | accesses | Cumulative Vortex segment cache `get()` calls. |
-| `cayenne_segment_cache_hits` | Gauge | hits | Cumulative Vortex segment cache hits. (Hit rate = `hits / accesses`.) |
+| `cayenne_segment_cache_accesses` | Counter | accesses | Cumulative Vortex segment cache `get()` calls. |
+| `cayenne_segment_cache_hits` | Counter | hits | Cumulative Vortex segment cache hits. |
 | `cayenne_segment_cache_entries` | Gauge | entries | Live Vortex segment cache entry count. |
 | `cayenne_segment_cache_weighted_bytes` | Gauge | By | Live Vortex segment cache size in bytes. |
 | `cayenne_segment_cache_capacity_bytes` | Gauge | By | Configured Vortex segment cache capacity in bytes. |


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12944` re-exported the Vortex segment-cache instruments so they appear on every scrape, and changed `accesses` and `hits` from gauges to **monotonic observable counters** (`crates/vortex/src/persistent/segment_cache.rs:56,70` on `trunk` — `u64_observable_counter`). The docs table still typed both as `Gauge` and told readers to compute the hit rate as a plain `hits / accesses` ratio, which is wrong for a counter series.

Also documented, from the same change: all five instruments are observable (sampled on each collection), the counters retain continuity across a cache being recreated, and caches sharing a dataset label are aggregated into one series.

Versioning: `u64_gauge` → `u64_observable_counter` landed in **v2.1.5** (`v2.1.4` and `v2.0.1` both still register `u64_gauge`), so this is a current-release behavioral change and belongs in vNext **and** `versioned_docs/version-2.1.x/`. `version-2.0.x/` correctly keeps `Gauge` and is untouched — verified against the tags.

Cross-page grep — `grep -rn 'segment_cache_accesses\|segment_cache_hits' docs/ versioned_docs/` returns hits in exactly three files (vNext, 2.1.x, 2.0.x Cayenne `deployment.md`); the first two are updated here.

## Source PRs

- spiceai/spiceai#12944 — fix(vortex): expose segment cache metrics on scrape (closes spiceai/spiceai#12939)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — v2.1.5 ships the counters, so vNext + `version-2.1.x`; `version-2.0.x` verified still gauges at `v2.0.1`
- [x] Files updated: 2 (`docs/.../cayenne/deployment.md`, `versioned_docs/version-2.1.x/.../cayenne/deployment.md`)
