### PR TITLE
docs(tool-registry): correct what tool_search returns

### DIFF
--- a/website/docs/features/tool-registry/index.md
+++ b/website/docs/features/tool-registry/index.md
@@ -138,7 +138,7 @@ models:
 
 Each channel produces a ranked list; RRF combines the ranks (not the scores) so a tool that places top-3 in two channels usually outranks one that places top-1 in a single channel. The final `score` is normalized to `0.0–1.0` against the highest-scoring tool in the result set.
 
-Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance. The runtime keeps an LRU cache (up to 64 entries) of search-tool instances keyed on `(runtime, embedding model, tools hash)` so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly.
+Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance — a model keeps its instance, and therefore its embeddings, until the model is reloaded. The `/v1/tools` HTTP endpoints build their instances through a separate bounded cache (up to 64 entries) keyed on `(runtime, embedding model, tools hash)`, so repeated calls reuse the same embeddings. That cache is not an LRU: once it is full, an arbitrary existing entry is evicted to make room.
 
 ## `tool_search` Reference
 
@@ -147,9 +147,9 @@ The model calls `tool_search` with a JSON object:
 | Parameter   | Type            | Description                                                                                                        |
 | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `query`     | `string` (required) | Natural-language description of the capability the model needs.                                                   |
-| `keywords`  | `string[]`      | Optional exact-match phrases that boost the keyword channel — useful for column or table names.                    |
+| `keywords`  | `string[]`      | Optional exact-match phrases — useful for column or table names. Their tokens are added to the `full_text` and `schema` channels, and they *replace* `query` as the phrase the `keyword` channel matches on (with `keywords` omitted, the whole `query` string is that phrase). |
 | `limit`     | `integer`       | Maximum results to return. Defaults to **5**, capped at **20**.                                                    |
-| `min_score` | `number`        | Optional minimum score (0.0–1.0). When the cutoff filters out everything, the registry still returns the unfiltered top match as a fallback so the model isn't left empty-handed. |
+| `min_score` | `number`        | Optional minimum score, clamped to 0.0–1.0. Scores are normalized against the best match, so the top result always scores `1.0` — a cutoff trims the tail and can never empty the list. If no tool matched any channel at all, every score is `0.0` and the cutoff is skipped entirely: the first `limit` tools are returned in `tool_id` order. |
 
 Example call (issued by the model):
 

--- a/website/versioned_docs/version-2.0.x/features/tool-registry/index.md
+++ b/website/versioned_docs/version-2.0.x/features/tool-registry/index.md
@@ -138,7 +138,7 @@ models:
 
 Each channel produces a ranked list; RRF combines the ranks (not the scores) so a tool that places top-3 in two channels usually outranks one that places top-1 in a single channel. The final `score` is normalized to `0.0–1.0` against the highest-scoring tool in the result set.
 
-Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance. The runtime keeps an LRU cache (up to 64 entries) of search-tool instances keyed on `(runtime, embedding model, tools hash)` so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly.
+Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance — a model keeps its instance, and therefore its embeddings, until the model is reloaded. The `/v1/tools` HTTP endpoints build their instances through a separate bounded cache (up to 64 entries) keyed on `(runtime, embedding model, tools hash)`, so repeated calls reuse the same embeddings. That cache is not an LRU: once it is full, an arbitrary existing entry is evicted to make room.
 
 ## `tool_search` Reference
 
@@ -147,9 +147,9 @@ The model calls `tool_search` with a JSON object:
 | Parameter   | Type            | Description                                                                                                        |
 | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `query`     | `string` (required) | Natural-language description of the capability the model needs.                                                   |
-| `keywords`  | `string[]`      | Optional exact-match phrases that boost the keyword channel — useful for column or table names.                    |
+| `keywords`  | `string[]`      | Optional exact-match phrases — useful for column or table names. Their tokens are added to the `full_text` and `schema` channels, and they *replace* `query` as the phrase the `keyword` channel matches on (with `keywords` omitted, the whole `query` string is that phrase). |
 | `limit`     | `integer`       | Maximum results to return. Defaults to **5**, capped at **20**.                                                    |
-| `min_score` | `number`        | Optional minimum score (0.0–1.0). When the cutoff filters out everything, the registry still returns the unfiltered top match as a fallback so the model isn't left empty-handed. |
+| `min_score` | `number`        | Optional minimum score, clamped to 0.0–1.0. Scores are normalized against the best match, so the top result always scores `1.0` — a cutoff trims the tail and can never empty the list. If no tool matched any channel at all, every score is `0.0` and the cutoff is skipped entirely: the first `limit` tools are returned in `tool_id` order. |
 
 Example call (issued by the model):
 

--- a/website/versioned_docs/version-2.1.x/features/tool-registry/index.md
+++ b/website/versioned_docs/version-2.1.x/features/tool-registry/index.md
@@ -138,7 +138,7 @@ models:
 
 Each channel produces a ranked list; RRF combines the ranks (not the scores) so a tool that places top-3 in two channels usually outranks one that places top-1 in a single channel. The final `score` is normalized to `0.0–1.0` against the highest-scoring tool in the result set.
 
-Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance. The runtime keeps an LRU cache (up to 64 entries) of search-tool instances keyed on `(runtime, embedding model, tools hash)` so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly.
+Per-tool embeddings are computed lazily on first search and cached for the lifetime of the registry instance — a model keeps its instance, and therefore its embeddings, until the model is reloaded. The `/v1/tools` HTTP endpoints build their instances through a separate bounded cache (up to 64 entries) keyed on `(runtime, embedding model, tools hash)`, so repeated calls reuse the same embeddings. That cache is not an LRU: once it is full, an arbitrary existing entry is evicted to make room.
 
 ## `tool_search` Reference
 
@@ -147,9 +147,9 @@ The model calls `tool_search` with a JSON object:
 | Parameter   | Type            | Description                                                                                                        |
 | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
 | `query`     | `string` (required) | Natural-language description of the capability the model needs.                                                   |
-| `keywords`  | `string[]`      | Optional exact-match phrases that boost the keyword channel — useful for column or table names.                    |
+| `keywords`  | `string[]`      | Optional exact-match phrases — useful for column or table names. Their tokens are added to the `full_text` and `schema` channels, and they *replace* `query` as the phrase the `keyword` channel matches on (with `keywords` omitted, the whole `query` string is that phrase). |
 | `limit`     | `integer`       | Maximum results to return. Defaults to **5**, capped at **20**.                                                    |
-| `min_score` | `number`        | Optional minimum score (0.0–1.0). When the cutoff filters out everything, the registry still returns the unfiltered top match as a fallback so the model isn't left empty-handed. |
+| `min_score` | `number`        | Optional minimum score, clamped to 0.0–1.0. Scores are normalized against the best match, so the top result always scores `1.0` — a cutoff trims the tail and can never empty the list. If no tool matched any channel at all, every score is `0.0` and the cutoff is skipped entirely: the first `limit` tools are returned in `tool_id` order. |
 
 Example call (issued by the model):
 


### PR DESCRIPTION
## Summary

Three claims on the Tool Registry page describe runtime behaviour the implementation does not have. All three date to the page's original authoring (#1632 / #1641, May 2026) and none has been corrected since.

### 1. The `min_score` fallback does not exist as described

**Docs:** "When the cutoff filters out everything, the registry still returns the unfiltered top match as a fallback so the model isn't left empty-handed."

**Code:** the filter is

```rust
.filter(|ranked_tool| ranked_tool.score >= min_score || max_score == 0.0)
.take(limit)
```

`score` is `fused_score / max_score` (`hybrid_rank_tools`), so whenever anything matched, the best tool scores exactly `1.0` and `min_score` — clamped to `0.0..=1.0` — can never empty the result set. The `max_score == 0.0` branch is not a "top match" fallback: it fires only when *no* tool matched any channel, and because every score then ties at `0.0`, the sort falls through to `tool_id` and `take(limit)` returns the first `limit` tools alphabetically.

### 2. `keywords` replace the query phrase, they don't just boost it

**Docs:** "Optional exact-match phrases that boost the keyword channel."

**Code:** `keyword_channel_matches` picks its phrase set as `if keywords.is_empty() { vec![query] } else { keywords }` — supplying `keywords` removes whole-query phrase matching from that channel. (Keyword *tokens* are separately unioned into the token set the `full_text` and `schema` channels use, which is the part the old wording got right.)

### 3. The search-tool cache is not an LRU

**Docs:** "The runtime keeps an LRU cache (up to 64 entries) … so a Spicepod that hot-reloads tools without restarting the runtime doesn't pay the embedding cost repeatedly."

**Code:** `TOOL_REGISTRY_SEARCH_TOOL_CACHE` is a plain `HashMap`; on overflow it evicts `cache.keys().next()` — an arbitrary entry in hash order, with no recency tracking. It is also reached only from `tool_registry_prompt_tools` / `get_tool_registry_tool`, i.e. the `/v1/tools` HTTP endpoints. The chat and responses paths go through `prepare_model_tools` → `tool_registry_tools`, which constructs a fresh instance at model-load time; that instance's `OnceCell` embeddings then live as long as the model, which is what makes the preceding sentence about lazy embeddings correct.

## What changed

Rewrote the `keywords` and `min_score` rows of the `tool_search` Reference table, and the cache paragraph under "How `tool_search` Ranks Results". The other rows of that table (`query`, `limit` — default 5, capped at 20) and the four-channel weighting table were verified against source and are correct, as are `AUTO_SEARCH_TOOL_THRESHOLD` (20), the `tool_embedding_model` resolution rules, the reserved-name conflict behaviour, `search_mode: hybrid_rrf`, and `list_datasets` always being exposed alongside the meta-tools.

## Verified source ref

`spiceai/spiceai` @ `trunk` (5f00c0d3). [`crates/runtime/src/tools/registry.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/tools/registry.rs) — `ToolRegistrySearchTool::call`, `hybrid_rank_tools`, `keyword_channel_matches`, `cached_tool_registry_search_tool`.

The relevant code is byte-identical at `v2.0.1` and `v2.1.5`, so the same correction applies to both versioned snapshots.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — the page exists in vNext, 2.0.x, and 2.1.x only (it postdates 1.11.x); all three were identical before this change and are updated together
- [x] Files updated: 3
