### PR TITLE
docs(sql/search): rerank() model is optional, and limit does not bound the candidate pool

### DIFF
--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -305,12 +305,19 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | Yes      | Name of a registered reranker or chat model. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
-| `limit`           | Integer           | No       | Maximum number of results to return. |
+| `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |
 | `strategy`        | String            | No       | LLM reranking strategy: `'listwise'` (default) or `'pointwise'`. Only applies when the model resolves to a chat model. |
 | `prompt_template` | String            | No       | Custom prompt template for LLM-as-reranker. Use `{query}` and `{document}` placeholders. Only applies when the model resolves to a chat model. |
+
+#### Candidate Pool
+
+`rerank` scores every row its input produces, so the input decides the reranker cost:
+
+- **Nested search UDTF** — the inner UDTF's own `limit` bounds the candidate pool. `rerank`'s `limit` is not pushed into it, which is what lets the recall-then-rerank pattern pass a large inner `limit` and a small outer one.
+- **Bare table** — there is no inner limit, so a fixed ceiling of **1000 candidate rows** is applied to the scan. A larger table is silently truncated to the first 1000 rows reaching the reranker; use a nested search UDTF, or a subquery with its own filter, when the table is bigger than that.
 
 #### Query Auto-Propagation
 

--- a/website/docs/reference/sql/search.md
+++ b/website/docs/reference/sql/search.md
@@ -305,7 +305,7 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Omit it only when exactly one reranker or chat model is registered, in which case that one is used. With more than one registered, the query fails and `model` chooses between them. With none registered, the query fails whether or not `model` is given — no name can resolve until a reranker or chat model is added to the Spicepod. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
 | `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |

--- a/website/versioned_docs/version-2.0.x/reference/sql/search.md
+++ b/website/versioned_docs/version-2.0.x/reference/sql/search.md
@@ -288,12 +288,19 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | Yes      | Name of a registered reranker or chat model. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
-| `limit`           | Integer           | No       | Maximum number of results to return. |
+| `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |
 | `strategy`        | String            | No       | LLM reranking strategy: `'listwise'` (default) or `'pointwise'`. Only applies when the model resolves to a chat model. |
 | `prompt_template` | String            | No       | Custom prompt template for LLM-as-reranker. Use `{query}` and `{document}` placeholders. Only applies when the model resolves to a chat model. |
+
+#### Candidate Pool
+
+`rerank` scores every row its input produces, so the input decides the reranker cost:
+
+- **Nested search UDTF** — the inner UDTF's own `limit` bounds the candidate pool. `rerank`'s `limit` is not pushed into it, which is what lets the recall-then-rerank pattern pass a large inner `limit` and a small outer one.
+- **Bare table** — there is no inner limit, so a fixed ceiling of **1000 candidate rows** is applied to the scan. A larger table is silently truncated to the first 1000 rows reaching the reranker; use a nested search UDTF, or a subquery with its own filter, when the table is bigger than that.
 
 #### Query Auto-Propagation
 

--- a/website/versioned_docs/version-2.0.x/reference/sql/search.md
+++ b/website/versioned_docs/version-2.0.x/reference/sql/search.md
@@ -288,7 +288,7 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Omit it only when exactly one reranker or chat model is registered, in which case that one is used. With more than one registered, the query fails and `model` chooses between them. With none registered, the query fails whether or not `model` is given — no name can resolve until a reranker or chat model is added to the Spicepod. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
 | `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |

