### PR TITLE
docs(s3): document the refresh_skip parameter for single-file datasets

### DIFF
--- a/website/docs/components/data-connectors/s3/deployment.md
+++ b/website/docs/components/data-connectors/s3/deployment.md
@@ -72,6 +72,30 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 - **Schema inference cost**: On first registration, Spice samples files to infer schema. Provide an explicit `schema` in the dataset definition for large datasets to avoid repeated list/head operations.
 - **DataFusion batch size**: Object-store reads yield 8192-row record batches by default. Increase via runtime tuning for CPU-bound scans over compressed formats.
 
+### Refresh Skipping for Single-File Datasets
+
+An **accelerated** dataset whose `from:` points at a single S3 object (not a prefix) is wrapped in a metadata-caching layer. Before each refresh, Spice issues a `HEAD` on the object and compares the returned version ID (authoritative when S3 Versioning is on) or `ETag` against the cached value; when they match, the refresh is skipped and no object data is fetched. Query execution always reads through to the underlying table and is unaffected.
+
+This is on by default. Set `refresh_skip: disabled` in the dataset's `params:` to force every refresh to re-fetch the object:
+
+```yaml
+datasets:
+  - from: s3://my-bucket/exports/daily.parquet
+    name: daily
+    params:
+      file_format: parquet
+      refresh_skip: disabled
+    acceleration:
+      enabled: true
+      refresh_check_interval: 10m
+```
+
+`refresh_skip` belongs in `params:`, not `acceleration.params:`. It applies only to the S3 connector, only to single-object datasets, and only when acceleration is enabled — a directory dataset or an unaccelerated dataset ignores it. An unrecognized value logs a warning and falls back to `enabled`.
+
+The skip check runs for `refresh_mode: full` and `refresh_mode: append` only. A manual refresh that supplies its own `refresh_sql` always re-materializes and clears the cached version, so the next scheduled refresh compares against fresh state rather than the narrowed result.
+
+Skipped refreshes are counted by the `dataset_acceleration_refresh_data_fetches_skipped` metric (labels `dataset`, `mode`) — a steadily climbing counter on an unchanged object is the expected signal, not a stalled refresh.
+
 ## Metrics
 
 The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.

--- a/website/docs/components/data-connectors/s3/index.md
+++ b/website/docs/components/data-connectors/s3/index.md
@@ -96,6 +96,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `s3_versioning`             | Enables support for S3 buckets with [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html). Options: `enabled` and `disabled`. Defaults to `enabled`.                                                                                                                          |
 | `allow_http`                | Enables insecure HTTP connections to `s3_endpoint`. Defaults to `false`.                                                                                                                                                                                                                                       |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
+| `refresh_skip`              | Controls skipping refreshes for accelerated **single-file** S3 datasets when the cached `ETag` / version ID still matches the object in S3. Options: `enabled` and `disabled`. Defaults to `enabled`. Has no effect on directory (prefix) datasets or on datasets without acceleration.                          |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
 

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/s3.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/s3.md
@@ -70,6 +70,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `s3_versioning`             | Enables support for S3 buckets with [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html). Options: `enabled` and `disabled`. Defaults to `enabled`. |
 | `allow_http`                | Enables insecure HTTP connections to `s3_endpoint`. Defaults to `false`.                                                                                                                                                                                                                                       |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
+| `refresh_skip`              | Controls skipping refreshes for accelerated **single-file** S3 datasets when the cached `ETag` / version ID still matches the object in S3. Options: `enabled` and `disabled`. Defaults to `enabled`. Has no effect on directory (prefix) datasets or on datasets without acceleration.                          |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/s3.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/s3.md
@@ -94,6 +94,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `s3_versioning`             | Enables support for S3 buckets with [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html). Options: `enabled` and `disabled`. Defaults to `enabled`.                                                                                                                          |
 | `allow_http`                | Enables insecure HTTP connections to `s3_endpoint`. Defaults to `false`.                                                                                                                                                                                                                                       |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
+| `refresh_skip`              | Controls skipping refreshes for accelerated **single-file** S3 datasets when the cached `ETag` / version ID still matches the object in S3. Options: `enabled` and `disabled`. Defaults to `enabled`. Has no effect on directory (prefix) datasets or on datasets without acceleration.                          |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/s3/deployment.md
@@ -72,6 +72,30 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 - **Schema inference cost**: On first registration, Spice samples files to infer schema. Provide an explicit `schema` in the dataset definition for large datasets to avoid repeated list/head operations.
 - **DataFusion batch size**: Object-store reads yield 8192-row record batches by default. Increase via runtime tuning for CPU-bound scans over compressed formats.
 
