### PR TITLE
fix(anthropic): document the default model that actually ships

### DIFF
--- a/website/docs/components/models/anthropic.md
+++ b/website/docs/components/models/anthropic.md
@@ -9,7 +9,7 @@ To use a language model hosted on Anthropic, specify `anthropic` in the `from` f
 
 To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-sonnet-4-6`. Name a model explicitly for anything long-lived: Anthropic retires model IDs, and a request for a retired one fails with a `not_found_error`.
 
-The default deliberately trails Anthropic's newest model. Claude 5 models reject the `temperature`, `top_p`, and `top_logprobs` parameters outright, so a request that sets any of them fails against them; the default names the newest model that still accepts all three. Set `from: anthropic:<model_id>` to use a newer model, and drop those parameters when you do.
+The default deliberately trails Anthropic's newest model. Claude 5 models reject `temperature`, `top_p`, and `top_logprobs` individually, so a request that sets any one of them fails against them; `claude-sonnet-4-6` is the newest model that still accepts each of them. It accepts them one at a time, not in every combination — Claude 4 and later reject `temperature` and `top_p` set *together*, and reject a trailing assistant message (a response prefill). Spice sends `top_logprobs` to Anthropic as `top_k`, so that is the parameter name an Anthropic error reports. Set `from: anthropic:<model_id>` to use a newer model, and drop these parameters when you do.
 
 The following parameters are specific to Anthropic models:
 

--- a/website/docs/components/models/anthropic.md
+++ b/website/docs/components/models/anthropic.md
@@ -7,7 +7,9 @@ sidebar_position: 3
 
 To use a language model hosted on Anthropic, specify `anthropic` in the `from` field.
 
-To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-sonnet-5`. Name a model explicitly for anything long-lived: Anthropic retires model IDs, and a request for a retired one fails with a `not_found_error`.
+To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-sonnet-4-6`. Name a model explicitly for anything long-lived: Anthropic retires model IDs, and a request for a retired one fails with a `not_found_error`.
+
+The default deliberately trails Anthropic's newest model. Claude 5 models reject the `temperature`, `top_p`, and `top_logprobs` parameters outright, so a request that sets any of them fails against them; the default names the newest model that still accepts all three. Set `from: anthropic:<model_id>` to use a newer model, and drop those parameters when you do.
 
 The following parameters are specific to Anthropic models:
 


### PR DESCRIPTION
## Summary

[#2127](https://github.com/spiceai/docs/pull/2127) corrected the documented Anthropic default off
the retired `claude-3-5-sonnet-latest`, but named **`claude-sonnet-5`** — and the runtime change it
accompanied ships **`claude-sonnet-4-6`**. So the published page currently states a default the
runtime does not use.

## Why the runtime does not use Claude 5

Claude 5 models reject `temperature`, `top_p`, and `top_k` outright — each one individually, not
just in combination:

```
ApiError { message: "`temperature` is deprecated for this model.", type: Some("invalid_request_error"), .. }
```

The Anthropic adapter forwards all three whenever a caller sets them, so a Claude 5 default would
turn every configuration that sets `temperature` from working into a guaranteed `400`. Measured
against the live API rather than inferred — the per-model, per-control table is in
spiceai/spiceai#13564.

## Changes

- The stated default becomes `claude-sonnet-4-6`.
- Adds one paragraph saying the default deliberately trails Anthropic's newest model, and what a
  reader has to change if they name a newer one — without it, someone following the advice to pin a
  model explicitly picks a Claude 5 id and hits the `400` this default exists to avoid.

## Test plan

- Rendered locally; the page is prose only, no code sample or snapshot affected.
- Model id cross-checked against `DEFAULT_ANTHROPIC_MODEL` in
  `crates/llms/src/anthropic/mod.rs` on spiceai/spiceai#13563.

Refs spiceai/spiceai#13557
Refs spiceai/spiceai#13564