### PR TITLE
docs(workers): remove the type key from worker examples

### DIFF
--- a/website/docs/features/workers/index.md
+++ b/website/docs/features/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.10.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.10.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/index.md
@@ -250,7 +250,6 @@ A Spicepod can contain one or more [workers](/docs/reference/spicepod/workers) d
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -258,7 +257,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -270,7 +268,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -151,7 +148,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.11.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.11.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/index.md
@@ -250,7 +250,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -258,7 +257,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -270,7 +268,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -151,7 +148,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.5.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.5.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.5.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.5.x/reference/spicepod/index.md
@@ -218,7 +218,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -226,7 +225,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -238,7 +236,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.5.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.5.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -152,7 +149,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.6.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.6.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.6.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.6.x/reference/spicepod/index.md
@@ -218,7 +218,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -226,7 +225,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -238,7 +236,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.6.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.6.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -152,7 +149,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.7.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.7.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.7.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.7.x/reference/spicepod/index.md
@@ -218,7 +218,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -226,7 +225,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -238,7 +236,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.7.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.7.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -151,7 +148,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.8.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.8.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.8.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.8.x/reference/spicepod/index.md
@@ -250,7 +250,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -258,7 +257,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -270,7 +268,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.8.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.8.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -151,7 +148,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-1.9.x/components/workers/index.md
+++ b/website/versioned_docs/version-1.9.x/components/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/index.md
@@ -250,7 +250,6 @@ A Spicepod can contain one or more [workers](spicepod/workers) defining configur
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -258,7 +257,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -270,7 +268,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/workers.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/workers.md
@@ -15,7 +15,6 @@ Example:
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -23,7 +22,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -35,7 +33,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:
@@ -151,7 +148,6 @@ Example
 ```yaml
 workers:
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2' (20% to 'gpt4_1').
     load_balance:

--- a/website/versioned_docs/version-2.0.x/features/workers/index.md
+++ b/website/versioned_docs/version-2.0.x/features/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:

--- a/website/versioned_docs/version-2.1.x/features/workers/index.md
+++ b/website/versioned_docs/version-2.1.x/features/workers/index.md
@@ -16,7 +16,6 @@ Workers are configured in the `workers` section of the `spicepod.yaml` file. Eac
 ```yaml
 workers:
   - name: round-robin
-    type: load_balance
     description: |
       Distributes requests between 'llama3_2' and 'gpt4_1' models in a round-robin fashion.
     load_balance:
@@ -24,7 +23,6 @@ workers:
         - from: llama3_2
         - from: gpt4_1
   - name: fallback
-    type: load_balance
     description: |
       Attempts 'gpt4_1' first, then 'llama3_2', then 'anth_haiku' if previous models fail.
     load_balance:
@@ -36,7 +34,6 @@ workers:
         - from: anth_haiku
           order: 3
   - name: weighted
-    type: load_balance
     description: |
       Routes 80% of traffic to 'llama3_2'.
     load_balance:


### PR DESCRIPTION
## Summary

Every published `workers:` example carries a `type: load_balance` key that the Spicepod schema does not define.

**What the docs said**

```yaml
workers:
  - name: round-robin
    type: load_balance # <- not a field
    load_balance:
      routing:
        - from: llama3_2
```

**What the code does**

`spicepod::component::worker::Worker` declares exactly `name`, `description`, `params`, `load_balance`, `sql`, and `cron` — there is no `type` field. It was deleted in spiceai/spiceai#6039 ("refactor: Remove worker type", first released in **v1.4.0**), which predates the oldest versioned snapshot in this repo (1.5.x), so every snapshot inherited a key that had already been removed.

The impact splits at v1.9.0, when `#[serde(deny_unknown_fields)]` was added to the base Spicepod components (spiceai/spiceai#7669):

| Versions | Effect of copying the example |
| --- | --- |
| 1.5.x – 1.8.x | `type` is silently ignored |
| 1.9.x, 1.10.x, 1.11.x, 2.0.x, 2.1.x, vNext | Spicepod **fails to load** — unknown field `type` |

The `workers:` routing behaviour itself is unchanged: the routing strategy is inferred from the *shape* of each `load_balance.routing` entry (`RouterConfig` is `#[serde(untagged)]` — bare `from` → round-robin, `from` + `order` → fallback, `from` + `weight` → weighted), which is why no discriminator key is needed.

## What changed

Removed the `type: load_balance` line from all 79 occurrences across 24 files. No prose section documented `type`, so this is an example-only deletion — nothing else on these pages changes.

`website/docs/reference/spicepod/workers.md` and `website/docs/reference/spicepod/index.md` (vNext) were already correct and are untouched; their versioned copies were not, and are fixed here.

## Verified source ref

`spiceai/spiceai` @ `trunk` (5f00c0d3), re-checked at tags `v1.5.2`, `v1.7.0`, `v1.8.3`, `v1.9.0`, `v2.0.1`, `v2.1.5`:

- [`crates/spicepod/src/component/worker.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/worker.rs) — `struct Worker` (fields + `deny_unknown_fields`), `enum RouterConfig` (`untagged`)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn "type: load_balance" website/docs/ website/versioned_docs/` returns 0 hits (was 79 across 24 files); changed-file count matches the diff
- [x] Files updated: 24