+### Refresh Skipping for Single-File Datasets
+
+An **accelerated** dataset whose `from:` points at a single S3 object (not a prefix) is wrapped in a metadata-caching layer. Before each refresh, Spice issues a `HEAD` on the object and compares the returned version ID (authoritative when S3 Versioning is on) or `ETag` against the cached value; when they match, the refresh is skipped and no object data is fetched. Query execution always reads through to the underlying table and is unaffected.
+
+This is on by default. Set `refresh_skip: disabled` in the dataset's `params:` to force every refresh to re-fetch the object:
+
+```yaml
+datasets:
+  - from: s3://my-bucket/exports/daily.parquet
+    name: daily
+    params:
+      file_format: parquet
+      refresh_skip: disabled
+    acceleration:
+      enabled: true
+      refresh_check_interval: 10m
+```
+
+`refresh_skip` belongs in `params:`, not `acceleration.params:`. It applies only to the S3 connector, only to single-object datasets, and only when acceleration is enabled — a directory dataset or an unaccelerated dataset ignores it. An unrecognized value logs a warning and falls back to `enabled`.
+
+The skip check runs for `refresh_mode: full` and `refresh_mode: append` only. A manual refresh that supplies its own `refresh_sql` always re-materializes and clears the cached version, so the next scheduled refresh compares against fresh state rather than the narrowed result.
+
+Skipped refreshes are counted by the `dataset_acceleration_refresh_data_fetches_skipped` metric (labels `dataset`, `mode`) — a steadily climbing counter on an unchanged object is the expected signal, not a stalled refresh.
+
 ## Metrics
 
 The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/s3/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/s3/index.md
@@ -96,6 +96,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `s3_versioning`             | Enables support for S3 buckets with [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html). Options: `enabled` and `disabled`. Defaults to `enabled`.                                                                                                                          |
 | `allow_http`                | Enables insecure HTTP connections to `s3_endpoint`. Defaults to `false`.                                                                                                                                                                                                                                       |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
+| `refresh_skip`              | Controls skipping refreshes for accelerated **single-file** S3 datasets when the cached `ETag` / version ID still matches the object in S3. Options: `enabled` and `disabled`. Defaults to `enabled`. Has no effect on directory (prefix) datasets or on datasets without acceleration.                          |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/s3/deployment.md
@@ -72,6 +72,30 @@ Authentication failures (`401`, `403`) and missing buckets (`404`) surface immed
 - **Schema inference cost**: On first registration, Spice samples files to infer schema. Provide an explicit `schema` in the dataset definition for large datasets to avoid repeated list/head operations.
 - **DataFusion batch size**: Object-store reads yield 8192-row record batches by default. Increase via runtime tuning for CPU-bound scans over compressed formats.
 
+### Refresh Skipping for Single-File Datasets
+
+An **accelerated** dataset whose `from:` points at a single S3 object (not a prefix) is wrapped in a metadata-caching layer. Before each refresh, Spice issues a `HEAD` on the object and compares the returned version ID (authoritative when S3 Versioning is on) or `ETag` against the cached value; when they match, the refresh is skipped and no object data is fetched. Query execution always reads through to the underlying table and is unaffected.
+
+This is on by default. Set `refresh_skip: disabled` in the dataset's `params:` to force every refresh to re-fetch the object:
+
+```yaml
+datasets:
+  - from: s3://my-bucket/exports/daily.parquet
+    name: daily
+    params:
+      file_format: parquet
+      refresh_skip: disabled
+    acceleration:
+      enabled: true
+      refresh_check_interval: 10m
+```
+
+`refresh_skip` belongs in `params:`, not `acceleration.params:`. It applies only to the S3 connector, only to single-object datasets, and only when acceleration is enabled — a directory dataset or an unaccelerated dataset ignores it. An unrecognized value logs a warning and falls back to `enabled`.
+
+The skip check runs for `refresh_mode: full` and `refresh_mode: append` only. A manual refresh that supplies its own `refresh_sql` always re-materializes and clears the cached version, so the next scheduled refresh compares against fresh state rather than the narrowed result.
+
+Skipped refreshes are counted by the `dataset_acceleration_refresh_data_fetches_skipped` metric (labels `dataset`, `mode`) — a steadily climbing counter on an unchanged object is the expected signal, not a stalled refresh.
+
 ## Metrics
 
 The `runtime-object-store` layer that performs S3 I/O is not instrumented, so Spice does not emit S3 transport metrics (request counts, retries, bytes read). See [Component Metrics](../../../features/observability/component_metrics) for the metrics that are available.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/s3/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/s3/index.md
