### PR TITLE
docs(hash-index): the row-count threshold never gated index creation; partitioned_arrow is supported

### DIFF
--- a/website/docs/components/data-accelerators/arrow/deployment.md
+++ b/website/docs/components/data-accelerators/arrow/deployment.md
@@ -28,7 +28,7 @@ The Arrow accelerator is **not durable**. Data is held in RAM and is lost on pro
 ## Capacity & Sizing
 
 - **Memory**: Plan for 1.0–1.5× the raw row-oriented size of the source data, plus overhead for string dictionaries. Use the source connector's schema and row count to estimate.
-- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
+- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows. The index stores no key bytes — only a 16-byte slot per entry (8-byte hash + packed 8-byte row location) plus roughly 1.25 bytes of bloom filter — so budget from the entry count, not the key width. Reported usage tracks allocated slot capacity, which exceeds the live entry count, so plan above the ~17 bytes/row floor.
 - **Startup cost**: Full-dataset materialization happens on startup. For tables larger than ~1 GB, consider a durable accelerator to avoid repeated full refresh on every restart.
 
 ## Metrics

--- a/website/docs/components/data-accelerators/arrow/deployment.md
+++ b/website/docs/components/data-accelerators/arrow/deployment.md
@@ -39,8 +39,8 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 | ---------------------------------- | --------- | --------------------------------------------------------- |
 | `hash_index_builds`                | Counter   | Total hash-index builds (one per refresh).                |
 | `hash_index_build_duration_ms`     | Histogram | Time to build the hash index.                             |
-| `hash_index_entries`               | Gauge     | Number of entries in the index.                           |
-| `hash_index_memory_bytes`          | Gauge     | Approximate memory footprint of the index.                |
+| `hash_index_entries`               | Histogram | Number of entries in the index.                           |
+| `hash_index_memory_bytes`          | Histogram | Approximate memory footprint of the index.                |
 | `hash_index_lookups`               | Counter   | Total hash-index lookups performed by queries.            |
 | `hash_index_lookup_rows`           | Counter   | Total rows returned via hash-index lookups.               |
 

--- a/website/docs/features/data-acceleration/hash-index.md
+++ b/website/docs/features/data-acceleration/hash-index.md
@@ -18,7 +18,6 @@ The hash index is an optional, high-performance indexing feature for Arrow-accel
 - **256-Shard Design**: Minimizes lock contention for concurrent reads
 - **SIMD-Optimized Hashing**: Uses XXH3_64 for fast, high-quality hashing
 - **Built-in Bloom Filter**: Fast negative lookups to skip unnecessary hash table probes
-- **Auto-Threshold**: Index is only built when data size exceeds a minimum threshold
 
 ## Configuration
 
@@ -133,23 +132,9 @@ SELECT * FROM my_dataset WHERE region = 'US' AND customer_id = 42;
 SELECT * FROM my_dataset WHERE status = 'active';
 ```
 
-## Index Threshold
+## Index Size
 
-The hash index is only built when the dataset exceeds a minimum size:
-
-```text
-threshold = 256 × CPU_cores
-```
-
-| CPU Cores | Minimum Rows for Index |
-| --------- | ---------------------- |
-| 1         | 256                    |
-| 4         | 1,024                  |
-| 8         | 2,048                  |
-| 16        | 4,096                  |
-| 32        | 8,192                  |
-
-For small tables below the threshold, a full scan is faster than index maintenance overhead.
+There is no minimum row count. Whenever the [activation rules](#configuration) are met, the index is built for the dataset regardless of size — including for an empty table, which is indexed at load and rebuilt as rows arrive. The row count is used only to pre-size the hash table and bloom filter, not to decide whether to index at all, so budget the [memory](#memory-usage) below for every indexed dataset.
 
 ## Performance
 
@@ -229,7 +214,7 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ## Limitations
 
-1. **Arrow Engine Only**: Hash index is only available for `engine: arrow` acceleration
+1. **Arrow Engines Only**: Hash index is only available for `engine: arrow` and `engine: partitioned_arrow` acceleration
 2. **Single-Column Primary Keys Only**: Composite primary keys are not yet supported for indexed lookups; only single-column primary keys use the index
 3. **Experimental**: API and behavior may change in future releases
 4. **No Persistence**: Index is rebuilt on restart (data persists, index is in-memory)
@@ -240,9 +225,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### "No index available for point lookup"
 
-**Cause**: Dataset row count is below the index threshold.
+**Cause**: A direct point lookup was issued against an indexed table that has no primary key index — `primary_key` is not set, so only the configured secondary indexes exist.
 
-**Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
+**Solution**: Set `primary_key` on the acceleration to build the primary key index. Dataset size is not a factor: the index is built at any row count once the [activation rules](#configuration) are met.
 
 ### Warning: "The hash_index acceleration parameter is ignored for Arrow acceleration"
 

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/hash-index.md
@@ -18,7 +18,6 @@ The hash index is an optional, high-performance indexing feature for Arrow-accel
 - **256-Shard Design**: Minimizes lock contention for concurrent reads
 - **SIMD-Optimized Hashing**: Uses XXH3_64 for fast, high-quality hashing
 - **Built-in Bloom Filter**: Fast negative lookups to skip unnecessary hash table probes
-- **Auto-Threshold**: Index is only built when data size exceeds a minimum threshold
 
 ## Configuration
 
@@ -128,23 +127,9 @@ SELECT * FROM my_dataset WHERE region = 'US' AND customer_id = 42;
 SELECT * FROM my_dataset WHERE status = 'active';
 ```
 
