### PR TITLE
docs(postgres): state the PostgreSQL 13 minimum and how the publication is built

### DIFF
--- a/website/docs/components/catalogs/postgres.md
+++ b/website/docs/components/catalogs/postgres.md
@@ -241,6 +241,31 @@ Because a slot can also read as active immediately after the runtime's *own* ung
 Run only one Spice instance per accelerated PostgreSQL catalog. Because the slot name is instance-independent, a second instance configured with the same catalog `name` competes for the same slot and fails to load rather than silently splitting the change stream.
 :::
 
+### Shared publication
+
+The catalog's publication is built from the **eligible-table set**, one table at a
+time (`CREATE PUBLICATION ... FOR TABLE`, then `ALTER PUBLICATION ... ADD TABLE`
+for each additional table). It is never created `FOR ALL TABLES`. Three things
+follow from that:
+
+- **A skipped table is never a publication member.** A table with no usable CDC
+  key is left out of the publication entirely, not merely ignored downstream — so
+  PostgreSQL does not decode its changes into the catalog's WAL stream at all.
+- **New tables arrive through catalog discovery, not the publication.** A table
+  created in a selected schema after startup is not published retroactively; it is
+  picked up by the periodic catalog refresh, which then adds it to the publication.
+  A `FOR ALL TABLES` publication would have included it immediately, keyless or
+  not.
+- **The publication is created `WITH (publish_via_partition_root = true)`**, so a
+  partitioned source table replicates as the single parent relation rather than as
+  its individual partitions. This option requires PostgreSQL 13 or later — see
+  [Prerequisites](../../features/cdc/postgres-replication#postgresql-13).
+
+Spice repairs `publish_via_partition_root` on a publication that predates it or
+was created by hand, provided the Spice role owns the publication; when it does
+not, the alter is skipped with a warning, which only matters if the catalog
+contains partitioned tables.
+
 ### Table eligibility
 
 Each discovered table is accelerated according to its PostgreSQL [`REPLICA IDENTITY`](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY), which determines the row identity available for change data capture:

--- a/website/docs/features/cdc/postgres-replication.md
+++ b/website/docs/features/cdc/postgres-replication.md
@@ -34,7 +34,22 @@ On subsequent restarts the connector compares the slot against the position it r
 
 ## Prerequisites
 
-### 1. Enable logical replication on the source Postgres
+### 1. PostgreSQL 13 or later {#postgresql-13}
+
+Spice creates its publication with `publish_via_partition_root = true`, an option
+introduced in PostgreSQL 13. On PostgreSQL 12 and earlier the `CREATE PUBLICATION`
+fails and the dataset does not start.
+
+```sql
+SHOW server_version;   -- must be 13 or later
+```
+
+The option makes a partitioned table's changes arrive under the parent relation
+rather than under each leaf partition, which is what lets a partitioned source
+table be accelerated as a single table. It has no effect on regular tables, but
+it is set unconditionally, so the version requirement applies either way.
+
+### 2. Enable logical replication on the source Postgres
 
 This requires a server restart.
 
@@ -62,7 +77,7 @@ On managed Postgres services:
 | Azure Database       | Under **Replication**, set *Replication support* to `LOGICAL`.                      |
 | Supabase / Neon      | Logical replication is enabled by default.                                          |
 
-### 2. The source table must have a replica identity
+### 3. The source table must have a replica identity
 
 Spice needs the primary key columns in every `UPDATE`/`DELETE` event, so one of the following must be true:
 
@@ -75,7 +90,7 @@ Spice needs the primary key columns in every `UPDATE`/`DELETE` event, so one of 
 
 Tables with `REPLICA IDENTITY NOTHING` are rejected at startup.
 
-### 3. The Postgres role needs these privileges
+### 4. The Postgres role needs these privileges
 
 ```sql
 GRANT CONNECT ON DATABASE mydb TO spice;


### PR DESCRIPTION
Closes the two remaining documentation items on spiceai/spiceai#11850 (changes mode for the PostgreSQL Catalog Connector).

## PostgreSQL 13 minimum — `features/cdc/postgres-replication`

Spice creates its publication `WITH (publish_via_partition_root = true)` ([`slot.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/postgres_replication/slot.rs)), an option introduced in **PostgreSQL 13**. On PostgreSQL 12 and earlier the `CREATE PUBLICATION` fails and the dataset does not start — but no page said so, and the prerequisites listed only `wal_level`, replica identity, and privileges.

Added as Prerequisite §1, renumbering the existing three. No anchor links pointed at the renumbered headings, so nothing else needed updating.

**Placed on the CDC feature page, not the catalog page**, because the publication is created on the shared replication path — per-dataset `refresh_mode: changes` carries the same requirement, so documenting it only for catalogs would understate it.

## Publication shape — `components/catalogs/postgres`

The catalog page described the publication only as "shared". It is built from the eligible-table set one table at a time (`CREATE PUBLICATION ... FOR TABLE`, then `ALTER PUBLICATION ... ADD TABLE`) and is never `FOR ALL TABLES`. That distinction has three consequences an operator can observe, none of which were written down:

- a skipped table is not a publication member, so PostgreSQL never decodes its changes into the catalog's stream — it is not merely filtered later;
- a table created after startup is not published retroactively; it arrives via the periodic catalog refresh, whereas `FOR ALL TABLES` would have picked it up immediately, keyless or not;
- the `publish_via_partition_root` option means a partitioned source table replicates as its parent relation, linked to the version prerequisite above.

Also documents the ownership caveat: Spice repairs the option on a hand-created publication only when it owns it, otherwise skipping with a warning that matters only for partitioned tables.

## Verification

- `npm run build` passes clean — relevant because the site sets `onBrokenAnchors: 'throw'` and `onBrokenLinks: 'throw'`. The cross-page link uses an explicit `{#postgresql-13}` heading id (matching the existing convention in the repo) rather than a guessed slug.
- Both claims verified against the source rather than inferred: the `CREATE PUBLICATION ... FOR TABLE ... WITH (publish_via_partition_root = true)` statement and the `ALTER PUBLICATION ... ADD TABLE` follow-up, plus `ensure_publish_via_partition_root`'s ownership-skip behavior.
- Consistent with the existing "Catalog Refresh" section, which already documents that each refresh cycle re-runs discovery and picks up new tables within roughly one interval.

Next docs only — the versioned 2.0.x/2.1.x copies of the catalog page do not contain the acceleration section.