### PR TITLE
docs(snapshots): caching datasets only accept the time_interval snapshot trigger

### DIFF
--- a/website/docs/features/data-acceleration/snapshots.md
+++ b/website/docs/features/data-acceleration/snapshots.md
@@ -111,7 +111,7 @@ The `snapshots_trigger` setting controls when Spice creates new snapshots. The a
 
 #### Batch-based datasets
 
-Datasets using `refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with a `time_column` support the following triggers:
+Datasets using `refresh_mode: full`, or `refresh_mode: append` with a `time_column`, support the following triggers:
 
 | Trigger            | Description                                                     |
 | ------------------ | --------------------------------------------------------------- |
@@ -150,6 +150,16 @@ datasets:
       params:
         duckdb_file: /nvme/some_table.db
 ```
+
+#### Caching datasets
+
+Datasets using `refresh_mode: caching` support a single trigger:
+
+| Trigger         | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `time_interval` | Create snapshots at a fixed time interval. (Default, and the only supported trigger.) |
+
+The interval is set with `snapshots_trigger_threshold` and defaults to `10m`. Setting `snapshots_trigger` to `refresh_complete` or `stream_batches` on a caching dataset is a configuration error.
 
 #### Stream-based datasets
 

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/snapshots.md
@@ -95,7 +95,7 @@ The `snapshots_trigger` setting controls when Spice creates new snapshots. The a
 
 #### Batch-based datasets
 
-Datasets using `refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with a `time_column` support the following triggers:
+Datasets using `refresh_mode: full`, or `refresh_mode: append` with a `time_column`, support the following triggers:
 
 | Trigger            | Description                                                     |
 | ------------------ | --------------------------------------------------------------- |
@@ -134,6 +134,16 @@ datasets:
       params:
         duckdb_file: /nvme/some_table.db
 ```
+
+#### Caching datasets
+
+Datasets using `refresh_mode: caching` support a single trigger:
+
+| Trigger         | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `time_interval` | Create snapshots at a fixed time interval. (Default, and the only supported trigger.) |
+
+The interval is set with `snapshots_trigger_threshold` and defaults to `10m`. Setting `snapshots_trigger` to `refresh_complete` or `stream_batches` on a caching dataset is a configuration error.
 
 #### Stream-based datasets
 

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
@@ -111,7 +111,7 @@ The `snapshots_trigger` setting controls when Spice creates new snapshots. The a
 
 #### Batch-based datasets
 
-Datasets using `refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with a `time_column` support the following triggers:
+Datasets using `refresh_mode: full`, or `refresh_mode: append` with a `time_column`, support the following triggers:
 
 | Trigger            | Description                                                     |
 | ------------------ | --------------------------------------------------------------- |
@@ -150,6 +150,16 @@ datasets:
       params:
         duckdb_file: /nvme/some_table.db
 ```
+
+#### Caching datasets
+
+Datasets using `refresh_mode: caching` support a single trigger:
+
+| Trigger         | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `time_interval` | Create snapshots at a fixed time interval. (Default, and the only supported trigger.) |
+
+The interval is set with `snapshots_trigger_threshold` and defaults to `10m`. Setting `snapshots_trigger` to `refresh_complete` or `stream_batches` on a caching dataset is a configuration error.
 
 #### Stream-based datasets
 

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
@@ -111,7 +111,7 @@ The `snapshots_trigger` setting controls when Spice creates new snapshots. The a
 
 #### Batch-based datasets
 
-Datasets using `refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with a `time_column` support the following triggers:
+Datasets using `refresh_mode: full`, or `refresh_mode: append` with a `time_column`, support the following triggers:
 
 | Trigger            | Description                                                     |
 | ------------------ | --------------------------------------------------------------- |
@@ -150,6 +150,16 @@ datasets:
       params:
         duckdb_file: /nvme/some_table.db
 ```
+
+#### Caching datasets
+
+Datasets using `refresh_mode: caching` support a single trigger:
+
+| Trigger         | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `time_interval` | Create snapshots at a fixed time interval. (Default, and the only supported trigger.) |
+
+The interval is set with `snapshots_trigger_threshold` and defaults to `10m`. Setting `snapshots_trigger` to `refresh_complete` or `stream_batches` on a caching dataset is a configuration error.
 
 #### Stream-based datasets
 

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
@@ -111,7 +111,7 @@ The `snapshots_trigger` setting controls when Spice creates new snapshots. The a
 
 #### Batch-based datasets
 
