### PR TITLE
docs(unity-catalog): the catalog refresh interval is fixed, and never re-lists schemas

### DIFF
--- a/website/docs/components/catalogs/unity-catalog/deployment.md
+++ b/website/docs/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Catalog refresh re-enumerates schemas and tables at the configured interval. For very large catalogs, refresh less frequently (every few hours) unless schemas change rapidly.
+- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,6 +113,8 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
+- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.
 - **Graceful degradation on permission-endpoint failures**: If UC effective-permissions is unreachable, Spice proceeds; authorization errors surface at query time rather than discovery time.
@@ -122,7 +124,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 | Symptom                                                                 | Likely cause                                                       | Resolution                                                                                                                  |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized` on catalog list                                      | Missing, expired, or wrong-workspace token.                        | Regenerate token in UC / Databricks; update secret store.                                                                   |
-| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE or permissions were denied.   | Confirm table type is supported and that the principal has `SELECT` (or equivalent).                                        |
+| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE, permissions were denied, or its schema was created after Spice started. | Confirm the table type is supported and that the principal has `SELECT` (or equivalent); restart Spice to pick up a schema created after startup. |
 | `InsufficientPermissions` on direct table reference                     | Role lacks read privilege on the table.                            | Grant `SELECT` on the table in UC.                                                                                          |
 | Slow catalog discovery on thousands of tables                           | Bounded concurrency + permission checks per table.                 | Expected behavior; schedule discovery during low-traffic windows and cache via accelerated datasets.                         |
 | Tables from a Lakehouse Federation source missing                       | FOREIGN precheck passed but Databricks denied at query time.       | Verify the Databricks workspace has federation privileges granted to the principal.                                          |

--- a/website/docs/components/catalogs/unity-catalog/deployment.md
+++ b/website/docs/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
+- **Refresh**: The catalog waits **60 seconds**, then re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. The wait begins after the previous pass finishes, so passes start 60 seconds apart *plus* the time a pass takes — for a catalog of thousands of tables, that pass time dominates the interval. The wait is not configurable, so the cadence cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,7 +113,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
-- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **Refresh cadence is fixed**: The 60-second wait between refresh passes is not user-configurable, and because it is a wait *between* passes, the effective interval is 60 seconds plus the duration of a pass.
 - **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.

--- a/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Catalog refresh re-enumerates schemas and tables at the configured interval. For very large catalogs, refresh less frequently (every few hours) unless schemas change rapidly.
+- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,6 +113,8 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
+- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.
 - **Graceful degradation on permission-endpoint failures**: If UC effective-permissions is unreachable, Spice proceeds; authorization errors surface at query time rather than discovery time.
@@ -122,7 +124,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 | Symptom                                                                 | Likely cause                                                       | Resolution                                                                                                                  |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized` on catalog list                                      | Missing, expired, or wrong-workspace token.                        | Regenerate token in UC / Databricks; update secret store.                                                                   |
-| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE or permissions were denied.   | Confirm table type is supported and that the principal has `SELECT` (or equivalent).                                        |
+| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE, permissions were denied, or its schema was created after Spice started. | Confirm the table type is supported and that the principal has `SELECT` (or equivalent); restart Spice to pick up a schema created after startup. |
 | `InsufficientPermissions` on direct table reference                     | Role lacks read privilege on the table.                            | Grant `SELECT` on the table in UC.                                                                                          |
 | Slow catalog discovery on thousands of tables                           | Bounded concurrency + permission checks per table.                 | Expected behavior; schedule discovery during low-traffic windows and cache via accelerated datasets.                         |
 | Tables from a Lakehouse Federation source missing                       | FOREIGN precheck passed but Databricks denied at query time.       | Verify the Databricks workspace has federation privileges granted to the principal.                                          |

