### PR TITLE
docs(json): which JSON functions push down into BigQuery, and which do not

### DIFF
--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -40,7 +40,7 @@ dbc install redshift
 
 See the [`dbc` documentation](https://docs.columnar.tech/dbc/) for other installation methods (pip, Homebrew, Windows MSI) and platform support.
 
-Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL automatically.
+Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL automatically. That dialect also rewrites the Spice [JSON extraction functions](../../reference/sql/json) — `json_get_str`, `json_get_int`, `json_get_float`, `json_get_bool`, `json_length` and `json_object_keys` — into native BigQuery SQL, so a predicate over a JSON column filters at the source instead of streaming the column to Spice. See [Federation and pushdown](../../reference/sql/json#federation-and-pushdown) for the functions that stay local and why.
 
 ## Configuration
 

--- a/website/docs/reference/sql/json.md
+++ b/website/docs/reference/sql/json.md
@@ -11,6 +11,7 @@ JSON support in Spice is based on [datafusion-functions-json](https://github.com
 
 - JSON functions and operators are supported only **during DataFusion (Arrow)** execution.
 - **Federated or accelerated sources** (non-Arrow) may **not support all JSON functions**.
+  See [Federation and pushdown](#federation-and-pushdown).
 
 :::
 
@@ -63,6 +64,7 @@ JSON support in Spice is based on [datafusion-functions-json](https://github.com
   - [Array Access](#array-access)
   - [Conditional JSON Queries](#conditional-json-queries)
   - [Using JSON Functions in Views](#using-json-functions-in-views)
+- [Federation and Pushdown](#federation-and-pushdown)
 - [Further Reading](#further-reading)
 
 ---
@@ -644,6 +646,50 @@ FROM (SELECT UNNEST(json_tree(body)) AS rows FROM documents);
 ```
 
 The scalar form takes only the JSON argument and always runs with default caps; the named options above are only accepted in the UDTF (`FROM` clause) form.
+
+## Federation and Pushdown
+
+These functions come from a Spice library, not from the source database, so a remote engine has no
+equivalent to call. A connector that installs the Spice function deny-list will not federate a plan
+containing one: a predicate such as `WHERE json_get_int(doc, 'id') = 1` disqualifies the node, the
+column is streamed to Spice, and the filter runs there. That is correct, but it costs a full remote
+scan. Whether — and which — JSON functions push down is therefore connector-specific.
+
+**BigQuery** is the exception. A dataset read through the [ADBC data
+connector](../../components/data-connectors/adbc) with `adbc_driver: bigquery` uses a BigQuery
+dialect that rewrites these functions into native BigQuery SQL, so they push down to the source:
+
+| Function                                    | Pushed down to BigQuery |
+| ------------------------------------------- | ----------------------- |
+| [`json_get_str`](#json_get_str)             | Yes                     |
+| [`json_get_int`](#json_get_int)             | Yes                     |
+| [`json_get_float`](#json_get_float)         | Yes                     |
+| [`json_get_bool`](#json_get_bool)           | Yes                     |
+| [`json_length`](#json_length)               | Yes (alias `json_len`)  |
+| [`json_object_keys`](#json_object_keys)     | Yes (alias `json_keys`) |
+| [`json_get`](#json_get)                     | No                      |
+| [`json_get_json`](#json_get_json)           | No                      |
+| [`json_get_array`](#json_get_array)         | No                      |
+| [`json_as_text`](#json_as_text)             | No                      |
+| [`json_contains`](#json_contains)           | No                      |
+
+The five that stay local do so because BigQuery cannot reproduce their results, not because the
+translation is unwritten:
+
+- `json_get_json` and `json_as_text` return the matched node's own bytes, spacing and number
+  spelling intact, where BigQuery's `JSON_QUERY` re-renders it — a document holding `{"b": -1}`
+  comes back as `{"b":-1}`.
+- `json_contains` counts a JSON `null` as present, and BigQuery returns SQL NULL for such a node
+  exactly as it does for a missing key, so the two cannot be told apart.
+- `json_get` and `json_get_array` return the library's JSON union type, which has no SQL type to
+  unparse into.
+
+The [operators](#json-operators) `->`, `->>` and `?` are spellings of `json_get`, `json_as_text`
+and `json_contains`, so they are not pushed down either.
+
+Pushdown also requires every path argument to be a **literal**, because BigQuery's JSON path must
+be a constant. `json_get_int(doc, 'id')` pushes down; `json_get_int(doc, key_column)` is legal SQL
+in Spice but is evaluated locally.
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13672` taught the BigQuery dialect to rewrite the Spice JSON extraction functions into native BigQuery SQL, and carved them out of the federation deny-list so they actually federate. Before it, no JSON function could be pushed down: `WHERE json_get_int(doc, 'id') = 1` disqualified the whole node, the column was streamed to Spice and filtered there, and a join on a JSON value became two full remote scans plus a local join — correct, but expensive, and invisible.

The docs said only that federated sources "may not support all JSON functions", which is now both vague and incomplete.

## What the pages now say

**`reference/sql/json.md`** gets a `## Federation and Pushdown` section (placed before Further Reading so no existing `#arguments-N` / `#example-N` anchor shifts) with a per-function table, the reason each of the five untranslated functions stays local, and the literal-path requirement. The top Limitations bullet now links to it.

**`components/data-connectors/adbc.md`** already claimed built-in BigQuery dialect support; that sentence now names the JSON functions it covers and links to the section above. Same fact, two page types — fixed together.

## Verification

The translated set is derived from one table, `SCALAR_OVERRIDES` (`crates/runtime-datafusion/src/dialect/bigquery.rs:232`) — the dialect's handlers, the deny-list carve-out and the per-call check are all generated from it, so the doc table mirrors it entry for entry: `json_get_int`, `json_get_str`, `json_get_bool`, `json_get_float`, `json_length` (+ `json_len`), `json_object_keys` (+ `json_keys`).

The reasons the rest stay denied are quoted from `bigquery_native_function_names`'s doc comment (`crates/runtime-datafusion/src/dialect/mod.rs:137-145`) — byte-fidelity for `json_get_json`/`json_as_text`, the JSON-`null`-vs-missing-key ambiguity for `json_contains`, and the unrepresentable JSON union for `json_get`/`json_get_array`.

The literal-path requirement is `bigquery_can_translate` → `json_path_is_renderable` → `json_path`, which returns `None` for a non-literal path element (`mod.rs:154-163`).

Wiring, so this is not a dialect nothing reaches: `BIGQUERY_DRIVER => Some(new_bigquery_dialect())` and `BIGQUERY_DRIVER => deny_spice_functions_for_bigquery_table_providers()` in `crates/data-connectors/connector-adbc/src/table_factory.rs:49,59`.

BigQuery is the only translating dialect — `crates/runtime-datafusion/src/dialect/` holds `bigquery.rs` and `duckdb.rs`, and the DuckDB one carries no JSON override.

The opening paragraph deliberately says *"a connector that installs the Spice function deny-list"* rather than asserting the behavior is universal: only three providers install it today (`connector-adbc`, `connector-mysql`, `accelerator-sqlite`), and #13664 tracks a case where the policy is missing.

## Versioned-docs propagation

**vNext only.** `git tag --contains` on the merge commit returns nothing, so the translation ships after v2.2.0 — in v2.2.x and earlier no JSON function pushed down, which is what those snapshots' generic limitation bullet already covers.

## Source PRs

- spiceai/spiceai#13672 — Translate the JSON extraction functions into BigQuery SQL, and read negative JSON numbers
- spiceai/spiceai#13590 — fix(adbc): restore the federation deny-list and query_federation wiring (closes #13586) — the deny-list this carve-out is carved out of

## Test plan

- [x] `cd website && npm run build` passes (every new intra-page anchor and both cross-page links resolve)
- [x] Versioned-docs propagation checked (vNext-only addition)
- [x] Files updated: 2