--- a/website/versioned_docs/version-2.1.x/reference/sql/search.md
+++ b/website/versioned_docs/version-2.1.x/reference/sql/search.md
@@ -288,12 +288,19 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | Yes      | Name of a registered reranker or chat model. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
-| `limit`           | Integer           | No       | Maximum number of results to return. |
+| `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |
 | `strategy`        | String            | No       | LLM reranking strategy: `'listwise'` (default) or `'pointwise'`. Only applies when the model resolves to a chat model. |
 | `prompt_template` | String            | No       | Custom prompt template for LLM-as-reranker. Use `{query}` and `{document}` placeholders. Only applies when the model resolves to a chat model. |
+
+#### Candidate Pool
+
+`rerank` scores every row its input produces, so the input decides the reranker cost:
+
+- **Nested search UDTF** — the inner UDTF's own `limit` bounds the candidate pool. `rerank`'s `limit` is not pushed into it, which is what lets the recall-then-rerank pattern pass a large inner `limit` and a small outer one.
+- **Bare table** — there is no inner limit, so a fixed ceiling of **1000 candidate rows** is applied to the scan. A larger table is silently truncated to the first 1000 rows reaching the reranker; use a nested search UDTF, or a subquery with its own filter, when the table is bigger than that.
 
 #### Query Auto-Propagation
 

--- a/website/versioned_docs/version-2.1.x/reference/sql/search.md
+++ b/website/versioned_docs/version-2.1.x/reference/sql/search.md
@@ -288,7 +288,7 @@ FROM rerank(
 | Parameter         | Type              | Required | Description |
 | ----------------- | ----------------- | -------- | ----------- |
 | `input`           | Table or UDTF     | Yes      | Input rows to rerank. Can be a search UDTF call (`vector_search`, `text_search`, `rrf`) or a table name. |
-| `model`           | String            | No       | Name of a registered reranker or chat model. Optional only when exactly one reranker or chat model is registered, in which case that one is used; with none configured, or more than one, the query fails and `model` must be given. |
+| `model`           | String            | No       | Name of a registered reranker or chat model. Omit it only when exactly one reranker or chat model is registered, in which case that one is used. With more than one registered, the query fails and `model` chooses between them. With none registered, the query fails whether or not `model` is given — no name can resolve until a reranker or chat model is added to the Spicepod. |
 | `document`        | String            | Yes      | Column containing the text to send to the reranker for scoring. |
 | `query`           | String            | No       | Query string for relevance scoring. Auto-extracted from nested search UDTFs when omitted; required for bare-table inputs. |
 | `limit`           | Integer           | No       | Maximum number of rows returned. It caps the **output** only and never shrinks the candidate pool, so every candidate is still scored by the reranker — narrow the inner search's own `limit` to reduce reranker calls. |


### PR DESCRIPTION
## Summary

Two corrections to the `rerank()` argument table in the SQL search reference, verified against `spiceai/spiceai` at `trunk` (`325c9fc37b`) and re-checked at `v2.1.5` and `v2.0.1` — the behavior is identical in all three.

### 1. `model` was documented as required

The table said **Required: Yes**. The parser does not require it: `document` is extracted with `.ok_or_else(…)` and errors when absent, while `model` is a plain `Option`:

```rust
let model = extract_string_named(&named, "model");
let document = extract_string_named(&named, "document").ok_or_else(|| { … })?;
```

`resolve_reranker()` then auto-picks when `model` is omitted, and only errors at the two boundaries:

- 0 models configured → `"no rerankers or chat models configured…"`
- exactly 1 → that one is used
- more than 1 → `"multiple models configured. Specify which with \`model => '<name>'\`."`

The struct field's own doc comment states it: `/// Reranker model name. Optional when exactly one model is registered.`

Source: [`crates/runtime-search/src/rerank.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-search/src/rerank.rs) — `RerankTableFuncArgs::model` (line 172), parse (line 362), `resolve_reranker` (line 590).

Documented as Optional with the condition spelled out, rather than a bare "No" — omitting it is only safe in the single-model case, so the condition is the load-bearing half.

### 2. `limit` read as if it bounded reranker work

The row said only "Maximum number of results to return." A reader budgeting LLM-reranker calls would reasonably take that as the number of documents scored. It is not: `limit` is an output cap that is deliberately **not** pushed into the input scan.

```rust
/// The rerank's own `limit =>` governs output size only — it intentionally does
/// not shrink the candidate pool, so the recall-then-rerank workflow can pass
/// a larger inner `limit =>` and a smaller outer `limit =>`.
const DEFAULT_MAX_CANDIDATES: usize = 1000;
```

The same constant is the undocumented ceiling on the bare-table path — `builder.limit(0, Some(DEFAULT_MAX_CANDIDATES))` on the scan, plus a defensive `truncate_batches` after collection. `FROM rerank(big_table, …)` therefore scores the first 1000 rows and silently drops the rest, which is worth stating since the truncation is not surfaced as an error. Nested search UDTFs are exempt: their own `limit =>` governs the pool.

Added as a short **Candidate Pool** subsection next to the argument table, and tightened the `limit` row to say it caps output only.

## Changes

- `model` row: Required `Yes` → `No`, with the single-model condition.
- `limit` row: states that it caps output, not the candidate pool.
- New **Candidate Pool** subsection covering the nested-UDTF vs bare-table difference and the 1000-row ceiling.

## Rest of the table audited (no change needed)

- `input` required; `document` required (`.ok_or_else`); `query` optional with auto-extraction and required for bare tables — all match.
- `strategy` — `'listwise'` default confirmed by `#[default] Listwise` on `LlmStrategy`; `'pointwise'` the only other value (`parse` also accepts the `list`/`point` aliases).
- `prompt_template` — `{query}` / `{document}` placeholders match `DEFAULT_POINTWISE_PROMPT` and `DEFAULT_LISTWISE_PROMPT` in `crates/llms/src/rerank/mod.rs`.
- The `rrf` table on the same page was re-verified while here: `k` 60.0, `recency_decay` exponential, `decay_constant` 0.01, `decay_scale_secs` 86400, `decay_window_secs` 86400 all match `crates/runtime-search/src/rrf.rs`.

## Propagation

`grep -rn "Name of a registered reranker or chat model" website/` → 3 hits (vNext, 2.1.x, 2.0.x); all 3 fixed. `resolve_reranker`'s auto-pick and `DEFAULT_MAX_CANDIDATES = 1000` are present at `v2.0.1` (`crates/runtime/src/search/rerank.rs`) and `v2.1.5`, so all three snapshots were equally wrong.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (3 hits, 3 files changed)
- [x] Files updated: 3