@@ -96,6 +96,7 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `s3_versioning`             | Enables support for S3 buckets with [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html). Options: `enabled` and `disabled`. Defaults to `enabled`.                                                                                                                          |
 | `allow_http`                | Enables insecure HTTP connections to `s3_endpoint`. Defaults to `false`.                                                                                                                                                                                                                                       |
 | `schema_source_path`        | Specifies the URL used to infer the dataset schema. Default to the most recently modified file                                                                                                                                                                                                                 |
+| `refresh_skip`              | Controls skipping refreshes for accelerated **single-file** S3 datasets when the cached `ETag` / version ID still matches the object in S3. Options: `enabled` and `disabled`. Defaults to `enabled`. Has no effect on directory (prefix) datasets or on datasets without acceleration.                          |
 
 For additional CSV, JSON, and Parquet specific parameters, see [File Formats](../../reference/file_format).
 


### PR DESCRIPTION
## Summary

`refresh_skip` is a real, wired S3 connector parameter that changes refresh behavior by default, and it was documented **nowhere** — `grep -rn refresh_skip website/` returned zero hits before this PR.

**What the code does**

Declared in the shared listing-table parameter set ([`crates/data-connector-api/src/listing/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connector-api/src/listing/mod.rs)):

```rust
ParameterSpec::runtime("refresh_skip")
    .description("Control skipping refreshes for single-file S3 datasets when cached ETag/Version metadata matches. Set to 'enabled' (default) or 'disabled'.")
    .default("enabled")
    .one_of(&["enabled", "disabled"]),
```

and consumed in `create_listing_table` ([`listing/connector.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connector-api/src/listing/connector.rs)):

```rust
if self.supports_single_file_version_cache()      // true only for the S3 connector
    && refresh_skip_enabled(dataset)
    && !table_path.is_collection()                 // single object, not a prefix
    && dataset.acceleration.is_some()
    && let Some(cached_table) = S3SingleFileCached::try_new(...)
```

`S3SingleFileCached::should_skip_refresh` `HEAD`s the object and compares the version ID (authoritative when S3 Versioning is on) against the cached one, falling back to `ETag`. `RefreshTask` calls it for `RefreshMode::Full` and `RefreshMode::Append` only, and a manual refresh carrying an `override_sql_raw` bypasses the skip and calls `reset_skip_state()` instead. A skip increments `dataset_acceleration_refresh_data_fetches_skipped` (labels `dataset`, `mode`).

That metric was **already** in the observability reference while the parameter that produces it was not — so a user could watch their accelerated single-file S3 dataset skip refreshes with no documented way to turn it off.

Config scope matters here: `refresh_skip_enabled` reads `dataset.params.get("refresh_skip")` directly, so the key belongs in `params:`. Putting it under `acceleration.params:` is silently ignored — the PR says so explicitly.

## Changes

- **`s3/index.md` params table** — new `refresh_skip` row (options, default, and the conditions under which it has no effect).
- **`s3/deployment.md`** — new "Refresh Skipping for Single-File Datasets" subsection under Capacity & Sizing: the mechanism, a YAML example opting out, the `params:` vs `acceleration.params:` scope note, the `refresh_mode` gating, the `refresh_sql`-override reset, and the skip counter.

An unrecognized value is not an error — it logs `Invalid refresh_skip value; expected 'enabled' or 'disabled'. Defaulting to 'enabled'.` and proceeds, which the docs now state rather than implying strict validation.

## Version scoping

`git show <tag>:...` confirms the `ParameterSpec` and the identical four-way gate in **v1.10.4, v1.11.6, v2.0.1, v2.1.5 and trunk** (trunk only refactors the S3 check from a `downcast_ref::<S3>()` into the `supports_single_file_version_cache()` trait method — still S3-only). It is absent in v1.9.3 and earlier, which are left untouched.

`s3/deployment.md` only exists for 2.0.x and later; the 1.10.x/1.11.x snapshots keep the connector on a single `s3.md`, so they get the params row only.

Files changed: 8. `grep -rln refresh_skip website/` now returns exactly those 8.

## Source ref

`spiceai/spiceai` @ `trunk` (`eb99a5f395`) — `crates/data-connector-api/src/listing/{mod.rs,connector.rs}`, `crates/data_components/src/s3_single_file_cached.rs`, `crates/data_components/src/refresh_skip.rs`, `crates/runtime-table/src/accelerated/refresh_task.rs`, `crates/runtime-metrics/src/acceleration.rs`.

## Test plan

- [x] `cd website && npm run build` passes (exit 0)
- [x] Versioned-docs propagation checked — every snapshot whose runtime has the parameter is updated; v1.9.x and earlier deliberately untouched
- [x] Files updated: 8