### PR TITLE
docs(snapshots): snapshots.location must be a URI; a bare filesystem path is rejected

### DIFF
--- a/website/docs/features/data-acceleration/snapshots.md
+++ b/website/docs/features/data-acceleration/snapshots.md
@@ -73,7 +73,9 @@ snapshots:
 | Amazon S3            | `s3://`                   | Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.)                                               |
 | Azure ADLS Gen2      | `abfss://`, `abfs://`     | `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_FEDERATED_TOKEN_FILE` |
 | Google Cloud Storage | `gs://`                   | `GOOGLE_APPLICATION_CREDENTIALS`, Workload Identity                                                                         |
-| Local filesystem     | Absolute or relative path | N/A                                                                                                                         |
+| Local filesystem     | `file://`                 | N/A                                                                                                                         |
+
+`location` must be a URI with a scheme — a bare filesystem path such as `/nvme/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. Use `file:///nvme/snapshots/` for a local folder.
 
 When the location is an S3 bucket, the configuration accepts any [S3 dataset parameters](../../components/data-connectors/s3) under `params`. Azure and GCS locations also accept their respective connector parameters under `params` for explicit credential overrides. When no explicit credentials are supplied, Spice reads standard environment variables for each cloud provider.
 

--- a/website/docs/reference/spicepod/index.md
+++ b/website/docs/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `true`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `false`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `false`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-1.8.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.8.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `false`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `false`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`) and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
@@ -73,7 +73,9 @@ snapshots:
 | Amazon S3            | `s3://`                   | Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.)                                               |
 | Azure ADLS Gen2      | `abfss://`, `abfs://`     | `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_FEDERATED_TOKEN_FILE` |
 | Google Cloud Storage | `gs://`                   | `GOOGLE_APPLICATION_CREDENTIALS`, Workload Identity                                                                         |
-| Local filesystem     | Absolute or relative path | N/A                                                                                                                         |
+| Local filesystem     | `file://`                 | N/A                                                                                                                         |
+
+`location` must be a URI with a scheme — a bare filesystem path such as `/nvme/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. Use `file:///nvme/snapshots/` for a local folder.
 
 When the location is an S3 bucket, the configuration accepts any [S3 dataset parameters](../../components/data-connectors/s3) under `params`. Azure and GCS locations also accept their respective connector parameters under `params` for explicit credential overrides. When no explicit credentials are supplied, Spice reads standard environment variables for each cloud provider.
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `true`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
@@ -73,7 +73,9 @@ snapshots:
 | Amazon S3            | `s3://`                   | Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.)                                               |
 | Azure ADLS Gen2      | `abfss://`, `abfs://`     | `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_FEDERATED_TOKEN_FILE` |
 | Google Cloud Storage | `gs://`                   | `GOOGLE_APPLICATION_CREDENTIALS`, Workload Identity                                                                         |
-| Local filesystem     | Absolute or relative path | N/A                                                                                                                         |
+| Local filesystem     | `file://`                 | N/A                                                                                                                         |
+
+`location` must be a URI with a scheme — a bare filesystem path such as `/nvme/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. Use `file:///nvme/snapshots/` for a local folder.
 
 When the location is an S3 bucket, the configuration accepts any [S3 dataset parameters](../../components/data-connectors/s3) under `params`. Azure and GCS locations also accept their respective connector parameters under `params` for explicit credential overrides. When no explicit credentials are supplied, Spice reads standard environment variables for each cloud provider.
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `true`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
@@ -73,7 +73,9 @@ snapshots:
 | Amazon S3            | `s3://`                   | Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc.)                                               |
 | Azure ADLS Gen2      | `abfss://`, `abfs://`     | `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_FEDERATED_TOKEN_FILE` |
 | Google Cloud Storage | `gs://`                   | `GOOGLE_APPLICATION_CREDENTIALS`, Workload Identity                                                                         |
-| Local filesystem     | Absolute or relative path | N/A                                                                                                                         |
+| Local filesystem     | `file://`                 | N/A                                                                                                                         |
+
+`location` must be a URI with a scheme — a bare filesystem path such as `/nvme/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. Use `file:///nvme/snapshots/` for a local folder.
 
 When the location is an S3 bucket, the configuration accepts any [S3 dataset parameters](../../components/data-connectors/s3) under `params`. Azure and GCS locations also accept their respective connector parameters under `params` for explicit credential overrides. When no explicit credentials are supplied, Spice reads standard environment variables for each cloud provider.
 

