### PR TITLE
docs(cayenne): file-mode Cayenne rejects refresh_append_overlap

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -797,6 +797,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **Transaction Constraints**: [Transactions](#transactions) support gated `INSERT`/`UPDATE` writes on accelerator-only, non-partitioned Cayenne tables only (no `DELETE`/`MERGE`, one write per table). See [Transactions](#transactions) for the full list.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read. The check runs during file-mode initialization, so a `mode: memory` dataset is not rejected.
 
 ## Example Spicepod
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -674,6 +674,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -167,6 +167,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.10.x/components/data-accelerators/cayenne.md
@@ -67,6 +67,7 @@ Consider the following limitations when using Cayenne acceleration:
 - **No Snapshot Support**: Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots) for bootstrapping from object storage.
 - **Data Types**: Some advanced data types may have limited support. Test your specific schema requirements.
 - **Index Support**: Index capabilities are still being developed. Check release notes for the latest supported features.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read.
 
 :::warning[Alpha Software]
 

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/datasets.md
@@ -433,6 +433,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 Specify as a duration string (e.g., `10m`, `1h`, `24h`).
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.10.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-1.10.x/reference/spicepod/views.md
@@ -148,6 +148,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 Specify as a duration string (e.g., `10m`, `1h`, `24h`).
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.11.x/components/data-accelerators/cayenne.md
@@ -511,6 +511,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **No File Compaction**: Automatic file compaction to reclaim space from deleted rows is not yet available.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read.
 
 :::warning BETA SOFTWARE
 As a Beta feature, Spice Cayenne should be thoroughly tested in development environments before production deployment. Monitor release notes for updates, breaking changes, and new capabilities.

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/datasets.md
@@ -520,6 +520,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.11.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-1.11.x/reference/spicepod/views.md
@@ -147,6 +147,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.9.x/components/data-accelerators/cayenne.md
+++ b/website/versioned_docs/version-1.9.x/components/data-accelerators/cayenne.md
@@ -67,6 +67,7 @@ Consider the following limitations when using Cayenne acceleration:
 - **No Snapshot Support**: Cayenne does not yet support [acceleration snapshots](../../features/data-acceleration/snapshots) for bootstrapping from object storage.
 - **Data Types**: Some advanced data types may have limited support. Test your specific schema requirements.
 - **Index Support**: Index capabilities are still being developed. Check release notes for the latest supported features.
