### PR TITLE
docs(trace): a proxied MCP tool is now recorded under one task name

### DIFF
--- a/website/docs/cli/reference/trace.md
+++ b/website/docs/cli/reference/trace.md
@@ -37,16 +37,11 @@ Tools proxied from MCP servers and custom tools are recorded dynamically as `too
 
 A tool that belongs to a non-default tool catalog — which includes every tool proxied from an MCP server — is exposed under a catalog-qualified name joining the catalog and the tool with `__`, for example `github__search_code`. That is the name `/v1/tools` lists and the name `POST /v1/tools/{name}` expects.
 
-:::warning A proxied MCP tool is recorded under two different task names
+Every entry point records the same task name — `tool_use::` followed by that exposed name, for example `tool_use::github__search_code` — whether the call arrives through the `/v1/mcp` gateway, through `POST /v1/tools/github__search_code`, or from a model deciding to use the tool. Grouping `runtime.task_history` by `task` therefore counts a tool once, and one `spice trace tool_use::github__search_code` sees every call to it.
 
-Which name `runtime.task_history` records depends on how the tool was invoked:
+:::note Rows an older runtime wrote use a `/` separator
 
-| Invoked via | `task` recorded |
-| --- | --- |
-| The `/v1/mcp` gateway | `tool_use::github__search_code` (the exposed name) |
-| A model-driven tool call, or `POST /v1/tools/github__search_code` | `tool_use::github/search_code` |
-
-`spice trace` matches the task name exactly, so trace both spellings to see every call to the tool. Tracked in [spiceai/spiceai#13338](https://github.com/spiceai/spiceai/issues/13338).
+Runtimes up to and including v2.2.0 recorded a model-driven or `POST /v1/tools/{name}` call under `tool_use::<catalog>/<tool>` (`tool_use::github/search_code`) while the `/v1/mcp` gateway used the exposed `__` name, so one tool's history was split across two task names. `spice trace` matches the task name exactly and still accepts the `/` spelling, so trace it as well to read history those runtimes wrote.
 
 :::
 


### PR DESCRIPTION
## Summary

`website/docs/cli/reference/trace.md` warned that a proxied MCP tool is recorded in `runtime.task_history` under two different task names depending on the entry point — `tool_use::github__search_code` via the `/v1/mcp` gateway, `tool_use::github/search_code` via a model-driven call or `POST /v1/tools/{name}`. That was true when the warning was written (#2114, citing spiceai/spiceai#13338), and is no longer true on `trunk`.

spiceai/spiceai#13437 fixed #13338: both entry points now label the task from the canonical exposed name.

- `crates/runtime-tools/src/mcp/mod.rs` — `task_name_for_exposed_tool()` is the single labeller.
- `crates/runtime-tools/src/mcp/tool.rs:75-78` — `task_history_labels()` builds the name from `encode_tool_name(server, tool)`, i.e. the `__` form. Previously (`v2.2.0:crates/runtime-tools/src/mcp/tool.rs:93`) this was `format!("tool_use::{}/{}", …)`.
- `crates/runtime-tools/src/mcp/server.rs:220-222` — the gateway labels from `resolved.exposed_name` (re-encoded from the resolved `(catalog, tool)` pair), not the requested spelling, so the several spellings `decode_tool_name` accepts can no longer split one tool across rows.

`spice trace` still accepts any non-empty `tool_use::`-prefixed task (`bin/spice/src/commands/trace.rs:182-195`), including the old `/` spelling, so history a v2.2.0-or-earlier runtime wrote stays traceable — kept as a note rather than dropped.

## Scope

vNext only. spiceai/spiceai#13437 merged 2026-08-26, after the `v2.2.0` tag (2026-08-24) — `git tag --contains 964e8b268df55bd643d791068e7e12b88b3a1f74` is empty. `versioned_docs/version-2.2.x/` and `version-2.1.x/` correctly describe the pre-fix behavior and are left alone.

Cross-page grep for the claim: `grep -rn "13338\|both spellings\|two different task names" website/` → only this file.

## Source PRs

- spiceai/spiceai#13437 — fix(tools): record one task_history task per proxied MCP tool (fixes #13338)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only change (fix not in any released tag)
- [x] Files updated: 1