### PR TITLE
docs(functions): SQL table functions can wrap the search functions

### DIFF
--- a/website/docs/features/functions/index.md
+++ b/website/docs/features/functions/index.md
@@ -248,6 +248,40 @@ functions:
 
 Calling `SELECT * FROM hn_user('pg')` resolves the `(SELECT username FROM args)` subquery to the literal `'pg'` before planning, so the resulting `WHERE request_path = '/users/pg'` predicate is pushed down to the HTTP connector.
 
+### Wrapping search functions
+
+A SQL table function can wrap the [search functions](../../reference/sql/search) — [`vector_search()`](../../reference/sql/search#vector-search-vector_search), [`text_search()`](../../reference/sql/search#full-text-search-text_search), and either of them nested inside [`rrf()`](../../reference/sql/search#reciprocal-rank-fusion-rrf) — passing its own argument through as the search query. This packages a hybrid-search query as one named, callable function:
+
+```yaml
+functions:
+  - name: search_cookbook
+    from: sql
+    kind: table
+    description: Hybrid search over the cookbook.
+    signature:
+      args:
+        - { name: q, type: utf8 }
+      returns:
+        - { name: path, type: utf8 }
+        - { name: content, type: utf8 }
+    body: |
+      SELECT path, content
+      FROM rrf(
+        vector_search(cookbook_files, q),
+        text_search(cookbook_files, q, content)
+      )
+```
+
+```sql
+SELECT * FROM search_cookbook('how does hybrid search work') LIMIT 10;
+```
+
+Search functions need their query as a string literal while the plan is being built, which is earlier than the `args` table can supply a value. The runtime handles this by substituting the literal into the search function's query position before the body is planned. What that supports, and what it does not:
+
+- **The argument must be a declared `utf8` argument, referenced by name.** `vector_search(docs, q)` resolves; an expression built from one — `vector_search(docs, concat(q, ' docs'))` — is not rewritten, and planning still rejects it with `Second argument must be a query string`. Compose the query text in the caller instead.
+- **Both positional and `query =>` forms work.** `text_search(docs, query => q, column => body)` is accepted; the named query argument is moved into the second positional slot, which is where every search function reads it from.
+- **Only the query position is rewritten.** Every other reference to a function argument in the body — a `WHERE` predicate, a `LIMIT`, a join key — still goes through the `args` table as described above.
+
 ## Volatility
 
 Volatility tells the optimizer how the function behaves across calls. Pick the strongest level that's actually true — the default (`volatile`) is the safest but disables constant folding, query-level caching, and pushdown.

--- a/website/docs/reference/spicepod/functions.md
+++ b/website/docs/reference/spicepod/functions.md
@@ -127,6 +127,8 @@ body: |
 
 The body can call any DataFusion built-in scalar function (math, string, datetime, JSON, regex, etc.).
 
+A table function body may also call the [search functions](../sql/search) — `vector_search()`, `text_search()`, or either nested in `rrf()` — with one of the function's own `utf8` arguments as the search query. Those arguments are substituted as literals before the body is planned rather than being read from the `args` table; see [Wrapping search functions](../../features/functions#wrapping-search-functions).
+
 Mutually exclusive with `body_ref`. Must not be set for non-SQL `from:` schemes.
 
 ### `body_ref`


### PR DESCRIPTION
## Summary

[spiceai/spiceai#12919](https://github.com/spiceai/spiceai/pull/12919) made the search functions usable inside a SQL function component's body, which previously failed to plan.

A search UDTF inspects its query argument while the table function is being *constructed* during planning, and all of them require that argument in the second positional slot as a string literal. A SQL-tier function's own arguments, by contrast, are only replaced with literal values on the logical plan *after* planning (`inline_args_into_plan`) — too late. The runtime now rewrites the parsed SQL body before planning: an argument in a search function's query position that resolves to a known `utf8` function argument is normalized into the second positional slot as a literal.

Documented on the Functions feature page (next to the existing *Filter pushdown with args* section, which covers the `args`-table mechanism this one is the exception to), with the three boundaries the implementation actually draws:

- Only a bare identifier naming a declared `utf8` argument resolves — an expression around it (`concat(q, ' docs')`) is not rewritten, and planning still rejects it with `Second argument must be a query string` (`full_text_udtf.rs`).
- Both `vector_search(docs, q)` and `vector_search(docs, query => q)` work; the named form is *moved* into the second positional slot, since it would otherwise be rejected as an unrecognized named argument.
- Only the query position is rewritten; every other argument reference in the body still goes through the `args` table.

Applies to `vector_search()` and `text_search()`, including when nested inside `rrf()` (the rewriter hooks both `Expr::Function` and `TableFactor::Table`, so a `FROM` source and a nested call are both covered).

## Source PRs

- spiceai/spiceai#12919 — bug: Support search UDTFs in SQL function components (resolves spiceai/spiceai#12899)

## Pages changed

- `website/docs/features/functions/index.md` — new **Wrapping search functions** subsection under *Table Functions*.
- `website/docs/reference/spicepod/functions.md` — `body` section notes the exception and links to it.

## Versioned docs

vNext-only — new capability, merged to `trunk` on 2026-08-13 after `v2.1.5` was cut. Older snapshots correctly document the `args`-table mechanism alone.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Anchors verified against `reference/sql/search.md` headings (`#vector-search-vector_search`, `#full-text-search-text_search`, `#reciprocal-rank-fusion-rrf`)
- [x] Named argument spelled `column =>` per `full_text_udtf.rs` (`query`/`column`/`limit`/`include_score`)
- [x] Files updated: 2 (matches the diff)

<!-- fix-failing-prs: enforce-check stale-payload note -->
**CI note — a red `enforce-pull-with-spice` run on this PR is a stale replay, not a rule violation.** The action reads the PR from the event payload, so runs queued by `opened` — before this PR's labels and assignee were applied moments later — fail, and re-running one replays that same original payload instead of re-reading the PR, so a re-run can only reproduce the failure. This PR satisfies every rule the action checks: title length, an `area/` label, an assignee, and no banned labels. A fresh `labeled` / `assigned` / `edited` / `synchronize` event re-evaluates it, which this edit supplies.
