### PR TITLE
docs(search): full-text search pushes WHERE filters into the index, before the limit

### DIFF
--- a/website/docs/features/search/full-text.md
+++ b/website/docs/features/search/full-text.md
@@ -87,6 +87,29 @@ A persisted index records the schema it was built with, and that schema is what 
 
 `index_store: memory` is never affected — it rebuilds from scratch on every start and so always matches the configuration.
 
+### Filtering on other columns
+
+Beyond the indexed text, the built-in index also carries the dataset's primary key (or `row_id`) and every column declared with [`metadata.vectors`](../../reference/spicepod/datasets.md#columnsmetadatavectors). Those columns are returned by searches and can be filtered on, and a `WHERE` predicate over them is applied **inside** the index scan — before the search's row limit, so a filtered search returns the best matches among the rows that pass the filter rather than whatever survives filtering the unfiltered top matches:
+
+```yaml
+columns:
+  - name: body
+    full_text_search:
+      enabled: true
+      row_id:
+        - id
+  - name: state
+    metadata:
+      vectors: filterable
+```
+
+```sql
+SELECT id, score FROM text_search(doc.pulls, 'search keywords', body, 5)
+WHERE state = 'open';
+```
+
+A column whose type the index cannot represent — a date or timestamp — is skipped when the index is built, with a warning naming the column; predicates on it are applied above the scan as before. See [Filter Pushdown](../../reference/sql/search#full-text-filter-pushdown) for the full set of predicates the index applies.
+
 ## Using Elasticsearch as the FTS Engine
 
 To use Elasticsearch instead of the built-in Tantivy engine, add a dataset-level `full_text_search` block with `engine: elasticsearch` and the connection parameters:

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -1030,7 +1030,9 @@ Optional. If provided, a vector engine (see [below](#vectors)) should store this
 - `non-filterable`: Store the column in the vector engine.
 - `filterable`: Store the column in the vector engine, and ensure the engine can filter on the column (if possible in the engine).
 
-Only applicable if `vectors.enabled` is both defined and `true`.
+For the vector engine, only applicable if `vectors.enabled` is both defined and `true`.
+
+The distinction between the two values is the vector engine's. When the dataset also has a [full-text search index](../../features/search/full-text), either value carries the column into that index, where it is returned by searches and [filterable](../sql/search#full-text-filter-pushdown) — whether or not a vector engine is configured. A column whose type the full-text index cannot represent (a date or timestamp) is skipped there, with a warning logged at startup.
 
 ## `embeddings`
 

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -113,6 +113,23 @@ LIMIT 5;
 
 By default, `text_search` retrieves up to 1000 results. To request fewer, specify a smaller `limit`.
 
+#### Filter Pushdown {#full-text-filter-pushdown}
+
+With the built-in Tantivy engine, `WHERE` predicates on columns carried in the full-text index are pushed into the index scan as **pre-filters** — they are applied before the top-K limit, so the results are the top-K _within the filtered set_ rather than the filtered remainder of an unfiltered top-K. A predicate the index cannot apply is left to Spice's query engine above the scan, and one the index applies only approximately is re-checked there, so results are the same either way; only how many rows survive the limit changes.
+
+```sql
+-- state and additions are applied inside the index, before the limit of 5
+SELECT id, title, score
+FROM text_search(doc.pulls, 'search keywords', body, 5)
+WHERE state = 'open' AND additions > 100;
+```
+
+Filterable columns are the dataset's primary key (or [`full_text_search.row_id`](../spicepod/datasets#columnsfull_text_searchrow_id)) and any column declared with [`metadata.vectors`](../spicepod/datasets#columnsmetadatavectors), whose values are carried into the index alongside the searched text. Columns of a type the index cannot represent — dates and timestamps — are skipped, with a warning logged at startup naming the column.
+
+Predicates that push down: `=`, `!=`, `<`, `<=`, `>`, `>=`, `BETWEEN`, `IN`, a prefix `LIKE 'x%'` on a string column, and `AND` / `OR` / `NOT` combinations of them. Predicates that do not, and are applied above the scan instead: anything on the searched text column itself (it is tokenized), on a floating-point column, or on a binary column; a case-insensitive or negated `LIKE`; an `IN` list containing `NULL`; and any comparison whose operands are not a column and a literal.
+
+The Tantivy warm tier used with [`engine: elasticsearch`](../../features/search/full-text#warm-tier) is built without those extra columns — its schema is the primary key and `_score` alone — so only primary-key predicates push into it.
+
 #### Example
 
 ```sql


### PR DESCRIPTION
## Summary

[spiceai/spiceai#12812](https://github.com/spiceai/spiceai/pull/12812) added SQL filter pushdown into the built-in (tantivy) full-text search index, via the new `tantivy_datafusion_filter` crate. `FullTextSearchQuery` now implements `supports_filters_pushdown`, and the executor builds the same tantivy query the classification promised.

This is user-visible beyond performance: the pushed filter is part of the tantivy query, so it applies **before** the top-K limit. Previously the index produced the top-K and the predicate removed rows afterwards, so a filtered `text_search` could return fewer rows than its limit — or none — while matching rows sat further down the ranking. That is the regression test the source PR added (`limit = 1` still finds the target row) and the issue it closes.

The docs already documented pre-filter semantics for `vector_search` and `rrf`; `text_search` had no such section. Added, with the boundaries read off the implementation:

- **Eligible columns** (`classify_column`, `schema.rs`): the column must be in the index — the primary key / `row_id`, or a column declared with `metadata.vectors` — indexed, and not tokenized text, bytes, dates, or floats.
- **`metadata.vectors` now means both values.** Before this PR the derived store-field set was `as_vector_metadata() == Some(NonFilterable)`, so a column marked `filterable` was *not* carried into the full-text index. It now takes either value, and skips a type the index cannot represent (`Date32`/`Date64`/`Timestamp`) with a warning rather than failing index construction.
- **Predicates that translate**: `=`, `!=`, `<`, `<=`, `>`, `>=`, `BETWEEN`, `IN`, prefix `LIKE 'x%'`, and `AND`/`OR`/`NOT` combinations. `Inexact` translations are re-checked above the scan, so results are unchanged either way — only how many rows survive the limit changes.
- **Warm tier caveat**: the Tantivy warm tier built for `engine: elasticsearch` uses `store_fields = []` (schema is `[primary key…, _score]`), so only primary-key predicates push into it.

The new `#### Filter Pushdown` heading carries an explicit id (`{#full-text-filter-pushdown}`) rather than relying on the deduplicated slug, since the page now has three headings with that text.

## Source PRs

- spiceai/spiceai#12812 — feat(search): push SQL filters down into tantivy full-text search (closes spiceai/spiceai#12231)

## Pages changed

- `website/docs/reference/sql/search.md` — new **Filter Pushdown** section under *Full-Text Search (`text_search`)*.
- `website/docs/features/search/full-text.md` — new **Filtering on other columns** section with the `metadata.vectors` configuration.
- `website/docs/reference/spicepod/datasets.md` — `columns[*].metadata.vectors` now describes its full-text-index effect; the previous "Only applicable if `vectors.enabled`" line is scoped to the vector engine, which is the only thing it was ever true of.

## Versioned docs

vNext-only — merged to `trunk` on 2026-08-14, after `v2.1.5` was cut. On released versions full-text filters are still applied above the scan.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Anchors verified (`#columnsmetadatavectors`, `#columnsfull_text_searchrow_id` both already in use elsewhere; new anchor is explicit)
- [x] Files updated: 3 (matches the diff)

<!-- fix-failing-prs: enforce-check stale-payload note -->
**CI note — a red `enforce-pull-with-spice` run on this PR is a stale replay, not a rule violation.** The action reads the PR from the event payload, so runs queued by `opened` — before this PR's labels and assignee were applied moments later — fail, and re-running one replays that same original payload instead of re-reading the PR, so a re-run can only reproduce the failure. This PR satisfies every rule the action checks: title length, an `area/` label, an assignee, and no banned labels. A fresh `labeled` / `assigned` / `edited` / `synchronize` event re-evaluates it, which this edit supplies.
