### PR TITLE
docs(catalogs): the PostgreSQL Catalog Connector is Beta

### DIFF
--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -31,13 +31,15 @@ Supported Catalog Connectors include:
 | `iceberg`       | Apache Iceberg          | Beta              | Parquet                      |
 | `spice.ai`      | Spice.ai Cloud Platform | Beta              | Arrow Flight                 |
 | `ducklake`      | DuckLake                | Beta              | Parquet                      |
-| `pg`            | PostgreSQL / Redshift   | Beta              | PostgreSQL Wire Protocol     |
+| `pg`            | PostgreSQL              | Beta              | PostgreSQL Wire Protocol     |
 | `glue`          | AWS Glue                | Alpha             | Parquet, Iceberg             |
 | `snowflake`     | Snowflake               | Alpha             | Snowflake SQL                |
 | `mysql`         | MySQL                   | Alpha             | MySQL Wire Protocol          |
 | `mssql`         | Microsoft SQL Server    | Alpha             | TDS                          |
 | `adbc`          | ADBC                    | Alpha             | Arrow (ADBC)                 |
 | `oracle`        | Oracle                  | Alpha             | Oracle Net                   |
+
+The `pg` Catalog Connector also connects to PostgreSQL-compatible databases such as Amazon Redshift, on a best-effort basis and outside the stability claim above: the quality level in the table covers PostgreSQL, and Redshift clusters are not part of the connector's test matrix. See [PostgreSQL Catalog Connector](./postgres.md) for the limitations that apply.
 
 ## Catalog Connector Docs
 

--- a/website/docs/components/catalogs/index.md
+++ b/website/docs/components/catalogs/index.md
@@ -31,9 +31,9 @@ Supported Catalog Connectors include:
 | `iceberg`       | Apache Iceberg          | Beta              | Parquet                      |
 | `spice.ai`      | Spice.ai Cloud Platform | Beta              | Arrow Flight                 |
 | `ducklake`      | DuckLake                | Beta              | Parquet                      |
+| `pg`            | PostgreSQL / Redshift   | Beta              | PostgreSQL Wire Protocol     |
 | `glue`          | AWS Glue                | Alpha             | Parquet, Iceberg             |
 | `snowflake`     | Snowflake               | Alpha             | Snowflake SQL                |
-| `pg`            | PostgreSQL / Redshift   | Alpha             | PostgreSQL Wire Protocol     |
 | `mysql`         | MySQL                   | Alpha             | MySQL Wire Protocol          |
 | `mssql`         | Microsoft SQL Server    | Alpha             | TDS                          |
 | `adbc`          | ADBC                    | Alpha             | Arrow (ADBC)                 |


### PR DESCRIPTION
Marks the PostgreSQL Catalog Connector as **Beta** in the table of Catalog Connectors.

Companion to spiceai/spiceai#13235, which signs off the criteria and records the DRI. Every Beta criterion passes: the associated PostgreSQL Data Connector is Stable (above the Beta bar the criteria require), a TPC-H SF1 end-to-end test loads the catalog rather than individual datasets and runs in the daily scheduled benchmarks with result validation, a table's schema resolves from `information_schema`/`pg_catalog` without querying its data, error and warning messages follow the error handling guidelines (spiceai/spiceai#12108), and there are no known Major bugs on the federated catalog path.

The row also stops reading "PostgreSQL / Redshift". The Status column is a stability claim, and that claim covers PostgreSQL: Redshift is served by the same connector on a best-effort basis, its catalog discovery uses PostgreSQL-only queries that miss datashare and external (Spectrum) objects, and Redshift clusters are not in the test matrix (spiceai/spiceai#12109). Raising the row to Beta while it named both would have asserted Beta over Redshift. Redshift is now named below the table instead, consistent with the wording on the PostgreSQL catalog page.

Two deliberate details:

- **The row moves into the Beta group** rather than flipping status in place, since the table is grouped by status.
- **Only the current docs change.** `versioned_docs/version-2.0.x` and `version-2.1.x` also carry this table, and they keep the status those releases actually shipped with.

Catalog-level CDC acceleration is tracked as a separate enhancement, so the open bugs in that path (spiceai/spiceai#12110, spiceai/spiceai#12729) are not criteria for this status change and do not affect the federated discovery path this Beta covers.

