### PR TITLE
docs(snapshot refresh mode): the mode never publishes snapshots, even with snapshots: enabled

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -168,7 +168,7 @@ datasets:
 
 **Requirements:**
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**
 
 **Behavior:**

--- a/website/docs/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/docs/features/data-acceleration/refresh-modes/snapshot.md
@@ -40,7 +40,7 @@ datasets:
 
 ## Requirements
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`.
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**.
 
 ## Behavior

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
@@ -168,7 +168,7 @@ datasets:
 
 **Requirements:**
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**
 
 **Behavior:**

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -40,7 +40,7 @@ datasets:
 
 ## Requirements
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`.
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**.
 
 ## Behavior

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
@@ -168,7 +168,7 @@ datasets:
 
 **Requirements:**
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**
 
 **Behavior:**

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -40,7 +40,7 @@ datasets:
 
 ## Requirements
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`.
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**.
 
 ## Behavior

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
@@ -168,7 +168,7 @@ datasets:
 
 **Requirements:**
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**
 
 **Behavior:**

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/snapshot.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/snapshot.md
@@ -40,7 +40,7 @@ datasets:
 
 ## Requirements
 
-- `acceleration.snapshots` must be `enabled` or `bootstrap_only`.
+- `acceleration.snapshots` must be `enabled` or `bootstrap_only`. Snapshot mode is a snapshot *consumer* only, so the two behave identically here: creation is skipped for the mode entirely and the dataset never publishes new snapshots — a separate writer must produce them.
 - The acceleration engine must be a snapshot-capable file-based engine: **DuckDB**, **SQLite**, **Cayenne**, or **Turso**.
 
 ## Behavior


### PR DESCRIPTION
## Summary

The `refresh_mode: snapshot` requirements say `acceleration.snapshots` must be `enabled` **or** `bootstrap_only`, and the Snapshots page defines `enabled` as "download snapshots on startup **and write a new snapshot after each refresh**". Read together, an operator reasonably concludes a snapshot-mode replica configured with `snapshots: enabled` re-publishes what it loads. It does not — and never has. Snapshot creation is short-circuited for the mode before any trigger or engine check runs, so `enabled` and `bootstrap_only` are behaviorally identical here.

This matters because the mode's whole use case is a fan-out of read replicas fed by a central writer. Someone who believes a replica also publishes may point several replicas at the same location expecting them to keep it warm, and nothing ever writes.

### What the code does

`build_snapshot_creation_config` in `crates/runtime/src/datafusion/mod.rs` (spiceai/spiceai @ `trunk`) returns before doing anything else:

```rust
// `refresh_mode: snapshot` is a read-only snapshot consumer. Even when the
// dataset uses `acceleration.snapshots: enabled` (which normally enables
// both bootstrap and creation), snapshot refresh mode must not publish new
// snapshots or run the refresh-complete snapshot creation path.
if matches!(refresh_mode, RefreshMode::Snapshot) {
    return Ok(None);
}
```

`Ok(None)` means no `SnapshotCreationConfig` is built, so no creation trigger is ever armed for the dataset.

The guard is present in every version that documents `refresh_mode: snapshot` — verified with `git grep "snapshot refresh mode must not publish new"` at `v2.0.1`, `v2.1.5` and `v2.2.0` — so the clarification propagates to all four copies rather than being vNext-only.

## What changed

Extended the existing `acceleration.snapshots` requirement bullet on both pages that document the mode (the dedicated Snapshot Refresh Mode page and the Snapshot Refresh Mode section of Data Refresh) to say the mode is a consumer only and that a separate writer must produce the snapshots.

## Source

- spiceai/spiceai @ `trunk` — `crates/runtime/src/datafusion/mod.rs` (`build_snapshot_creation_config`)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page sweep: `grep -rln 'must be .enabled. or .bootstrap_only' website/` returns exactly these 8 files
- [x] Versioned-docs propagation: 8 files (vNext + 2.0.x/2.1.x/2.2.x × 2 pages — `refresh_mode: snapshot` does not exist in 1.x snapshots)
- [x] Files updated: 8 (matches the diff)