### PR TITLE
docs(embeddings/openai): credential params require the openai_ prefix since v2.1.0; embeddings have no max_concurrency knob

### DIFF
--- a/website/docs/components/embeddings/openai/deployment.md
+++ b/website/docs/components/embeddings/openai/deployment.md
@@ -17,13 +17,19 @@ Production operating guide for the OpenAI embedding provider (and OpenAI-compati
 
 | Parameter                                 | Description                                                                                                                |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `openai_api_key` / `api_key`              | OpenAI API key. Use `${secrets:...}` to resolve from a configured secret store.                                             |
-| `openai_org_id` / `org_id`                | OpenAI organization ID (optional).                                                                                          |
-| `openai_project_id` / `project_id`        | OpenAI project ID (optional).                                                                                               |
-| `openai_usage_tier` / `usage_tier`        | OpenAI account [usage tier](https://platform.openai.com/settings/organization/limits).                                      |
+| `openai_api_key`                          | OpenAI API key. Use `${secrets:...}` to resolve from a configured secret store.                                             |
+| `openai_org_id`                           | OpenAI organization ID (optional).                                                                                          |
+| `openai_project_id`                       | OpenAI project ID (optional).                                                                                               |
+| `openai_usage_tier`                       | OpenAI account [usage tier](https://platform.openai.com/settings/organization/limits). Defaults to `tier1`.                  |
 | `endpoint`                                | Endpoint override. Defaults to `https://api.openai.com/v1`. Set for OpenAI-compatible providers (Azure OpenAI, etc.).       |
 
-API keys must be sourced from a [secret store](../../secret-stores/) in production. Aliases exist for credential parameters: `api_key` ↔ `openai_api_key`, `org_id` ↔ `openai_org_id`, etc.
+API keys must be sourced from a [secret store](../../secret-stores/) in production.
+
+:::warning[Credential parameters require the openai_ prefix]
+
+`openai_api_key`, `openai_org_id`, `openai_project_id`, and `openai_usage_tier` are only read under their prefixed names. An unprefixed `api_key`, `org_id`, `project_id`, or `usage_tier` is discarded with an `Ignoring parameter ...: must be prefixed with 'openai_'` warning at load time — the embedding model then starts with no credential and fails authentication at first use. `endpoint` is the one parameter that must **not** be prefixed.
+
+:::
 
 ### OpenAI-Compatible Providers
 
@@ -57,9 +63,10 @@ Large embedding jobs are transparently split across multiple API calls.
 
 Embeddings retry with fibonacci backoff, up to **10 retries**. Retriable conditions:
 
-- HTTP 429 (rate limit, throttling)
-- HTTP 500, 503 (transient server errors)
-- Transient `reqwest` errors (connect failures, timeouts)
+- An OpenAI API error carrying code `429` (rate limit, throttling), `500`, or `503` — or no code at all
+- A transport-level response with status `429`, `500`, `502`, `503`, or `504`
+- Transient `reqwest` errors (connect failures, timeouts, request/body errors)
+- Malformed response bodies that fail JSON deserialization
 
 Throttling (429 with rate-limit body) is detected explicitly and surfaces as a structured rate-limit error after retries are exhausted.
 
@@ -104,7 +111,7 @@ Embedding request operations emit `text_embed` spans in [task history](../../../
 | Symptom                                  | Likely cause                                            | Resolution                                                                                                       |
 | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized`                       | Wrong / revoked API key.                                | Rotate the key; update the secret store.                                                                         |
-| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier`, reduce `max_concurrency`, or upgrade the OpenAI tier.                                 |
+| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier` to match the account's actual tier, or upgrade the OpenAI tier. Embeddings have no per-model concurrency override — the tier is the only knob. |
 | `400` with "maximum context length"      | Input exceeds model context window.                     | Truncate or chunk inputs at the caller.                                                                          |
 | Embeddings much slower than expected     | Single-threaded caller, no batching.                    | Batch inputs; the client chunks into 256-input / 512 KiB batches but the caller must parallelize embedding jobs. |
 | Latency spikes every few hundred requests | Transient 429 with fibonacci backoff recovering.        | Expected at tier ceiling; raise tier or reduce load.                                                             |

--- a/website/docs/components/embeddings/openai/index.md
+++ b/website/docs/components/embeddings/openai/index.md
@@ -18,6 +18,8 @@ The following parameters are specific to OpenAI models:
 | `openai_usage_tier` | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
 | `endpoint`          | The base endpoint for the OpenAI API.                                                                                                                                                                                                                                                  | `https://api.openai.com/v1` |
 
+Credential parameters must keep the `openai_` prefix, including when `endpoint` points at an OpenAI-compatible provider such as Mistral — an unprefixed `api_key` is ignored with a warning at load time. `endpoint` is the exception and must not be prefixed.
+
 Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
@@ -31,7 +33,7 @@ embeddings:
     from: openai:mistral-embed
     params:
       endpoint: https://api.mistral.ai/v1
-      api_key: ${ secrets:SPICE_MISTRAL_API_KEY }
+      openai_api_key: ${ secrets:SPICE_MISTRAL_API_KEY }
 ```
 
 For detailed instructions and examples on running vector searches, refer to the [Vector-Based Search documentation](../../features/search/vector-search).

--- a/website/versioned_docs/version-2.0.x/components/embeddings/openai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/embeddings/openai/deployment.md
@@ -57,9 +57,10 @@ Large embedding jobs are transparently split across multiple API calls.
 
 Embeddings retry with fibonacci backoff, up to **10 retries**. Retriable conditions:
 
-- HTTP 429 (rate limit, throttling)
-- HTTP 500, 503 (transient server errors)
-- Transient `reqwest` errors (connect failures, timeouts)
+- An OpenAI API error carrying code `429` (rate limit, throttling), `500`, or `503` — or no code at all
+- A transport-level response with status `429`, `500`, `502`, `503`, or `504`
+- Transient `reqwest` errors (connect failures, timeouts, request/body errors)
+- Malformed response bodies that fail JSON deserialization
 
 Throttling (429 with rate-limit body) is detected explicitly and surfaces as a structured rate-limit error after retries are exhausted.
 
@@ -104,7 +105,7 @@ Embedding request operations emit `text_embed` spans in [task history](../../../
 | Symptom                                  | Likely cause                                            | Resolution                                                                                                       |
 | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized`                       | Wrong / revoked API key.                                | Rotate the key; update the secret store.                                                                         |
-| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier`, reduce `max_concurrency`, or upgrade the OpenAI tier.                                 |
+| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier` to match the account's actual tier, or upgrade the OpenAI tier. Embeddings have no per-model concurrency override — the tier is the only knob. |
 | `400` with "maximum context length"      | Input exceeds model context window.                     | Truncate or chunk inputs at the caller.                                                                          |
 | Embeddings much slower than expected     | Single-threaded caller, no batching.                    | Batch inputs; the client chunks into 256-input / 512 KiB batches but the caller must parallelize embedding jobs. |
 | Latency spikes every few hundred requests | Transient 429 with fibonacci backoff recovering.        | Expected at tier ceiling; raise tier or reduce load.                                                             |

--- a/website/versioned_docs/version-2.1.x/components/embeddings/openai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/embeddings/openai/deployment.md
@@ -17,13 +17,19 @@ Production operating guide for the OpenAI embedding provider (and OpenAI-compati
 
 | Parameter                                 | Description                                                                                                                |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `openai_api_key` / `api_key`              | OpenAI API key. Use `${secrets:...}` to resolve from a configured secret store.                                             |
-| `openai_org_id` / `org_id`                | OpenAI organization ID (optional).                                                                                          |
-| `openai_project_id` / `project_id`        | OpenAI project ID (optional).                                                                                               |
-| `openai_usage_tier` / `usage_tier`        | OpenAI account [usage tier](https://platform.openai.com/settings/organization/limits).                                      |
+| `openai_api_key`                          | OpenAI API key. Use `${secrets:...}` to resolve from a configured secret store.                                             |
+| `openai_org_id`                           | OpenAI organization ID (optional).                                                                                          |
+| `openai_project_id`                       | OpenAI project ID (optional).                                                                                               |
+| `openai_usage_tier`                       | OpenAI account [usage tier](https://platform.openai.com/settings/organization/limits). Defaults to `tier1`.                  |
 | `endpoint`                                | Endpoint override. Defaults to `https://api.openai.com/v1`. Set for OpenAI-compatible providers (Azure OpenAI, etc.).       |
 
-API keys must be sourced from a [secret store](../../secret-stores/) in production. Aliases exist for credential parameters: `api_key` ↔ `openai_api_key`, `org_id` ↔ `openai_org_id`, etc.
+API keys must be sourced from a [secret store](../../secret-stores/) in production.
+
+:::warning[Credential parameters require the openai_ prefix]
+
+`openai_api_key`, `openai_org_id`, `openai_project_id`, and `openai_usage_tier` are only read under their prefixed names. An unprefixed `api_key`, `org_id`, `project_id`, or `usage_tier` is discarded with an `Ignoring parameter ...: must be prefixed with 'openai_'` warning at load time — the embedding model then starts with no credential and fails authentication at first use. `endpoint` is the one parameter that must **not** be prefixed.
+
+:::
 
 ### OpenAI-Compatible Providers
 
@@ -57,9 +63,10 @@ Large embedding jobs are transparently split across multiple API calls.
 
 Embeddings retry with fibonacci backoff, up to **10 retries**. Retriable conditions:
 
-- HTTP 429 (rate limit, throttling)
-- HTTP 500, 503 (transient server errors)
-- Transient `reqwest` errors (connect failures, timeouts)
+- An OpenAI API error carrying code `429` (rate limit, throttling), `500`, or `503` — or no code at all
+- A transport-level response with status `429`, `500`, `502`, `503`, or `504`
+- Transient `reqwest` errors (connect failures, timeouts, request/body errors)
+- Malformed response bodies that fail JSON deserialization
 
 Throttling (429 with rate-limit body) is detected explicitly and surfaces as a structured rate-limit error after retries are exhausted.
 
@@ -104,7 +111,7 @@ Embedding request operations emit `text_embed` spans in [task history](../../../
 | Symptom                                  | Likely cause                                            | Resolution                                                                                                       |
 | ---------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized`                       | Wrong / revoked API key.                                | Rotate the key; update the secret store.                                                                         |
-| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier`, reduce `max_concurrency`, or upgrade the OpenAI tier.                                 |
+| Sustained `429 rate_limit_exceeded`      | Tier budget too low or burst exceeds concurrency.       | Raise `openai_usage_tier` to match the account's actual tier, or upgrade the OpenAI tier. Embeddings have no per-model concurrency override — the tier is the only knob. |
 | `400` with "maximum context length"      | Input exceeds model context window.                     | Truncate or chunk inputs at the caller.                                                                          |
 | Embeddings much slower than expected     | Single-threaded caller, no batching.                    | Batch inputs; the client chunks into 256-input / 512 KiB batches but the caller must parallelize embedding jobs. |
 | Latency spikes every few hundred requests | Transient 429 with fibonacci backoff recovering.        | Expected at tier ceiling; raise tier or reduce load.                                                             |

--- a/website/versioned_docs/version-2.1.x/components/embeddings/openai/index.md
+++ b/website/versioned_docs/version-2.1.x/components/embeddings/openai/index.md
@@ -18,6 +18,8 @@ The following parameters are specific to OpenAI models:
 | `openai_usage_tier` | The [OpenAI usage tier](https://platform.openai.com/settings/organization/limits) for the account. This parameter sets the maximum number of concurrent requests based on OpenAI's published limits per tier. Valid values are `free`, `tier1`, `tier2`, `tier3`, `tier4`, or `tier5`. | `tier1`                     |
 | `endpoint`          | The base endpoint for the OpenAI API.                                                                                                                                                                                                                                                  | `https://api.openai.com/v1` |
 
+Credential parameters must keep the `openai_` prefix, including when `endpoint` points at an OpenAI-compatible provider such as Mistral — an unprefixed `api_key` is ignored with a warning at load time. `endpoint` is the exception and must not be prefixed.
+
 Below is an example configuration in `spicepod.yaml`:
 
 ```yaml
@@ -31,7 +33,7 @@ embeddings:
     from: openai:mistral-embed
     params:
       endpoint: https://api.mistral.ai/v1
-      api_key: ${ secrets:SPICE_MISTRAL_API_KEY }
+      openai_api_key: ${ secrets:SPICE_MISTRAL_API_KEY }
 ```
 
 For detailed instructions and examples on running vector searches, refer to the [Vector-Based Search documentation](../../features/search/vector-search).


### PR DESCRIPTION
## Summary

Audit of the OpenAI embedding provider pages (last touched in #1524, April 2026) against `spiceai/spiceai` `trunk`, `v2.1.5`, and `v2.0.1`. Three claims were wrong; each is fixed at the version scope where it is actually wrong.

### 1. Unprefixed credential params stopped working in v2.1.0 (vNext + 2.1.x)

The deployment guide listed `openai_api_key` / `api_key`, `openai_org_id` / `org_id`, `openai_project_id` / `project_id`, `openai_usage_tier` / `usage_tier` as accepted alternatives and stated "Aliases exist for credential parameters". The reference page's Mistral example used a bare `api_key:`.

`OpenAiEmbeddingParams` declares `#[params(prefix = "openai")]` with no `alias` on any field, so the only accepted keys are `openai_api_key`, `openai_org_id`, `openai_project_id`, `openai_usage_tier` (plus the unprefixed `endpoint`, which is `#[param(runtime, …)]`). An unprefixed component key hits `warn_leftover_keys` and is dropped — the model then loads with no credential and fails auth at first use.

**This is version-scoped, not a flat correction.** Through v2.0.x, `embed.rs::openai()` took a raw `HashMap` and did an explicit dual lookup (`params.get("api_key").or(params.get("openai_api_key"))`), so the unprefixed forms genuinely worked. v2.1.0 switched the signature to `&crate::parameters::Parameters`, whose `validate_and_format_key` drops an unprefixed component param with `Ignoring parameter {key}: must be prefixed with 'openai_'`. So **the 2.0.x and 1.x snapshots are left untouched — they are correct for those releases** — and only vNext + 2.1.x are fixed.

### 2. `max_concurrency` is not an embedding knob (vNext + 2.1.x + 2.0.x)

Troubleshooting told readers to "reduce `max_concurrency`" for sustained 429s. `max_concurrency` is a *model* runtime tunable: it lives in `RUNTIME_TUNABLES` (`model/params/common.rs`) and is read by `build_model_rate_controller`, which is only called from `init/model.rs`. The embedding client's rate controller comes solely from `UsageTier` (`impl From<UsageTier> for Arc<RateController>`) via `OpenaiEmbed::new(client, Some(usage_tier.into()))`. No release reads it for embeddings (verified at `v2.0.1`, `v2.1.5`, `trunk`), so this is a flat correction across all three snapshots that carry the page.

### 3. Retriable conditions were under-enumerated (all three snapshots)

Docs listed 429 / 500 / 503 + "transient reqwest errors". `is_retriable_error` also retries transport statuses **502** and **504**, `reqwest` request/body errors, and `JSONDeserialize` failures — identical in all three versions.

### Verified as accurate (no change)

The tier table (`free` 1/100, `tier1` 35/3,000, `tier2`–`tier3` 60/5,000, `tier4`–`tier5` 125/10,000), the 256-input / 512 KiB batch caps, the 10-retry fibonacci backoff, all six `embeddings_*` metric names and their labels, the `text_embed` task-history span, and `outputs_produced` all match source in every version.

## Source refs

`spiceai/spiceai` @ `trunk` (`acd6944079`), `v2.1.5`, `v2.0.1`:

- [`crates/runtime/src/embeddings/params/openai.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/embeddings/params/openai.rs) — prefix, no aliases, `tier1` default
- [`crates/runtime-parameters-derive/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-parameters-derive/src/lib.rs) — `alias` is "prefixed like the field"; unknown keys → `warn_leftover_keys`
- [`crates/llms/src/openai/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/openai/mod.rs) — `impl From<UsageTier> for Arc<RateController>`
- [`crates/runtime/src/model/rate_limit.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/rate_limit.rs) — `max_concurrency`, models-only
- [`crates/llms/src/openai/embed.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/openai/embed.rs) — `is_retriable_error`, batch caps, retry count
- `v2.0.1:crates/runtime/src/model/embed.rs:644-655` — the pre-2.1 dual lookup that makes the 2.0.x docs correct

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — grep-count gate run per claim; `Aliases exist` and `openai_api_key` / `api_key` intentionally remain **only** in `version-2.0.x`, bare `api_key:` example intentionally remains in 1.5.x–1.11.x + 2.0.x
- [x] Files updated: 5

<!-- fix-failing-prs: enforce-check stale-payload note -->
**CI note — a red `enforce-pull-with-spice` run on this PR is a stale replay, not a rule violation.** The action reads the PR from the event payload, so runs queued by `opened` — before this PR's labels and assignee were applied moments later — fail, and re-running one replays that same original payload instead of re-reading the PR, so a re-run can only reproduce the failure. This PR satisfies every rule the action checks: title length, an `area/` label, an assignee, and no banned labels. A fresh `labeled` / `assigned` / `edited` / `synchronize` event re-evaluates it, which this edit supplies.
