### PR TITLE
docs(otlp): document how an export's rejected data points are reported

### DIFF
--- a/website/docs/features/data-ingestion/index.md
+++ b/website/docs/features/data-ingestion/index.md
@@ -105,10 +105,21 @@ OTEL metrics will be inserted into datasets with matching names (metric name = d
 | `Gauge`                 | Yes       | Ingested as number data points.                                                                  |
 | `Sum`                   | Yes       | Ingested as number data points.                                                                  |
 | `Histogram`             | Yes       | Ingested with explicit bucket bounds and counts.                                                 |
-| `ExponentialHistogram`  | No        | Dropped, logging an unsupported metric data type error.                                          |
-| `Summary`               | No        | Dropped, logging an unsupported metric data type error.                                          |
+| `ExponentialHistogram`  | No        | Not written. Its data points are counted as rejected, and an unsupported metric data type error is logged. |
+| `Summary`               | No        | Not written. Its data points are counted as rejected, and an unsupported metric data type error is logged. |
 
-Data points for a metric with no matching writable dataset are rejected and reported back to the exporter in the OTLP partial-success response.
+### Export outcomes
+
+Data points that cannot be written — a metric with no matching writable dataset, an unsupported metric type, or a batch that fails to build — are counted and reported back to the exporter:
+
+| Export | Response |
+| ------ | -------- |
+| No data points rejected | Success. |
+| Some data points rejected | Success with `ExportMetricsPartialSuccess`, carrying `rejected_data_points` and the message `Some data points were rejected`. |
+| Every data point rejected | Fails with `INVALID_ARGUMENT` and the message `All data points were rejected`. |
+| No data points at all (e.g. only metrics carrying no data) | Success — nothing was rejected. |
+
+A metric whose existing table has more than one column of the same name (Arrow permits duplicate field names, so an attribute sharing a name with one of the metric's value columns can produce one) can never be matched by a new batch. Rather than warning on every export, the ingest fails the export with an error naming the metric, the duplicated column, and the remedy: drop and recreate that metric's dataset.
 
 ### Ingested schema
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#12923` fixed how the OTLP metrics ingest accounts for data points it cannot write. Data points of a metric type with no batch builder (`ExponentialHistogram`, `Summary`) were counted as **zero**, so a mixed export reported full success while silently dropping them; they now report their real count into `ExportMetricsPartialSuccess.rejected_data_points`. An export carrying no data points at all now succeeds instead of failing with `All data points were rejected` (the guard gained a `total_data_points > 0` condition). And a metric whose table carries two columns of the same name — legal in Arrow, and reachable via an attribute colliding with a value column — now fails the export with an error naming the metric, the column, and the fix, instead of rejecting every export with only a warning.

On `docs/features/data-ingestion/index.md`:

- The `ExponentialHistogram` / `Summary` rows say their data points are counted as rejected, not just "dropped".
- New **Export outcomes** section: the four response cases (none / some / all rejected, and an empty export), with the exact status and message the runtime returns (`crates/runtime/src/opentelemetry.rs:347-360`).
- A paragraph on the duplicate-column failure and its remedy, from the `MetricTableHasDuplicateColumns` error text.

vNext-only: `v2.1.5` has neither the duplicate-column error nor the empty-export guard, so the versioned snapshots correctly describe the prior behavior.

## Source PRs

- spiceai/spiceai#12923 — fix(runtime): surface OTel metric tables with duplicate columns, and count unsupported metric types as rejected (fixes spiceai/spiceai#12095, spiceai/spiceai#12188)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — change post-dates v2.1.5, so vNext only
- [x] Files updated: 1 (`docs/features/data-ingestion/index.md`)
