### PR TITLE
docs(file-formats): XLSX and PPTX are supported document formats since v2.0.0

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -124,11 +124,12 @@ datasets:
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Stable  | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                                                                                       |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha   | Excel spreadsheet format (document format)                                                                     |
 | Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)                                                                   |
 | Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)                                                                             |
 | PDF                                           | `file_format: pdf`     | Beta    | Portable Document Format (document format)                                                                     |
 | Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)                                                                         |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha   | PowerPoint presentation format (document format)                                                               |
 
 ### Format-Specific Parameters
 
@@ -312,21 +313,22 @@ Runtime schema evolution controls are planned for a future release. When availab
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha     | ✅                  |
 | Markdown                                      | `file_format: md`      | ✅         | ✅                  |
 | Text                                          | `file_format: txt`     | ✅         | ✅                  |
 | PDF                                           | `file_format: pdf`     | Beta      | ✅                  |
 | Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha     | ✅                  |
 
 ### Document Formats {#document-formats}
 
 <!-- Backwards compatibility anchor for older versioned docs -->
 <a id="document-support"></a>
 
-Document formats (Markdown, Text, PDF, Word) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
+Document formats (Markdown, Text, PDF, Word, Excel, PowerPoint) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
 
 :::warning[Note]
-Document formats in Alpha (DOCX) may not parse all structure or text from the underlying documents correctly.
+Document formats in Alpha (DOCX, XLSX, PPTX) may not parse all structure or text from the underlying documents correctly.
 :::
 
 #### Document Table Schema

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/index.md
@@ -124,11 +124,12 @@ datasets:
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Stable  | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                                                                                       |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha   | Excel spreadsheet format (document format)                                                                     |
 | Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)                                                                   |
 | Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)                                                                             |
 | PDF                                           | `file_format: pdf`     | Beta    | Portable Document Format (document format)                                                                     |
 | Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)                                                                         |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha   | PowerPoint presentation format (document format)                                                               |
 
 ### Format-Specific Parameters
 
@@ -312,21 +313,22 @@ Runtime schema evolution controls are planned for a future release. When availab
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha     | ✅                  |
 | Markdown                                      | `file_format: md`      | ✅         | ✅                  |
 | Text                                          | `file_format: txt`     | ✅         | ✅                  |
 | PDF                                           | `file_format: pdf`     | Beta      | ✅                  |
 | Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha     | ✅                  |
 
 ### Document Formats {#document-formats}
 
 <!-- Backwards compatibility anchor for older versioned docs -->
 <a id="document-support"></a>
 
-Document formats (Markdown, Text, PDF, Word) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
+Document formats (Markdown, Text, PDF, Word, Excel, PowerPoint) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
 
 :::warning[Note]
-Document formats in Alpha (DOCX) may not parse all structure or text from the underlying documents correctly.
+Document formats in Alpha (DOCX, XLSX, PPTX) may not parse all structure or text from the underlying documents correctly.
 :::
 
 #### Document Table Schema

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/index.md
@@ -124,11 +124,12 @@ datasets:
 | JSON                                          | `file_format: json`    | Stable  | JavaScript Object Notation                                                                                     |
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | Stable  | Open table format with ACID transactions. Object stores only.                                                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | Stable  | Open table format for large analytic datasets. Object stores only. Requires a [catalog](../catalogs/index.md). |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap | Excel spreadsheet format                                                                                       |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha   | Excel spreadsheet format (document format)                                                                     |
 | Markdown                                      | `file_format: md`      | Stable  | Plain text with formatting (document format)                                                                   |
 | Text                                          | `file_format: txt`     | Stable  | Plain text files (document format)                                                                             |
 | PDF                                           | `file_format: pdf`     | Beta    | Portable Document Format (document format)                                                                     |
 | Microsoft Word                                | `file_format: docx`    | Alpha   | Word document format (document format)                                                                         |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha   | PowerPoint presentation format (document format)                                                               |
 
 ### Format-Specific Parameters
 
