### PR TITLE
docs(v2.2.0 blog): `spice cloud link` is what enrolls, not `spice connect`

### DIFF
--- a/website/releases/tags.yml
+++ b/website/releases/tags.yml
@@ -98,10 +98,6 @@ blobs:
   label: 'Blobs'
   permalink: '/blobs'
   description: 'Blobs related topics and usage.'
-byoc:
-  label: 'BYOC'
-  permalink: '/byoc'
-  description: 'BYOC (Bring Your Own Cloud) related topics and usage.'
 cache:
   label: 'Cache'
   permalink: '/cache'

--- a/website/releases/tags.yml
+++ b/website/releases/tags.yml
@@ -98,6 +98,10 @@ blobs:
   label: 'Blobs'
   permalink: '/blobs'
   description: 'Blobs related topics and usage.'
+byoc:
+  label: 'BYOC'
+  permalink: '/byoc'
+  description: 'BYOC (Bring Your Own Cloud) related topics and usage.'
 cache:
   label: 'Cache'
   permalink: '/cache'

--- a/website/releases/v2.2.0.md
+++ b/website/releases/v2.2.0.md
@@ -3,7 +3,7 @@ date: 2026-08-25
 title: 'Spice v2.2.0 (Aug 25, 2026)'
 type: blog
 authors: [krinart]
-tags: [release, cdc, mysql, postgresql, search, cloud, debezium kafka, observability, dashboard]
+tags: [release, cdc, mysql, postgresql, search, byoc, debezium kafka, observability, dashboard]
 
 ---
 Spice v2.2.0 is now available! 🚀
@@ -23,7 +23,7 @@ Highlights in v2.2.0 include:
 
 > Spice Cloud Connect is a feature of [Spice.ai Cloud](https://spice.ai/).
 
-[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes to Spice.ai Cloud for management and observability. Run [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link) to enroll a standalone runtime.
+[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability. Run [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link) to enroll a standalone runtime.
 
 Try it with the [Cloud Connect on a Development Machine](https://github.com/spiceai/cookbook/tree/trunk/cloud-connect-dev) recipe.
 

--- a/website/releases/v2.2.0.md
+++ b/website/releases/v2.2.0.md
@@ -3,7 +3,7 @@ date: 2026-08-25
 title: 'Spice v2.2.0 (Aug 25, 2026)'
 type: blog
 authors: [krinart]
-tags: [release, cdc, mysql, postgresql, search, byoc, debezium kafka, observability, dashboard]
+tags: [release, cdc, mysql, postgresql, search, cloud, debezium kafka, observability, dashboard]
 
 ---
 Spice v2.2.0 is now available! 🚀
@@ -12,7 +12,7 @@ Spice v2.2.0 focuses on real-time data, performance, and stability. **Cloud Conn
 
 Highlights in v2.2.0 include:
 
-- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability
+- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes to Spice.ai Cloud for management and observability
 - **[MySQL CDC](#mysql-change-data-capture)** — MySQL tables now stay in sync in real time using MySQL binlog replication, with no Kafka or Debezium infrastructure and no scheduled refreshes
 - **[PostgreSQL Catalog CDC](#postgresql-catalog-cdc)** — accelerate an entire PostgreSQL database in real time with a few lines of configuration and no per-table setup
 - **[Faster Search](#faster-search-with-warm-in-memory-indexes)** — vector and full-text search can now serve from an in-memory index by default, with no configuration change
@@ -23,7 +23,7 @@ Highlights in v2.2.0 include:
 
 > Spice Cloud Connect is a feature of [Spice.ai Cloud](https://spice.ai/).
 
-[Spice Cloud Connect](https://spiceai.org/docs/next/deployment/cloud/cloud-connect) links self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability. Run `spice connect` to enroll a standalone runtime.
+[Spice Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect) links self-hosted runtimes to Spice.ai Cloud for management and observability. Run [`spice cloud link`](https://spiceai.org/docs/cli/reference/cloud#link) to enroll a standalone runtime.
 
 Try it with the [Cloud Connect on a Development Machine](https://github.com/spiceai/cookbook/tree/trunk/cloud-connect-dev) recipe.
 

--- a/website/releases/v2.2.0.md
+++ b/website/releases/v2.2.0.md
@@ -12,7 +12,7 @@ Spice v2.2.0 focuses on real-time data, performance, and stability. **Cloud Conn
 
 Highlights in v2.2.0 include:
 
-- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes to Spice.ai Cloud for management and observability
+- **[Cloud Connect](#cloud-connect)** — link self-hosted runtimes for BYOC (Bring Your Own Cloud) to Spice.ai Cloud for management and observability
 - **[MySQL CDC](#mysql-change-data-capture)** — MySQL tables now stay in sync in real time using MySQL binlog replication, with no Kafka or Debezium infrastructure and no scheduled refreshes
 - **[PostgreSQL Catalog CDC](#postgresql-catalog-cdc)** — accelerate an entire PostgreSQL database in real time with a few lines of configuration and no per-table setup
 - **[Faster Search](#faster-search-with-warm-in-memory-indexes)** — vector and full-text search can now serve from an in-memory index by default, with no configuration change


### PR DESCRIPTION
Fixes the enrollment command — `spice connect` errors out and points at `spice cloud link` — plus the `/docs/next/` link path. Companion: spiceai/spiceai#13533