--- a/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
+- **Refresh**: The catalog waits **60 seconds**, then re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. The wait begins after the previous pass finishes, so passes start 60 seconds apart *plus* the time a pass takes — for a catalog of thousands of tables, that pass time dominates the interval. The wait is not configurable, so the cadence cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,7 +113,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
-- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **Refresh cadence is fixed**: The 60-second wait between refresh passes is not user-configurable, and because it is a wait *between* passes, the effective interval is 60 seconds plus the duration of a pass.
 - **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.

--- a/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Catalog refresh re-enumerates schemas and tables at the configured interval. For very large catalogs, refresh less frequently (every few hours) unless schemas change rapidly.
+- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,6 +113,8 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
+- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.
 - **Graceful degradation on permission-endpoint failures**: If UC effective-permissions is unreachable, Spice proceeds; authorization errors surface at query time rather than discovery time.
@@ -122,7 +124,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 | Symptom                                                                 | Likely cause                                                       | Resolution                                                                                                                  |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
 | `401 Unauthorized` on catalog list                                      | Missing, expired, or wrong-workspace token.                        | Regenerate token in UC / Databricks; update secret store.                                                                   |
-| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE or permissions were denied.   | Confirm table type is supported and that the principal has `SELECT` (or equivalent).                                        |
+| Table visible in UC but missing from the Spice catalog                  | Table type is VIEW / STREAMING_TABLE, permissions were denied, or its schema was created after Spice started. | Confirm the table type is supported and that the principal has `SELECT` (or equivalent); restart Spice to pick up a schema created after startup. |
 | `InsufficientPermissions` on direct table reference                     | Role lacks read privilege on the table.                            | Grant `SELECT` on the table in UC.                                                                                          |
 | Slow catalog discovery on thousands of tables                           | Bounded concurrency + permission checks per table.                 | Expected behavior; schedule discovery during low-traffic windows and cache via accelerated datasets.                         |
 | Tables from a Lakehouse Federation source missing                       | FOREIGN precheck passed but Databricks denied at query time.       | Verify the Databricks workspace has federation privileges granted to the principal.                                          |

--- a/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/unity-catalog/deployment.md
@@ -83,7 +83,7 @@ Before creating a table provider, the connector checks permissions via `GET /api
 ## Capacity & Sizing
 
 - **Initial discovery**: Scales with the number of schemas × tables. Bounded concurrency caps throughput; plan 5–30 minutes for catalogs with thousands of tables on a cold start.
-- **Refresh**: Every **60 seconds** the catalog re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. This cadence is not configurable, so it cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
+- **Refresh**: The catalog waits **60 seconds**, then re-lists the tables of each schema it discovered at startup, adding and dropping table providers as the source changes. The wait begins after the previous pass finishes, so passes start 60 seconds apart *plus* the time a pass takes — for a catalog of thousands of tables, that pass time dominates the interval. The wait is not configurable, so the cadence cannot be lengthened for very large catalogs. The schema list itself is built once when the catalog first loads and is never re-listed, so a schema created in Unity Catalog after Spice started is not picked up until Spice restarts.
 - **Permission-check cost**: One API call per table. The buffer of 5 caps concurrency.
 
 ## Metrics
@@ -113,7 +113,7 @@ Unity Catalog operations emit the following [task history](../../../reference/ta
 ## Known Limitations
 
 - **VIEW and STREAMING_TABLE are skipped**: Only queryable table types are exposed.
-- **Refresh cadence is fixed at 60 seconds**: The catalog refresh interval is not user-configurable.
+- **Refresh cadence is fixed**: The 60-second wait between refresh passes is not user-configurable, and because it is a wait *between* passes, the effective interval is 60 seconds plus the duration of a pass.
 - **New schemas need a restart**: Refresh re-lists tables inside the schemas found at startup; a schema added to the catalog afterwards appears only after Spice restarts.
 - **No UC write-back**: The connector is read-only; writes to UC are not supported through Spice.
 - **HTTP retry/concurrency parameters not exposed**: The resilient-HTTP defaults (3 retries, fibonacci backoff, concurrency 5) are not currently user-tunable on the UC connector.


### PR DESCRIPTION
## Summary

Two wrong claims in the Unity Catalog **Capacity & Sizing** section, verified against `spiceai/spiceai` at `trunk` (`325c9fc37b`) and re-checked at `v2.1.5` and `v2.0.1`.

The page said:

> **Refresh**: Catalog refresh re-enumerates schemas and tables at the configured interval. For very large catalogs, refresh less frequently (every few hours) unless schemas change rapidly.

### 1. There is no configured interval

`init/catalog.rs` passes `None` for the refresh interval, and `RefreshingCatalogProvider::start_refresh` resolves `None` to `Duration::from_mins(1)` — a hard-coded **60 seconds** with no user-facing knob:

- [`crates/runtime/src/init/catalog.rs:185`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/init/catalog.rs) — `get_catalog_provider(catalog_connector, …, catalog, None)`
- [`crates/data_components/src/lib.rs:392`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/lib.rs) — `let interval = interval.unwrap_or(std::time::Duration::from_mins(1));`

Advising a reader to "refresh less frequently (every few hours)" pointed at a configuration channel that does not exist — the invented-mechanism failure mode, where the guidance is a silent no-op rather than an error. The same 60s cadence is already documented correctly on [`catalogs/postgres.md`](https://github.com/spiceai/docs/blob/trunk/website/docs/components/catalogs/postgres.md) ("This interval is not currently configurable", added in #2003); that PR did not sweep this page.

### 2. Refresh does not re-enumerate schemas

`UnityCatalogProvider::refresh` iterates the `schemas` map captured at construction and calls `UnityCatalogSchemaProvider::refresh` on each; the only `client.list_schemas(…)` call sits in `UnityCatalogProvider::try_new`. Per-schema refresh re-lists **tables** and diffs added/removed ones — it never re-lists schemas.

- [`crates/data_components/src/unity_catalog/provider.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data_components/src/unity_catalog/provider.rs) — `list_schemas` in `try_new` (line 106); `refresh` at line 151 maps over `self.schemas.values()`; `UnityCatalogSchemaProvider::refresh` (line 307) calls `list_tables` only.

