### PR TITLE
fix(releases): correct the v2.2.0 spice-rs link and the v2.1.4 post date

### DIFF
--- a/website/releases/v2.1.4.md
+++ b/website/releases/v2.1.4.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-08-06
+date: 2026-08-05
 title: 'Spice v2.1.4 (Aug 5, 2026)'
 type: blog
 authors: [sgrebnov]

--- a/website/releases/v2.2.0.md
+++ b/website/releases/v2.2.0.md
@@ -121,7 +121,7 @@ Updated SDKs release alongside v2.2.0:
 
 - [spice.js v3.2.0](https://github.com/spiceai/spice.js/releases/tag/v3.2.0) — adds query cancellation (`listActiveQueries`/`cancelActiveQuery`), mTLS client certificates, HTTP fallback when Flight is unavailable, and typed parameter binding via Flight SQL prepared statements. Also fixes `nsql()` and `search()` response handling and named parameters over HTTP.
 - [spicepy v4.0.0](https://github.com/spiceai/spicepy/releases/tag/v4.0.0) — adds streaming of large results, natural-language queries (`nsql`), vector and hybrid search, and query cancellation. Spice.ai Cloud users need this update: the legacy hostnames are retired in favor of region-specific endpoints.
-- [spice-rs v3.2.0](https://github.com/spiceai/spice-rs/releases/tag/v3.2.0) — adds search, NSQL, async queries, query cancellation, and mTLS.
+- [spice-rs v4.0.0](https://github.com/spiceai/spice-rs/releases/tag/v4.0.0) — adds search, NSQL, async queries, query cancellation, and mTLS.
 
 ### Dependency Updates
 


### PR DESCRIPTION
Two corrections to August release posts. Both are reproducible against public endpoints.

## 1. The v2.2.0 post links a spice-rs release that does not exist

The **SDK Updates** section links `spice-rs v3.2.0`. That tag was never published, so the link is a dead end for every reader who follows it:

```console
$ curl -s -o /dev/null -w '%{http_code}\n' -L https://github.com/spiceai/spice-rs/releases/tag/v3.2.0
404

$ gh api repos/spiceai/spice-rs/tags --jq '.[].name' | head -4
v4.0.0
v3.1.0
v3.0.0
v2.0.0

$ gh api repos/spiceai/spice-rs/releases/latest --jq '.tag_name, .published_at'
v4.0.0
2026-08-25T...
```

v4.0.0 is the release that shipped with v2.2.0, and it carries exactly the features the post already lists — search, NSQL, async queries, query cancellation, and mTLS. The fix is the version number and the URL; the description is unchanged.

## 2. The v2.1.4 post contradicts itself on its date

The frontmatter says `date: 2026-08-06`. The title on the same post says `Aug 5, 2026`, and the v2.1.4 release was published on Aug 5:

```console
$ gh api repos/spiceai/spiceai/releases/tags/v2.1.4 --jq '.published_at'
2026-08-05T19:15:42Z
```

Two independent signals say Aug 5 and one says Aug 6, so this changes the frontmatter to `2026-08-05`. The frontmatter is what renders as the post date, so today the site shows a date that the post's own heading disagrees with.

The neighbouring posts are all self-consistent — v2.1.3 (`2026-08-04` / "Aug 4"), v2.1.5 (`2026-08-12` / "Aug 12") — which is why this one stands out.

If Aug 6 is deliberate and the title is what is wrong, say so and I will flip the change to the title instead.
