### PR TITLE
docs(scylladb): the connector left the default spiced build

### DIFF
--- a/website/docs/components/data-connectors/index.md
+++ b/website/docs/components/data-connectors/index.md
@@ -74,7 +74,7 @@ Supported Data Connectors include:
 | `imap`                             | IMAP                                  | Alpha             | IMAP Emails                  |
 | `localpod`                         | [Local dataset replication][localpod] | Alpha             |                              |
 | `mongodb`                          | MongoDB (with native Change Streams CDC) | Alpha          |                              |
-| `scylladb`                         | ScyllaDB                              | Alpha             |                              |
+| `scylladb`                         | ScyllaDB (Spice.ai Enterprise)        | Alpha             |                              |
 | `smb`                              | SMB 3.1.1                             | Alpha             | SMB                          |
 | `nfs`                              | NFS (Spice.ai Enterprise)             | Alpha             | Parquet, CSV, JSON           |
 

--- a/website/docs/components/data-connectors/scylladb/index.md
+++ b/website/docs/components/data-connectors/scylladb/index.md
@@ -9,6 +9,10 @@ tags:
 
 The ScyllaDB Data Connector enables federated SQL queries on data stored in [ScyllaDB](https://www.scylladb.com/) clusters using CQL (Cassandra Query Language).
 
+:::note[Enterprise edition]
+The ScyllaDB Data Connector is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is feature-gated and not included in the default open source build; open source users can build it from source with the `scylladb` feature (`make install-scylladb`).
+:::
+
 ```yaml
 datasets:
   - from: scylladb:users

--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -57,7 +57,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 
 ## Default Distribution
 
-The default distribution includes all features including AI/ML model support. This is the recommended distribution for most users.
+The default distribution includes the standard `spiced` feature set, including AI/ML model support. This is the recommended distribution for most users.
 
 **Included Features:**
 
@@ -248,7 +248,7 @@ Four data connectors sit outside the `spiced` default feature set, so the publis
 | NFS           | `nfs`           | `make install-nfs`      |
 | Elasticsearch | `elasticsearch` | `SPICED_NON_DEFAULT_FEATURES="elasticsearch" make install` |
 
-A Spicepod naming a connector the running build does not include fails to load with an error naming the Cargo feature to build and linking the Enterprise distributions — the dataset is not silently skipped.
+For ScyllaDB specifically, a Spicepod using `from: scylladb:` on a build without the `scylladb` feature fails to load with an error naming the Cargo feature to build and linking the Enterprise distributions — the dataset is not silently skipped.
 
 ## Platform-Specific Notes
 

--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -53,6 +53,7 @@ Windows support is CLI (`spice`) only. The runtime daemon (`spiced`) is not supp
 | CUDA (Linux) | `latest-cuda` | Local build only | ✅ | ✅ |
 | Allocator variants | `latest-{jemalloc,mimalloc,sysalloc}` | Local build only | ✅ | ✅ |
 | ODBC connector | — | Local build only | ✅ | ✅ |
+| ScyllaDB connector | — | Local build only | ✅ | ✅ |
 
 ## Default Distribution
 
@@ -65,6 +66,10 @@ The default distribution includes all features including AI/ML model support. Th
 - AI/ML model inference (LLMs, embeddings)
 - Search capabilities (Vector and BM-25 Full-Text-Search)
 - Default memory allocator (snmalloc)
+
+**Not included by default:**
+
+- The ODBC (`odbc`), Elasticsearch (`elasticsearch`), NFS (`nfs`), and ScyllaDB (`scylladb`) data connectors — see [Additional Connectors](#additional-connectors)
 
 :::note
 The PostgreSQL data accelerator is only available in nightly builds. The PostgreSQL data connector is included in all distributions.
@@ -94,7 +99,7 @@ The data distribution excludes AI/ML model support, resulting in a smaller binar
 
 **Included Features:**
 
-- All data connectors
+- The default distribution's data connectors, minus ADBC
 - All data accelerators
 - Default memory allocator (snmalloc)
 
@@ -234,15 +239,16 @@ Native Windows support for the Spice runtime is available with the [Spice Cloud 
 
 ## Additional Connectors
 
-Some connectors require additional dependencies and are available with the [Spice Cloud Platform and Spice.ai Enterprise](https://spice.ai/pricing):
+Four data connectors sit outside the `spiced` default feature set, so the published open source images do not include them. Each is available in the [Spice.ai Enterprise](https://spice.ai/pricing) distributions (see [Distribution Availability](#distribution-availability) for Spice Cloud coverage), and open source users can build each locally for development and testing:
 
-- **ODBC** - Connect to any ODBC-compatible data source
+| Connector     | Cargo feature   | Local build            |
+| ------------- | --------------- | ---------------------- |
+| ODBC          | `odbc`          | `make install-odbc`     |
+| ScyllaDB      | `scylladb`      | `make install-scylladb` |
+| NFS           | `nfs`           | `make install-nfs`      |
+| Elasticsearch | `elasticsearch` | `SPICED_NON_DEFAULT_FEATURES="elasticsearch" make install` |
 
-These can be built locally for development and testing:
-
-```bash
-make install-odbc
-```
+A Spicepod naming a connector the running build does not include fails to load with an error naming the Cargo feature to build and linking the Enterprise distributions — the dataset is not silently skipped.
 
 ## Platform-Specific Notes
 


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13532` (merged 2026-08-30) dropped `scylladb` from `spiced`'s `default` feature set and from `SPICED_DATA_FEATURES`, making the ScyllaDB data connector opt-in alongside ODBC. The published docs still presented it as a stock connector.

**What the docs said vs. what the code does**

| Page | Said | Code |
| --- | --- | --- |
| `components/data-connectors/index.md` | `scylladb` listed with no edition marker, while `odbc`, `elasticsearch` and `nfs` carry "(Spice.ai Enterprise)" | all four sit outside `spiced`'s `default` feature set |
| `components/data-connectors/scylladb/index.md` | no edition callout | not in the default open source build |
| `reference/distributions.md` → Distribution Availability | no ScyllaDB row | `Local build only` for open source |
| `reference/distributions.md` → Data Distribution | "All data connectors" | four connectors are outside `default`, and ADBC is in `default` but absent from `SPICED_DATA_FEATURES` |
| `reference/distributions.md` → Additional Connectors | ODBC only | ODBC, ScyllaDB, Elasticsearch, NFS |

A `from: scylladb:` dataset on a default build is not silently skipped — `crates/runtime/src/init/dataset.rs` returns `DataConnectorNotInBuild`, naming the `scylladb` feature and linking the Enterprise distributions, and classifies the failure permanent.

## What changed

- Marked `scylladb` as "(Spice.ai Enterprise)" in the connector listing table, matching the three peers already outside the default build.
- Added the standard Enterprise-edition callout to the ScyllaDB connector page, worded like the ODBC and NFS pages.
- Added a `ScyllaDB connector` row to Distribution Availability (`Local build only` / ✅ / ✅), mirroring `docs/DISTRIBUTIONS.md` upstream.
- Named the four excluded connectors under Default Distribution, and replaced Additional Connectors' ODBC-only bullet with a table of all four (Cargo feature + local-build command).
- Data Distribution now says "The default distribution's data connectors, minus ADBC" instead of "All data connectors".

## Verification

Run against `spiceai/spiceai` at `origin/trunk` (`f67da93bb8`), using cargo's own feature resolver rather than reading the manifest:

```
$ cargo tree -p spiced -i connector-scylladb
error: package ID specification `connector-scylladb` did not match any packages

$ cargo tree -p spiced -i connector-odbc          # known-excluded control
error: package ID specification `connector-odbc` did not match any packages

$ cargo tree -p spiced -i connector-mongodb       # known-included control
connector-mongodb v2.3.0-unstable (crates/data-connectors/connector-mongodb)
└── spiced v2.3.0-unstable (bin/spiced)

$ cargo tree -p spiced --features scylladb -i connector-scylladb
connector-scylladb v2.3.0-unstable (crates/data-connectors/connector-scylladb)
└── spiced v2.3.0-unstable (bin/spiced)
```

Source refs: [`bin/spiced/Cargo.toml` `default`](https://github.com/spiceai/spiceai/blob/trunk/bin/spiced/Cargo.toml), [`Makefile` `install-scylladb`](https://github.com/spiceai/spiceai/blob/trunk/Makefile), [`crates/runtime/src/init/dataset.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/init/dataset.rs).

## Version scoping

vNext only. `git tag --contains 282917b7e8` is empty, and `git show v2.2.1:bin/spiced/Cargo.toml` still lists `scylladb` in `default` — so every `versioned_docs/version-*/` snapshot is correct as written and is deliberately untouched.

## Source PRs

- spiceai/spiceai#13532 — chore(scylladb): take the ScyllaDB connector out of the default build

## Noted, not changed

Elasticsearch has no Distribution Availability row here. It is named in Additional Connectors with its feature, but I could not verify its Spice Cloud availability from source, so I did not invent a row rather than guess at the ✅/❌ columns.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus `onBrokenLinks: 'throw'`; both new anchors `#distribution-availability` and `#additional-connectors` resolve)
- [x] Versioned-docs propagation checked — deliberately vNext-only, see Version scoping
- [x] Files updated: 3 (matches the diff)