### PR TITLE
docs(search/rerank): document the local huggingface and file reranker providers

### DIFF
--- a/website/docs/features/search/rerank.md
+++ b/website/docs/features/search/rerank.md
@@ -30,6 +30,8 @@ Define dedicated reranker models in the `rerankers:` section of the spicepod. Su
 | `voyage:`       | Voyage Rerank API (e.g., `voyage:rerank-2`) |
 | `jina:`         | Jina Rerank API (e.g., `jina:jina-reranker-v2-base-multilingual`) |
 | `http://` / `https://` | Any HTTP endpoint implementing the standard rerank API schema |
+| `huggingface:` (or `hf:`) | A cross-encoder reranker downloaded from Hugging Face and run locally, in-process (e.g. `huggingface:huggingface.co/BAAI/bge-reranker-base`) |
+| `file:`         | A cross-encoder reranker loaded locally from a directory of model artifacts (e.g. `file:/models/bge-reranker-base`) |
 
 ```yaml
 rerankers:
@@ -53,6 +55,32 @@ rerankers:
     params:
       api_key: ${secrets:INTERNAL_RR_KEY}  # optional
 ```
+
+### Local Rerankers
+
+The `huggingface:` and `file:` prefixes run a cross-encoder reranker in-process instead of calling a hosted API, so no request leaves the runtime. Both are included in the default `spiced` build.
+
+```yaml
+rerankers:
+  # Downloaded from the Hugging Face Hub. Pin a revision with a trailing `:<rev>`.
+  - from: huggingface:huggingface.co/BAAI/bge-reranker-base
+    name: local_rr
+    params:
+      hf_token: ${secrets:HF_TOKEN} # only needed for a private repo
+
+  # Loaded from a directory holding config.json, tokenizer.json, and the weights.
+  - from: file:/models/gte-reranker-modernbert-base
+    name: dir_rr
+```
+
+Both accept the same two tuning parameters:
+
+| Parameter         | Description                                                                                                                                                                | Default |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `max_seq_length`  | Maximum sequence length for the `(query, document)` pair. When unset, the model's own configured maximum applies.                                                            | -       |
+| `truncate`        | How to handle a pair longer than the maximum sequence length: `none` rejects the request with an input-validation error, `end` discards the end of the pair, `start` discards the start. Matched case-insensitively. | `none`  |
+
+`huggingface:` rerankers additionally accept `hf_token` (also spelled `api_key`) for private repositories.
 
 ### LLM-as-Reranker
 

--- a/website/docs/features/search/rerank.md
+++ b/website/docs/features/search/rerank.md
@@ -58,7 +58,7 @@ rerankers:
 
 ### Local Rerankers
 
-The `huggingface:` and `file:` prefixes run a cross-encoder reranker in-process instead of calling a hosted API, so no request leaves the runtime. Both are included in the default `spiced` build.
+The `huggingface:` and `file:` prefixes run a cross-encoder reranker in-process instead of calling a hosted API. `file:` uses local artifacts only. `huggingface:` downloads model artifacts from the Hugging Face Hub, then runs scoring locally. Both are included in the default `spiced` build.
 
 ```yaml
 rerankers:
@@ -66,7 +66,7 @@ rerankers:
   - from: huggingface:huggingface.co/BAAI/bge-reranker-base
     name: local_rr
     params:
-      hf_token: ${secrets:HF_TOKEN} # only needed for a private repo
+      hf_token: ${secrets:HF_TOKEN} # needed for private or gated repositories
 
   # Loaded from a directory holding config.json, tokenizer.json, and the weights.
   - from: file:/models/gte-reranker-modernbert-base
@@ -80,7 +80,7 @@ Both accept the same two tuning parameters:
 | `max_seq_length`  | Maximum sequence length for the `(query, document)` pair. When unset, the model's own configured maximum applies.                                                            | -       |
 | `truncate`        | How to handle a pair longer than the maximum sequence length: `none` rejects the request with an input-validation error, `end` discards the end of the pair, `start` discards the start. Matched case-insensitively. | `none`  |
 
-`huggingface:` rerankers additionally accept `hf_token` (also spelled `api_key`) for private repositories.
+`huggingface:` rerankers additionally accept `hf_token` (also spelled `api_key`) for private or gated repositories.
 
 ### LLM-as-Reranker
 


### PR DESCRIPTION
## Summary

The **Supported providers** table on the Reranking page enumerates four `from:` prefixes. `RerankerPrefix` accepts **six** — the table is missing the two that run a cross-encoder locally, in-process, rather than calling a hosted API.

Verified against `spiceai/spiceai` at `trunk` (`325c9fc37b`):

- [`crates/spicepod/src/component/rerankers.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/rerankers.rs) — `RerankerPrefix` variants `HuggingFace` and `File`; `TryFrom<&str>` matches `huggingface`/`hf` and `file` (each requiring a `:` or `/` delimiter), and `get_model_id()` recovers the repo id (with an optional pinned `:<revision>`) or the directory path.
- [`crates/runtime/src/model/rerank/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/rerank/mod.rs) — both dispatch arms are wired: `TeiRerank::from_hf(...)` (line 209) and `TeiRerank::from_dir(...)` (line 235).
- Parameter structs: [`params/huggingface.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/rerank/params/huggingface.rs) (`hf_token`, alias `api_key`; `max_seq_length`; `truncate`) and [`params/file.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/model/rerank/params/file.rs) (`max_seq_length`; `truncate`). `truncate` values come from `Truncation::from_str` — `none` (default, rejects an over-long pair), `end`, `start`, matched case-insensitively.

### Not gated out of the OSS build

The two arms are `#[cfg(feature = "models")]`, and `models` is in the `spiced` default feature set (`bin/spiced/Cargo.toml`), which pulls `llms/local_embed` via `crates/runtime/Cargo.toml`. So no Spice.ai Enterprise callout applies — a stock `spiced` binary can serve them. Without the feature, the arm returns `Error::LocalRerankerNotEnabled`.

## Changes

`website/docs/features/search/rerank.md`:

- Two rows added to the Supported providers table (`huggingface:` / `hf:`, and `file:`).
- A **Local Rerankers** subsection with a Spicepod example for each and the shared `max_seq_length` / `truncate` parameters, plus `hf_token` for private Hub repos.

## Versioning

vNext only. Neither prefix exists in the released snapshots: `crates/llms/src/rerank/tei.rs` and the `HuggingFace` / `File` variants are absent at both `v2.1.5` and `v2.0.1` (the `rerank/` module there has only `cohere`, `http`, `jina`, `voyage`), and they first appear at `v2.2.0`. `versioned_docs/version-2.1.x` and `-2.0.x` are correct as they stand and are left untouched.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — addition, so vNext only
- [x] Files updated: 1