### PR TITLE
docs(tool-registry): /v1/functions is not a view of the tool catalog

### DIFF
--- a/website/docs/features/tool-registry/index.md
+++ b/website/docs/features/tool-registry/index.md
@@ -284,6 +284,8 @@ Rename the offending tool, or set `as_tool: false` to keep it SQL-only.
 Two ways to inspect the catalog from outside the model:
 
 - **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';` lists every user-declared function, regardless of whether it's currently in the registry.
-- **From the HTTP API** — `GET /v1/functions` returns the functions registered as both SQL and tool entries.
+- **From the HTTP API** — `GET /v1/tools` lists every tool the runtime has registered, which is what the registry indexes. Tool routes are refused with a `401` unless [`runtime.auth`](../reference/spicepod/runtime#runtimeauth) is configured.
+
+`GET /v1/functions` is a *function* listing, not a tool one: it returns every enabled entry in the Spicepod's `functions:` section that registered successfully — scalar and table functions alike, whether or not they are exposed as tools — and returns an empty list when `runtime.functions.enabled` is false. Use it to check that a function loaded; use `GET /v1/tools` to check what the model can reach.
 
 For tools (built-in plus MCP plus function-derived), the model can call `tool_search` with an open-ended query (e.g. `query: "*"`) — though in practice, asking for the tools relevant to the current step is what the model actually wants.

--- a/website/versioned_docs/version-2.0.x/features/tool-registry/index.md
+++ b/website/versioned_docs/version-2.0.x/features/tool-registry/index.md
@@ -284,6 +284,8 @@ Rename the offending tool, or set `as_tool: false` to keep it SQL-only.
 Two ways to inspect the catalog from outside the model:
 
 - **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';` lists every user-declared function, regardless of whether it's currently in the registry.
-- **From the HTTP API** — `GET /v1/functions` returns the functions registered as both SQL and tool entries.
+- **From the HTTP API** — `GET /v1/tools` lists every tool the runtime has registered, which is what the registry indexes. Tool routes are refused with a `401` unless [`runtime.auth`](../reference/spicepod/runtime#runtimeauth) is configured.
+
+`GET /v1/functions` is a *function* listing, not a tool one: it returns every enabled entry in the Spicepod's `functions:` section that registered successfully — scalar and table functions alike, whether or not they are exposed as tools — and returns an empty list when `runtime.functions.enabled` is false. Use it to check that a function loaded; use `GET /v1/tools` to check what the model can reach.
 
 For tools (built-in plus MCP plus function-derived), the model can call `tool_search` with an open-ended query (e.g. `query: "*"`) — though in practice, asking for the tools relevant to the current step is what the model actually wants.

--- a/website/versioned_docs/version-2.1.x/features/tool-registry/index.md
+++ b/website/versioned_docs/version-2.1.x/features/tool-registry/index.md
@@ -284,6 +284,8 @@ Rename the offending tool, or set `as_tool: false` to keep it SQL-only.
 Two ways to inspect the catalog from outside the model:
 
 - **From SQL** — `SELECT * FROM list_udfs() WHERE source = 'user';` lists every user-declared function, regardless of whether it's currently in the registry.
-- **From the HTTP API** — `GET /v1/functions` returns the functions registered as both SQL and tool entries.
+- **From the HTTP API** — `GET /v1/tools` lists every tool the runtime has registered, which is what the registry indexes. Tool routes are refused with a `401` unless [`runtime.auth`](../reference/spicepod/runtime#runtimeauth) is configured.
+
+`GET /v1/functions` is a *function* listing, not a tool one: it returns every enabled entry in the Spicepod's `functions:` section that registered successfully — scalar and table functions alike, whether or not they are exposed as tools — and returns an empty list when `runtime.functions.enabled` is false. Use it to check that a function loaded; use `GET /v1/tools` to check what the model can reach.
 
 For tools (built-in plus MCP plus function-derived), the model can call `tool_search` with an open-ended query (e.g. `query: "*"`) — though in practice, asking for the tools relevant to the current step is what the model actually wants.


### PR DESCRIPTION
## Summary

The "Discovering What's in the Registry" section offered `GET /v1/functions` as the HTTP way to see the tool catalog.

**What the docs said**

> **From the HTTP API** — `GET /v1/functions` returns the functions registered as both SQL and tool entries.

**What the code does**

`v1::functions::list` has no notion of tool exposure. It short-circuits to `[]` when `app.runtime.functions.enabled` is false, then filters the Spicepod's `functions:` entries on `decl.enabled` and on whether the name resolved as a DataFusion scalar or table function:

```rust
.filter(|decl| decl.enabled && match decl.kind {
    FunctionKind::Scalar => scalar_function_names.iter().any(...),
    FunctionKind::Table  => table_function_names.iter().any(...),
})
```

So the endpoint lists functions declared with `as_tool: false`, and lists table functions — which the same page correctly notes are never registered as LLM tools (`udf.rs` logs "User table functions cannot be exposed as tools" and skips them). The endpoint's own doc comment says as much: "Returns only the functions declared in a spicepod's `functions:` section." Its unit tests build their fixtures with `as_tool: false` and expect them listed.

The endpoint that *does* answer "what's in the tool catalog" is `GET /v1/tools`, which maps over `rt.list_all_tools()`. Worth knowing before reaching for it: the whole `/v1/tools*` router sits behind `require_auth_configured`, so it returns `401` unless `runtime.auth` is set.

## What changed

Replaced the HTTP bullet with `GET /v1/tools`, and kept `GET /v1/functions` on the page as what it actually is — a function listing — since checking that a function loaded is a real thing readers come here to do. The `list_udfs()` bullet was verified and is unchanged (`source` is a real, non-nullable column, `'user'` marks Spicepod-declared functions).

## Verified source ref

`spiceai/spiceai` @ `trunk` (5f00c0d3); the same filtering, routing, and auth gate are present at `v2.0.1` and `v2.1.5`.

- [`crates/runtime/src/http/v1/functions.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/http/v1/functions.rs) — `list`
- [`crates/runtime/src/http/v1/tools.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/http/v1/tools.rs) — `list`
- [`crates/runtime/src/http/routes.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/http/routes.rs) — `tools_router` / `require_auth_configured`
- [`crates/runtime/src/datafusion/udf.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/datafusion/udf.rs) — table functions skipped for tool exposure

## Test plan

- [x] `cd website && npm run build` passes — the added `../reference/spicepod/runtime#runtimeauth` link and its `## runtime.auth` anchor were confirmed to exist in vNext, 2.0.x, and 2.1.x
- [x] Versioned-docs propagation checked — the page exists in vNext, 2.0.x, and 2.1.x only; all three updated
- [x] Files updated: 3
