### PR TITLE
docs(spicepod): acceleration enabled: false discards the rest of the block

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -410,6 +410,20 @@ Optional. Accelerate queries to the dataset by caching data locally.
 
 Enable or disable acceleration, defaults to `true`.
 
+:::warning `enabled: false` discards the rest of the acceleration block
+
+`enabled: false` turns the whole block off rather than parking it. Every other setting in it — `engine`, `mode`, `refresh_mode`, `primary_key`, `indexes`, `on_conflict`, everything under `params`, and the rest — is read, accepted, and then never applied. The dataset loads, reports healthy, and federates every query straight to the source, which is hard to tell from a working accelerator. It is most misleading under `refresh_mode: caching`, where a block that appears to cache with a one-second freshness window is sending every query to the origin.
+
+The runtime warns at load naming the dataset and the settings it discarded:
+
+```
+Dataset 'my_dataset' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: `engine`, `mode`, `params`, `primary_key`, `refresh_mode`. Remove `enabled: false` to apply them, or remove them to keep the dataset unaccelerated. See: https://spiceai.org/docs/reference/spicepod/datasets#acceleration
+```
+
+`enabled: false` on its own — with nothing else in the block — is a complete configuration and is not warned about. The deprecated `acceleration.ready_state` is also never reported, because a dataset applies it whether or not acceleration is enabled.
+
+:::
+
 ## `acceleration.engine`
 
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:

--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -87,6 +87,20 @@ Optional. Accelerate queries to the view by caching data locally.
 
 Enable or disable acceleration, defaults to `true`.
 
+:::warning `enabled: false` discards the rest of the acceleration block
+
+A view carries the same acceleration block as a dataset and discards it the same way: with `enabled: false`, every other setting in the block — `engine`, `mode`, `refresh_mode`, `primary_key`, `indexes`, `on_conflict`, everything under `params` — is read, accepted, and then never applied. The view loads and reports healthy while every query runs against its source.
+
+The runtime warns at load naming the view and the settings it discarded:
+
+```
+View 'my_view' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: `engine`, `mode`, `refresh_mode`. Remove `enabled: false` to apply them, or remove them to keep the view unaccelerated. See: https://spiceai.org/docs/reference/spicepod/views#acceleration
+```
+
+`enabled: false` on its own — with nothing else in the block — is a complete configuration and is not warned about.
+
+:::
+
 ## `acceleration.engine`
 
 The acceleration engine to use, defaults to `arrow`. The following engines are supported:


### PR DESCRIPTION
## Summary

`acceleration.enabled` was documented as "Enable or disable acceleration, defaults to `true`" and nothing more, on both the datasets and views references. `enabled: false` does not park the rest of the block — it discards it. `engine`, `mode`, `refresh_mode`, `primary_key`, `indexes`, `on_conflict` and everything under `params` are read, accepted, and never applied, while the component loads, reports healthy, and federates every query to the source. That is hard to distinguish from a working accelerator, and worst under `refresh_mode: caching`, where a block that looks like it caches with a one-second freshness window is sending every query to the origin.

spiceai/spiceai#13602 makes the runtime say so at load. This documents the same thing on the two reference pages the warning itself links to.

Verified against `origin/trunk`:

- `crates/spicepod/src/acceleration/mod.rs:684-711` — `fields_ignored_when_disabled()` derives the list from the serialized block (any field differing from what a disabled block carries at its default), so it is open-ended rather than a fixed list; the docs name the common ones and say "and the rest".
- `crates/spicepod/src/acceleration/mod.rs:662` — `CONSUMED_WHEN_DISABLED = ["enabled", "ready_state"]`. The datasets page notes the deprecated `acceleration.ready_state` exclusion and why (a dataset applies it either way, per the comment at lines 653-657); the views page does not, because `ViewBuilder` drops it unconditionally rather than because of `enabled: false` — that is spiceai/spiceai#13615, not this.
- `crates/runtime/src/component/mod.rs:101-121` — the message text, quoted verbatim including the trailing `See:` URL, and `crates/runtime/src/component/mod.rs:50-74` for the `Dataset`/`View` noun and the per-component reference URL each page's sample uses.
- The sample field lists are alphabetical because `fields_ignored_when_disabled` sorts; the datasets sample matches the unit test at lines 784-792 verbatim.
- An `enabled: false` block that sets nothing else returns an empty list and is not warned about (`a_disabled_acceleration_that_sets_nothing_else_discards_nothing`, line 795) — stated so the docs do not read as discouraging the legitimate spelling.

## Scope

vNext only. The discard itself is longstanding, but the warning these sections quote is not in any released tag — spiceai/spiceai#13602 merged 2026-08-29, after `v2.2.0` (2026-08-24). A released snapshot describing a warning its runtime does not emit would be wrong.

## Source PRs

- spiceai/spiceai#13602 — fix(spicepod): say which acceleration settings enabled: false discards (fixes #13514)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext only (warning not in any released tag)
- [x] Files updated: 2