### PR TITLE
docs(anthropic): logprobs and top_logprobs are refused, not mapped onto top_k

### DIFF
--- a/website/docs/components/models/anthropic.md
+++ b/website/docs/components/models/anthropic.md
@@ -9,7 +9,15 @@ To use a language model hosted on Anthropic, specify `anthropic` in the `from` f
 
 To use a specific model, include its model ID in the `from` field (see example below). If not specified, the default model is `claude-sonnet-4-6`. Name a model explicitly for anything long-lived: Anthropic retires model IDs, and a request for a retired one fails with a `not_found_error`.
 
-The default deliberately trails Anthropic's newest model. Claude 5 models reject `temperature`, `top_p`, and `top_logprobs` individually, so a request that sets any one of them fails against them; `claude-sonnet-4-6` is the newest model that still accepts each of them. It accepts them one at a time, not in every combination — Claude 4 and later reject `temperature` and `top_p` set *together*, and reject a trailing assistant message (a response prefill). Spice sends `top_logprobs` to Anthropic as `top_k`, so that is the parameter name an Anthropic error reports. Set `from: anthropic:<model_id>` to use a newer model, and drop these parameters when you do.
+The default deliberately trails Anthropic's newest model. Claude 5 models reject `temperature` and `top_p` individually, so a request that sets either of them fails against them; `claude-sonnet-4-6` is the newest model that still accepts each of them. It accepts them one at a time, not in every combination — Claude 4 and later reject `temperature` and `top_p` set *together*, and reject a trailing assistant message (a response prefill). Set `from: anthropic:<model_id>` to use a newer model, and drop these parameters when you do.
+
+Per-token log probabilities are not available from any Anthropic model — the Messages API returns none. A request that sets `logprobs: true` or `top_logprobs` is therefore refused by Spice before it reaches Anthropic, rather than answered with a completion that silently omits what was asked for. The refusal is an `invalid_request_error` naming the parameter:
+
+```
+Failed to run model 'claude-sonnet-4-6' (anthropic): the `top_logprobs` parameter is not supported. Anthropic's Messages API returns no per-token log probabilities. Remove `top_logprobs` from the request and from the model's parameters, or use a model provider that reports them. See: https://spiceai.org/docs/components/models/anthropic
+```
+
+Either field can arrive from the request or from the model's [parameter overrides](../../features/large-language-models/parameter_overrides), so remove it from both. `logprobs: false` asks for nothing and is accepted.
 
 The following parameters are specific to Anthropic models:
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13682` removed a mistranslation in the Anthropic adapter and replaced it with a refusal, and the page documented the mistranslation as the intended behavior.

Two claims on `components/models/anthropic.md` are now false on `trunk`:

1. **"Spice sends `top_logprobs` to Anthropic as `top_k`."** It no longer does. `MessageCreateParams::try_from` sets `top_k: None` unconditionally (`crates/llms/src/anthropic/chat.rs`), with a comment saying why the mapping must not come back: `top_logprobs` asks how many alternatives to *report* and leaves sampling untouched, while `top_k` restricts which tokens may be *sampled*. Carrying one into the other answered a request to observe the distribution by narrowing it.
2. **"`claude-sonnet-4-6` is the newest model that still accepts each of them"**, listing `top_logprobs` alongside `temperature` and `top_p`. No Anthropic model accepts `top_logprobs` now — `refuse_unsupported_logprobs` rejects the request before it reaches Anthropic, for every model.

## What the page now says

- `top_logprobs` is dropped from the Claude 5 sentence; the `temperature` / `top_p` claims are unchanged.
- A new paragraph states that per-token log probabilities are unavailable on every Anthropic model, quotes the refusal verbatim from the source format string, and says `logprobs: false` is still accepted (it asks for nothing, so Anthropic can satisfy it exactly).
- The remedy names both origins — the request and the model's parameter overrides — matching the error's own wording.

## Verification

```
$ git grep -n "top_k: None" origin/trunk -- crates/llms/src/anthropic/chat.rs
440:            top_k: None,
$ git grep -n "refuse_unsupported_logprobs" origin/trunk -- crates/llms/src/anthropic/chat.rs
378:fn refuse_unsupported_logprobs(
422:        refuse_unsupported_logprobs(&model, &value)?;
```

`DEFAULT_ANTHROPIC_MODEL` is still `claude-sonnet-4-6` (`crates/llms/src/anthropic/mod.rs:61`) — unchanged, and left as-is.

## Versioned-docs propagation

**vNext only.** `git tag --contains` on the merge commit returns nothing, so the refusal ships after v2.2.0. No `versioned_docs/*/components/models/anthropic.md` mentions `top_logprobs` or `top_k` at all, so there is nothing stale to sweep:

```
$ grep -rn "top_logprobs\|top_k" website/versioned_docs/*/components/models/anthropic.md
(no matches)
```

## Source PRs

- spiceai/spiceai#13682 — fix(anthropic): refuse a log-probability request instead of narrowing sampling (fixes #13581)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (grep above — vNext-only addition)
- [x] Files updated: 1