### PR TITLE
docs(cayenne): Union and RunEndEncoded are unsupported types too

### DIFF
--- a/website/docs/components/data-accelerators/cayenne/index.md
+++ b/website/docs/components/data-accelerators/cayenne/index.md
@@ -665,6 +665,8 @@ The following types require the `unsupported_type_action` parameter:
 - `Interval` types
 - `Duration` types
 - `FixedSizeBinary`
+- `Union` types
+- `RunEndEncoded`
 
 **`unsupported_type_action` options:**
 
@@ -793,7 +795,7 @@ Consider the following limitations when using Spice Cayenne acceleration:
 
 - **Memory Mode Constraints**: `mode: memory` (fully in-RAM, ephemeral) is supported alongside `mode: file`, but it does not persist any data (the dataset reloads from its source on restart), does not support partitioned tables (`partition_by`), and enforces a hard per-table RAM bound instead of spilling to disk — a breach returns an error rather than growing without limit. Use `mode: file` when persistence across restarts is required.
 - **S3 Express Only**: Standard S3 buckets are not supported for remote storage. Only S3 Express One Zone directory buckets are supported.
-- **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
+- **Unsupported Data Types**: `Interval`, `Duration`, `FixedSizeBinary`, `Union`, and `RunEndEncoded` types require `unsupported_type_action` configuration.
 - **No Traditional Indexes**: Spice Cayenne does not support explicit index creation via the `indexes` configuration. Vortex's segment statistics and fast random access encodings provide equivalent or better performance for most point lookup workloads.
 - **No MVCC**: Multi-version concurrency control is not yet implemented. Snapshots and time-travel queries are planned for future releases.
 - **Transaction Constraints**: [Transactions](#transactions) support gated `INSERT`/`UPDATE` writes on accelerator-only, non-partitioned Cayenne tables only (no `DELETE`/`MERGE`, one write per table). See [Transactions](#transactions) for the full list.


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13567` pinned Cayenne's Vortex type-capability list to what Vortex actually encodes, by a test that probes Vortex per type family instead of restating its behavior. The probe found two types the hand-maintained list was wrong about: **`Union` and `RunEndEncoded` cannot be stored**. They are now refused while the table is being created — naming the column — instead of being accepted and then failing on every write.

The docs carried the pre-probe list of three types, in two places on the same page.

## Verification

The list on `trunk` is five types, not three:

```
$ git show origin/trunk:crates/cayenne/src/schema.rs | sed -n '70,79p'
fn is_vortex_supported_type(data_type: &DataType) -> bool {
    !matches!(
        data_type,
        DataType::Interval(_)
            | DataType::Duration(_)
            | DataType::FixedSizeBinary(_)
            | DataType::Union(..)
            | DataType::RunEndEncoded(..)
    )
}
```

Both new entries reach the same handler as the existing three — `transform_data_type_for_vortex` calls `handle_unsupported_type(data_type, path, unsupported_type_action, …)` for anything `is_vortex_supported_type` rejects (`crates/cayenne/src/schema.rs:122`) — so the documented `error` / `string` / `warn` / `ignore` options apply to them unchanged, and no new row is needed in that table.

## Cross-page audit

The same claim appears twice on the vNext page and both are fixed here:

```
$ grep -rn "FixedSizeBinary" website/docs/components/data-accelerators/cayenne/index.md
667:- `FixedSizeBinary`
796:- **Unsupported Data Types**: `Interval`, `Duration`, and `FixedSizeBinary` types require `unsupported_type_action` configuration.
```

`Maps` stays under **Fully Supported Types**: the same source PR restored the Vortex `Map` → `List<Struct<keys, values>>` alias that a fork re-cut had dropped, and added a round-trip test as its tripwire, so that row is now true rather than aspirational.

## Versioned-docs propagation

**vNext only** — this is an addition, not a correction. `git tag --contains` on the merge commit returns nothing, so the load-time refusal ships after v2.2.0. The versioned snapshots that carry this list (`version-2.2.x`, `version-2.1.x`, `version-1.10.x`) correctly document the three types their releases refused; in those releases a `Union` or `RunEndEncoded` column was accepted at creation and failed per-batch on write, which is the behavior this PR's source change replaced. Adding the two names there would describe a refusal those releases do not perform.

## Source PRs

- spiceai/spiceai#13567 — fix(cayenne): store Arrow Map columns in a file-mode accelerator (fixes #13524)

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked (vNext-only addition; rationale above)
- [x] Files updated: 1