+- **No `refresh_append_overlap`**: A dataset accelerated by Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read.
 
 :::warning[Alpha Software]
 

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/datasets.md
@@ -345,6 +345,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-1.9.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-1.9.x/reference/spicepod/views.md
@@ -148,6 +148,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/cayenne/index.md
@@ -588,6 +588,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read.
 
 ## Example Spicepod
 

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/datasets.md
@@ -610,6 +610,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/views.md
@@ -147,6 +147,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/cayenne/index.md
@@ -775,6 +775,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read.
 
 ## Example Spicepod
 

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/datasets.md
@@ -658,6 +658,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/views.md
@@ -167,6 +167,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.2.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.2.x/components/data-accelerators/cayenne/index.md
@@ -789,6 +789,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **Transaction Constraints**: [Transactions](#transactions) support gated `INSERT`/`UPDATE` writes on accelerator-only, non-partitioned Cayenne tables only (no `DELETE`/`MERGE`, one write per table). See [Transactions](#transactions) for the full list.
+- **No `refresh_append_overlap`**: A dataset accelerated by Spice Cayenne that sets [`acceleration.refresh_append_overlap`](../../reference/spicepod/datasets#accelerationrefresh_append_overlap) fails to load, with `Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration`. [`refresh_mode: append`](../../features/data-acceleration/data-refresh) itself is supported — only the overlap window is not, so late-arriving rows behind the high-water mark are missed rather than re-read. The check runs during file-mode initialization, so a `mode: memory` dataset is not rejected.
 
 ## Example Spicepod
 

--- a/website/versioned_docs/version-2.2.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.2.x/reference/spicepod/datasets.md
@@ -674,6 +674,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.2.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-2.2.x/reference/spicepod/views.md
@@ -167,6 +167,8 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
+Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
+
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.


### PR DESCRIPTION
## Summary

Spice Cayenne refuses to load a dataset that sets `refresh_append_overlap`, and no page said so. spiceai/spiceai#13680 had to comment the setting out of the repo-root sample spicepod for exactly this reason — `spice run` from the repo root failed dataset registration once the GitHub datasets moved to `engine: cayenne` (spiceai/spiceai#13571).

Verified against `origin/trunk`, `crates/accelerators/accelerator-cayenne/src/lib.rs:3403-3410`:

```rust
// Validate that refresh_append_overlap is not specified
if acceleration.refresh_append_overlap.is_some() {
    return Err(Box::new(Error::InvalidConfiguration {
        detail: Arc::from(
            "Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration",
        ),
    }));
}
```

The error string is quoted verbatim from that literal.

Two distinctions the code makes that the wording keeps:

- **File mode only.** The check sits inside `init()`, which returns early at line 3379 when `!source.is_file_accelerated()`. `is_file_accelerated()` (`crates/runtime-component/src/dataset/mod.rs:662-674`) is true for `mode: file`/`file_create`/`file_update`, so a `mode: memory` Cayenne dataset never reaches the check. Stated only on the two pages that document memory mode (vNext and 2.2.x); the 1.9.x–2.1.x pages say "File Mode Only" in the same list, so the qualifier would be noise there.
- **`refresh_mode: append` is fine.** Only the overlap window is rejected. Said explicitly so the bullet does not read as "Cayenne cannot do append refresh", and the consequence — late-arriving rows behind the high-water mark are missed rather than re-read — is named, since that is why a reader wanted the setting.

## Scope

Not a new restriction — it is present in every released version that ships Cayenne, so this is a correction-class omission swept across all of them rather than a vNext addition. Confirmed by reading the same guarded block at each tag:

| Tag | Location |
| --- | --- |
| `v1.9.2` | `crates/runtime/src/dataaccelerator/cayenne.rs:590-594` (gate at 569) |
| `v1.10.4` | `crates/runtime/src/dataaccelerator/cayenne.rs:566-570` (gate at 545) |
| `v1.11.6` | `crates/runtime/src/dataaccelerator/cayenne/mod.rs:1746-1750` (gate at 1722) |
| `v2.0.0` | `crates/runtime/src/dataaccelerator/cayenne/mod.rs:1395` (gate at 1367) |
| `v2.1.5` | `crates/runtime/src/dataaccelerator/cayenne/mod.rs:2128` (gate at 2100) |
| `v2.2.0` | `crates/runtime/src/dataaccelerator/cayenne/mod.rs:3142` (gate at 3115) |

21 files: the 7 Cayenne accelerator pages (vNext + 2.2.x/2.1.x/2.0.x/1.11.x/1.10.x/1.9.x), and the `acceleration.refresh_append_overlap` entry in `reference/spicepod/datasets.md` **and** `views.md` for those same 7 versions — the reference pages already carry per-engine support statements (`mode`, `on_schema_change`), so an engine that rejects the key belongs there too. `version-1.5.x`–`1.8.x` also document `refresh_append_overlap` but predate Cayenne and are untouched.

Completeness check: every Cayenne accelerator page now carries the bullet, and staged files (21) equals the pages mentioning the key on those two page types (21).

## Source PRs

- spiceai/spiceai#13680 — fix: comment out refresh_append_overlap in the sample spicepod
- spiceai/spiceai#13571 — chore(spicepod): accelerate GitHub datasets with Cayenne instead of DuckDB (the change that exposed it)

## Test plan

- [x] `cd website && npm run build` passes (14 new cross-page links and the `#limitations` anchors resolve in every version)
- [x] Versioned-docs propagation checked — all 7 Cayenne-bearing versions
- [x] Files updated: 21