### PR TITLE
docs(trace): give both task names a proxied MCP tool is recorded under (fixes #2113)

### DIFF
--- a/website/docs/cli/reference/trace.md
+++ b/website/docs/cli/reference/trace.md
@@ -33,7 +33,22 @@ spice trace [task] [flags]
 - `search`
 - `scheduled_worker`
 
-Tools proxied from MCP servers and custom tools are recorded dynamically as `tool_use::<tool>` or `tool_use::<server>/<tool>` (for example, `tool_use::github/search_code`). Any such `tool_use::`-prefixed task name can be traced, not just the built-in tools listed above.
+Tools proxied from MCP servers and custom tools are recorded dynamically as `tool_use::<tool>`. Any such `tool_use::`-prefixed task name can be traced, not just the built-in tools listed above.
+
+A tool that belongs to a non-default tool catalog — which includes every tool proxied from an MCP server — is exposed under a catalog-qualified name joining the catalog and the tool with `__`, for example `github__search_code`. That is the name `/v1/tools` lists and the name `POST /v1/tools/{name}` expects.
+
+:::warning A proxied MCP tool is recorded under two different task names
+
+Which name `runtime.task_history` records depends on how the tool was invoked:
+
+| Invoked via | `task` recorded |
+| --- | --- |
+| The `/v1/mcp` gateway | `tool_use::github__search_code` (the exposed name) |
+| A model-driven tool call, or `POST /v1/tools/github__search_code` | `tool_use::github/search_code` |
+
+`spice trace` matches the task name exactly, so trace both spellings to see every call to the tool. Tracked in [spiceai/spiceai#13338](https://github.com/spiceai/spiceai/issues/13338).
+
+:::
 
 These tasks are from the `task` column in the Spice SQL `runtime.task_history` table.
 


### PR DESCRIPTION
## Summary

Fixes #2113

`website/docs/cli/reference/trace.md` documented proxied MCP tool tasks as `tool_use::<server>/<tool>` only, with `tool_use::github/search_code` as the worked example. On trunk two different task names are in play, and the page gave one of them with no hint the other exists.

**Note the issue's premise is not quite right, and this PR does not apply the change it proposed.** The issue reads spiceai/spiceai#13338 as a merged runtime fix; it is an **open issue**, and its fix (spiceai/spiceai#13437) is still open too. `crates/runtime-tools/src/mcp/tool.rs:93` on trunk today is unchanged:

```rust
let task_name = format!("tool_use::{}/{}", self.server_name, self.spec.name);
```

So swapping `/` for `__` outright — the issue's proposal — would have made the page wrong for the more common path rather than right.

What is actually true on trunk:

| Invoked via | `task` recorded |
| --- | --- |
| The `/v1/mcp` gateway (`server.rs:172`, encoded name) | `tool_use::github__search_code` |
| A model-driven tool call, or `POST /v1/tools/{name}` (`tool.rs:93`) | `tool_use::github/search_code` |

`spice trace` matches the task name exactly (`get_trace_filter` builds `task='<value>'`) and does no `/`↔`__` normalization — its validation only checks for a non-empty `tool_use::` prefix. So each spelling returns only the calls recorded under it.

## Changes

- `website/docs/cli/reference/trace.md` — describe the `__` catalog-qualified exposed name (the name `/v1/tools` lists and `POST /v1/tools/{name}` expects), and add a warning giving both task-name spellings with the entry point that produces each, linked to spiceai/spiceai#13338.

**Unversioned docs only.** The issue asked whether `website/versioned_docs/version-2.1.x/` should change: it should not. spiceai/spiceai#11629 (the `__` encoding) is not an ancestor of `v2.1.5` — `crates/tools/src/naming.rs` does not exist there, and `tooling.rs` qualifies with `format!("{catalog_name}/{}", …)` — so both paths use `/` in v2.1.x and the existing text is correct for it.

## Follow-ups

- When spiceai/spiceai#13437 merges, the warning collapses to the single `__` name. That is a small follow-up, not a blocker — the split is real in every released version and on trunk today.
- If #2111 (publish v2.2 as latest) merges first, its `version-2.2.x` snapshot will carry the pre-fix text and will need this same edit.

## Reference

Verified against `spiceai/spiceai` at `origin/trunk` (`eb99a5f395`, v2.2.0 release notes):

- [`crates/runtime-tools/src/mcp/tool.rs#L93`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-tools/src/mcp/tool.rs#L93) — the `/` form
- [`crates/runtime-tools/src/mcp/server.rs#L172`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-tools/src/mcp/server.rs#L172) — the encoded form
- [`crates/tools/src/naming.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/tools/src/naming.rs) — `__` separator, `_-_` escape
- `default_available_catalogs` returns only `builtin` and `memory`, so an MCP tool catalog is always non-default and therefore always catalog-qualified

## Test plan

- [x] `cd website && npm run build` passes locally
- [x] Links valid (no broken-link-checker failures)
- [x] Rendered `/docs/next/cli/reference/trace` shows both spellings; rendered `/docs/cli/reference/trace` (v2.1.x) unchanged
- [x] Correction scoped correctly — v2.1.x verified to predate the `__` encoding, so no versioned-docs propagation