-Datasets using `refresh_mode: full`, `refresh_mode: caching`, or `refresh_mode: append` with a `time_column` support the following triggers:
+Datasets using `refresh_mode: full`, or `refresh_mode: append` with a `time_column`, support the following triggers:
 
 | Trigger            | Description                                                     |
 | ------------------ | --------------------------------------------------------------- |
@@ -150,6 +150,16 @@ datasets:
       params:
         duckdb_file: /nvme/some_table.db
 ```
+
+#### Caching datasets
+
+Datasets using `refresh_mode: caching` support a single trigger:
+
+| Trigger         | Description                                                                           |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `time_interval` | Create snapshots at a fixed time interval. (Default, and the only supported trigger.) |
+
+The interval is set with `snapshots_trigger_threshold` and defaults to `10m`. Setting `snapshots_trigger` to `refresh_complete` or `stream_batches` on a caching dataset is a configuration error.
 
 #### Stream-based datasets
 


### PR DESCRIPTION
## Summary

The Snapshots feature page groups `refresh_mode: caching` with the *batch-based* datasets and tells readers those support `refresh_complete` (as the default) and `time_interval`. The runtime does not: caching is checked in its own branch **before** the batch/stream split, it defaults to `time_interval`, and it **rejects** both `refresh_complete` and `stream_batches` with a hard configuration error.

A reader who copies the page's batch-based guidance onto a caching dataset — or who leaves `snapshots_trigger: refresh_complete` from the page's own top-of-page example — fails to start with `Caching refresh mode only supports 'time_interval' for snapshots_trigger`.

### What the code does

`build_snapshot_creation_config` in `crates/runtime/src/datafusion/mod.rs` (spiceai/spiceai @ `trunk`, [mod.rs#L5333-L5344](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/datafusion/mod.rs)):

```rust
// Caching mode only supports time_interval - no "refresh complete" or "stream_batches" events.
let is_caching = matches!(refresh_mode, RefreshMode::Caching);

let snapshot_creation_trigger = if is_caching {
    match snapshot_trigger {
        None | Some(SnapshotsTrigger::TimeInterval) => {
            let interval = parse_interval(&snapshot_threshold)?;   // DEFAULT_SNAPSHOT_CREATION_INTERVAL = 10m
            SnapshotCreateTrigger::Interval(interval)
        }
        Some(SnapshotsTrigger::RefreshComplete | SnapshotsTrigger::StreamBatches) => {
            return Err(Error::UnsupportedSnapshotTriggerForCaching);
        }
    }
} else if is_streaming_refresh {
    ...
```

`DEFAULT_SNAPSHOT_CREATION_INTERVAL` is `Duration::from_mins(10)` (`mod.rs:719`).

The same branch, unchanged, is present in every released version this page ships for — verified with `git grep UnsupportedSnapshotTriggerForCaching` at `v1.11.4`, `v2.0.1`, `v2.1.5` and `v2.2.0` — so the correction applies to every snapshot, not just vNext.

### What changed

- Dropped `refresh_mode: caching` from the **Batch-based datasets** list.
- Added a **Caching datasets** section documenting `time_interval` as the only (and default) trigger, the `10m` default interval, and that `refresh_complete` / `stream_batches` are a configuration error.

### Why this is a re-sweep

spiceai/docs#1855 already made exactly this correction on `reference/spicepod/datasets.md` (vNext + 1.11.x + 2.0.x, later inherited by 2.1.x/2.2.x), but it only touched the reference page — the `features/data-acceleration/snapshots.md` feature page kept the wrong bucketing in all five copies. This PR closes the cross-page gap; the two pages now agree.

## Source

- spiceai/spiceai @ `trunk` — `crates/runtime/src/datafusion/mod.rs` (`build_snapshot_creation_config`, `DEFAULT_SNAPSHOT_CREATION_INTERVAL`, `Error::UnsupportedSnapshotTriggerForCaching`)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rn 'For batch-based datasets\|Batch-based datasets' docs/ versioned_docs/` — the 10 `reference/spicepod/datasets.md` hits are already correct; the 5 `features/data-acceleration/snapshots.md` hits are the ones fixed here
- [x] Versioned-docs propagation: 5 files (1 unversioned + 1.11.x, 2.0.x, 2.1.x, 2.2.x — the only snapshots that carry this page)
- [x] Files updated: 5 (matches the diff)