### PR TITLE
docs(caching): stale-if-error is not a supported directive, and --cache-control takes only cache/no-cache

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -247,7 +247,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -266,9 +265,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -301,7 +297,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -310,14 +306,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -325,9 +313,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -317,11 +317,12 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
-`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
-Flight API.
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: `spice search` rejects any value
+other than `cache` or `no-cache`, and `spice sql` silently falls back to `cache`. To use
+`min-fresh`, `max-stale`, or `only-if-cached`, send the `Cache-Control` header directly
+against the HTTP or Arrow Flight API.
 
 :::
 

--- a/website/src/partials/deployment/architectures/_cluster-sidecar.mdx
+++ b/website/src/partials/deployment/architectures/_cluster-sidecar.mdx
@@ -72,7 +72,7 @@ Useful cache knobs in this topology:
 
 - `cache_key_type: plan` (default) shares a cache entry across semantically equivalent SQL, which matters for ORM-generated queries. `sql` is a faster, string-exact lookup.
 - `stale_while_revalidate_ttl` lets the sidecar serve a stale cached result immediately while a background refresh runs.
-- Clients can send `Cache-Control` directives per request (`no-cache`, `only-if-cached`, `stale-if-error`).
+- Clients can send `Cache-Control` directives per request (`no-cache`, `min-fresh`, `max-stale`, `only-if-cached`).
 - `encoding: zstd` typically cuts results-cache memory by 50–90%.
 
 ### The cluster ingests once
@@ -117,7 +117,7 @@ Sidecars pull from the cluster on a configurable interval using append or full r
 
 For workloads that need sub-second freshness, the cluster consumes [CDC streams](../../features/cdc) (Postgres logical replication, DynamoDB Streams, Debezium, Kafka) once, and the sidecars pull the resulting accelerated dataset on a short interval. That gives near-real-time propagation without a fleet-wide invalidation bus.
 
-If the cluster is temporarily unavailable — a rolling upgrade, a network blip, a zone event — sidecars keep serving cached data and their accelerated working sets. Refreshes pause and resume when connectivity returns. The blast radius of a cluster incident is slightly staler data, not application downtime. A `stale-if-error` cache directive can extend this further for delegated queries.
+If the cluster is temporarily unavailable — a rolling upgrade, a network blip, a zone event — sidecars keep serving cached data and their accelerated working sets. Refreshes pause and resume when connectivity returns. The blast radius of a cluster incident is slightly staler data, not application downtime.
 
 ## Example Spicepods
 

--- a/website/versioned_docs/version-1.10.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.10.x/features/caching/index.md
@@ -220,7 +220,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -239,9 +238,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -274,7 +270,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -283,14 +279,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -298,9 +286,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-1.10.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.10.x/features/caching/index.md
@@ -290,9 +290,10 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: both `spice search` and `spice sql`
+reject any value other than `cache` or `no-cache`. To use `min-fresh`, `max-stale`, or
 `only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
 Flight API.
 

--- a/website/versioned_docs/version-1.11.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.11.x/features/caching/index.md
@@ -220,7 +220,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -239,9 +238,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -274,7 +270,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -283,14 +279,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -298,9 +286,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-1.11.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.11.x/features/caching/index.md
@@ -290,11 +290,12 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
-`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
-Flight API.
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: `spice search` rejects any value
+other than `cache` or `no-cache`, and `spice sql` silently falls back to `cache`. To use
+`min-fresh`, `max-stale`, or `only-if-cached`, send the `Cache-Control` header directly
+against the HTTP or Arrow Flight API.
 
 :::
 

--- a/website/versioned_docs/version-1.9.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.9.x/features/caching/index.md
@@ -207,7 +207,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -226,9 +225,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -261,7 +257,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -270,14 +266,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -285,9 +273,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-1.9.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.9.x/features/caching/index.md
@@ -277,9 +277,10 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: both `spice search` and `spice sql`
+reject any value other than `cache` or `no-cache`. To use `min-fresh`, `max-stale`, or
 `only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
 Flight API.
 