-## Index Threshold
+## Index Size
 
-The hash index is only built when the dataset exceeds a minimum size:
-
-```text
-threshold = 256 × CPU_cores
-```
-
-| CPU Cores | Minimum Rows for Index |
-| --------- | ---------------------- |
-| 1         | 256                    |
-| 4         | 1,024                  |
-| 8         | 2,048                  |
-| 16        | 4,096                  |
-| 32        | 8,192                  |
-
-For small tables below the threshold, a full scan is faster than index maintenance overhead.
+There is no minimum row count. Whenever `hash_index: enabled` is set with a `primary_key`, the index is built for the dataset regardless of size — including for an empty table, which is indexed at load and rebuilt as rows arrive. The row count is used only to pre-size the hash table and bloom filter, not to decide whether to index at all, so budget the [memory](#memory-usage) below for every indexed dataset.
 
 ## Performance
 
@@ -235,9 +220,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### "No index available for point lookup"
 
-**Cause**: Dataset row count is below the index threshold.
+**Cause**: A direct point lookup was issued against an indexed table that has no primary key index — `primary_key` is not set, so only the configured secondary indexes exist.
 
-**Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
+**Solution**: Set `primary_key` on the acceleration to build the primary key index. Dataset size is not a factor: the index is built at any row count once `hash_index: enabled` and a `primary_key` are configured.
 
 ### Warning: "Add 'hash_index: enabled' to use primary_key for fast lookups"
 

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
@@ -28,7 +28,7 @@ The Arrow accelerator is **not durable**. Data is held in RAM and is lost on pro
 ## Capacity & Sizing
 
 - **Memory**: Plan for 1.0–1.5× the raw row-oriented size of the source data, plus overhead for string dictionaries. Use the source connector's schema and row count to estimate.
-- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
+- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows. The index stores no key bytes — only a 16-byte slot per entry (8-byte hash + packed 8-byte row location) plus roughly 1.25 bytes of bloom filter — so budget from the entry count, not the key width. Reported usage tracks allocated slot capacity, which exceeds the live entry count, so plan above the ~17 bytes/row floor.
 - **Startup cost**: Full-dataset materialization happens on startup. For tables larger than ~1 GB, consider a durable accelerator to avoid repeated full refresh on every restart.
 
 ## Metrics

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
@@ -39,8 +39,8 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 | ---------------------------------- | --------- | --------------------------------------------------------- |
 | `hash_index_builds`                | Counter   | Total hash-index builds (one per refresh).                |
 | `hash_index_build_duration_ms`     | Histogram | Time to build the hash index.                             |
-| `hash_index_entries`               | Gauge     | Number of entries in the index.                           |
-| `hash_index_memory_bytes`          | Gauge     | Approximate memory footprint of the index.                |
+| `hash_index_entries`               | Histogram | Number of entries in the index.                           |
+| `hash_index_memory_bytes`          | Histogram | Approximate memory footprint of the index.                |
 | `hash_index_lookups`               | Counter   | Total hash-index lookups performed by queries.            |
 | `hash_index_lookup_rows`           | Counter   | Total rows returned via hash-index lookups.               |
 

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/hash-index.md
@@ -18,7 +18,6 @@ The hash index is an optional, high-performance indexing feature for Arrow-accel
 - **256-Shard Design**: Minimizes lock contention for concurrent reads
 - **SIMD-Optimized Hashing**: Uses XXH3_64 for fast, high-quality hashing
 - **Built-in Bloom Filter**: Fast negative lookups to skip unnecessary hash table probes
-- **Auto-Threshold**: Index is only built when data size exceeds a minimum threshold
 
 ## Configuration
 
@@ -133,23 +132,9 @@ SELECT * FROM my_dataset WHERE region = 'US' AND customer_id = 42;
 SELECT * FROM my_dataset WHERE status = 'active';
 ```
 
-## Index Threshold
+## Index Size
 
-The hash index is only built when the dataset exceeds a minimum size:
-
-```text
-threshold = 256 × CPU_cores
-```
-
-| CPU Cores | Minimum Rows for Index |
-| --------- | ---------------------- |
-| 1         | 256                    |
-| 4         | 1,024                  |
-| 8         | 2,048                  |
-| 16        | 4,096                  |
-| 32        | 8,192                  |
-
-For small tables below the threshold, a full scan is faster than index maintenance overhead.
+There is no minimum row count. Whenever the [activation rules](#configuration) are met, the index is built for the dataset regardless of size — including for an empty table, which is indexed at load and rebuilt as rows arrive. The row count is used only to pre-size the hash table and bloom filter, not to decide whether to index at all, so budget the [memory](#memory-usage) below for every indexed dataset.
 
 ## Performance
 
@@ -229,7 +214,7 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ## Limitations
 
-1. **Arrow Engine Only**: Hash index is only available for `engine: arrow` acceleration
+1. **Arrow Engines Only**: Hash index is only available for `engine: arrow` and `engine: partitioned_arrow` acceleration
 2. **Single-Column Primary Keys Only**: Composite primary keys are not yet supported for indexed lookups; only single-column primary keys use the index
 3. **Experimental**: API and behavior may change in future releases
 4. **No Persistence**: Index is rebuilt on restart (data persists, index is in-memory)
@@ -240,9 +225,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### "No index available for point lookup"
 
-**Cause**: Dataset row count is below the index threshold.
+**Cause**: A direct point lookup was issued against an indexed table that has no primary key index — `primary_key` is not set, so only the configured secondary indexes exist.
 
-**Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
+**Solution**: Set `primary_key` on the acceleration to build the primary key index. Dataset size is not a factor: the index is built at any row count once the [activation rules](#configuration) are met.
 
 ### Warning: "The hash_index acceleration parameter is ignored for Arrow acceleration"
 

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
@@ -28,7 +28,7 @@ The Arrow accelerator is **not durable**. Data is held in RAM and is lost on pro
 ## Capacity & Sizing
 
 - **Memory**: Plan for 1.0–1.5× the raw row-oriented size of the source data, plus overhead for string dictionaries. Use the source connector's schema and row count to estimate.
-- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows; memory overhead is approximately 24–48 bytes per row plus the key size.
+- **Hash index**: Optional. Activated automatically when a `primary_key` (or secondary `indexes` entry) is configured, building a hash map over the indexed columns. Build time scales linearly with rows. The index stores no key bytes — only a 16-byte slot per entry (8-byte hash + packed 8-byte row location) plus roughly 1.25 bytes of bloom filter — so budget from the entry count, not the key width. Reported usage tracks allocated slot capacity, which exceeds the live entry count, so plan above the ~17 bytes/row floor.
 - **Startup cost**: Full-dataset materialization happens on startup. For tables larger than ~1 GB, consider a durable accelerator to avoid repeated full refresh on every restart.
 
 ## Metrics

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
@@ -39,8 +39,8 @@ Generic acceleration metrics are available with the `dataset_acceleration_` pref
 | ---------------------------------- | --------- | --------------------------------------------------------- |
 | `hash_index_builds`                | Counter   | Total hash-index builds (one per refresh).                |
 | `hash_index_build_duration_ms`     | Histogram | Time to build the hash index.                             |
-| `hash_index_entries`               | Gauge     | Number of entries in the index.                           |
-| `hash_index_memory_bytes`          | Gauge     | Approximate memory footprint of the index.                |
+| `hash_index_entries`               | Histogram | Number of entries in the index.                           |
+| `hash_index_memory_bytes`          | Histogram | Approximate memory footprint of the index.                |
 | `hash_index_lookups`               | Counter   | Total hash-index lookups performed by queries.            |
 | `hash_index_lookup_rows`           | Counter   | Total rows returned via hash-index lookups.               |
 

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/hash-index.md
@@ -18,7 +18,6 @@ The hash index is an optional, high-performance indexing feature for Arrow-accel
 - **256-Shard Design**: Minimizes lock contention for concurrent reads
 - **SIMD-Optimized Hashing**: Uses XXH3_64 for fast, high-quality hashing
 - **Built-in Bloom Filter**: Fast negative lookups to skip unnecessary hash table probes
-- **Auto-Threshold**: Index is only built when data size exceeds a minimum threshold
 
 ## Configuration
 
@@ -133,23 +132,9 @@ SELECT * FROM my_dataset WHERE region = 'US' AND customer_id = 42;
 SELECT * FROM my_dataset WHERE status = 'active';
 ```
 
-## Index Threshold
+## Index Size
 
-The hash index is only built when the dataset exceeds a minimum size:
-
-```text
-threshold = 256 × CPU_cores
-```
-
-| CPU Cores | Minimum Rows for Index |
-| --------- | ---------------------- |
-| 1         | 256                    |
-| 4         | 1,024                  |
-| 8         | 2,048                  |
-| 16        | 4,096                  |
-| 32        | 8,192                  |
-
-For small tables below the threshold, a full scan is faster than index maintenance overhead.
+There is no minimum row count. Whenever the [activation rules](#configuration) are met, the index is built for the dataset regardless of size — including for an empty table, which is indexed at load and rebuilt as rows arrive. The row count is used only to pre-size the hash table and bloom filter, not to decide whether to index at all, so budget the [memory](#memory-usage) below for every indexed dataset.
 
 ## Performance
 
@@ -229,7 +214,7 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ## Limitations
 
-1. **Arrow Engine Only**: Hash index is only available for `engine: arrow` acceleration
+1. **Arrow Engines Only**: Hash index is only available for `engine: arrow` and `engine: partitioned_arrow` acceleration
 2. **Single-Column Primary Keys Only**: Composite primary keys are not yet supported for indexed lookups; only single-column primary keys use the index
 3. **Experimental**: API and behavior may change in future releases
 4. **No Persistence**: Index is rebuilt on restart (data persists, index is in-memory)
@@ -240,9 +225,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### "No index available for point lookup"
 
-**Cause**: Dataset row count is below the index threshold.
+**Cause**: A direct point lookup was issued against an indexed table that has no primary key index — `primary_key` is not set, so only the configured secondary indexes exist.
 
-**Solution**: This is expected behavior for small datasets. The full scan is faster than index overhead.
+**Solution**: Set `primary_key` on the acceleration to build the primary key index. Dataset size is not a factor: the index is built at any row count once the [activation rules](#configuration) are met.
 
 ### Warning: "The hash_index acceleration parameter is ignored for Arrow acceleration"
 


### PR DESCRIPTION
## Summary

End-to-end audit of the Hash Index docs against `spiceai/spiceai` `trunk`, `v2.1.5`, `v2.0.1`, and `v1.11.6`. Three claims are wrong.

### 1. The row-count threshold has never gated index creation (all four snapshots)

The page documented a hard activation rule — `threshold = 256 × CPU_cores`, a CPU-cores→minimum-rows table, an **Auto-Threshold** key feature ("Index is only built when data size exceeds a minimum threshold"), and a troubleshooting entry attributing `"No index available for point lookup"` to being under the threshold.

The threshold code exists but is dead outside benchmarks:

- `HashIndexBuilder::try_build()` is the variant that checks `total_rows < self.min_rows_threshold`. Its **only** occurrence outside `crates/hash-index` is the comment that declines to use it: `// Force index creation with .build() instead of .try_build()` (`crates/data_components/src/arrow/indexed.rs:1145`).
- The other construction path is equally explicit: `// Always build the hash index when primary key is specified. … we should always create the index even if empty` (`indexed.rs:178`).
- `index_threshold()` is referenced only from `crates/hash-index/benches/lookup.rs`.
- `IndexedMemTable::try_new_with_parallelism` takes the parallelism argument as `_parallelism` — unused.

`total_rows` survives only as `with_expected_rows(total_rows)`, a capacity hint for pre-sizing. So the index is built at **any** row count, including for an empty table (the single construction site passes `vec![]`). This has been true in every release — `Always build the hash index` and `Force index creation` are both present at `v1.11.6`, `v2.0.1`, and `v2.1.5` — so it is a flat correction, not a version-specific one. The claim dates to #1296 (v1.11 docs) and was never true.

The practical impact is a sizing surprise: readers were told small datasets pay no index memory, when in fact every dataset meeting the activation rules pays the ~17.25 bytes/row documented in the same page.

The troubleshooting cause is also corrected — `"No index available for point lookup"` (a real string, `indexed.rs:278` and `:337`) is returned when `self.index` is `None`, i.e. no `primary_key` was configured. Not a size condition.

### 2. `partitioned_arrow` is supported (vNext + 2.1.x + 2.0.x)

Limitations #1 said "Hash index is only available for `engine: arrow`" while the Configuration section on the *same page* correctly listed "`engine` is `arrow` or `partitioned_arrow`" — a self-contradiction. `is_hash_index_enabled()` matches `Engine::Arrow | Engine::PartitionedArrow`.

**Version-scoped:** at `v1.11.6` the check really was `self.engine == Engine::Arrow` (and gated on the old `hash_index: enabled` param), so **`version-1.11.x` keeps its "Arrow Engine Only" wording** and receives only the threshold fixes. The engine widened at v2.0.0.

### 3. Two hash-index metrics are histograms, not gauges (vNext + 2.1.x + 2.0.x)

`components/data-accelerators/arrow/deployment.md` typed `hash_index_entries` and `hash_index_memory_bytes` as **Gauge**. Both register as `u64_histogram` (`crates/telemetry/src/lib.rs`), so `/metrics` exposes `_bucket`/`_sum`/`_count` series rather than a single value — a reader writing a dashboard query from the docs gets nothing back. Identical shapes at `v1.11.6`/`v2.0.1`/`v2.1.5`/`trunk`. (`version-1.11.x` has no `arrow/deployment.md`.) The other four rows — `hash_index_builds`, `hash_index_build_duration_ms`, `hash_index_lookups`, `hash_index_lookup_rows` — are correct and complete against the registration block.

### 4. The hash index stores no key bytes (vNext + 2.1.x + 2.0.x)

`arrow/deployment.md` sized index memory as "approximately 24–48 bytes per row **plus the key size**". `ShardTable` holds only `slots: Vec<Slot>` — an 8-byte hash plus a `RowLocation` that packs into 8 bytes — and never retains key bytes. That is precisely why `get_by_key` carries the warning that "in the rare case of a hash collision, this could return the wrong row". Key width therefore does not affect the footprint. `memory_usage_bytes()` sums `shard.capacity() * 16` plus the bloom filter, so it scales with *allocated slot capacity* (above the live entry count) — reworded to give the ~17 bytes/row floor and say usage runs above it, rather than a per-key figure.

### Verified as accurate (no change)

256 shards and the XOR-fold shard selection `((hash >> 56) ^ (hash >> 48) ^ hash) & 0xFF`; the XXH3_64 seed `0x5370_6963_6541_4920`; the bloom filter's 10 bits/item, 7 hash functions, ~0.82% FPR (`DEFAULT_BITS_PER_ITEM`/`DEFAULT_NUM_HASHES` and the doc comment stating the same FPR); the full supported-key-type list (`Int8/16/32/64`, `UInt8/16/32/64`, `Utf8`, `LargeUtf8`, `Binary`, `LargeBinary` — exactly the `impl_primitive_key!` set plus the `StringKeys`/`BinaryKeys` enums); the `refresh_mode: caching` exclusion; and the `hash_index`-is-ignored warning text.

## Source refs

`spiceai/spiceai` @ `trunk` (`acd6944079`):

- [`crates/data_components/src/arrow/indexed.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/arrow/indexed.rs) — both unconditional `.build()` sites, unused `_parallelism`, the point-lookup error
- [`crates/hash-index/src/index.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/hash-index/src/index.rs) — `try_build()` threshold check, `index_threshold()`, `NUM_SHARDS`, `HASH_SEED`, `shard()`
- [`crates/hash-index/src/extract.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/hash-index/src/extract.rs) — supported key types
- [`crates/hash-index/src/bloom.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/hash-index/src/bloom.rs) — bloom parameters
- [`crates/runtime-acceleration/src/acceleration.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-acceleration/src/acceleration.rs) — `is_hash_index_enabled()`
- [`crates/telemetry/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/telemetry/src/lib.rs) — the six hash-index metric registrations

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — zero remaining hits for `256 × CPU_cores` / `Minimum Rows for Index` / `Auto-Threshold` / `below the index threshold`; `only available for \`engine: arrow\` acceleration` intentionally remains **only** in `version-1.11.x`; zero remaining `hash_index_entries`/`hash_index_memory_bytes` Gauge rows
- [x] Cross-page sweep run — `indexes.md`, `arrow/index.md`, `partitioning.md`, `reference/memory.md`, and `reference/performance-tuning.md` reference the hash index but restate neither the threshold nor the engine list
- [x] Files updated: 7 (3 also carry the memory-sizing fix)