So a schema created in Unity Catalog after startup is never discovered, and a user waiting for the "next refresh" waits forever. That is the reader-visible consequence, so it is also added to Known Limitations and to the "table visible in UC but missing from the Spice catalog" troubleshooting row.

Contrast with the PostgreSQL catalog connector, which genuinely does re-run discovery from scratch each cycle — hence the per-connector wording rather than a shared statement.

## Changes

- Replaced the Refresh bullet with the actual cadence (fixed 60s) and the actual scope (tables within startup-discovered schemas).
- Added two Known Limitations bullets: fixed cadence, and new schemas requiring a restart.
- Extended the troubleshooting row for a table missing from the Spice catalog to include a schema created after startup.

## Other claims on this page audited (no change needed)

- Table-type support table — matches `UCTableType::is_queryable()` (`Managed | External | Foreign | MaterializedView`).
- Read privileges `SELECT` / `ALL_PRIVILEGES` / `ALL PRIVILEGES` / `OWNER` / `OWNERSHIP` — matches `READ_PRIVILEGES`.
- `FOREIGN` skipping the precheck — matches `requires_read_permission_validation()` (`!matches!(self, Self::Foreign)`).
- Concurrency of 5 for schema refresh and permission checks — matches both `buffer_unordered(5)` sites.
- Task-history spans `uc_get_table` / `uc_get_catalog` / `uc_list_schemas` / `uc_list_tables` / `uc_get_effective_permissions` — all present verbatim in `unity_catalog.rs`.
- `query_duration_ms` / `query_returned_rows` — registered in `crates/runtime-metrics/src/telemetry/mod.rs`.

## Propagation

The wrong sentence existed in exactly 3 files (`grep -rn "at the configured interval" website/`) and all 3 are fixed. Behavior is identical at `v2.0.1` and `v2.1.5` (`start_refresh` resolved `None` to `Duration::from_secs(60)` there), so all three snapshots needed the same correction.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (3 hits, 3 files changed)
- [x] Files updated: 3