### PR TITLE
docs(embeddings/huggingface): pytorch_model.bin fallback when a repository has no safetensors

### DIFF
--- a/website/docs/components/embeddings/huggingface/index.md
+++ b/website/docs/components/embeddings/huggingface/index.md
@@ -26,6 +26,16 @@ Supported models include:
 - All models tagged as [text-embeddings-inference](https://huggingface.co/models?other=text-embeddings-inference) on Huggingface
 - Any Huggingface repository with the correct files to be loaded as a [local embedding model](local).
 
+## Model Weights
+
+Spice downloads the repository's `safetensors` weights. When a repository publishes none, it falls back to `pytorch_model.bin` and logs a warning at startup:
+
+```text
+safetensors weights not found; falling back to `pytorch_model.bin`. Model loading is significantly slower.
+```
+
+A repository that publishes neither format fails to load. Prefer a repository with `safetensors` weights where one is available.
+
 With the same semantics as [language models](../models/huggingface#access-tokens), `spice` can run private HuggingFace embedding models:
 
 ```yaml


### PR DESCRIPTION
## Summary

[spiceai/spiceai#12971](https://github.com/spiceai/spiceai/pull/12971) added a `safetensors` → `pytorch_model.bin` fallback to the HuggingFace embedding download path (`download_hf_artifacts`, `crates/llms/src/embeddings/candle/util.rs`). Before it, a HuggingFace repository that publishes only `pytorch_model.bin` could not be served as an embedding model, even though the [local embedding model](https://docs.spiceai.org/docs/components/embeddings/local) page has always listed both formats.

The HuggingFace embeddings page said nothing about weight formats at all. This documents:

- `safetensors` is what Spice downloads first.
- When the repository publishes none, it falls back to `pytorch_model.bin` and logs the warning verbatim from source (`safetensors weights not found; falling back to \`pytorch_model.bin\`. Model loading is significantly slower.`).
- A repository with neither fails to load — `api_repo.get("pytorch_model.bin")` is the last attempt and its error propagates.

## Source PRs

- spiceai/spiceai#12971 — fix(llms): fall back to pytorch_model.bin for embeddings without safetensors (closes spiceai/spiceai#12970)

## Pages changed

- `website/docs/components/embeddings/huggingface/index.md` — new **Model Weights** section.

## Versioned docs

vNext-only — the fallback merged to `trunk` on 2026-08-13, after `v2.1.5` was cut. On every released version the HuggingFace embedding path still downloads `safetensors` only.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Warning string quoted verbatim from `crates/llms/src/embeddings/candle/util.rs`
- [x] Files updated: 1 (matches the diff)

<!-- fix-failing-prs: enforce-check stale-payload note -->
**CI note — a red `enforce-pull-with-spice` run on this PR is a stale replay, not a rule violation.** The action reads the PR from the event payload, so runs queued by `opened` — before this PR's labels and assignee were applied moments later — fail, and re-running one replays that same original payload instead of re-reading the PR, so a re-run can only reproduce the failure. This PR satisfies every rule the action checks: title length, an `area/` label, an assignee, and no banned labels. A fresh `labeled` / `assigned` / `edited` / `synchronize` event re-evaluates it, which this edit supplies.