--- a/website/versioned_docs/version-2.0.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.0.x/features/caching/index.md
@@ -247,7 +247,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -266,9 +265,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -301,7 +297,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -310,14 +306,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -325,9 +313,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-2.0.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.0.x/features/caching/index.md
@@ -317,11 +317,12 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
-`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
-Flight API.
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: `spice search` rejects any value
+other than `cache` or `no-cache`, and `spice sql` silently falls back to `cache`. To use
+`min-fresh`, `max-stale`, or `only-if-cached`, send the `Cache-Control` header directly
+against the HTTP or Arrow Flight API.
 
 :::
 

--- a/website/versioned_docs/version-2.1.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.1.x/features/caching/index.md
@@ -247,7 +247,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -266,9 +265,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -301,7 +297,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -310,14 +306,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -325,9 +313,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-2.1.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.1.x/features/caching/index.md
@@ -317,11 +317,12 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
-`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
-Flight API.
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: `spice search` rejects any value
+other than `cache` or `no-cache`, and `spice sql` silently falls back to `cache`. To use
+`min-fresh`, `max-stale`, or `only-if-cached`, send the `Cache-Control` header directly
+against the HTTP or Arrow Flight API.
 
 :::
 

--- a/website/versioned_docs/version-2.2.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.2.x/features/caching/index.md
@@ -247,7 +247,6 @@ The following `Cache-Control` directives are supported:
 | [`min-fresh`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh)           | Specifies the minimum time (in seconds) that a cached response must remain fresh. For example, `min-fresh=60` requires the cached entry to be fresh for at least 60 more seconds.                                                                  |
 | [`max-stale`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale)           | Indicates the client will accept a stale response. An optional value in seconds specifies the maximum staleness allowed. For example, `max-stale=30` accepts responses stale for up to 30 seconds.                                                 |
 | [`only-if-cached`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached) | Returns only cached responses. If no cached response is available, returns an error instead of fetching fresh data.                                                                                                                                |
-| [`stale-if-error`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error) | Serves stale cached responses if an error occurs while fetching fresh data. An optional value in seconds specifies how stale the response can be. For example, `stale-if-error=600` serves responses stale for up to 10 minutes if fetching fails. |
 
 #### HTTP Example
 
@@ -266,9 +265,6 @@ curl -H "cache-control: max-stale=60" -XPOST http://localhost:8090/v1/sql -d 'SE
 
 # Only return cached responses, fail if cache miss
 curl -H "cache-control: only-if-cached" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
-
-# Serve stale cache (up to 300 seconds old) if fetching fresh data fails
-curl -H "cache-control: stale-if-error=300" -XPOST http://localhost:8090/v1/sql -d 'SELECT 1'
 ```
 
 #### Arrow FlightSQL Example
@@ -301,7 +297,7 @@ Connection conn = DriverManager.getConnection("jdbc:arrow-flight-sql://localhost
 
 ### `spice` CLI
 
-The `spice sql` and `spice search` commands accept a `--cache-control` flag that supports all cache-control directives:
+The `spice sql` and `spice search` commands accept a `--cache-control` flag, which takes `cache` (the default) or `no-cache`:
 
 ```bash
 # Default behavior (use cache if available)
@@ -310,14 +306,6 @@ spice sql
 spice sql --cache-control cache
 # Skip cache for this query, but cache the results for future queries
 spice sql --cache-control no-cache
-# Only use cached response if fresh for at least 30 more seconds
-spice sql --cache-control min-fresh=30
-# Accept cached responses stale for up to 60 seconds
-spice sql --cache-control max-stale=60
-# Only return cached responses, fail if cache miss
-spice sql --cache-control only-if-cached
-# Serve stale cache (up to 300 seconds) if fetching fails
-spice sql --cache-control stale-if-error=300
 
 # Default behavior (use cache if available)
 spice search
@@ -325,9 +313,17 @@ spice search
 spice search --cache-control cache
 # Skip cache for this search, but cache the results for future searches
 spice search --cache-control no-cache