@@ -312,21 +313,22 @@ Runtime schema evolution controls are planned for a future release. When availab
 | [Delta Lake](https://delta.io/)               | `file_format: delta`   | ✅         | ❌                  |
 | [Apache Iceberg](https://iceberg.apache.org/) | `file_format: iceberg` | ✅         | ❌                  |
 | JSON                                          | `file_format: json`    | ✅         | ❌                  |
-| Microsoft Excel                               | `file_format: xlsx`    | Roadmap   | ❌                  |
+| Microsoft Excel                               | `file_format: xlsx`    | Alpha     | ✅                  |
 | Markdown                                      | `file_format: md`      | ✅         | ✅                  |
 | Text                                          | `file_format: txt`     | ✅         | ✅                  |
 | PDF                                           | `file_format: pdf`     | Beta      | ✅                  |
 | Microsoft Word                                | `file_format: docx`    | Alpha     | ✅                  |
+| Microsoft PowerPoint                          | `file_format: pptx`    | Alpha     | ✅                  |
 
 ### Document Formats {#document-formats}
 
 <!-- Backwards compatibility anchor for older versioned docs -->
 <a id="document-support"></a>
 
-Document formats (Markdown, Text, PDF, Word) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
+Document formats (Markdown, Text, PDF, Word, Excel, PowerPoint) are handled differently from structured data formats. Each file becomes a row in the resulting table, with the file contents stored in a `content` column.
 
 :::warning[Note]
-Document formats in Alpha (DOCX) may not parse all structure or text from the underlying documents correctly.
+Document formats in Alpha (DOCX, XLSX, PPTX) may not parse all structure or text from the underlying documents correctly.
 :::
 
 #### Document Table Schema


### PR DESCRIPTION
## Summary

The data-connectors index documented `file_format: xlsx` as **Roadmap** and did not mention PPTX at all. Both parsers have been registered since **v2.0.0** and are reachable today.

**What the docs said**

- Supported Formats table: `Microsoft Excel | file_format: xlsx | Roadmap | Excel spreadsheet format`
- Support matrix: `Microsoft Excel | file_format: xlsx | Roadmap | Is Document Format: ❌`
- No PowerPoint / `pptx` row anywhere in the docs.

**What the code does**

`document_parse::register_all()` registers four document parsers — `docx`, `pdf`, `pptx`, `xlsx` ([`crates/document_parse/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/document_parse/src/lib.rs)):

```rust
register_parser_factory("docx", Arc::new(docx::DocxParserFactory {})).await;
register_parser_factory("pdf",  Arc::new(pdf::PdfParserFactory {})).await;
register_parser_factory("pptx", Arc::new(pptx::PptxParserFactory {})).await;
register_parser_factory("xlsx", Arc::new(xlsx::XlsxParserFactory {})).await;
```

Both are real implementations, not stubs — `xlsx.rs` reads workbooks via `calamine`, `pptx.rs` extracts slide text in presentation order with a decompression-bomb guard.

They are reachable from any listing connector: a `file_format` value with no tabular dispatch arm falls through to `(Some(format), _) => Ok((None, format!(".{format}")))` in `get_file_format_and_extension`, which routes to `create_text_table` → `document_parse::get_parser_factory(extension)` ([`crates/data-connector-api/src/listing/connector.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connector-api/src/listing/connector.rs)). The SharePoint connector documents the same path in-source ("format for non-tabular extensions like `.xlsx`/`.pdf`") and unit-tests `.XLSX` extension inference.

The docs already contradicted themselves on this: the SharePoint page states `from: sharepoint://me/Documents/Q4.xlsx` resolves without setting `file_format: xlsx`, while the index called XLSX Roadmap.

## Changes

- `file_format: xlsx` — status `Roadmap` → `Alpha`; `Is Document Format` `❌` → `✅`; description gains the `(document format)` marker used by the other document rows.
- New `Microsoft PowerPoint` / `file_format: pptx` row in both tables (Alpha).
- Document Formats intro now reads "(Markdown, Text, PDF, Word, Excel, PowerPoint)".
- Alpha caveat now reads "Document formats in Alpha (DOCX, XLSX, PPTX)".

`Alpha` matches the existing DOCX label: both extract flat text without preserving structure, which is exactly what the Alpha caveat on this page warns about.

## Version scoping

Version-specific change, not a blanket correction. `git show <tag>:crates/document_parse/src/lib.rs` confirms:

| Version | Registered parsers | Docs status |
| --- | --- | --- |
| vNext (trunk), v2.1.5, v2.0.1 | docx, pdf, **pptx**, **xlsx** | fixed here |
| v1.11.6 and earlier | docx, pdf only (no `xlsx.rs`/`pptx.rs` in the tree) | `Roadmap` is correct — left untouched |

The `xlsx`/`pptx` parsers were added by spiceai/spiceai#10473, first released in `v2.0.0`.

Files changed: 3 (vNext + `version-2.1.x` + `version-2.0.x`). The other three files matching `file_format: xlsx` are the SharePoint pages, which were already correct.

## Source ref

`spiceai/spiceai` @ `trunk` (`eb99a5f395`) — `crates/document_parse/src/lib.rs`, `crates/document_parse/src/{xlsx,pptx}.rs`, `crates/data-connector-api/src/listing/connector.rs`, `crates/data-connectors/connector-sharepoint/src/lib.rs`.

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — `grep -rn "xlsx.*Roadmap" website/docs website/versioned_docs/version-2.{0,1}.x` returns nothing; 1.x snapshots deliberately unchanged
- [x] Files updated: 3