### PR TITLE
docs(caching): the cache metrics table was missing misses and the two stale-while-revalidate counters

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -416,10 +416,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of entries removed from the cache, split by a `reason` label. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 `*_cache_evictions` carries a `reason` label with one of three values:
 

--- a/website/versioned_docs/version-1.10.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.10.x/features/caching/index.md
@@ -389,10 +389,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of cache evictions due to size or TTL limits. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 The `*` prefix corresponds to the cache type:
 

--- a/website/versioned_docs/version-1.11.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.11.x/features/caching/index.md
@@ -389,10 +389,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of cache evictions due to size or TTL limits. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 The `*` prefix corresponds to the cache type:
 

--- a/website/versioned_docs/version-1.9.x/features/caching/index.md
+++ b/website/versioned_docs/version-1.9.x/features/caching/index.md
@@ -376,6 +376,7 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of cache evictions due to size or TTL limits. |

--- a/website/versioned_docs/version-2.0.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.0.x/features/caching/index.md
@@ -416,10 +416,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of cache evictions due to size or TTL limits. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 The `*` prefix corresponds to the cache type:
 

--- a/website/versioned_docs/version-2.1.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.1.x/features/caching/index.md
@@ -416,10 +416,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of cache evictions due to size or TTL limits. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 The `*` prefix corresponds to the cache type:
 

--- a/website/versioned_docs/version-2.2.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.2.x/features/caching/index.md
@@ -416,10 +416,13 @@ Cache metrics can be monitored using the [Prometheus-compatible Metrics Endpoint
 | `*_cache_max_size_bytes` | Gauge   | Maximum configured cache size in bytes.                    |
 | `*_cache_requests`       | Counter | Total number of cache lookup requests.                     |
 | `*_cache_hits`           | Counter | Total number of cache hits.                                |
+| `*_cache_misses`         | Counter | Total number of cache misses.                              |
 | `*_cache_items_count`    | Gauge   | Current number of items in the cache.                      |
 | `*_cache_size_bytes`     | Gauge   | Current cache size in bytes.                               |
 | `*_cache_evictions`      | Counter | Total number of entries removed from the cache, split by a `reason` label. |
 | `*_cache_hit_ratio`      | Gauge   | Current cache hit ratio (hits / total requests).           |
+| `*_cache_stale_swr_count` | Counter | Stale-while-revalidate background refreshes skipped because a revalidation was already in flight. |
+| `*_cache_swr_background_query_count` | Counter | Background queries triggered to revalidate a stale entry. |
 
 `*_cache_evictions` carries a `reason` label with one of three values:
 


### PR DESCRIPTION
## Summary

The Caching page's metrics table is introduced as "The following metrics are available for each cache type" and then lists 7 of the 10 counters/gauges the `generate_cache_metrics!` macro registers for each prefix. Three are missing:

| Missing row | Registration in `crates/cache/src/metrics.rs` |
| --- | --- |
| `*_cache_misses` | `MISSES` — `.u64_counter(concat!($prefix, "_cache_misses"))` |
| `*_cache_stale_swr_count` | `STALE_WHILE_REVALIDATE_SKIPPED` — `.u64_counter(concat!($prefix, "_cache_stale_swr_count"))` |
| `*_cache_swr_background_query_count` | `STALE_WHILE_REVALIDATE_BACKGROUND_QUERIES` — `.u64_counter(concat!($prefix, "_cache_swr_background_query_count"))` |

`*_cache_misses` is the one that makes the page self-inconsistent: the example `/metrics` output printed a few lines below the table already shows `results_cache_misses`, and the prose above it refers to `results_cache_misses` by name, so the table is the only place a reader looks it up and the only place it is absent. The two stale-while-revalidate counters appear nowhere on the page at all, even though `publish_counters_at_zero()` emits both for every enabled cache — so an operator writing a scrape config or an alert off this table sees series in `/metrics` that the documentation never named.

All three are documented (correctly) on the Observability page's metrics table; only the Caching page's table is short.

## Version scope

Per-version, from `crates/cache/src/metrics.rs` at each release tag:

- `_cache_misses` is registered in every version from `v1.9.0` onward → added to vNext and all 7 snapshots that have this table.
- `_cache_stale_swr_count` and `_cache_swr_background_query_count` first appear at `v1.10.0` → added to vNext and `version-1.10.x` through `version-2.2.x`; `version-1.9.x` gets only the `misses` row.
- `version-1.5.x` – `version-1.8.x` have no cache-metrics table and are untouched.

Types come from the registration call (`u64_counter` → Counter for all three), not inferred.

## Source refs

- `crates/cache/src/metrics.rs` — `generate_cache_metrics!`, the three instrument declarations, their `with_description` strings, and `publish_counters_at_zero()`

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — `grep -rn '\`\*_cache_misses\`' docs/ versioned_docs/` returns 7 hits (vNext + 6 snapshots), `\`\*_cache_stale_swr_count\`` returns 6; the counts match the per-version availability above
- [x] Files updated: 7 (matches the diff)