-# Accept stale search results up to 60 seconds old
-spice search --cache-control max-stale=60
 ```
+
+:::note
+
+`--cache-control` only turns the cache on or off. It does not accept the other
+`Cache-Control` directives: `spice search` rejects any value other than `cache` or
+`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
+`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
+Flight API.
+
+:::
 
 ## Custom Cache Keys
 

--- a/website/versioned_docs/version-2.2.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.2.x/features/caching/index.md
@@ -317,11 +317,12 @@ spice search --cache-control no-cache
 
 :::note
 
-`--cache-control` only turns the cache on or off. It does not accept the other
-`Cache-Control` directives: `spice search` rejects any value other than `cache` or
-`no-cache`, and `spice sql` falls back to `cache`. To use `min-fresh`, `max-stale`, or
-`only-if-cached`, send the `Cache-Control` header directly against the HTTP or Arrow
-Flight API.
+`--cache-control` chooses between normal cache behavior (`cache`) and bypassing the cache
+lookup for this request (`no-cache`, which still stores the result for later requests). It
+does not accept the other `Cache-Control` directives: `spice search` rejects any value
+other than `cache` or `no-cache`, and `spice sql` silently falls back to `cache`. To use
+`min-fresh`, `max-stale`, or `only-if-cached`, send the `Cache-Control` header directly
+against the HTTP or Arrow Flight API.
 
 :::
 


### PR DESCRIPTION
## Summary

Two claims on the Caching page overstate what the runtime accepts. Both are wrong in **every** released version, so this is a correction swept across vNext and all six versioned snapshots that carry the text (1.9.x–2.2.x), plus the cluster+sidecar deployment partial.

### 1. `stale-if-error` is not a supported `Cache-Control` request directive

The page listed it in the supported-directives table and gave a `curl` example and a `spice sql` example.

`CacheControl::from_headers` parses exactly four directives and falls through to the default `Cache` variant for anything else — the enum has five variants total (`Cache`, `NoCache`, `MaxStale`, `MinFresh`, `OnlyIfCached`):

- `no-cache` → `NoCache`
- `only-if-cached` → `OnlyIfCached`
- `min-fresh=N` → `MinFresh`
- `max-stale[=N]` → `MaxStale`

`stale-if-error` has never appeared in that parser: `git log -S'stale_if_error' -- crates/runtime-request-context/src/cache_control.rs` is empty across all history, and the string is absent from that file at every one of `v1.9.2`, `v1.10.1`, `v1.11.5`, `v2.0.3`, `v2.1.5`, `v2.2.0`. Sending the header today is silently ignored.

The only `stale_if_error` in the runtime is `caching_stale_if_error`, an **acceleration param** for `refresh_mode: caching` datasets (values `enabled` / `disabled`) — a different layer with a different spelling, and correctly documented elsewhere. Those occurrences are untouched by this PR.

### 2. `--cache-control` does not support "all cache-control directives"

The page claimed the CLI flag "supports all cache-control directives" and gave five examples that do not work:

- `spice search --cache-control` is declared `#[arg(long, default_value = "cache", value_parser = ["cache", "no-cache"])]`, so clap **hard-errors** on `max-stale=60`.
- `spice sql --cache-control` takes a free-form `String` and then matches only the literal `"no-cache"`, collapsing every other value to `Cache` — and the header is inserted only for `NoCache`. So `min-fresh=30`, `max-stale=60`, `only-if-cached`, and `stale-if-error=300` are accepted by the parser and then **silently dropped**.

This is not a regression in the code — the pre-Rust Go CLI was already restricted the same way (`[possible values: cache, no-cache]` at `v1.9.2` and `v1.10.1`), and the 1.5.x–1.8.x doc snapshots correctly show only `cache`/`no-cache`. The extra directives look like an extrapolation from the HTTP table when the 1.9 docs were written (#1221).

## What changed

- Removed the `stale-if-error` row from the directives table and its `curl` example.
- Corrected the CLI sentence to "takes `cache` (the default) or `no-cache`", trimmed the four `spice sql` and one `spice search` examples that don't work, and added a note pointing readers at the HTTP/Flight API for `min-fresh` / `max-stale` / `only-if-cached`.
- `_cluster-sidecar.mdx`: replaced `stale-if-error` in the per-request directive list with the directives that are actually parsed, and dropped the trailing "A `stale-if-error` cache directive can extend this further" sentence.

The `min-fresh`, `max-stale`, and `only-if-cached` rows in the HTTP table are **correct** and are kept — all three are wired through to both the SQL results cache and search.

## Verified source refs

`spiceai/spiceai` @ `trunk` (and tags `v1.9.2`, `v1.10.1`, `v1.11.5`, `v2.0.3`, `v2.1.5`, `v2.2.0`):

- [`crates/runtime-request-context/src/cache_control.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-request-context/src/cache_control.rs) — `CacheControl` variants and `parse_cache_control_header`
- [`bin/spice/src/commands/search.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/search.rs) — `value_parser = ["cache", "no-cache"]`
- [`bin/spice/src/commands/sql.rs`](https://github.com/spiceai/spiceai/blob/trunk/bin/spice/src/commands/sql.rs) — `match args.cache_control.as_str() { "no-cache" => NoCache, _ => Cache }`
- [`crates/repl/src/cache_control.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/repl/src/cache_control.rs) — two-variant `ValueEnum`

## Test plan

- [x] `npm run build` passes (exit 0; `onBrokenLinks: 'throw'`), and the built `docs/features/caching.html` contains no `stale-if-error` and does render the new CLI note
- [x] Versioned-docs propagation checked — 0 remaining hits for every fabricated phrasing across `website/`
- [x] Files updated: 8 (1 unversioned page + 6 versioned snapshots + 1 partial)