### PR TITLE
docs(cloud): document the spice cloud command surface

### DIFF
--- a/website/docs/cli/reference/cloud.md
+++ b/website/docs/cli/reference/cloud.md
@@ -1,0 +1,402 @@
+---
+title: 'cloud'
+sidebar_label: 'cloud'
+pagination_prev: null
+pagination_next: null
+---
+
+Manage Spice Cloud: sign in, enroll a directory, create and inspect projects, manage secrets, read logs, and deploy.
+
+Most subcommands require an active Spice Cloud session. See [Authentication](#authentication).
+
+### Usage
+
+```shell
+spice cloud <command> [flags]
+```
+
+### Commands
+
+| Command                              | Description                                                            |
+| ------------------------------------ | ---------------------------------------------------------------------- |
+| [`login`](#login)                    | Login to Spice Cloud                                                   |
+| [`logout`](#logout)                  | Logout from Spice Cloud                                                |
+| [`whoami`](#whoami)                  | Show current authenticated user                                        |
+| [`orgs`](#orgs)                      | List organizations this identity can act on                            |
+| [`org`](#org)                        | Show or change the active organization                                 |
+| [`link`](#link)                      | Link the current directory to a Spice Cloud project                    |
+| [`unlink`](#unlink)                  | Unlink the current directory from its Spice Cloud project              |
+| [`projects`](#projects)              | List all projects                                                      |
+| [`project`](#project)                | Create, inspect, and change one project                                |
+| [`deploy`](#deploy)                  | Deploy a project                                                       |
+| [`deployments`](#deployments)        | List deployments for a project                                         |
+| [`status`](#status)                  | Show whether a project is healthy                                      |
+| [`logs`](#logs)                      | View runtime logs                                                      |
+| [`datasets`](#datasets)              | Show dataset load state for a project                                  |
+| [`metrics`](#metrics)                | Show resource usage for a project's instances                          |
+| [`secrets`](#secrets)                | Manage secrets for a project                                           |
+| [`api-keys`](#api-keys)              | Show API keys for a project                                            |
+| [`service`](#service)                | Install and manage the persistent service for this enrolled directory  |
+| [`regions`](#regions-and-images)     | List available regions                                                 |
+| [`images`](#regions-and-images)      | List available container images                                        |
+
+## Authentication
+
+### `login`
+
+```shell
+spice cloud login
+spice cloud login subscription [--device]
+spice cloud login token [--token <TOKEN>]
+spice cloud login api [--client-id <ID>] [--client-secret <SECRET>]
+```
+
+Run with no subcommand to choose between a browser login and an access token. The chooser needs an interactive terminal; name a method explicitly when running non-interactively.
+
+- `subscription` — Open a browser and complete the login there. `--device` prints the URL and a one-time code to enter on another device instead, for SSH sessions and headless shells.
+- `token` — Log in with a Spice Cloud access token. Omit `--token` to enter it at a secure prompt. Generate a token at `/account/tokens` in the Spice Cloud portal. Alias: `pat`.
+- `api` — Log in with OAuth client credentials, for CI and other automation. Omit either flag to enter its value interactively.
+
+Flags:
+
+- `-o`, `--output <FORMAT>` Where to store or print the resulting credentials: `env` (default, writes to a local `.env` file), `json` (prints them to stdout), or `keychain` (stores them in the platform keychain).
+- `--org <ORG>` Store the credential for one organization rather than the whole membership.
+
+The browser flow is bounded at 5 minutes; see [`spice login`](./login#browser-login-flow) for its polling and failure behavior.
+
+### `logout`
+
+```shell
+spice cloud logout
+spice cloud logout --scope all
+```
+
+Discards stored credentials from both the `.env` file and the platform keychain, and clears the active organization.
+
+- `--scope <SCOPE>` Which stored sessions to discard: `active` (default) for the organization in effect, or `all` for every stored organization credential plus the shared user credential and the OAuth client pair.
+
+`--scope active` is refused while a shared user credential is stored, because that credential may authenticate to every organization the user belongs to — use `--scope all`.
+
+Logging out does not revoke the token in Spice Cloud. Revoke it from the portal.
+
+### `whoami`
+
+```shell
+spice cloud whoami
+```
+
+Prints the authenticated identity, the organization in effect, and where that organization came from.
+
+## Organizations
+
+Commands act on one organization at a time. Name it inline as `<org>/<project>`, select it for a single invocation with `--org`, or set it for good with `spice cloud org use`.
+
+### `orgs`
+
+```shell
+spice cloud orgs
+```
+
+Lists the organizations this identity can act on, marking the active one and which have a stored credential.
+
+### `org`
+
+```shell
+spice cloud org use <ORG>
+spice cloud org current
+spice cloud org clear
+```
+
+- `use` — Set the organization subsequent commands act on, persisted for this machine. Alias: `switch`.
+- `current` — Show the organization in effect.
+- `clear` — Return to the organization the credential was issued for.
+
+For scripts and CI prefer `SPICE_CLOUD_ORG`, which is scoped to the shell rather than to the machine.
+
+## Enrolling a directory
+
+An enrolled directory holds an instance identity in `.spice/identity.json`, and that identity is what attaches the instance to a project. Once a directory is enrolled and attached, commands run from it without `--project`.
+
+### `link`
+
+```shell
+spice cloud link
+spice cloud link <org>/<project>
+```
+
+Enrolls the current directory as a Spice Cloud instance and attaches it to a project. Omit the argument to choose from the projects available to you.
+
+`link` requires an interactive terminal and a Spice Cloud user login — an OAuth client-credentials session cannot enroll an instance. For unattended enrollment, mint an enrollment key in the portal and start the runtime with [`spiced --token <enrollment-key>`](./spiced#spice-cloud-connect-flags).
+
+Linking also:
+
+- Adds `.spice/` to `.gitignore`, so the instance's mTLS private key is not committed.
+- Uploads the local `spicepod.yaml` when the project has no stored Spicepod. When the project already has one, the local file is left alone; replace the stored Spicepod explicitly with `spice cloud project update --spicepod <path>`.
+
+`link` does not start the runtime. Start it from the enrolled directory with [`spice run`](./run), or install a supervised service with [`spice cloud service install`](#service).
+
+### `unlink`
+
+```shell
+spice cloud unlink
+```
+
+Detaches the current directory's instance, releases it in Spice Cloud, removes the directory's service when one is installed, and clears the local identity.
+
+Stop the runtime before running it — `unlink` refuses while an instance is running in the directory.
+
+`unlink` does not delete the project. Delete a project with [`spice cloud project delete`](#project). To remove the service and keep the Cloud identity, use [`spice cloud service uninstall`](#service).
+
+## Project resolution
+
+Commands that act on a project take `--project <org>/<project>` (alias `--app`). When it is omitted, the project comes from the enrolled instance in the current directory. Only `.spice/identity.json` is consulted; no other file in `.spice` selects a project.
+
+A command with no `--project` and no enrolled identity fails rather than guessing.
+
+The organization a command acts on is resolved separately, most authoritative first:
+
+| Rank | Source                                             |
+| ---- | -------------------------------------------------- |
+| 1    | The `<org>` half of an `<org>/<project>` argument  |
+| 2    | The `--org` flag                                    |
+| 3    | The `SPICE_CLOUD_ORG` environment variable          |
+| 4    | The enrolled instance in the current directory      |
+| 5    | The active organization, set by `spice cloud org use` |
+| 6    | The organization the credential was issued for      |
+
+Commands that do not resolve a project — `orgs`, `projects`, `regions`, `images`, and `project create` — skip rank 4.
+
+A bare `--project <name>` with no `<org>/` prefix takes the organization in effect.
+
+When two explicitly stated sources name different organizations, the command fails and names both rather than picking one. The `<org>/<project>` argument, `--org`, and `SPICE_CLOUD_ORG` are explicit; the enrolled instance conflicts with `--org` and `SPICE_CLOUD_ORG` too. The active organization is a standing default and yields to any of them.
+
+Commands that change something print the fully-qualified target and where its organization came from before they act.
+
+## Managing projects
+
+### `projects`
+
+```shell
+spice cloud projects [--org <ORG>]
+```
+
+Lists the projects in the organization in effect. Alias: `apps`.
+
+### `project`
+
+```shell
+spice cloud project create <NAME> --region <REGION> [flags]
+spice cloud project get <org>/<project>
+spice cloud project update [--project <org>/<project>] [flags]
+spice cloud project delete <org>/<project> [--yes]
+```
+
+#### `project create`
+
+Creates a Spice-managed project — one whose runtime Spice Cloud hosts — and prints its primary API key.
+
+- `--region <REGION>` Required. Accepts a short region name (`us-east-1`) or a full data region name (`us-east-1-prod-aws-data`). List them with [`spice cloud regions`](#regions-and-images).
+- `--kind <KIND>` `set` (default) or `cluster`.
+- `--description <TEXT>`
+- `--visibility <VISIBILITY>` `private` (default) or `public`.
+- `--replicas <N>` Scheduler replicas.
+- `--cpu <VCPUS>` Scheduler CPU limit, in vCPUs.
+- `--memory <SIZE>` Scheduler memory limit (for example `16Gi`).
+- `--storage-size-gb <GB>` Block storage size.
+- `--executor-replicas <N>`, `--executor-cpu <VCPUS>`, `--executor-memory <SIZE>` Executor sizing.
+- `--spicepod <PATH>` Path to a `spicepod.yaml` to store on the project.
+- `--channel <CHANNEL>` Update channel: `stable`, `preview`, `nightly`, or `internal`.
+
+`--kind cluster` requires `--replicas 1` and all three executor flags.
+
+:::note
+`spice cloud project create` requires `--region`, so it creates Spice-managed projects only. Create the project that [`spice cloud link`](#link) attaches an instance to from the Spice Cloud portal.
+:::
+
+#### `project get`
+
+Shows one project's configuration.
+
+#### `project update`
+
+Changes a project's configuration. Takes `--description`, `--visibility`, `--replicas`, `--image`, `--region`, the CPU, memory, storage and executor flags, `--spicepod`, and `--channel`.
+
+#### `project delete`
+
+Deletes a project. Prompts for confirmation unless `--yes` is passed. Alias: `rm`.
+
+## Deploying
+
+### `deploy`
+
+```shell
+spice cloud deploy [--project <org>/<project>] [flags]
+```
+
+Deploys the project's stored Spicepod. Local edits are not synchronized — replace the stored Spicepod with `spice cloud project update --spicepod <path>`, or deploy a different repository revision with `--branch` / `--commit`.
+
+- `--project <ORG/PROJECT>`
+- `--image <IMAGE>` Container image tag to deploy.
+- `--branch <BRANCH>` Git branch to deploy the Spicepod from. Defaults to the project's production branch.
+- `--commit <SHA>` Git commit SHA to deploy the Spicepod from.
+- `--replicas <N>`
+- `--debug` Enable debug mode.
+- `--wait` Wait for the deployment to reach a terminal status.
+- `--timeout <DURATION>` How long to wait with `--wait`. Default `10m`.
+- `-o`, `--output <FORMAT>` `table` (default) or `json`.
+
+### `deployments`
+
+```shell
+spice cloud deployments
+```
+
+Lists a project's deployments, most recent first.
+
+- `--project <ORG/PROJECT>`
+- `--limit <N>` Default `10`.
+- `--status <STATUS>` Filter by deployment status.
+- `-o`, `--output <FORMAT>`
+
+## Inspecting
+
+### `status`
+
+```shell
+spice cloud status [--project <org>/<project>] [--instance <NAME>]
+```
+
+Reports the project, its latest deployment, every instance serving it with per-instance health, and any dataset that is not loading. The current directory's own enrolled-instance state — connection, service, and deployment — is appended under `Local enrolled-instance state:`.
+
+The project half of the report comes from Spice Cloud, so the command needs an authenticated session and a project it can resolve. Run with no `--project` from a directory that holds no enrolled identity, it exits non-zero with `No app specified.` It also exits non-zero when the local state is degraded, or when instance and dataset health could not be read.
+
+- `--project <ORG/PROJECT>`
+- `--instance <NAME>` Pin the report to one instance. Without it the report comes from the project's general endpoint and describes the deployment as a whole.
+- `-o`, `--output <FORMAT>` `table` (default) or `json`.
+
+`--output json` carries the project report at the top level and the local enrolled-instance state under `link`:
+
+```json
+{
+  "schema_version": 1,
+  "project": {},
+  "org": "acme",
+  "instance": null,
+  "latest_deployment": {},
+  "instances": [],
+  "datasets_total": 0,
+  "datasets_unhealthy": [],
+  "runtime_error": null,
+  "link": { "connection": {}, "service": {}, "deployment": {} }
+}
+```
+
+### `logs`
+
+```shell
+spice cloud logs
+spice cloud logs --level error --limit 500
+spice cloud logs -f
+```
+
+Reads logs from the runtime instances serving the project. When Spice Cloud returns no logs, or cannot be reached, and the current directory's enrolled instance is attached to that project, the directory's installed service logs are read instead and a warning names the cause.
+
+- `--project <ORG/PROJECT>`
+- `--limit <N>` Maximum entries to request per runtime instance. Default `100`, maximum `100000`. Alias: `--tail`.
+- `--level <LEVEL>` `all` (default), `warn`, or `error`. Entries with no level are always shown.
+- `--since <TIMESTAMP>` Only entries after this RFC 3339 timestamp.
+- `-f`, `--follow` Stream new entries. Supported only on local service logs, and not combinable with `--level`, `--since`, or `--output json`.
+- `-o`, `--output <FORMAT>` `table` (default) or `json`.
+
+### `datasets`
+
+```shell
+spice cloud datasets
+```
+
+Shows the dataset load state for a project. Takes `--project`, `--instance`, and `-o`.
+
+### `metrics`
+
+```shell
+spice cloud metrics --window 5m
+```
+
+Shows resource usage for a project's instances. Takes `--project`, `-o`, and `--window <DURATION>` for the counter metrics window.
+
+### `api-keys`
+
+```shell
+spice cloud api-keys [--regenerate <1|2>]
+```
+
+Shows a project's API keys. `--regenerate <1|2>` reissues one of the two keys. Takes `--project` and `-o`.
+
+## Secrets
+
+```shell
+spice cloud secrets list
+spice cloud secrets set <NAME> <VALUE>
+spice cloud secrets get <NAME>
+spice cloud secrets delete <NAME>
+```
+
+Manages a project's secrets. Every subcommand takes `--project <ORG/PROJECT>` and `-o`. `list` has the alias `ls`.
+
+## Service
+
+```shell
+spice cloud service install
+spice cloud service uninstall
+spice cloud service start
+spice cloud service stop
+spice cloud service restart
+```
+
+Manages a supervised service that runs the enrolled instance in the current directory. Every action resolves its target from that directory — there is no way to name a systemd unit or a launchd label.
+
+- `install` — Stage the runtime, write the service definition, and start it. Idempotent: re-running restages the current runtime and restarts the service without touching the enrolled identity. Requires an enrolled identity and an installed runtime.
+- `uninstall` — Stop and remove the service, keeping the Cloud identity. [`spice cloud unlink`](#unlink) is what releases the identity.
+- `start` — Start an installed, stopped service. Succeeds if it is already running.
+- `stop` — Stop a running service, leaving it installed and enabled.
+- `restart` — Restart the service through its supervisor and wait for the result.
+
+Run `spice cloud service install` to install a user service, and `sudo spice cloud service install` for a system service that starts at boot without a user login.
+
+Supported on Linux with systemd and on macOS with launchd. On other hosts, run `spiced` from the enrolled directory under your own supervisor.
+
+Read the service's logs with [`spice cloud logs -f`](#logs), and its health with [`spice cloud status`](#status).
+
+## Regions and images
+
+`spice cloud regions` lists the regions available for `spice cloud project create --region`, marking the default.
+
+`spice cloud images [--channel <CHANNEL>]` lists the container images available for `spice cloud deploy --image`.
+
+## Flags
+
+Accepted by every `spice cloud` command:
+
+- `--org <ORG>` Organization to act on, outranking `SPICE_CLOUD_ORG` and the active organization.
+- `--machine` Machine-readable mode: prefer JSON output where supported, and always emit structured JSON errors. Alias: `--programmatic`.
+- `-v`, `--verbose` Increase log verbosity. `-v` for debug, `-vv` for trace.
+- `-h`, `--help` Print the help message.
+
+Most subcommands also take `-o`, `--output <FORMAT>`, which is `table` or `json`.
+
+## Environment variables
+
+| Variable                     | Purpose                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `SPICE_CLOUD_ORG`            | Organization to act on, outranking the active organization                 |
+| `SPICE_CLOUD_PAT`            | Access token for `spice cloud login token`                                 |
+| `SPICE_CLOUD_CLIENT_ID`      | OAuth client ID for `spice cloud login api`                                |
+| `SPICE_CLOUD_CLIENT_SECRET`  | OAuth client secret for `spice cloud login api`                            |
+| `SPICE_CONFIG_DIR`           | Complete path to the instance state directory, instead of `<dir>/.spice`   |
+
+## See also
+
+- [Spice Cloud Platform](../../deployment/cloud/index.md)
+- [Cloud Connect](../../deployment/cloud/cloud-connect/index.md)
+- [`spiced`](./spiced#spice-cloud-connect-flags) — unattended enrollment with `--token`
+- [`spice login`](./login) — data source credentials, and the Spice.ai browser login flow

--- a/website/docs/cli/reference/cloud.md
+++ b/website/docs/cli/reference/cloud.md
@@ -185,7 +185,7 @@ Lists the projects in the organization in effect. Alias: `apps`.
 ### `project`
 
 ```shell
-spice cloud project create <NAME> --region <REGION> [flags]
+spice cloud project create <NAME> [flags]
 spice cloud project get <org>/<project>
 spice cloud project update [--project <org>/<project>] [flags]
 spice cloud project delete <org>/<project> [--yes]
@@ -193,25 +193,38 @@ spice cloud project delete <org>/<project> [--yes]
 
 #### `project create`
 
-Creates a Spice-managed project — one whose runtime Spice Cloud hosts — and prints its primary API key.
+`--kind` decides which kind of project is created. Either way, the command prints the new project's primary API key.
 
-- `--region <REGION>` Required. Accepts a short region name (`us-east-1`) or a full data region name (`us-east-1-prod-aws-data`). List them with [`spice cloud regions`](#regions-and-images).
-- `--kind <KIND>` `set` (default) or `cluster`.
+```shell
+spice cloud project create <NAME>                              # Cloud Connect project
+spice cloud project create <NAME> --kind set --region <REGION> # Spice-managed project
+```
+
+- **Omit `--kind`** for a **Cloud Connect** project — one Spice Cloud does not run, served by your own runtime. This is the project [`spice cloud link`](#link) attaches an instance to.
+- **Name a `--kind`**, `set` or `cluster`, for a **Spice-managed** project, whose runtime Spice Cloud hosts. `--region` is required alongside it.
+
+Flags that configure a hosted runtime are **refused, not ignored**, when no `--kind` is named: `--region`, `--replicas`, `--cpu`, `--memory`, `--storage-size-gb`, `--executor-replicas`, `--executor-cpu`, `--executor-memory`, and `--channel` each fail the command. A Cloud Connect project's region is not chosen here — it follows from the stamp its attached instance's control stream terminates on.
+
+Flags:
+
+- `--kind <KIND>` `set` or `cluster`. Omit for a Cloud Connect project.
+- `--region <REGION>` Required with `--kind`, refused without it. Accepts a short region name (`us-east-1`) or a full data region name (`us-east-1-prod-aws-data`). List them with [`spice cloud regions`](#regions-and-images).
 - `--description <TEXT>`
 - `--visibility <VISIBILITY>` `private` (default) or `public`.
+- `--spicepod <PATH>` Path to a `spicepod.yaml` to store on the project.
+
+Hosted-runtime flags, each requiring `--kind`:
+
 - `--replicas <N>` Scheduler replicas.
 - `--cpu <VCPUS>` Scheduler CPU limit, in vCPUs.
 - `--memory <SIZE>` Scheduler memory limit (for example `16Gi`).
 - `--storage-size-gb <GB>` Block storage size.
 - `--executor-replicas <N>`, `--executor-cpu <VCPUS>`, `--executor-memory <SIZE>` Executor sizing.
-- `--spicepod <PATH>` Path to a `spicepod.yaml` to store on the project.
 - `--channel <CHANNEL>` Update channel: `stable`, `preview`, `nightly`, or `internal`.
 
 `--kind cluster` requires `--replicas 1` and all three executor flags.
 
-:::note
-`spice cloud project create` requires `--region`, so it creates Spice-managed projects only. Create the project that [`spice cloud link`](#link) attaches an instance to from the Spice Cloud portal.
-:::
+The kind reported for the new project is Spice Cloud's answer, read from the create response rather than restated from the request.
 
 #### `project get`
 

--- a/website/docs/cli/reference/connect.md
+++ b/website/docs/cli/reference/connect.md
@@ -5,113 +5,42 @@ pagination_prev: null
 pagination_next: null
 ---
 
-Connect an instance to Spice Cloud.
+:::warning
+`spice connect <org>/<pod>` is deprecated. Use [`spice add <org>/<pod>`](./add).
+:::
 
-Use `spice connect` for interactive setup. For unattended setup, use [`spiced --token`](./spiced#spice-cloud-connect-flags).
+Adds a Spicepod dependency to the current project, and prints a deprecation warning.
 
 ### Usage
 
 ```shell
-spice connect [flags]
-spice connect status [--output table|json]
-spice connect service <install|uninstall|start|stop|restart|status|logs>
-spice connect remove [--yes] [--force]
+spice connect <org>/<pod>
 ```
 
-### Connect an instance
-
-Run this command from the instance directory:
+### Example
 
 ```shell
-spice connect
+spice connect spiceai/quickstart
 ```
 
-You need a terminal and the owner or admin role in a Spice Cloud organization. The command can log you in. It enrolls the directory, creates a project, and starts the runtime.
+The command takes no flags of its own beyond the [global flags](../reference#command-flags).
 
-The identity is stored in `<dir>/.spice/identity.json`. If an identity exists, the command starts the existing instance. It does not enroll a new instance.
+### Connecting a runtime to Spice Cloud
 
-### `status`
+`spice connect` does not enroll or attach an instance. Use [`spice cloud`](./cloud):
 
-Show the Cloud connection, service, and deployment status:
+| Task                                          | Command                                       |
+| --------------------------------------------- | --------------------------------------------- |
+| Enroll this directory and attach it to a project | [`spice cloud link`](./cloud#link)          |
+| Check the project's health                    | [`spice cloud status`](./cloud#status)        |
+| Read runtime logs                             | [`spice cloud logs`](./cloud#logs)            |
+| Run the instance as a supervised service      | [`spice cloud service`](./cloud#service)      |
+| Detach and release the instance               | [`spice cloud unlink`](./cloud#unlink)        |
 
-```shell
-spice connect status
-spice connect status --output json
-```
-
-- `-o`, `--output <table|json>`: Set the output format. The default is `table`.
-
-The command returns a nonzero exit code if the service state is `failed` or `unavailable`.
-
-### `service`
-
-Manage a Linux or macOS service:
-
-```shell
-spice connect service install
-spice connect service uninstall
-spice connect service start
-spice connect service stop
-spice connect service restart
-spice connect service status
-spice connect service logs
-```
-
-Enroll the instance before you install the service.
-
-Install a user service with `spice connect service install`. Install a system service with `sudo spice connect service install`. A system service starts at boot without a user login.
-
-Log options:
-
-- `-n`, `--number <LINES>`: Set the number of existing lines. The default is `100`. The maximum is `100000`.
-- `-f`, `--follow`: Show new lines until you stop the command.
-
-Windows does not support service actions. `service status` is available on all platforms.
-
-See [Cloud Connect as a service](../../deployment/cloud/cloud-connect/service.md).
-
-### `remove`
-
-Stop the runtime. Then run:
-
-```shell
-spice connect remove
-```
-
-This command deletes the project, removes the service, and deletes the local Cloud identity. You must be logged in to the organization that owns the instance.
-
-Use `--yes` to skip confirmation. Use `--force` only to remove local state when Spice Cloud cannot complete the removal.
-
-To keep the Cloud identity, use `spice connect service uninstall`.
-
-### Flags
-
-- `--dir <PATH>`: Set the instance directory. The default is the current directory. This option applies to `status`, `remove`, and `service`.
-- `--region <LABEL>`: Set a location label during enrollment. Use 2–64 lowercase letters, digits, or hyphens.
-- `--endpoint <URL>`: Set the Spice Cloud API endpoint. The default is `https://api.spice.ai`.
-- `-y`, `--yes`: Skip confirmation for `remove`.
-- `--force`: Remove local state if Spice Cloud cannot complete `remove`.
-- `-h`, `--help`: Show help.
-
-### Environment variables
-
-| Variable           | Purpose                                                      |
-| ------------------ | ------------------------------------------------------------ |
-| `SPICE_CONFIG_DIR` | Set the complete path for the Cloud Connect state directory. |
-
-`SPICE_CONFIG_DIR` takes precedence over `--dir`.
-
-### Deprecated syntax
-
-`spice connect <org>/<pod>` is deprecated. Use:
-
-```shell
-spice add <org>/<pod>
-```
+For unattended enrollment, start the runtime with [`spiced --token <enrollment-key>`](./spiced#spice-cloud-connect-flags).
 
 ### See also
 
-- [Cloud Connect overview](../../deployment/cloud/cloud-connect/index.md)
-- [Development machine](../../deployment/cloud/cloud-connect/development.md)
-- [Service](../../deployment/cloud/cloud-connect/service.md)
-- [Headless](../../deployment/cloud/cloud-connect/headless.md)
+- [`spice add`](./add) — add a Spicepod dependency
+- [`spice cloud`](./cloud) — Spice Cloud commands
+- [Cloud Connect](../../deployment/cloud/cloud-connect/index.md)

--- a/website/docs/cli/reference/index.md
+++ b/website/docs/cli/reference/index.md
@@ -23,9 +23,9 @@ spice [command] [--help]
 | [catalogs](reference/catalogs)     | List [catalogs](../components/catalogs) loaded by the Spice runtime |
 | [chat](reference/chat)             | Chat with an LLM                                                       |
 | [completions](reference/completions) | Generate shell completions for the Spice CLI                         |
-| cloud                              | Manage Spice Cloud resources                                           |
+| [cloud](reference/cloud)           | Manage Spice Cloud resources                                           |
 | cluster                            | Cluster operations for the Spice runtime                               |
-| [connect](reference/connect)       | Connect a Spice instance to Spice Cloud                                     |
+| [connect](reference/connect)       | Deprecated alias for adding a Spicepod dependency                      |
 | [dataset](reference/dataset)       | Add or configure dataset entries in `spicepod.yaml`                    |
 | [datasets](reference/datasets)     | Lists datasets loaded by the Spice runtime                             |
 | embedding                          | Add or configure embedding entries in `spicepod.yaml`                  |

--- a/website/docs/cli/reference/login.md
+++ b/website/docs/cli/reference/login.md
@@ -69,7 +69,9 @@ An off-origin redirect surfaces as the `3xx` response itself rather than as a tr
 
 ## `spice cloud login`
 
-Authenticate with the Spice Cloud Platform. Running `spice cloud login` without a subcommand opens an interactive method chooser when stdin is a TTY. Non-interactive callers must specify a method explicitly.
+Authenticate with the Spice Cloud Platform. See [`spice cloud`](./cloud#login) for the rest of the Spice Cloud command surface.
+
+Running `spice cloud login` with no subcommand offers two choices — **Login with a web browser** and **Paste an access token** — which run `subscription` and `token` respectively. The chooser needs an interactive terminal; non-interactive callers must name a method. `api` is not offered in the chooser and is always named explicitly.
 
 ### Methods
 
@@ -87,19 +89,21 @@ Use `--device` to print the URL and one-time code without opening a browser (use
 spice cloud login subscription --device
 ```
 
-#### `spice cloud login pat`
+#### `spice cloud login token`
 
-Authenticate with a personal access token.
+Authenticate with a Spice Cloud access token. Alias: `pat`.
 
 ```shell
-spice cloud login pat --token <TOKEN>
+spice cloud login token --token <TOKEN>
 ```
+
+Omit `--token` to enter the token at a secure prompt. Generate one at `/account/tokens` in the Spice Cloud portal.
 
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
 export SPICE_CLOUD_PAT=<TOKEN>
-spice cloud login pat
+spice cloud login token
 ```
 
 #### `spice cloud login api`
@@ -122,6 +126,6 @@ spice cloud login api
 
 | Variable | Used by | Description |
 | --- | --- | --- |
-| `SPICE_CLOUD_PAT` | `login pat` | Personal access token |
+| `SPICE_CLOUD_PAT` | `login token` | Spice Cloud access token |
 | `SPICE_CLOUD_CLIENT_ID` | `login api` | OAuth2 client ID |
 | `SPICE_CLOUD_CLIENT_SECRET` | `login api` | OAuth2 client secret |

--- a/website/docs/cli/reference/spiced.md
+++ b/website/docs/cli/reference/spiced.md
@@ -65,7 +65,7 @@ Each key can enroll one instance. After enrollment, remove the key and `--token`
 
 Set `SPICE_CONFIG_DIR` to a persistent location. The instance cannot reconnect if you lose its identity.
 
-See [`spice connect`](./connect) and [Headless Cloud Connect](../../deployment/cloud/cloud-connect/headless).
+See [`spice cloud`](./cloud) and [Headless Cloud Connect](../../deployment/cloud/cloud-connect/headless).
 
 ### SQL REPL flags
 

--- a/website/docs/deployment/cloud/cloud-connect/development.md
+++ b/website/docs/deployment/cloud/cloud-connect/development.md
@@ -16,7 +16,7 @@ tags:
 
 - The [Spice CLI](../../../installation.md).
 - The owner or admin role in a Spice Cloud organization. A `member` cannot enroll an instance.
-- A project in that organization. `spice cloud link` attaches to a project that already exists; create one in the Spice Cloud portal.
+- A project in that organization. `spice cloud link` attaches to a project that already exists; create one with `spice cloud project create <name>`, or in the Spice Cloud portal.
 
 Log in first. `spice cloud link` needs a Spice Cloud user session and does not create one:
 

--- a/website/docs/deployment/cloud/cloud-connect/development.md
+++ b/website/docs/deployment/cloud/cloud-connect/development.md
@@ -2,7 +2,7 @@
 title: 'Cloud Connect on a Development Machine'
 sidebar_label: 'Development machine'
 description: 'Connect a development machine to Spice Cloud and run the instance in the foreground.'
-keywords: [spice.ai, cloud connect, spice connect, development]
+keywords: [spice.ai, cloud connect, spice cloud link, development]
 sidebar_position: 1
 tags:
   - deployment
@@ -10,14 +10,19 @@ tags:
   - spiceai
 ---
 
-`spice connect` enrolls an instance and runs it in the terminal that started it. This method works on Linux, macOS, and Windows.
+`spice cloud link` enrolls an instance and attaches it to a project. `spice run` then runs it in the terminal that started it. This method works on Linux, macOS, and Windows.
 
 ## Prerequisites
 
 - The [Spice CLI](../../../installation.md).
 - The owner or admin role in a Spice Cloud organization. A `member` cannot enroll an instance.
+- A project in that organization. `spice cloud link` attaches to a project that already exists; create one in the Spice Cloud portal.
 
-A prior `spice login` is optional — `spice connect` runs the login inline when there is no saved session.
+Log in first. `spice cloud link` needs a Spice Cloud user session and does not create one:
+
+```shell
+spice cloud login
+```
 
 ## Connecting
 
@@ -26,12 +31,15 @@ The directory the command runs from is the instance:
 ```shell
 mkdir -p ~/work/retail-analytics
 cd ~/work/retail-analytics
-spice connect
+spice cloud link acme/retail-analytics
+spice run
 ```
 
-The flow authenticates, resolves an organization, proposes a project name derived from the directory, enrolls the instance, and starts the runtime. `Ctrl-C` stops it.
+`spice cloud link` enrolls the directory and attaches it to the named project. Omit the argument to choose from the projects available to you. Either way it needs an interactive terminal.
 
-An [enrollment key](https://spice.ai/connect) is the alternative when a login cannot enroll into the wanted organization. The **Use an enrollment key** choice takes one; an instance enrolled that way is connected but unattached, and the portal link in the output creates its project.
+`link` does not start the runtime; `spice run` does, and `Ctrl-C` stops it.
+
+An [enrollment key](https://spice.ai/connect) is the alternative when a login cannot enroll into the wanted organization, or when there is no interactive terminal. Pass it to `spiced --token`; an instance enrolled that way is connected but unattached, and the portal link in the output creates its project. See [Headless Cloud Connect](./headless.md).
 
 ## Reconnecting
 
@@ -40,7 +48,6 @@ The identity stays in the instance directory, so any of these reconnect the same
 ```shell
 spice run
 spiced
-spice connect
 ```
 
 ## Applying a deployment
@@ -51,20 +58,20 @@ A deployment from the portal reconciles into the running process. When it change
 INFO Spice Cloud Connect: applied the deployed spicepod (4 datasets, 0 models, 0 catalogs, 1 views); runtime takes effect when this instance next starts
 ```
 
-The project in Spice Cloud reports the same pending set. In a terminal, `Ctrl-C` followed by `spice connect` is what applies it. See [Deployments and restarts](./index.md#deployments-and-restarts).
+The project in Spice Cloud reports the same pending set. In a terminal, `Ctrl-C` followed by `spice run` is what applies it. See [Deployments and restarts](./index.md#deployments-and-restarts).
 
 ## Removing the instance
 
-`spice connect remove` deletes the project and clears the local identity, and refuses while the runtime is running:
+`spice cloud unlink` releases the instance and clears the local identity, and refuses while the runtime is running:
 
 ```shell
-spice connect remove
+spice cloud unlink
 ```
 
-`--force` clears only this host's state, for an instance already deleted in the portal. It is a recovery path, not a faster one.
+The project stays. Delete it from the Spice Cloud portal, or with `spice cloud project delete <org>/<project>`.
 
 ## Next steps
 
 - [Run Cloud Connect as a service](./service.md)
 - [Run Cloud Connect without an interactive terminal](./headless.md)
-- [`spice connect` command reference](../../../cli/reference/connect.md)
+- [`spice cloud` command reference](../../../cli/reference/cloud.md)

--- a/website/docs/deployment/cloud/cloud-connect/headless.md
+++ b/website/docs/deployment/cloud/cloud-connect/headless.md
@@ -120,7 +120,7 @@ The label is 2–64 lowercase letters, digits, or hyphens, and is a declared val
 ## Checking the connection
 
 ```shell
-spice connect status --output json
+spice cloud status --output json
 ```
 
 The [`spiced` command reference](../../../cli/reference/spiced.md) documents every runtime option.

--- a/website/docs/deployment/cloud/cloud-connect/index.md
+++ b/website/docs/deployment/cloud/cloud-connect/index.md
@@ -45,7 +45,7 @@ An identity expires after 30 days offline. An instance that has been down longer
 
 Two credentials can enroll an instance:
 
-- **A Spice Cloud login**, used by `spice cloud link`. It requires the owner or admin role in the organization, and attaches the instance to a project that already exists.
+- **A Spice Cloud login**, used by `spice cloud link`. It requires the owner or admin role in the organization, and attaches the instance to a project that already exists — `spice cloud project create <name>` creates one.
 - **An enrollment key**, minted at [spice.ai/connect](https://spice.ai/connect) and passed to `spiced --token`. A key enrolls exactly one instance and creates no project; the runtime log carries a portal link for that.
 
 A key is shown once and is never recoverable from Spice Cloud. What restarts an instance is the issued identity under `<dir>/.spice`, which belongs on persistent storage.

--- a/website/docs/deployment/cloud/cloud-connect/index.md
+++ b/website/docs/deployment/cloud/cloud-connect/index.md
@@ -18,21 +18,22 @@ The instance dials out to Spice Cloud. Spice Cloud never opens an inbound connec
 
 | Method                          | The instance runs                      | Command                         |
 | ------------------------------- | -------------------------------------- | ------------------------------- |
-| [Development](./development.md) | in the terminal that started it        | `spice connect`                 |
-| [Service](./service.md)         | as a Linux or macOS service            | `spice connect service install` |
+| [Development](./development.md) | in the terminal that started it        | `spice cloud link`, then `spice run` |
+| [Service](./service.md)         | as a Linux or macOS service            | `spice cloud service install`   |
 | [Headless](./headless.md)       | in a container or under any supervisor | `spiced --token <key>`          |
 
-Windows has no managed service. A Windows host runs the instance with `spice connect` or under its own supervisor.
+Windows has no managed service. A Windows host runs the instance with `spice run` or under its own supervisor.
 
 ## Instance directory
 
-Cloud Connect state belongs to an instance directory, not to the host: the issued identity lives at `<dir>/.spice/identity.json`. The directory defaults to the working directory, and `--dir` selects another one.
+Cloud Connect state belongs to an instance directory, not to the host: the issued identity lives at `<dir>/.spice/identity.json`. Commands act on the directory they run from.
 
 ```shell
-spice connect status --dir /srv/edge-analytics
+cd /srv/edge-analytics
+spice cloud status
 ```
 
-`SPICE_CONFIG_DIR` replaces the derived path entirely and takes precedence over `--dir`, which is how a container places the identity on a mounted volume.
+`SPICE_CONFIG_DIR` replaces the derived path entirely, which is how a container places the identity on a mounted volume.
 
 An enrolled directory reconnects on its own. A later `spice run` or `spiced` started there connects with no Cloud Connect flag.
 
@@ -44,7 +45,7 @@ An identity expires after 30 days offline. An instance that has been down longer
 
 Two credentials can enroll an instance:
 
-- **A Spice Cloud login**, used by `spice connect`. It requires the owner or admin role in the organization, and it is the only path that also creates the instance's project.
+- **A Spice Cloud login**, used by `spice cloud link`. It requires the owner or admin role in the organization, and attaches the instance to a project that already exists.
 - **An enrollment key**, minted at [spice.ai/connect](https://spice.ai/connect) and passed to `spiced --token`. A key enrolls exactly one instance and creates no project; the runtime log carries a portal link for that.
 
 A key is shown once and is never recoverable from Spice Cloud. What restarts an instance is the issued identity under `<dir>/.spice`, which belongs on persistent storage.
@@ -65,10 +66,10 @@ Every other section is read only when the runtime starts, as is a removed catalo
 INFO Spice Cloud Connect: applied the deployed spicepod (4 datasets, 1 models, 0 catalogs, 2 views); runtime, tools takes effect when this instance next starts
 ```
 
-Whatever owns the process performs the restart: `spice connect service restart` for a service, a stop and a fresh `spice connect` in a terminal, or a recreated container or pod.
+Whatever owns the process performs the restart: `spice cloud service restart` for a service, a stop and a fresh `spice run` in a terminal, or a recreated container or pod.
 
 ## Removing an instance
 
-`spice connect remove` deletes the instance's project in Spice Cloud, uninstalls its service, and clears the local identity. It refuses while the instance is running.
+`spice cloud unlink` releases the instance in Spice Cloud, uninstalls its service, and clears the local identity. It refuses while the instance is running, and it leaves the project in place — delete that with `spice cloud project delete <org>/<project>`.
 
-`spice connect service uninstall` is the narrower operation: it removes the service and keeps the Cloud identity, so a later install resumes the same enrollment.
+`spice cloud service uninstall` is the narrower operation: it removes the service and keeps the Cloud identity, so a later install resumes the same enrollment.

--- a/website/docs/deployment/cloud/cloud-connect/service.md
+++ b/website/docs/deployment/cloud/cloud-connect/service.md
@@ -12,17 +12,17 @@ tags:
   - spiceai
 ---
 
-A managed service keeps a connected instance running after the terminal closes. `spice connect service` drives systemd on Linux and launchd on macOS, with one set of commands for both.
+A managed service keeps a connected instance running after the terminal closes. `spice cloud service` drives systemd on Linux and launchd on macOS, with one set of commands for both.
 
-Windows has no managed service: every action except `status` exits non-zero there, and such a host runs the instance with `spice connect` or under its own supervisor.
+Windows has no managed service: every action is refused there, and such a host runs the instance with `spice run` or under its own supervisor.
 
 ## Enrollment comes first
 
-The directory must already hold a Cloud Connect identity; `install` never enrolls one. On an interactive host, `spice connect` enrolls it and `Ctrl-C` stops the foreground runtime once it is serving:
+The directory must already hold a Cloud Connect identity; `install` never enrolls one. On an interactive host, `spice cloud link` enrolls it:
 
 ```shell
 cd /srv/edge-analytics
-spice connect
+spice cloud link acme/edge-analytics
 ```
 
 An unattended host enrolls through [Headless Cloud Connect](./headless.md) instead.
@@ -33,8 +33,8 @@ The privilege the install runs with selects the service domain, and with it the 
 
 | Command                              | Starts                         |
 | ------------------------------------ | ------------------------------ |
-| `spice connect service install`      | when its owner logs in         |
-| `sudo spice connect service install` | at boot, with nobody logged in |
+| `spice cloud service install`        | when its owner logs in         |
+| `sudo spice cloud service install`   | at boot, with nobody logged in |
 
 Both run from the instance directory, and both install and start the service. A system service still runs `spiced` as the operator who invoked `sudo`.
 
@@ -51,23 +51,22 @@ Re-running `install` is the in-place upgrade: it stages the current `spiced`, re
 ## Managing
 
 ```shell
-spice connect service start
-spice connect service stop
-spice connect service restart
-spice connect service status
-spice connect service logs
-spice connect service uninstall
+spice cloud service start
+spice cloud service stop
+spice cloud service restart
+spice cloud service uninstall
 ```
 
-Each action resolves the service for the instance directory, or for the one `--dir <path>` names. `stop` leaves the definition in place, so the service still comes back at the next boot or login.
+Each action resolves the service for the directory it runs from. `stop` leaves the definition in place, so the service still comes back at the next boot or login.
+
+`spice cloud status` reports the service's state, under `Local enrolled-instance state:`, and `spice cloud logs` reads its output. Both read the project from Spice Cloud, so both need an authenticated session.
 
 ## Reading logs
 
 ```shell
-spice connect service logs          # the last 100 lines
-spice connect service logs -n 500   # the last 500 lines
-spice connect service logs -f       # follow new lines
-spice connect service logs -n 0 -f  # follow only new lines
+spice cloud logs               # the last 100 lines
+spice cloud logs --limit 500   # the last 500 lines
+spice cloud logs -f            # follow new lines
 ```
 
 `Ctrl-C` ends the log output without touching the service.
@@ -79,32 +78,32 @@ On Linux the lines come from the systemd journal. launchd stores no logs, so on 
 | User    | `~/Library/Logs/Spice/<service>/spiced.log` |
 | System  | `/Library/Logs/Spice/<service>/spiced.log`  |
 
-The runtime keeps five files of about 10 MiB each and discards the oldest. `spice connect service status` reports the location, and an uninstall leaves the files in place.
+The runtime keeps five files of about 10 MiB each and discards the oldest. `spice cloud status` reports the location, and an uninstall leaves the files in place.
 
 ## Applying changes that require a restart
 
 A deployment that changes a section only a start reads leaves the instance serving its current configuration. The runtime names those sections in the service log, and the project in Spice Cloud reports them:
 
 ```shell
-spice connect service logs -n 20
+spice cloud logs --limit 20
 ```
 
 ```text
 INFO Spice Cloud Connect: applied the deployed spicepod (12 datasets, 1 models, 0 catalogs, 0 views); runtime, secrets takes effect when this instance next starts
 ```
 
-`spice connect service restart` is what applies them.
+`spice cloud service restart` is what applies them.
 
 ## Removing the service
 
 ```shell
-spice connect service uninstall
+spice cloud service uninstall
 ```
 
-This keeps the Cloud identity and the project, so a later install resumes the same enrollment. [`spice connect remove`](../../../cli/reference/connect.md#remove) is what releases the instance from Spice Cloud.
+This keeps the Cloud identity and the project, so a later install resumes the same enrollment. [`spice cloud unlink`](../../../cli/reference/cloud.md#unlink) is what releases the instance from Spice Cloud.
 
 :::note
 One managed service per host. Additional instances on the same host run in the foreground or under an operator's own supervisor.
 :::
 
-The [`spice connect` command reference](../../../cli/reference/connect.md) documents every service option.
+The [`spice cloud` command reference](../../../cli/reference/cloud.md#service) documents every service option.

--- a/website/docs/monitoring/spice-cloud/index.md
+++ b/website/docs/monitoring/spice-cloud/index.md
@@ -65,10 +65,10 @@ To create the app from the CLI:
 
 ```bash
 spice cloud login
-spice cloud project create my-observability --region us-east-1 --visibility private
+spice cloud project create my-observability --kind set --region us-east-1 --visibility private
 ```
 
-List the available regions with `spice cloud regions`. See [`spice cloud`](../cli/reference/cloud) for the full command reference.
+`--kind set` makes this a Spice-managed app; list the available regions with `spice cloud regions`. See [`spice cloud`](../cli/reference/cloud) for the full command reference.
 
 The output includes the app's primary API key. Treat the key as a secret — anyone with the key can write task history to (and read it from) the app.
 

--- a/website/docs/monitoring/spice-cloud/index.md
+++ b/website/docs/monitoring/spice-cloud/index.md
@@ -65,15 +65,17 @@ To create the app from the CLI:
 
 ```bash
 spice cloud login
-spice cloud create app my-observability --visibility private
+spice cloud project create my-observability --region us-east-1 --visibility private
 ```
+
+List the available regions with `spice cloud regions`. See [`spice cloud`](../cli/reference/cloud) for the full command reference.
 
 The output includes the app's primary API key. Treat the key as a secret — anyone with the key can write task history to (and read it from) the app.
 
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --app <org>/<app>
+spice cloud api-keys --project <org>/<app>
 ```
 
 ## Configuration


### PR DESCRIPTION
## What

spiceai/spiceai#13321 unified Spice Cloud enrollment and lifecycle under `spice cloud`. The CLI docs still described the interactive `spice connect` enrollment surface that unification removed, and `spice cloud` had no reference page at all.

This adds that page, retargets every doc that taught the removed surface, and fixes two commands that no longer parse.

### New: `website/docs/cli/reference/cloud.md`

Documents the whole shipped `spice cloud` surface — `login`/`logout`/`whoami`, `orgs`/`org`, `link`/`unlink`, `projects`/`project`, `deploy`/`deployments`, `status`, `logs`, `datasets`, `metrics`, `secrets`, `api-keys`, `service`, `regions`/`images`.

Written from `spice cloud --help` and each subcommand's help, then cross-checked line by line against `bin/spice/src/commands/cloud/mod.rs` on spiceai/spiceai trunk.

Two things it documents that were not written down anywhere:

- **Project and organization resolution precedence.** `--project` falls back to this directory's enrolled instance, and only `.spice/identity.json` is consulted. The org ladder is `<org>/<project>` argument → `--org` → `SPICE_CLOUD_ORG` → enrolled instance → active org → the credential's own org. Two *explicitly stated* sources that disagree fail the command and name both, rather than being silently ranked; the active org is a standing default and yields.
- **Two `link` footguns**, stated as behavior. `spice cloud link` always needs an interactive terminal — even with an explicit `<org>/<project>` — and needs a **user** login, so an OAuth client-credentials session cannot enroll; unattended enrollment stays `spiced --token`. Linking also adds `.spice/` to `.gitignore` (the mTLS private key) and uploads the local Spicepod only when the project has none.

`spice cloud status`'s auth requirement and its `--output json` shape are documented too — the project half comes from the control plane, so it needs a session and a resolvable project, and the local view is appended under `Local enrolled-instance state:` / nested under `link` in JSON.

### `spice cloud project create`

`--kind` is the discriminator, not `--region`:

- **Omit `--kind`** → a **Cloud Connect** project, the unattached project `spice cloud link` attaches an instance to. Create-then-link therefore works entirely from the CLI.
- **`--kind set` / `--kind cluster`** → a **Spice-managed** project, with `--region` required alongside it.

The refusals are documented as refusals, because that is what they are: `--region` and the eight hosted-runtime flags (`--replicas`, `--cpu`, `--memory`, `--storage-size-gb`, `--executor-replicas`, `--executor-cpu`, `--executor-memory`, `--channel`) **fail the command** when no `--kind` is named, rather than being silently dropped. A region quietly ignored would look like a working region selection until someone checked where the project actually ran. The created project's kind is read from the create response — Spice Cloud's answer, not a restatement of the request.

### `connect.md` reduced, not deleted

Bare `spice connect` now errors and names the `spice cloud` commands. Only `spice connect <org>/<pod>` still parses, and it still prints its deprecation warning — so the page is reduced to that form, pointing at `spice add` for Spicepods and `spice cloud` for connecting a runtime. Deleting it would have left a shipped command undocumented and orphaned four inbound links.

### Retargeted pages

`deployment/cloud/cloud-connect/{index,development,service,headless}.md` and `cli/reference/spiced.md` all taught `spice connect`. Retargeted minimally — but **three of these five rows are behaviour changes, not renames**, so read the right-hand column rather than assuming a substitution:

| Was | Now | Difference |
| --- | --- | --- |
| `spice connect` | `spice cloud link`, then `spice run` | `link` does not start the runtime, and attaches to a project that must already exist |
| `spice connect remove` | `spice cloud unlink` | ⚠️ **`remove` deleted the project; `unlink` does not** — it releases the instance and leaves the project standing |
| `spice connect status` | `spice cloud status` | ⚠️ now needs an authenticated session and a resolvable project; the old local view is appended under `Local enrolled-instance state:`, and in `--output json` it moved under `link` |
| `spice connect service status\|logs` | `spice cloud status` / `spice cloud logs` | no longer service subcommands |
| `--dir <path>` | — | ⚠️ gone entirely; commands act on the directory they run from |

### Two commands that did not work

- `monitoring/spice-cloud` used `spice cloud create app`, which does not parse at all — `create` takes only `project` and `deployment`. Now `spice cloud project create ... --kind set --region <region>`; `--kind set` is required, because a bare `--region` is refused. `--app` is modernized to `--project`.
- `cli/reference/index.md`'s `cloud` row was unlinked plain text; the `connect` row described connecting to Cloud. Both fixed.

`login.md` gets the two-option chooser (browser or access token — `api` is always named explicitly) and the `token` spelling, with `pat` noted as its alias.

## Testing

Local `docusaurus build`: **green**. The site sets `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'`, so every cross-page link and every in-page anchor added here is validated by that build. It caught one real break en route — `service.md` linking `connect#remove`, an anchor this PR removes — which is fixed.

Verified against spiceai/spiceai trunk `0657b39d`. Every `project create` refusal path was **executed** against the CLI — `--region` without `--kind`, hosted-runtime flags without `--kind` in both plural and singular message forms, `--channel` without `--kind`, and `--kind` without `--region`. All exit 1 during argument validation, before any network call, so none of them create anything.

