### PR TITLE
docs(catalogs): every Catalog Connector applies exclude, not just PostgreSQL

### DIFF
--- a/website/docs/components/catalogs/adbc.md
+++ b/website/docs/components/catalogs/adbc.md
@@ -42,6 +42,10 @@ The `name` field specifies the name of the catalog in Spice. Tables from the ADB
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+### `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ### `params`
 
 The following parameters are supported:

--- a/website/docs/components/catalogs/databricks.md
+++ b/website/docs/components/catalogs/databricks.md
@@ -48,6 +48,10 @@ The `name` field is used to specify the name of the catalog in Spice. Tables fro
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 The following parameters are supported for configuring the connection to the Databricks Unity Catalog:

--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -58,6 +58,10 @@ catalogs:
       - 'main.*' # Include all tables in the "main" schema
 ```
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `access`
 
 The `access` field controls what operations are allowed on the catalog:

--- a/website/docs/components/catalogs/glue.md
+++ b/website/docs/components/catalogs/glue.md
@@ -54,6 +54,10 @@ The `name` field is used to specify the name of the catalog in Spice. Tables fro
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+### `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ### `params`
 
 The following parameters are supported for configuring the connection to the Glue Data Catalog:

--- a/website/docs/components/catalogs/iceberg.md
+++ b/website/docs/components/catalogs/iceberg.md
@@ -102,6 +102,10 @@ The `name` field is used to specify the name of the catalog in Spice. Tables fro
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 The following parameters are supported for configuring the connection to the Iceberg catalog, file, or S3 storage:

--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -59,7 +59,9 @@ catalogs:
 
 ### `exclude`
 
-Use the `exclude` field to omit tables that would otherwise be included. It uses the same `schema.table` glob syntax as `include`, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
+Every Catalog Connector applies `exclude`.
 
 Example:
 
@@ -72,10 +74,6 @@ catalogs:
     exclude:
       - 'public.*_audit' # ...except the audit tables.
 ```
-
-:::warning
-`exclude` is currently only honored by the [PostgreSQL Catalog Connector](./postgres.md). Other Catalog Connectors accept the field without error but ignore it, so an `exclude` pattern set on them has no effect — use `include` to scope those catalogs.
-:::
 
 import DocCardList from '@theme/DocCardList';
 

--- a/website/docs/components/catalogs/mssql.md
+++ b/website/docs/components/catalogs/mssql.md
@@ -39,6 +39,10 @@ The `name` field specifies the name of the catalog in Spice. Tables from the SQL
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 Connection can be configured using a connection string or individual parameters.

--- a/website/docs/components/catalogs/mysql.md
+++ b/website/docs/components/catalogs/mysql.md
@@ -39,6 +39,10 @@ The `name` field specifies the name of the catalog in Spice. Tables from the MyS
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 Connection can be configured using a connection string or individual parameters.

--- a/website/docs/components/catalogs/oracle.md
+++ b/website/docs/components/catalogs/oracle.md
@@ -43,6 +43,10 @@ The `name` field specifies the name of the catalog in Spice. Tables from the Ora
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 Connection can be configured using a connection string or individual parameters. In both cases, `oracle_username` and `oracle_password` are required.

--- a/website/docs/components/catalogs/snowflake.md
+++ b/website/docs/components/catalogs/snowflake.md
@@ -47,6 +47,10 @@ The `name` field specifies the name of the catalog in Spice. Tables from the Sno
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` from any schema. Multiple `include` patterns are OR'ed together.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 | Parameter Name                     | Description                                                                                              |

