### PR TITLE
docs(snapshot refresh mode): UPDATE, DELETE and TRUNCATE are rejected too, not just INSERT

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -177,7 +177,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60 seconds) for newer snapshots
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that don't need direct access to the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/docs/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/docs/features/data-acceleration/refresh-modes/snapshot.md
@@ -49,7 +49,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60s) for newer snapshots.
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading.
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes.
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots.
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots.
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that should not access the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
@@ -177,7 +177,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60 seconds) for newer snapshots
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots
+- `INSERT`, `UPDATE`, and `DELETE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that don't need direct access to the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -49,7 +49,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60s) for newer snapshots.
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading.
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes.
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots.
+- `INSERT`, `UPDATE`, and `DELETE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots.
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that should not access the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
@@ -177,7 +177,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60 seconds) for newer snapshots
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that don't need direct access to the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -49,7 +49,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60s) for newer snapshots.
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading.
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes.
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots.
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots.
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that should not access the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
@@ -177,7 +177,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60 seconds) for newer snapshots
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that don't need direct access to the federated source — for example, edge nodes that receive snapshots from a centralized writer.

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -49,7 +49,7 @@ datasets:
 - After bootstrap, the runtime polls the snapshot store at `refresh_check_interval` (default: 60s) for newer snapshots.
 - When a newer snapshot is found, its schema is validated against the current acceleration schema before downloading.
 - The accelerator file is swapped atomically — queries continue to be served from the previous snapshot until the swap completes.
-- `INSERT INTO` statements are rejected with an error since the acceleration is driven exclusively from snapshots.
+- `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` statements are all rejected with an error since the acceleration is driven exclusively from snapshots.
 
 :::tip
 Use `refresh_mode: snapshot` for read-only replicas that should not access the federated source — for example, edge nodes that receive snapshots from a centralized writer.


### PR DESCRIPTION
## Summary

Both places that describe `refresh_mode: snapshot` behavior list a single rejected statement — "`INSERT INTO` statements are rejected with an error". The accelerated table rejects **every** mutating operation in snapshot mode, each with its own error. A reader who takes the docs literally will plan a `DELETE`-based retention job or a `TRUNCATE` on a snapshot-mode replica and only find out at query time.

### What the code does

`AcceleratedTable` in `crates/runtime-table/src/accelerated/mod.rs` (spiceai/spiceai @ `trunk`) guards four separate entry points with the same `refresh_mode == RefreshMode::Snapshot` check:

```rust
if self.refresh_mode == RefreshMode::Snapshot {
    return Err(DataFusionError::Execution(format!(
        "writes to accelerated table {} are not permitted when refresh_mode is 'snapshot'; \
         the accelerator is driven exclusively from the snapshot store", self.dataset_name)));
}
```

…and the same shape for `deletes on …`, `updates on …`, and `truncate on …`.

### Version scoping

The truncate guard is not in every release, so the correction differs per snapshot (`git grep -c "not permitted when refresh_mode is 'snapshot'"`):

| Version | Guards present | Documented as |
| --- | --- | --- |
| `v2.0.1` (`crates/runtime/src/accelerated_table/mod.rs`) | writes, deletes, updates — **3** | `INSERT`, `UPDATE`, `DELETE` |
| `v2.1.5` (`crates/runtime/src/accelerated_table/mod.rs`) | + truncate — **4** | `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE` |
| `v2.2.0` / `trunk` (`crates/runtime-table/src/accelerated/mod.rs`) | **4** | `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE` |

So `version-2.0.x` correctly keeps the three-statement list and only 2.1.x, 2.2.x and vNext gain `TRUNCATE`.

## What changed

The one-line bullet on both pages that carry it — the dedicated Snapshot Refresh Mode page and the Snapshot Refresh Mode section of the Data Refresh page — in each of the four versions where `refresh_mode: snapshot` exists.

## Source

- spiceai/spiceai @ `trunk` — `crates/runtime-table/src/accelerated/mod.rs` (`insert_into` / `delete_from` / `update` / `truncate` snapshot-mode guards)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page sweep: `grep -rln 'INSERT INTO` statements are rejected' website/` returned exactly these 8 files before the change and **0** after
- [x] Versioned-docs propagation: 8 files (vNext + 2.0.x/2.1.x/2.2.x × 2 pages — `refresh_mode: snapshot` does not exist in 1.x snapshots)
- [x] Files updated: 8 (matches the diff)