### PR TITLE
docs(http): document the connector's bounded response cache

### DIFF
--- a/website/docs/components/data-connectors/https/deployment.md
+++ b/website/docs/components/data-connectors/https/deployment.md
@@ -110,12 +110,28 @@ When using `refresh_mode: caching`, transient HTTP errors (5xx, 429) are exclude
 
 - **Throughput**: Bounded by the upstream rate limit, then by `max_concurrent_requests` and `connect_timeout`. Plan limits to stay within the API quota.
 - **Memory**: Response bodies are streamed; memory footprint is bounded by `max_request_body_bytes` (filter inputs) and DataFusion's record-batch size for response rows.
+- **Response cache**: Each dynamic JSON API dataset holds its own [response cache](./index.md#response-cache), bounded by `response_cache_max_size_bytes` — `67108864` (64 MiB) by default, **per dataset**. The runtime's total exposure therefore scales with the number of HTTP datasets, not with the budget alone: budget it as `datasets × response_cache_max_size_bytes` and raise the value only for the datasets that earn it. Set `0` on a dataset whose responses are never repeated. This cache is not one of the caches under `runtime.caching`, so its memory is not counted against those limits.
 - **Connection setup**: TLS handshake adds latency. The connection pool keeps `pool_max_idle_per_host` warm connections to absorb burst traffic.
 - **Partitioned refreshes**: When using `IN`-list filters or cross-product partitioning, the runtime issues one HTTP request per partition. Use `max_request_partitions` to cap the request count for unbounded filter combinations, and `max_concurrent_requests` to throttle their fan-out.
 
 ## Metrics
 
-The connector exposes per-origin HTTP rate-control metrics for every dynamic JSON API dataset. They are registered automatically — no `metrics` configuration is required — and the limit gauges report `0` when the corresponding limit is not configured. Structured file-format datasets (`parquet`, `csv`, and the other listing-table formats) do not expose them:
+The connector reports two metric families: response-cache occupancy, and per-origin rate control. Both are registered automatically — no `metrics` configuration is required.
+
+### Response cache
+
+Occupancy of the dataset's [response cache](./index.md#response-cache). These are reported for every HTTP dataset, because the memory the cache holds is otherwise attributable to nothing; structured file-format datasets do not use the cache and report `0`.
+
+| Metric Name                  | Type  | Description                                                                                                                                                                                     |
+| ---------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `response_cache_size_bytes`  | Gauge | Bytes retained by the response cache, counting response bodies, their headers, and the request keys they are held under. Excludes the cache's own per-entry bookkeeping. Compare against `response_cache_max_size_bytes` to see how close a dataset is to its budget. |
+| `response_cache_items_count` | Gauge | Number of responses held by the response cache. Read beside the byte figure, this separates a cache holding a few large responses from one holding very many small ones.                        |
+
+Both are refreshed when a request consults the cache, so an idle dataset reports its last observed occupancy — which is the same figure, since nothing enters or leaves the cache except on a request.
+
+### Rate control
+
+Per-origin rate-control metrics, exposed for dynamic JSON API datasets. The limit gauges report `0` when the corresponding limit is not configured. Structured file-format datasets (`parquet`, `csv`, and the other listing-table formats) do not expose them:
 
 | Metric Name                                 | Type    | Description                                                                                              |
 | ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
@@ -147,7 +163,7 @@ datasets:
         enabled: false
 ```
 
-Instruments are exposed with the prefix `dataset_http_` — the HTTP connector's component name is `http`, not `https` — and each carries an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
+Instruments from both families are exposed with the prefix `dataset_http_` — the HTTP connector's component name is `http`, not `https` — so the exported names are `dataset_http_response_cache_size_bytes`, `dataset_http_rate_control_wait_duration_ms`, and so on. The two families are attributed differently: the rate-control instruments carry an `origin` attribute (`scheme://host:port`) identifying the upstream origin instead of a dataset `name`, because datasets sharing an origin share one rate controller, while the response-cache gauges carry the dataset `name`, because each dataset has its own cache. See [Component Metrics](../../../features/observability/component_metrics) for general configuration.
 
 For broader observability, also monitor:
 
@@ -175,3 +191,5 @@ HTTP requests participate in [task history](../../../reference/task_history) thr
 | Request rejected: "OR across HTTP filter columns" | `WHERE request_path = '...' OR request_query = '...'`.    | Split into separate refreshes or `UNION ALL`.                                                             |
 | Many partitions created from cross-product       | Multiple `IN`-list filters multiplied into many requests.   | Set `max_request_partitions` to cap; tighten filters.                                                     |
 | Slow first refresh                               | Cold connection pool + TLS handshake per request.           | Raise `pool_max_idle_per_host`; ensure `pool_idle_timeout` is long enough to keep connections warm.       |
+| Runtime memory grows with HTTP traffic           | Response caches are held per dataset, 64 MiB each by default. | Check `dataset_http_response_cache_size_bytes` per dataset; lower `response_cache_max_size_bytes`, or set it to `0` where responses are never repeated. |
+| Repeat queries still hit the origin              | The origin refuses retention (`no-store`, `no-cache`, `private`, `Vary: *`), or sends no `Cache-Control` at all. | Confirm with `dataset_http_response_cache_items_count` staying at `0`. For a header-less origin, set `response_cache_fallback_ttl`; an origin that refuses explicitly is always honored. |

--- a/website/docs/components/data-connectors/https/index.md
+++ b/website/docs/components/data-connectors/https/index.md
@@ -165,6 +165,8 @@ The connector supports authentication, timeout, connection pooling, and retry co
 | `request_header_allowlist` | Comma-separated list of HTTP header names that `request_headers` filters may set (e.g., `x-sandbox-id, x-region`). **Required** when `request_header_filters` is enabled. The `authorization` header cannot be allowlisted when HTTP authentication is configured.
 | `max_request_headers_length` | Optional. Maximum size in bytes for `request_headers` filter values. Default: `16384` (16 KiB).
 | `max_request_partitions`   | Optional. Maximum number of HTTP request partitions created from the cross product of `request_path`, `request_query`, `request_body`, and `request_headers` filters. If unset, partition count is unlimited.                                                                                                                                                                                                                                                                                                                   |
+| `response_cache_max_size_bytes` | Optional. Byte budget for the responses this dataset retains in its [response cache](#response-cache), counting response bodies and the request keys they are held under. Once reached, entries are evicted to stay inside it. Set `0` to disable the response cache. Default: `67108864` (64 MiB), applied **per dataset**. Applies to dynamic JSON API endpoints only; structured HTTP file datasets do not use this cache. |
+| `response_cache_fallback_ttl` | Optional. How long to retain a response whose origin sent no `Cache-Control` header at all (e.g. `5m`, `30s`). An origin that did send `Cache-Control` is always honored instead, including its refusals. Unset by default, which keeps such responses uncached. |
 | `health_probe`             | Optional. Custom health probe path for endpoint validation during initialization (e.g., `/health`, `/api/status`). The endpoint must return a 2xx status code to pass validation. If not set, a random path is used and any status (including 404) is accepted. Must start with `/`.                                                                                                                                                      |
 | `auth_token_url`           | Optional. OAuth2 token endpoint URL (must be HTTPS; `http://localhost` and loopback IPs are allowed for local testing). Enables OAuth2: the connector acquires short-lived access tokens (refresh-token grant by default, or `client_credentials` via `auth_grant_type`) and attaches them to all data requests (`Authorization: Bearer <token>` by default, or the bare token under a custom `auth_header_name`). Applies to dynamic JSON API endpoints only; structured HTTP file datasets reject OAuth2 params. See [OAuth2 Authentication](#oauth2-authentication). |
 | `auth_grant_type`          | Optional. OAuth2 grant type: `refresh_token` (default, RFC 6749 §6) or `client_credentials` (RFC 6749 §4.4). `client_credentials` authenticates with `http_auth_client_id`/`http_auth_client_secret` and issues no refresh token.                                                                                                                                                                                                          |
@@ -284,6 +286,50 @@ Clients querying Spice will receive this header and can:
 3. After 20 seconds, fetch fresh data before serving the next request.
 
 The stale-while-revalidate behavior in Spice is controlled by the `stale_while_revalidate_ttl` parameter in the [caching configuration](../../features/caching#stale-while-revalidate). When `stale_while_revalidate_ttl` is set to `0` (default), stale data will not be served. When set to a non-zero value, Spice serves stale cache entries while revalidating in the background.
+
+## Response Cache
+
+For dynamic JSON API endpoints, the connector keeps origin responses in an in-memory cache keyed by the request shape — path, query, body, and request headers — so a repeat of the same request inside the response's own freshness window is served without another origin call. This cache is the connector's own; it is **not** one of the caches configured under [`runtime.caching`](../../features/caching), and it is unrelated to [`refresh_mode: caching`](../../features/data-acceleration/refresh-modes/caching), which caches query results rather than HTTP responses. Structured HTTP file datasets (`parquet`, `csv`, and the other listing-table formats) do not use it.
+
+### Size budget
+
+`response_cache_max_size_bytes` bounds what one dataset's cache retains, counting each response body together with the request key it is held under. It defaults to `67108864` (64 MiB) and is applied **per dataset**, so the runtime's total exposure grows with the number of HTTP datasets — raise it only for a dataset that earns it. Once the budget is reached, entries are evicted to stay inside it. Set `0` to disable the cache entirely.
+
+The value must be a whole number of bytes; suffixed forms such as `64MiB` are rejected at load with an error naming the parameter, rather than being replaced by the default.
+
+A single entry — one response plus the request key it is held under — of 4 GiB or more is never admitted, whatever the budget is set to, because it cannot be charged what it holds.
+
+### What is retained, and for how long
+
+The origin decides first, from the `Cache-Control` header on its response:
+
+| Origin response                                      | Retained                                                                                                     |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `Cache-Control: max-age=<n>` (`n` > 0)               | Yes, for the part of `<n>` that has not already elapsed according to the response's `Age` / `Date` headers.  |
+| `Cache-Control: s-maxage=<n>`                        | Yes, for `<n>`. `s-maxage` is addressed to shared caches and outranks a `max-age` sent alongside it.          |
+| `Cache-Control: no-store`, `no-cache`, or `private`  | No. The response is still served to the query, but never retained — even if `max-age` was sent with it.       |
+| `Cache-Control` with no usable `max-age`/`s-maxage`  | No. The origin has spoken, so `response_cache_fallback_ttl` does not step in.                                 |
+| No `Cache-Control` header at all                     | Only if `response_cache_fallback_ttl` is set — see below.                                                     |
+
+A `Vary` response header additionally refuses retention when it is `*`, when it names the header the connector's HTTP authentication uses, or when its bytes cannot be read as text. Any other named field is safe, because everything a query can vary — path, query, body, and pushed-down request headers — is already part of the cache key.
+
+### Caching an origin that sends no `Cache-Control`
+
+`response_cache_fallback_ttl` is how long to retain a response whose origin sent **no** `Cache-Control` header at all, for example:
+
+```yaml
+datasets:
+  - from: https://api.example.com/v1
+    name: api_data
+    params:
+      file_format: json
+      response_cache_fallback_ttl: 5m
+      response_cache_max_size_bytes: 134217728 # 128 MiB
+```
+
+It is unset by default, so responses from a header-less origin stay uncached until an operator asks for them to be retained. It never overrides an origin that did send `Cache-Control`, including that origin's refusals, and unlike an origin-supplied `max-age` it is not reduced by the response's `Age` — it is how long you asked Spice to keep a response the origin said nothing about.
+
+Occupancy of the cache is reported per dataset — see [Metrics](./deployment.md#metrics).
 
 ## Advanced Features
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13462` bounded the HTTP connector's response cache and made it honour an origin's refusal to retain. The cache itself was effectively undocumented (one bullet saying responses "are cached"), and the change adds two parameters and two metrics that had no docs at all:

- `response_cache_max_size_bytes` — byte budget, `67108864` (64 MiB) by default, applied **per dataset**; `0` disables the cache. An unparseable value (e.g. `64MiB`) is refused at load rather than replaced by the default.
- `response_cache_fallback_ttl` — how long to retain a response whose origin sent **no** `Cache-Control` at all. Unset by default, so such responses stay uncached; it never overrides an origin that did speak, including its refusals.
- `dataset_http_response_cache_size_bytes` / `dataset_http_response_cache_items_count` — auto-registered occupancy gauges (`MetricSpec` stems `response_cache_size_bytes` / `response_cache_items_count`, `ComponentType::Dataset` + component name `http`).

Also documents what is and is not retained (`no-store` / `no-cache` / `private` refuse absolutely; `s-maxage` outranks `max-age`; `max-age` is reduced by `Age`; `Vary: *`, a `Vary` naming the auth header, and an unreadable `Vary` refuse), and records that the cache-occupancy gauges carry the dataset `name` attribute while the rate-control family carries `origin` — the existing prose said the whole `dataset_http_` prefix used `origin`, which is now only half true.

Verified against `origin/trunk`, not the merged diff: `DEFAULT_HTTP_CACHE_MAX_SIZE_BYTES = 64 * 1024 * 1024` (`crates/data_components/src/http/provider.rs:320`), both `ParameterSpec::runtime` declarations (`crates/runtime/src/dataconnector/https.rs:1884-1887`), the metric-name literals (`crates/data_components/src/http/metrics.rs`), the `origin` relabel (`crates/data-http-rate-control/src/lib.rs:475`), and the `entry_weight` admission guard.

vNext only: `#13462` merged after `v2.2.0` was cut and is in no release tag, so no versioned snapshot carries this behaviour.

## Source PRs

- spiceai/spiceai#13462 — fix(http): bound the connector's response cache and honour `no-store` (fixes #13460)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — addition, vNext only (not in any `v2.*` tag)
- [x] Files updated: 2