--- a/website/docs/components/catalogs/spiceai.md
+++ b/website/docs/components/catalogs/spiceai.md
@@ -160,6 +160,10 @@ include:
   - "tpch.supplier" # Include the "supplier" table from the "tpch" schema
 ```
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 ### Authentication

--- a/website/docs/components/catalogs/unity-catalog/index.md
+++ b/website/docs/components/catalogs/unity-catalog/index.md
@@ -41,6 +41,10 @@ The `name` field is used to specify the name of the catalog in Spice. The schema
 
 Use the `include` field to specify which tables to include from the catalog. The `include` field supports glob patterns to match multiple tables. For example, `*.my_table_name` would include all tables with the name `my_table_name` in the catalog from any schema. Multiple `include` patterns are OR'ed together and can be specified to include multiple tables.
 
+## `exclude`
+
+Optional. Use the `exclude` field to omit tables that would otherwise be included. It is matched against the same table name as `include`, using the same glob syntax, and multiple `exclude` patterns are OR'ed together. `exclude` takes precedence over `include`: a table is registered only when it matches `include` (or no `include` is set) **and** matches no `exclude` pattern.
+
 ## `params`
 
 The `params` field is used to configure the connection to the Unity Catalog. The following parameters are supported:

--- a/website/docs/reference/spicepod/catalogs.md
+++ b/website/docs/reference/spicepod/catalogs.md
@@ -76,7 +76,7 @@ Optional. The `include` field is used to specify which tables to include from th
 
 ## `exclude`
 
-Optional. The `exclude` field specifies tables to omit from the catalog, using the same `schema.table` glob syntax as `include`. Multiple `exclude` patterns are OR'ed together, and `exclude` takes precedence over `include` — a table matched by both is omitted. It is currently honored by the [PostgreSQL catalog connector](../../components/catalogs/postgres). A common use is to keep tables that cannot be [CDC-accelerated](../../components/catalogs/postgres#catalog-level-cdc-acceleration) out of an accelerated catalog's scope.
+Optional. The `exclude` field specifies tables to omit from the catalog, matched against the same table name as `include` and using the same glob syntax. Multiple `exclude` patterns are OR'ed together, and `exclude` takes precedence over `include` — a table matched by both is omitted. Every Catalog Connector applies it. A common use is to keep tables that cannot be [CDC-accelerated](../../components/catalogs/postgres#catalog-level-cdc-acceleration) out of an accelerated catalog's scope.
 
 ## `access`
 


### PR DESCRIPTION
## Summary

The catalogs docs carried a warning that `exclude` is "currently only honored by the PostgreSQL Catalog Connector" and that other connectors "accept the field without error but ignore it". That is no longer true on `trunk`: every catalog connector now resolves `include`/`exclude` through the shared `TableSelector`.

Verified against `origin/trunk`:

- `crates/runtime/src/component/catalog.rs` → `table_selector(catalog)` builds `TableSelector::new(catalog.include, catalog.exclude)`, and the selector applies **both** halves (`crates/data_components/src/catalog_filter.rs`). `exclude` is a constructor argument precisely so a connector cannot forget it.
- Every connector under `crates/runtime/src/catalogconnector/` passes `table_selector(catalog)` into its provider: adbc, cayenne, databricks, ducklake, glue, iceberg, mssql, mysql, oracle, postgres, postgres_accelerated, snowflake, spice_cloud, unity_catalog.
- spiceai/spiceai#12641 swept the connectors onto the shared selector; spiceai/spiceai#13103 converted Glue, which was still filtering on `include` alone through its own bespoke filter.

`exclude` is matched against whatever table name each connector matches `include` against (the SQL catalogs use `schema.table`; Iceberg uses a fully qualified identifier), so the wording says "the same table name as `include`" rather than hard-coding `schema.table`.

vNext-only: neither source commit is contained in any `v*` tag, so `versioned_docs/` is untouched — the older snapshots correctly keep the PostgreSQL-only limitation.

## Source PRs

- spiceai/spiceai#13103 — fix(catalogs): apply the Glue catalog's exclude patterns (fixes #12634)
- spiceai/spiceai#12641 — fix(catalogs): apply a catalog's exclude patterns, not just its include (fixes #12636)

## Doc pages changed (13)

- `components/catalogs/index.md` — removed the PostgreSQL-only warning; states that every Catalog Connector applies `exclude`
- `reference/spicepod/catalogs.md` — same correction on the `exclude` field reference
- Added an `exclude` section to each connector page that documents `include`: `adbc`, `databricks`, `ducklake`, `glue`, `iceberg`, `mssql`, `mysql`, `oracle`, `snowflake`, `spiceai`, `unity-catalog` (`postgres` already had one)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only (`git tag --contains` on both source commits returns no release tag)
- [x] Files updated: 13 (matches the diff)
