### PR TITLE
docs(iceberg): what an equality delete can match on, and when DELETE is refused

### DIFF
--- a/website/docs/components/catalogs/iceberg.md
+++ b/website/docs/components/catalogs/iceberg.md
@@ -282,7 +282,7 @@ INSERT INTO ice.sales.transactions
 SELECT * FROM staging_transactions;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported on Iceberg v2+ tables, written as equality delete files — which constrains what a `WHERE` condition may read, see [Deleting rows](../data-connectors/iceberg#deleting-rows). `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
 

--- a/website/docs/components/data-connectors/iceberg.md
+++ b/website/docs/components/data-connectors/iceberg.md
@@ -265,9 +265,32 @@ INSERT INTO my_table
 SELECT * FROM source_table;
 ```
 
-Inserting into partitioned Iceberg tables is supported. `DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only). `UPDATE` operations are not currently supported.
+Inserting into partitioned Iceberg tables is supported. `UPDATE` operations are not currently supported.
 
 Write operations require `s3:PutObject` permission on the target S3 bucket in addition to the read permissions listed above. For more details, see [Data Ingestion](../../features/data-ingestion).
+
+### Deleting rows
+
+`DELETE FROM` is supported on **Iceberg v2+ tables only** — a v1 table is refused, because a v1 snapshot has no delete files to write into.
+
+A delete is written as an Iceberg **equality delete file**: "remove rows whose key columns equal these values". The columns that key can carry are every top-level column of the table **except**:
+
+- **Floating-point columns** (`float`, `double`) — equality is not well defined for them (`NaN` is not equal to itself, and `-0.0` equals `0.0`).
+- **Nested columns** (`struct`, `list`, `map`).
+- **Any column without a Parquet field ID** — the reader resolves delete columns by ID, never by name.
+
+Because the key covers only a subset of the row, a `WHERE` condition that reads a column outside it cannot be expressed exactly: two rows that differ only in an excluded column are indistinguishable to the delete file, so honoring the condition would delete the row beside the one selected. Spice **refuses** those statements rather than deleting more than the condition asked for:
+
+| Statement | Result |
+| --- | --- |
+| `DELETE FROM t WHERE <keyable columns only>` | Deletes exactly the matching rows. |
+| `DELETE FROM t` (no condition) | Deletes every row. |
+| `DELETE FROM t WHERE <float or nested column>` | Refused, naming the offending column and the columns the delete *can* match on. |
+| `DELETE FROM t WHERE id IN (SELECT ...)` | Refused — a subquery cannot be checked against the columns the delete matches on. Run the subquery first and delete by the values it returns. |
+| `DELETE FROM t WHERE <volatile function>` | Refused — a non-deterministic condition such as `random()` is not a function of the row, so no key reproduces it. `now()` and other stable functions are fine. |
+| `DELETE FROM t WHERE ...` on a table with **no** keyable column | Refused — an equality delete with no key columns imposes no condition and would empty the table. |
+
+Row-level deletes that address rows by position, which can reproduce any predicate exactly, are a planned follow-up.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The Iceberg connector page said only that "`DELETE FROM` is supported via equality delete files (Iceberg v2+ tables only)". Since spiceai/spiceai#13322 and #13224, the connector refuses several classes of `DELETE` outright rather than approximating them, and the refusal messages link to this page — so what the page documents is what an operator reads after being refused.

Adds a **Deleting rows** section under Write Support covering:

- Which columns an equality delete can key on: every top-level column except floating-point (`NaN != NaN`, `-0.0 == 0.0`), nested types, and any column without a Parquet field ID (`equality_delete_columns`, `crates/data_components/src/iceberg/delete.rs`).
- Why a `WHERE` reading a column outside that key is refused: the delete file cannot tell a matched row from an unmatched one beside it, so honoring the condition would delete both.
- The four refusal cases, each verified against its arm in `delete_from_impl`: an unkeyable predicate column, a subquery, a volatile condition (`random()`; stable functions such as `now()` are fine), and a table with no keyable column at all (an equality delete with no key columns would empty the table).
- What still works unchanged: a condition over keyable columns, and `DELETE FROM t` with no condition.

Also updates the Iceberg **catalog** page, which carried the identical one-line claim, to point at the new section instead of restating it (`grep -rn "DELETE FROM" website/docs` — 2 files).

Scope: vNext only. Neither source PR is in a release tag, and the versioned snapshots correctly describe their own release's behavior.

## Source PRs

- spiceai/spiceai#13322 — fix(iceberg): refuse a delete an equality key cannot express
- spiceai/spiceai#13224 — fix(correctness): validate Decimal128 precision and overflow on write paths (the no-eligible-column refusal)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked: addition, vNext-only behavior → `website/docs/` only
- [x] Files updated: 2
