### PR TITLE
docs(cayenne): durable federated write-back is supported on PostgreSQL sources

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -760,19 +760,27 @@ COMMIT;
 
 **Durable federated write-back:** A Cayenne dataset configured with [`write_mode: write_back`](../../reference/spicepod/datasets#accelerationwrite_mode), `on_conflict`, and `refresh_mode: changes` (CDC) stages its committed writes to the accelerator and then reconciles them asynchronously back to the federated source by a per-table write-back worker. `write_mode: write_back` requires `replication.enabled: true` as an explicit opt-in to asynchronous source durability.
 
-:::warning Durable write-back is not currently available
-Reconciling a row to the source is delivered as a separate `DELETE` followed by an `INSERT`. Because the accelerator is CDC-fed from that same source, the standalone `DELETE` echoes back over the changes stream and removes the committed row from the accelerator; if the follow-up `INSERT` then fails, the write is silently gone from both sides. Closing that window needs a source that can apply a delivered row in **one atomic step** — a single transaction covering both legs, or a native conditional upsert.
+:::warning PostgreSQL is the only supported source
+Reconciling a row to the source has to happen in **one atomic step**. Delivered as a separate `DELETE` followed by an `INSERT`, the standalone `DELETE` echoes back over the changes stream — the accelerator is CDC-fed from that same source — and removes the committed row from the accelerator; if the follow-up `INSERT` then fails, the write is silently gone from both sides.
 
-No connector advertises that capability yet, so rather than accept a configuration that can lose a committed write, Spice now **rejects the dataset at registration**:
+The [PostgreSQL connector](../../data-connectors/postgres/index.md) delivers each row as a single `INSERT ... ON CONFLICT (<primary key>) DO UPDATE`, so it is the only source durable write-back can be configured against today. Any other source is **rejected at registration** rather than accepted as a configuration that can lose a committed write:
 
 > Failed to register dataset `<name>` (`<connector>`): durable write-back needs a source that can apply a delivered row in one atomic step, and the `<connector>` connector cannot yet.
 
-Remove `on_conflict` to keep writes on the accelerator, or choose a different [`acceleration.write_mode`](../../reference/spicepod/datasets#accelerationwrite_mode). Per-connector atomic delivery is planned; until it lands, this combination cannot be loaded.
+Remove `on_conflict` to keep writes on the accelerator, or choose a different [`acceleration.write_mode`](../../reference/spicepod/datasets#accelerationwrite_mode). Atomic delivery for other connectors is planned.
 :::
+
+**Durable write-back requirements:**
+
+- The federated source must be **PostgreSQL** (see the warning above).
+- The dataset must declare a **single-column [`acceleration.primary_key`](../../reference/spicepod/datasets#accelerationprimary_key)**. Delivery keys each committed row on that column, and a composite key cannot be expressed as the key filter it delivers with, so a multi-column key is rejected at registration with an error naming the columns rather than registering and then never delivering.
+- The accelerator must be the **sole writer** of the rows it delivers. The upsert is an unconditional `ON CONFLICT ... DO UPDATE` with no compare-and-set against the source, so a second writer mutating the same source row directly can be overwritten by a later delivery.
+
+Delivery is asynchronous and does not block accelerator commits: a delivery failure leaves the pending set to grow and retries on the next pass, and only a delivery that has been accepted by the source clears its marker.
 
 **Requirements and v1 limitations:**
 
-- Write targets must be **accelerator-only, non-partitioned Cayenne datasets**. Other dataset modes route writes to the federated source — where the gate cannot govern them — and are rejected. Durable write-back datasets are not currently loadable (see the warning above).
+- Write targets must be **accelerator-only, non-partitioned Cayenne datasets**. Other dataset modes route writes to the federated source — where the gate cannot govern them — and are rejected.
 - Only **`INSERT` and `UPDATE`** writes are supported inside a transaction. `DELETE` and `MERGE` are rejected.
 - At most **one write per table** per transaction. Multiple tables may be written in the same transaction and are committed atomically together.
 - Reading a Cayenne table that is not a registered participant (for example, a partitioned table) fails the transaction closed.


### PR DESCRIPTION
## Summary

The Cayenne accelerator page carried a blanket `:::warning Durable write-back is not currently available`, on the premise that no connector could apply a delivered row in one atomic step. That is stale on vNext: the PostgreSQL connector now advertises `supports_durable_write_back_delivery()` (`crates/data-connectors/connector-postgres/src/lib.rs`) and delivers each committed row as a single `INSERT ... ON CONFLICT (pk) DO UPDATE`, so `write_mode: write_back` + `on_conflict` + `refresh_mode: changes` over a PostgreSQL source is loadable. Every other source is still refused at registration by the same gate (`crates/runtime/src/init/dataset.rs`).

Changes:

- Narrows the warning to "PostgreSQL is the only supported source", keeping the data-loss rationale and the registration error other connectors still produce.
- Documents the **single-column `acceleration.primary_key`** requirement — the delivery worker keys each row on one primary-key column, and a composite key is rejected at registration rather than registered and silently never delivered.
- Documents that the accelerator must be the **sole writer** of the rows it delivers: the upsert is an unconditional `ON CONFLICT ... DO UPDATE` with no compare-and-set, so a second writer mutating the same source row directly can be overwritten (`crates/runtime-table/src/accelerated/write_back_worker.rs`, "Known limitation — mixed writers").
- Drops the now-wrong "Durable write-back datasets are not currently loadable" clause from the transaction limitations list.

Scope: vNext only. `#13323` is not in a release tag, and the registration gate itself is absent from `version-2.1.x` — `grep -rl "durable write-back" website/` returns this one file.

## Source PRs

- spiceai/spiceai#13323 — feat(postgres): native upsert delivery for durable write-back

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked: addition + vNext-only gate, `website/docs/` only (cross-page grep returns 1 file)
- [x] Files updated: 1