--- a/website/versioned_docs/version-2.2.x/reference/spicepod/index.md
+++ b/website/versioned_docs/version-2.2.x/reference/spicepod/index.md
@@ -135,7 +135,7 @@ Enable or disable snapshot management globally. Defaults to `true`.
 
 ### `snapshots.location`
 
-The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and absolute or relative filesystem paths. The path must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
+The folder where snapshots are stored. Supports S3 bucket URIs (`s3://bucket/prefix/`), Azure ADLS Gen2 URIs (`abfss://container@account.dfs.core.windows.net/path/`), Google Cloud Storage URIs (`gs://bucket/prefix/`), and local filesystem URIs (`file:///path/to/folder/`). The value must be a URI with a scheme: a bare filesystem path such as `/var/spice/snapshots` is not a valid URI, so it fails to parse and snapshots are disabled with an error logged. The location must resolve to a single folder; Spice creates per-dataset folders underneath using Hive-style partitions (`month=YYYY-MM/day=YYYY-MM-DD/dataset=<name>`).
 
 ### `snapshots.bootstrap_on_failure_behavior`
 


### PR DESCRIPTION
## Summary

Both the Spicepod reference (`snapshots.location`) and the Snapshots feature page ("Supported storage backends") tell readers a snapshot location may be an **absolute or relative filesystem path**. It cannot be. The runtime parses `snapshots.location` with `Url::from_str` before any scheme dispatch, and a bare path — absolute or relative — is not a valid URI, so the parse fails, an error is logged, and **snapshots are silently disabled for that dataset**. The user gets no snapshot bootstrap and no snapshot creation, having configured exactly what the docs told them to.

The local filesystem *is* supported, but only through a `file://` URI, which reaches `object_store::parse_url` via the fallback arm.

### What the code does

`crates/runtime-acceleration/src/snapshot/mod.rs` (spiceai/spiceai @ `trunk`, both construction paths — `:842` and `:927`):

```rust
let snapshots_location_url = match Url::from_str(snapshot_location) {
    Ok(url) => url,
    Err(e) => {
        tracing::error!("Failed to parse snapshot location URL: {snapshot_location}, error: {e}");
        return None;   // no snapshotter is built
    }
};
```

`Url::from_str` is the `url` crate's WHATWG parser: without a base, `/nvme/snapshots/` and `./snapshots/` both fail with `RelativeUrlWithoutBase`. Only after a successful parse does `build_snapshot_object_store` dispatch on `.scheme()` — `s3`, `abfss`/`abfs`, `gs`/`gcs`, and a `_ =>` fallback to `object_store::parse_url`, which is what makes `file://` work.

This is not a recent regression: the same `Url::from_str(snapshot_location)` gate is present at `v1.8.3`, `v1.9.2`, `v1.10.2`, `v1.11.4`, `v2.0.1`, `v2.1.5` and `v2.2.0` (verified with `git grep`), so the claim has never been true in any version that carries it.

### What changed

- `reference/spicepod/index.md` — `snapshots.location` now says S3 / (where listed) Azure / GCS URIs **and local filesystem URIs (`file:///path/to/folder/`)**, with an explicit note that a bare path is not a valid URI and disables snapshots with an error logged.
- `features/data-acceleration/snapshots.md` — the "Supported storage backends" table's Local filesystem row now reads `file://` instead of "Absolute or relative path", with the same note under the table.

## Source

- spiceai/spiceai @ `trunk` — `crates/runtime-acceleration/src/snapshot/mod.rs` (`Url::from_str(snapshot_location)`, `build_snapshot_object_store` scheme dispatch)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page + cross-version sweep of both phrasings — `grep -rn 'absolute or relative filesystem path\|Absolute or relative path' website/` returns **0** hits after the change (12 before)
- [x] Versioned-docs propagation: 8 `reference/spicepod/index.md` (vNext + 1.8.x–2.2.x) + 4 `features/data-acceleration/snapshots.md` (vNext + 2.0.x/2.1.x/2.2.x — the older snapshots have no storage-backends table)
- [x] Files updated: 12 (matches the diff)