### PR TITLE
fix: point CODEOWNERS at a team GitHub can resolve (fixes #2097)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Repo maintainers
-*   @spiceai/maintainers
+*   @spiceai/spice-core-maintainers


### PR DESCRIPTION
## Summary
Fixes #2097

`CODEOWNERS` had a single catch-all rule pointing at `@spiceai/maintainers`, a team GitHub cannot resolve. An unresolvable owner does not fail loudly — the rule matches every file and then applies to nobody, with no warning on push and no annotation on the PR.

The visible symptom was that **no PR in this repo was ever auto-assigned a reviewer**: every open PR had an empty `reviewRequests` while `reviewDecision` sat at `REVIEW_REQUIRED`, so each was blocked on a review requested from nobody.

## Changes
- `CODEOWNERS`: `@spiceai/maintainers` → `@spiceai/spice-core-maintainers`

## Reference
`spice-core-maintainers` is the real slug — it is what `spiceai/spiceai` uses, and that repo's codeowners errors endpoint returns clean. Confirmed here before changing:

- `GET /orgs/spiceai/teams` confirms the org has no team with the slug `maintainers`; `spice-core-maintainers` is the maintainer team.
- `GET /orgs/spiceai/teams/spice-core-maintainers/repos/spiceai/docs` reports `role_name: maintain` (`push: true`), satisfying the write-access requirement for a valid owner.
- The team's privacy is `closed`, i.e. visible, satisfying the visibility requirement.

Sibling-repo sweep, as the issue suggested:

| Repo | State |
|---|---|
| `spiceai/spiceai` | clean — `@spiceai/spice-core-maintainers` |
| `spiceai/cookbook` | no `CODEOWNERS` file |
| `spicehq/docs` | no `CODEOWNERS` file |
| `spicehq/spiceai` | **broken** — names `@spiceai/spice-core-maintainers`, a team in the `spiceai` org, from a repo in the `spicehq` org, so the cross-org reference does not resolve |

`spicehq/spiceai` needs its own fix in that repo; it is out of scope for this PR.

## Test plan
- [ ] After merge, `GET /repos/spiceai/docs/codeowners/errors` returns `{"errors":[]}`
- [ ] A PR opened after merge gets `spice-core-maintainers` auto-requested
- [x] No content under `website/` is touched, so the Docusaurus build and link checker are unaffected — CI still runs both

Note: fixing the file only affects PRs opened afterwards. PRs already open (including this one) need their review requested once by hand.

<!-- fix-failing-prs: enforce-check stale-payload note -->
**CI note — a red `enforce-pull-with-spice` run on this PR is a stale replay, not a rule violation.** The action reads the PR from the event payload, so runs queued by `opened` — before this PR's labels and assignee were applied moments later — fail, and re-running one replays that same original payload instead of re-reading the PR, so a re-run can only reproduce the failure. This PR satisfies every rule the action checks: title length, an `area/` label, an assignee, and no banned labels. A fresh `labeled` / `assigned` / `edited` / `synchronize` event re-evaluates it, which this edit supplies.
