### PR TITLE
fix(anthropic): the documented default model is retired

### DIFF
--- a/website/docs/components/models/anthropic.md
+++ b/website/docs/components/models/anthropic.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 To use a language model hosted on Anthropic, specify `anthropic` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-3-5-sonnet-latest`.
+To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-sonnet-5`. Name a model explicitly for anything long-lived: Anthropic retires model IDs, and a request for a retired one fails with a `not_found_error`.
 
 The following parameters are specific to Anthropic models:
 


### PR DESCRIPTION
## Summary

The Anthropic page told readers the default model is `claude-3-5-sonnet-latest`. Anthropic has
retired that model, so a reader who followed the page and left the model ID out of `from` got:

```
ApiError { message: "model: claude-3-5-sonnet-latest", type: Some("not_found_error"), .. }
```

Companion to spiceai/spiceai#13563, which moves the runtime default to `claude-sonnet-5` — measured
against the live API, not just asserted.

## Changes

- `website/docs/components/models/anthropic.md`: default is `claude-sonnet-5`, plus one sentence
  saying to name a model explicitly for anything long-lived, since Anthropic retires model IDs.

## Not changed

The versioned pages (`versioned_docs/version-*`) still document `claude-3-5-sonnet-latest`, which is
accurate: that *is* the default those releases shipped. Changing them would misdescribe released
versions.

## Test plan

- Prose-only change to one page; no code, config, or link targets touched.