### PR TITLE
docs(localpod): synchronized refreshes need the same refresh mode on both datasets

### DIFF
--- a/website/docs/components/data-connectors/localpod.md
+++ b/website/docs/components/data-connectors/localpod.md
@@ -11,7 +11,9 @@ The dataset created by the `localpod` connector will logically have the same dat
 
 ## Synchronized Refreshes
 
-The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.
+The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require the parent and child accelerations to use the **same** refresh mode, and only two pairings qualify: both `refresh_mode: full` (which is the default), or both `refresh_mode: caching`. A mismatched pair — a `caching` child under a `full` parent, for example — is not synchronized.
+
+Synchronization is best-effort. When it cannot be established — mismatched refresh modes, a parent that is not accelerated, or a parent dataset that is not registered — the child silently falls back to refreshing on its own schedule, and the reason is logged only at `DEBUG`. At default log levels the `INFO` line below is the sole confirmation that synchronization took effect; its absence means the two datasets refresh independently.
 
 When synchronization is enabled, the following logs will be emitted:
 

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/localpod.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/localpod.md
@@ -11,7 +11,9 @@ The dataset created by the `localpod` connector will logically have the same dat
 
 ## Synchronized Refreshes
 
-The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.
+The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require the parent and child accelerations to use the **same** refresh mode, and only two pairings qualify: both `refresh_mode: full` (which is the default), or both `refresh_mode: caching`. A mismatched pair — a `caching` child under a `full` parent, for example — is not synchronized.
+
+Synchronization is best-effort. When it cannot be established — mismatched refresh modes, a parent that is not accelerated, or a parent dataset that is not registered — the child silently falls back to refreshing on its own schedule, and the reason is logged only at `DEBUG`. At default log levels the `INFO` line below is the sole confirmation that synchronization took effect; its absence means the two datasets refresh independently.
 
 When synchronization is enabled, the following logs will be emitted:
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/localpod.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/localpod.md
@@ -11,7 +11,9 @@ The dataset created by the `localpod` connector will logically have the same dat
 
 ## Synchronized Refreshes
 
-The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.
+The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require the parent and child accelerations to use the **same** refresh mode, and only two pairings qualify: both `refresh_mode: full` (which is the default), or both `refresh_mode: caching`. A mismatched pair — a `caching` child under a `full` parent, for example — is not synchronized.
+
+Synchronization is best-effort. When it cannot be established — mismatched refresh modes, a parent that is not accelerated, or a parent dataset that is not registered — the child silently falls back to refreshing on its own schedule, and the reason is logged only at `DEBUG`. At default log levels the `INFO` line below is the sole confirmation that synchronization took effect; its absence means the two datasets refresh independently.
 
 When synchronization is enabled, the following logs will be emitted:
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/localpod.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/localpod.md
@@ -11,7 +11,9 @@ The dataset created by the `localpod` connector will logically have the same dat
 
 ## Synchronized Refreshes
 
-The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.
+The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require the parent and child accelerations to use the **same** refresh mode, and only two pairings qualify: both `refresh_mode: full` (which is the default), or both `refresh_mode: caching`. A mismatched pair — a `caching` child under a `full` parent, for example — is not synchronized.
+
+Synchronization is best-effort. When it cannot be established — mismatched refresh modes, a parent that is not accelerated, or a parent dataset that is not registered — the child silently falls back to refreshing on its own schedule, and the reason is logged only at `DEBUG`. At default log levels the `INFO` line below is the sole confirmation that synchronization took effect; its absence means the two datasets refresh independently.
 
 When synchronization is enabled, the following logs will be emitted:
 

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/localpod.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/localpod.md
@@ -11,7 +11,9 @@ The dataset created by the `localpod` connector will logically have the same dat
 
 ## Synchronized Refreshes
 
-The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.
+The `localpod` connector supports synchronized refreshes, which ensures that the child dataset is refreshed from the same data as the parent dataset. Synchronized refreshes require the parent and child accelerations to use the **same** refresh mode, and only two pairings qualify: both `refresh_mode: full` (which is the default), or both `refresh_mode: caching`. A mismatched pair — a `caching` child under a `full` parent, for example — is not synchronized.
+
+Synchronization is best-effort. When it cannot be established — mismatched refresh modes, a parent that is not accelerated, or a parent dataset that is not registered — the child silently falls back to refreshing on its own schedule, and the reason is logged only at `DEBUG`. At default log levels the `INFO` line below is the sole confirmation that synchronization took effect; its absence means the two datasets refresh independently.
 
 When synchronization is enabled, the following logs will be emitted:
 


### PR DESCRIPTION
## Summary

The Localpod connector page states the precondition for synchronized refreshes as:

> Synchronized refreshes require that both the parent and child datasets are accelerated with `refresh_mode: full` (which is the default) or `refresh_mode: caching`.

Read literally, a `full` parent with a `caching` child satisfies that sentence. The runtime disagrees — `AcceleratedTable::Builder::synchronize_with` requires the two modes to be **equal**:

```rust
// Both parent and child must use the same refresh mode (Full or Caching)
let is_valid_sync = matches!(
    (child_mode, parent_mode),
    (RefreshMode::Full, RefreshMode::Full) | (RefreshMode::Caching, RefreshMode::Caching)
);
ensure!(is_valid_sync, SynchronizedAcceleratedTableRequiresFullOrCachingRefreshSnafu);
```

The doc-comment on the caller says the same thing in words: "The parent and child acceleration modes don't match (both must be Full or both must be Caching)."

The second, worse half is that a mismatch is **silent**. `attempt_to_synchronize_accelerated_table` returns early on every failure path — mismatched modes, a parent that isn't an accelerated table, a parent that isn't registered — and each one logs at `tracing::debug!`, below the default level. Nothing is emitted; the child simply refreshes on its own schedule. The page already shows the `INFO` success line but never tells the reader it is the *only* signal, so a misconfigured pair looks identical to a working one at default log levels.

## What changed

The precondition sentence now says the modes must match and names the two valid pairings plus a concrete invalid one; a new paragraph states that synchronization is best-effort, lists the three failure conditions, and points at the absence of the `INFO` line as the tell. No change to the example or the log snippet.

## Version scope

The equal-modes check reads identically at `v1.11.6`, `v2.0.1`, `v2.1.5`, `v2.2.0` and `origin/trunk`, and every one of those failure paths is `debug!` in all of them — so this is a correction across `version-1.11.x`, `version-2.0.x`, `version-2.1.x`, `version-2.2.x` and vNext. `version-1.5.x` through `version-1.10.x` document `refresh_mode: full` only (no `caching` pairing) and are left alone.

## Source refs

- `crates/runtime-table/src/accelerated/mod.rs` — `AcceleratedTable::Builder::synchronize_with` (`origin/trunk`); `crates/runtime/src/accelerated_table/mod.rs` in `v1.11.6` / `v2.0.1` / `v2.1.5`
- `crates/runtime/src/datafusion/mod.rs` — `attempt_to_synchronize_accelerated_table`, its doc-comment, and the four `tracing::debug!` early-returns vs. the single `tracing::info!` success line

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn "Synchronized refreshes require" docs/ versioned_docs/` returns 11 hits; the 5 carrying the `caching` pairing are corrected here, the 6 older full-only ones are correct as written
- [x] Files updated: 5 (matches the diff)