### PR TITLE
docs(scylladb): the connector is feature-gated out of the default build

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -74,7 +74,7 @@ Supported Data Connectors include:
 | `imap`                             | IMAP                                  | Alpha             | IMAP Emails                  |
 | `localpod`                         | [Local dataset replication][localpod] | Alpha             |                              |
 | `mongodb`                          | MongoDB (with native Change Streams CDC) | Alpha          |                              |
-| `scylladb`                         | ScyllaDB                              | Alpha             |                              |
+| `scylladb`                         | ScyllaDB (Spice.ai Enterprise)        | Alpha             |                              |
 | `smb`                              | SMB 3.1.1                             | Alpha             | SMB                          |
 | `nfs`                              | NFS (Spice.ai Enterprise)             | Alpha             | Parquet, CSV, JSON           |
 

--- a/website/docs/components/data-connectors/scylladb/index.md
+++ b/website/docs/components/data-connectors/scylladb/index.md
@@ -9,6 +9,10 @@ tags:
 
 The ScyllaDB Data Connector enables federated SQL queries on data stored in [ScyllaDB](https://www.scylladb.com/) clusters using CQL (Cassandra Query Language).
 
+:::note[Enterprise edition]
+The ScyllaDB Data Connector is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is feature-gated and not included in the default open source build; open source users can build it from source with the `scylladb` feature (`make install-scylladb`, or `cargo build --release --features scylladb`).
+:::
+
 ```yaml
 datasets:
   - from: scylladb:users

--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -53,6 +53,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
 | ODBC connector | — | Local build only | ✅ | ✅ |
+| ScyllaDB connector | — | Local build only | ✅ | ✅ |
 
 ## Default Distribution
 
@@ -237,11 +238,13 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 Some connectors require additional dependencies and are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing):
 
 - **ODBC** - Connect to any ODBC-compatible data source
+- **ScyllaDB** - Query ScyllaDB clusters over CQL
 
 These can be built locally for development and testing:
 
 ```bash
 make install-odbc
+make install-scylladb
 ```
 
 ## Platform-Specific Notes


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13532` took the ScyllaDB data connector out of `spiced`'s `default` feature set and out of `SPICED_DATA_FEATURES`, making it opt-in alongside ODBC and NFS. The docs still presented ScyllaDB as a standard, always-present connector.

Verified against `origin/trunk`:

- `bin/spiced/Cargo.toml` — `default = [...]` no longer lists `scylladb` (the `scylladb` feature definition itself is unchanged).
- `Makefile:477` — `SPICED_DATA_FEATURES` no longer lists it; `Makefile:537` adds a `make install-scylladb` target matching `install-odbc` / `install-nfs`.
- `crates/runtime/src/init/dataset.rs:2910` — a `from: scylladb:` on a build without the connector now reports `This build of Spice.ai does not include the scylladb data connector` instead of falling through to `UnknownDataConnector`'s nearest-name suggestion.

`git tag --contains 282917b7e8` is empty, so this is vNext-only — `v2.2.0` and `v2.2.1` still ship `scylladb` in the default build, and the versioned snapshots are correct as they stand.

## Changes

- `components/data-connectors/scylladb/index.md` — the standard `:::note[Enterprise edition]` callout used by the NFS and ODBC pages, naming `make install-scylladb` as the open source build path.
- `components/data-connectors/index.md` — the `scylladb` row is labelled `(Spice.ai Enterprise)`, matching `odbc`, `nfs` and `elasticsearch`.
- `reference/distributions.md` — ScyllaDB added to the Distribution Availability table and to Additional Connectors.

## Source PRs

- spiceai/spiceai#13532 — chore(scylladb): take the ScyllaDB connector out of the default build

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — vNext-only (no release tag contains the source commit); `versioned_docs/version-2.2.x/` correctly still describes ScyllaDB as a default-build connector
- [x] Files updated: 3