### PR TITLE
docs(github): document the review, release, milestone, repo and user tables

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -22,7 +22,15 @@ The `from` field specifies the GitHub resource to query. The owner and repositor
 | `github:github.com/<owner>/<repo>/pulls`       | Query pull requests from a repository                     |
 | `github:github.com/<owner>/<repo>/commits`     | Query commits from a repository                           |
 | `github:github.com/<owner>/<repo>/stargazers`  | Query stargazers from a repository                        |
+| `github:github.com/<owner>/<repo>/reviews`     | Query pull request reviews from a repository              |
+| `github:github.com/<owner>/<repo>/review_threads` | Query pull request review threads from a repository    |
+| `github:github.com/<owner>/<repo>/releases`    | Query releases from a repository                          |
+| `github:github.com/<owner>/<repo>/release_assets` | Query release assets from a repository                 |
+| `github:github.com/<owner>/<repo>/milestones`  | Query milestones from a repository                        |
+| `github:github.com/<owner>/<repo>/repo`        | Query one row of repository metadata                      |
 | `github:github.com/<organization>/members`     | Query members from an organization                        |
+| `github:github.com/<owner>/repos`              | Query every repository an owner has (an organization or a user) |
+| `github:github.com/<login>/user`               | Query the public profile of one login                     |
 
 ### `name`
 
@@ -77,6 +85,30 @@ With GitHub App Installation authentication, the connector's functionality depen
 | `github_max_comments_fetched` | Optional. Pull-request connector only. Maximum number of comments to fetch per review thread (when `github_include_comments` is set to `review` or `all`) or per pull-request discussion (when set to `discussion` or `all`). Defaults to `25`, and is capped at `75` to protect against GitHub secondary rate limits. |
 | `github_include_commits`      | Optional. Files connector only. Whether to fetch commit metadata (adds the `created_at` and `updated_at` timestamp columns) for each file. Set to `true` to enable. Defaults to `false`.                                                                                                                                                    |
 | `github_workflow_logs`        | Optional. Workflow-runs connector only (`github.com/<owner>/<repo>/workflows/<workflow_file.yml>/runs`). Set to `enabled` to download and include the workflow run logs for each row. Defaults to `disabled`.                                                                                                         |
+
+## Identity Columns
+
+Every GitHub table carries an `owner` column, and every repository-scoped table also carries a `repo` column. Both are non-nullable.
+
+| Column  | Type | Description                                                                                                          |
+| ------- | ---- | -------------------------------------------------------------------------------------------------------------------- |
+| `owner` | Utf8 | The login of the user or organization that owns the row's repository. On an owner-scoped table (`members`, `repos`, `user`) it is the owner the dataset names. |
+| `repo`  | Utf8 | The name of the repository the row came from, without the owner prefix. Absent from owner-scoped tables.              |
+
+GitHub scopes a response by owner and repository *above* the row array, so without these columns a query that unions several repositories cannot tell the rows apart. They are stamped onto each row from the dataset path rather than requested from GitHub, so they cost nothing against the API rate limit.
+
+Both values are stored **lower-cased**. GitHub treats owner and repository names as case-insensitive and will answer a dataset path spelled `SpiceAI/spiceai` with rows it calls `spiceai/spiceai`; SQL equality is not case-insensitive, so folding the value is what keeps a join across datasets matching. Where GitHub's own spelling matters, use `name_with_owner` on the `repo` / `repos` tables.
+
+```sql
+SELECT owner, repo, COUNT(*) AS open_pulls
+FROM (
+  SELECT owner, repo, state FROM spiceai_pulls
+  UNION ALL
+  SELECT owner, repo, state FROM cookbook_pulls
+)
+WHERE state = 'OPEN'
+GROUP BY owner, repo;
+```
 
 ## Advanced Configuration
 
@@ -186,6 +218,8 @@ datasets:
 | created_at   | Timestamp | YES         |
 | updated_at   | Timestamp | YES         |
 | content      | Utf8      | YES         |
+| owner        | Utf8      | NO          |
+| repo         | Utf8      | NO          |
 
 `created_at` and `updated_at` are present only when `github_include_commits` is set to `true`.
 
@@ -240,16 +274,23 @@ datasets:
 | author          | Utf8         | YES         |
 | body            | Utf8         | YES         |
 | closed_at       | Timestamp    | YES         |
+| closed_by       | Utf8         | YES         |
 | comments        | List(Struct) | YES         |
+| comments_count  | Int64        | YES         |
 | created_at      | Timestamp    | YES         |
 | id              | Utf8         | YES         |
 | labels          | List(Struct(name: Utf8)) | YES         |
 | milestone_id    | Utf8         | YES         |
 | milestone_title | Utf8         | YES         |
-| comments_count  | Int64        | YES         |
 | number          | Int64        | YES         |
+| owner           | Utf8         | NO          |
+| reactions_count | Int64        | YES         |
+| repo            | Utf8         | NO          |
 | state           | Utf8         | YES         |
+| state_reason    | Utf8         | YES         |
 | title           | Utf8         | YES         |
+| type            | Utf8         | YES         |
+| type_color      | Utf8         | YES         |
 | updated_at      | Timestamp    | YES         |
 | url             | Utf8         | YES         |
 
@@ -303,28 +344,47 @@ datasets:
 
 | Column Name     | Data Type                                                     | Is Nullable |
 | --------------- | ------------------------------------------------------------- | ----------- |
-| additions       | Int64                                                         | YES         |
-| assignees       | List(Struct(login: Utf8))                                     | YES         |
-| author          | Utf8                                                          | YES         |
-| body            | Utf8                                                          | YES         |
-| changed_files   | Int64                                                         | YES         |
-| closed_at       | Timestamp                                                     | YES         |
-| comments_count  | Int64                                                         | YES         |
-| commits_count   | Int64                                                         | YES         |
-| created_at      | Timestamp                                                     | YES         |
-| deletions       | Int64                                                         | YES         |
-| discussion      | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
-| hashes          | List(Struct(id: Utf8))                                        | YES         |
-| id              | Utf8                                                          | YES         |
-| labels          | List(Struct(name: Utf8))                                      | YES         |
-| merged_at       | Timestamp                                                     | YES         |
-| number          | Int64                                                         | YES         |
-| review_comments | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
-| reviews_count   | Int64                                                         | YES         |
-| state           | Utf8                                                          | YES         |
-| title           | Utf8                                                          | YES         |
-| updated_at      | Timestamp                                                     | YES         |
-| url             | Utf8                                                          | YES         |
+| additions                  | Int64                                                         | YES         |
+| assignees                  | List(Struct(login: Utf8))                                     | YES         |
+| author                     | Utf8                                                          | YES         |
+| base_ref                   | Utf8                                                          | YES         |
+| body                       | Utf8                                                          | YES         |
+| changed_files              | Int64                                                         | YES         |
+| closed_at                  | Timestamp                                                     | YES         |
+| closed_by                  | Utf8                                                          | YES         |
+| closing_issues_count       | Int64                                                         | YES         |
+| closing_issues_references  | List(Struct(number: Int64))                                   | YES         |
+| comments_count             | Int64                                                         | YES         |
+| commits_count              | Int64                                                         | YES         |
+| created_at                 | Timestamp                                                     | YES         |
+| deletions                  | Int64                                                         | YES         |
+| discussion                 | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
+| hashes                     | List(Struct(id: Utf8))                                        | YES         |
+| head_ref                   | Utf8                                                          | YES         |
+| head_sha                   | Utf8                                                          | YES         |
+| id                         | Utf8                                                          | YES         |
+| is_draft                   | Boolean                                                       | YES         |
+| labels                     | List(Struct(name: Utf8))                                      | YES         |
+| merge_queue_position       | Int64                                                         | YES         |
+| merge_queue_state          | Utf8                                                          | YES         |
+| merge_state_status         | Utf8                                                          | YES         |
+| mergeable                  | Utf8                                                          | YES         |
+| merged_at                  | Timestamp                                                     | YES         |
+| merged_by                  | Utf8                                                          | YES         |
+| milestone_id               | Utf8                                                          | YES         |
+| milestone_title            | Utf8                                                          | YES         |
+| number                     | Int64                                                         | YES         |
+| owner                      | Utf8                                                          | NO          |
+| reactions_count            | Int64                                                         | YES         |
+| repo                       | Utf8                                                          | NO          |
+| review_comments            | List(Struct(body: Utf8, author: Utf8, created_at: Timestamp)) | YES         |
+| review_decision            | Utf8                                                          | YES         |
+| reviews_count              | Int64                                                         | YES         |
+| state                      | Utf8                                                          | YES         |
+| status_check_rollup        | Utf8                                                          | YES         |
+| title                      | Utf8                                                          | YES         |
+| updated_at                 | Timestamp                                                     | YES         |
+| url                        | Utf8                                                          | YES         |
 
 **Note**: The `discussion` and `review_comments` columns are only included in the schema when the `github_include_comments` parameter is set accordingly.
 
@@ -442,6 +502,8 @@ datasets:
 | ref                            | Utf8      | YES         |
 | sha                            | Utf8      | YES         |
 | status                         | Utf8      | YES         |
+| owner                          | Utf8      | NO          |
+| repo                           | Utf8      | NO          |
 
 #### Example
 
@@ -505,6 +567,8 @@ datasets:
 | location    | Utf8      | YES         |
 | avatar_url  | Utf8      | YES         |
 | bio         | Utf8      | YES         |
+| owner       | Utf8      | NO          |
+| repo        | Utf8      | NO          |
 
 #### Example
 
@@ -568,6 +632,7 @@ datasets:
 | company     | Utf8      | YES         |
 | created_at  | Timestamp | YES         |
 | bio         | Utf8      | YES         |
+| owner       | Utf8      | NO          |
 
 #### Example
 
@@ -600,6 +665,251 @@ sql> select created_at, username from apache.members order by created_at desc li
 
 Time: 0.054390375 seconds. 10 rows.
 ```
+
+### Querying Pull Request Reviews
+
+`pulls.reviews_count` is a bare count and `pulls.review_comments` records only inline comments, so an approval left without an inline comment is invisible in SQL. The `reviews` table carries one row per review, with its state, reviewer and submission time.
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/reviews
+    name: spiceai.reviews
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+    acceleration:
+      enabled: true
+```
+
+#### Schema
+
+| Column Name         | Data Type | Is Nullable |
+| ------------------- | --------- | ----------- |
+| id                  | Utf8      | YES         |
+| pull_request_id     | Utf8      | YES         |
+| pull_request_number | Int64     | YES         |
+| author              | Utf8      | YES         |
+| state               | Utf8      | YES         |
+| body                | Utf8      | YES         |
+| submitted_at        | Timestamp | YES         |
+| commit_sha          | Utf8      | YES         |
+| author_association  | Utf8      | YES         |
+| url                 | Utf8      | YES         |
+| owner               | Utf8      | NO          |
+| repo                | Utf8      | NO          |
+
+Join back to `pulls` on `pull_request_number`:
+
+```sql
+SELECT p.number, p.title, r.author, r.state, r.submitted_at
+FROM spiceai_pulls p
+JOIN spiceai_reviews r ON r.pull_request_number = p.number
+WHERE r.state = 'APPROVED';
+```
+
+:::note[Limit pushdown is disabled on this table]
+One pull request fans out into many review rows, so a row limit cannot bound how many pull requests must be fetched. A pull request with more than 100 reviews has reviews the scan cannot reach — a nested GraphQL connection cannot be paginated — and the scan fails naming that pull request rather than returning a partial set.
+:::
+
+### Querying Pull Request Review Threads
+
+One row per resolvable review thread, which is what "which pull requests are blocked on unresolved feedback" is computed from.
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/review_threads
+    name: spiceai.review_threads
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+```
+
+#### Schema
+
+| Column Name         | Data Type | Is Nullable |
+| ------------------- | --------- | ----------- |
+| id                  | Utf8      | YES         |
+| pull_request_id     | Utf8      | YES         |
+| pull_request_number | Int64     | YES         |
+| is_resolved         | Boolean   | YES         |
+| is_outdated         | Boolean   | YES         |
+| is_collapsed        | Boolean   | YES         |
+| path                | Utf8      | YES         |
+| line                | Int64     | YES         |
+| start_line          | Int64     | YES         |
+| diff_side           | Utf8      | YES         |
+| resolved_by         | Utf8      | YES         |
+| comments_count      | Int64     | YES         |
+| owner               | Utf8      | NO          |
+| repo                | Utf8      | NO          |
+
+### Querying Releases and Release Assets
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/releases
+    name: spiceai.releases
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+  - from: github:github.com/spiceai/spiceai/release_assets
+    name: spiceai.release_assets
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+```
+
+#### `releases` Schema
+
+| Column Name          | Data Type | Is Nullable |
+| -------------------- | --------- | ----------- |
+| id                   | Utf8      | YES         |
+| tag_name             | Utf8      | YES         |
+| name                 | Utf8      | YES         |
+| body                 | Utf8      | YES         |
+| author               | Utf8      | YES         |
+| tag_sha              | Utf8      | YES         |
+| is_draft             | Boolean   | YES         |
+| is_prerelease        | Boolean   | YES         |
+| is_latest            | Boolean   | YES         |
+| created_at           | Timestamp | YES         |
+| published_at         | Timestamp | YES         |
+| updated_at           | Timestamp | YES         |
+| url                  | Utf8      | YES         |
+| assets_count         | Int64     | YES         |
+| total_download_count | Int64     | YES         |
+| owner                | Utf8      | NO          |
+| repo                 | Utf8      | NO          |
+
+#### `release_assets` Schema
+
+| Column Name      | Data Type | Is Nullable |
+| ---------------- | --------- | ----------- |
+| id               | Utf8      | YES         |
+| release_id       | Utf8      | YES         |
+| release_tag_name | Utf8      | YES         |
+| name             | Utf8      | YES         |
+| download_count   | Int64     | YES         |
+| size             | Int64     | YES         |
+| content_type     | Utf8      | YES         |
+| url              | Utf8      | YES         |
+| created_at       | Timestamp | YES         |
+| updated_at       | Timestamp | YES         |
+| owner            | Utf8      | NO          |
+| repo             | Utf8      | NO          |
+
+### Querying Milestones
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/milestones
+    name: spiceai.milestones
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+```
+
+#### Schema
+
+| Column Name          | Data Type | Is Nullable |
+| -------------------- | --------- | ----------- |
+| id                   | Utf8      | YES         |
+| number               | Int64     | YES         |
+| title                | Utf8      | YES         |
+| description          | Utf8      | YES         |
+| state                | Utf8      | YES         |
+| creator              | Utf8      | YES         |
+| due_on               | Timestamp | YES         |
+| created_at           | Timestamp | YES         |
+| updated_at           | Timestamp | YES         |
+| closed_at            | Timestamp | YES         |
+| open_issues_count    | Int64     | YES         |
+| closed_issues_count  | Int64     | YES         |
+| progress_percentage  | Float64   | YES         |
+| url                  | Utf8      | YES         |
+| owner                | Utf8      | NO          |
+| repo                 | Utf8      | NO          |
+
+`pulls.milestone_id` and `issues.milestone_id` join to `milestones.id`.
+
+### Querying Repository Metadata
+
+`…/repo` returns one row of metadata for the repository the path names; `…/repos` returns one row per repository an owner has. Both resolve an organization and a user alike, and both share the same schema.
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/spiceai/repo
+    name: spiceai.repo
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+  - from: github:github.com/spiceai/repos
+    name: spiceai.repos
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+```
+
+#### Schema
+
+| Column Name              | Data Type       | Is Nullable |
+| ------------------------ | --------------- | ----------- |
+| id                       | Utf8            | YES         |
+| owner                    | Utf8            | NO          |
+| repo                     | Utf8            | NO          |
+| name_with_owner          | Utf8            | YES         |
+| description              | Utf8            | YES         |
+| url                      | Utf8            | YES         |
+| homepage_url             | Utf8            | YES         |
+| default_branch           | Utf8            | YES         |
+| license                  | Utf8            | YES         |
+| primary_language         | Utf8            | YES         |
+| is_archived              | Boolean         | YES         |
+| is_private               | Boolean         | YES         |
+| is_fork                  | Boolean         | YES         |
+| is_template              | Boolean         | YES         |
+| is_disabled              | Boolean         | YES         |
+| is_locked                | Boolean         | YES         |
+| created_at               | Timestamp       | YES         |
+| updated_at               | Timestamp       | YES         |
+| pushed_at                | Timestamp       | YES         |
+| disk_usage               | Int64           | YES         |
+| stargazers_count         | Int64           | YES         |
+| forks_count              | Int64           | YES         |
+| watchers_count           | Int64           | YES         |
+| open_issues_count        | Int64           | YES         |
+| open_pull_requests_count | Int64           | YES         |
+| topics_count             | Int64           | YES         |
+| topics                   | List(Utf8)      | YES         |
+
+`name_with_owner` keeps GitHub's own capitalization; `owner` and `repo` are lower-cased for joining (see [Identity Columns](#identity-columns)).
+
+### Querying a User Profile
+
+`…/user` returns the public profile of one login.
+
+```yaml
+datasets:
+  - from: github:github.com/spiceai/user
+    name: spiceai.user
+    params:
+      github_token: ${secrets:GITHUB_TOKEN}
+```
+
+#### Schema
+
+| Column Name      | Data Type | Is Nullable |
+| ---------------- | --------- | ----------- |
+| id               | Utf8      | YES         |
+| login            | Utf8      | YES         |
+| name             | Utf8      | YES         |
+| company          | Utf8      | YES         |
+| bio              | Utf8      | YES         |
+| blog             | Utf8      | YES         |
+| twitter_username | Utf8      | YES         |
+| location         | Utf8      | YES         |
+| avatar_url       | Utf8      | YES         |
+| url              | Utf8      | YES         |
+| is_hireable      | Boolean   | YES         |
+| followers        | Int64     | YES         |
+| following        | Int64     | YES         |
+| public_repos     | Int64     | YES         |
+| created_at       | Timestamp | YES         |
+| updated_at       | Timestamp | YES         |
+| owner            | Utf8      | NO          |
 
 ## Cookbook
 

--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -88,23 +88,23 @@ With GitHub App Installation authentication, the connector's functionality depen
 
 ## Identity Columns
 
-Every GitHub table carries an `owner` column, and every repository-scoped table also carries a `repo` column. Both are non-nullable.
+Every GitHub table carries an `owner` column, and every table whose rows belong to a repository also carries a `repo` column. Both are non-nullable.
 
 | Column  | Type | Description                                                                                                          |
 | ------- | ---- | -------------------------------------------------------------------------------------------------------------------- |
 | `owner` | Utf8 | The login of the user or organization that owns the row's repository. On an owner-scoped table (`members`, `repos`, `user`) it is the owner the dataset names. |
-| `repo`  | Utf8 | The name of the repository the row came from, without the owner prefix. Absent from owner-scoped tables.              |
+| `repo`  | Utf8 | The name of the repository the row came from, without the owner prefix. Absent from `members` and `user`, whose rows do not belong to a repository. On `repos` it is the repository each row describes. |
 
 GitHub scopes a response by owner and repository *above* the row array, so without these columns a query that unions several repositories cannot tell the rows apart. They are stamped onto each row from the dataset path rather than requested from GitHub, so they cost nothing against the API rate limit.
 
-Both values are stored **lower-cased**. GitHub treats owner and repository names as case-insensitive and will answer a dataset path spelled `SpiceAI/spiceai` with rows it calls `spiceai/spiceai`; SQL equality is not case-insensitive, so folding the value is what keeps a join across datasets matching. Where GitHub's own spelling matters, use `name_with_owner` on the `repo` / `repos` tables.
+Both values are stored **lowercased**. GitHub treats owner and repository names as case-insensitive and will answer a dataset path spelled `SpiceAI/spiceai` with rows it calls `spiceai/spiceai`; SQL equality is not case-insensitive, so folding the value is what keeps a join across datasets matching. Where GitHub's own spelling matters, use `name_with_owner` on the `repo` / `repos` tables.
 
 ```sql
 SELECT owner, repo, COUNT(*) AS open_pulls
 FROM (
-  SELECT owner, repo, state FROM spiceai_pulls
+  SELECT owner, repo, state FROM spiceai.pulls
   UNION ALL
-  SELECT owner, repo, state FROM cookbook_pulls
+  SELECT owner, repo, state FROM cookbook.pulls
 )
 WHERE state = 'OPEN'
 GROUP BY owner, repo;
@@ -701,8 +701,8 @@ Join back to `pulls` on `pull_request_number`:
 
 ```sql
 SELECT p.number, p.title, r.author, r.state, r.submitted_at
-FROM spiceai_pulls p
-JOIN spiceai_reviews r ON r.pull_request_number = p.number
+FROM spiceai.pulls p
+JOIN spiceai.reviews r ON r.pull_request_number = p.number
 WHERE r.state = 'APPROVED';
 ```
 
@@ -829,7 +829,7 @@ datasets:
 
 ### Querying Repository Metadata
 
-`…/repo` returns one row of metadata for the repository the path names; `…/repos` returns one row per repository an owner has. Both resolve an organization and a user alike, and both share the same schema.
+`github:github.com/<owner>/<repo>/repo` returns one row of metadata for the repository the path names; `github:github.com/<owner>/repos` returns one row per repository an owner has. Both resolve an organization and a user alike, and both share the same schema.
 
 ```yaml
 datasets:
@@ -875,11 +875,11 @@ datasets:
 | topics_count             | Int64           | YES         |
 | topics                   | List(Utf8)      | YES         |
 
-`name_with_owner` keeps GitHub's own capitalization; `owner` and `repo` are lower-cased for joining (see [Identity Columns](#identity-columns)).
+`name_with_owner` keeps GitHub's own capitalization; `owner` and `repo` are lowercased for joining (see [Identity Columns](#identity-columns)).
 
 ### Querying a User Profile
 
-`…/user` returns the public profile of one login.
+`github:github.com/<owner>/user` returns the public profile of one login.
 
 ```yaml
 datasets:


### PR DESCRIPTION
## Summary

spiceai/spiceai#13545 adds eight dataset paths to the GitHub connector, stamps `owner` / `repo` identity columns onto every table, and widens the `pulls` and `issues` schemas. None of it was documented — the `from` table still listed six paths.

Every column below was read off the Arrow schema on `origin/trunk`, not from the source PR description:

- `crates/data-connectors/connector-github/src/lib.rs:1270-1590` — the dispatch arms: `pulls`, `commits`, `issues`, `reviews`, `review_threads`, `releases`, `release_assets`, `milestones`, `repo`, `repos`, `user`, `stargazers`, `files`, `workflows`, `projects`, `members`.
- `identity.rs:60-72` — `push_identity_fields` adds a non-nullable `owner`, plus `repo` for repository-scoped tables; `canonical_identity` ASCII-lower-cases both so a cross-dataset join key cannot disagree between a table that stamps the dataset path and one that reports what GitHub returned. `repos.rs:260` keeps GitHub's own spelling in `name_with_owner`.
- `push_identity_fields` is called by `commits.rs`, `issues.rs`, `pull_requests.rs`, `stargazers.rs`, `milestones.rs`, `releases.rs`, `release_assets.rs`, `reviews.rs`, `review_threads.rs`, `projects.rs`, `workflows.rs`, `workflow_runs.rs` and `github.rs` (files); `members.rs:96` and `users.rs:136` pass `repo_scoped: false`, so those two carry `owner` only. `repos.rs` declares both columns inline.
- `reviews.rs:151-171`, `review_threads.rs:161-179`, `releases.rs:193-226`, `release_assets.rs:140-164`, `milestones.rs:107-143`, `repos.rs:251-300`, `users.rs:106-138` — the schemas transcribed into the new sections.
- `reviews.rs:76` — `supports_limit_pushdown` is `false` (one pull request fans out into many review rows); `REVIEWS_PER_PULL_REQUEST = 100` is GitHub's per-connection maximum and a nested connection cannot be paginated, so the fan-out fails by name rather than returning a partial set. Both are in the page as a note.
- `pull_requests.rs:640-728` and `issues.rs:237-310` — the new columns, and their exact Arrow types (`mergeable` is `Utf8`, not a boolean; `closing_issues_references` is `List(Struct(number: Int64))`).
- `lib.rs:1414` / `:1430` — `repo` and `repos` both build a `ReposTableArgs`, so they share one schema; `repos` is backed by `repositoryOwner`, resolving an organization and a user alike.

`git tag --contains 020011bc43` is empty, so this is vNext-only — no versioned snapshot has these tables.

## Changes

- `components/data-connectors/github/index.md`
  - `from` table: eight new paths.
  - New `## Identity Columns` section with the lower-casing rule and a cross-repository `UNION ALL` example.
  - New `### Querying …` sections with schemas for `reviews`, `review_threads`, `releases` + `release_assets`, `milestones`, `repo` / `repos`, and `user`.
  - `owner` / `repo` added to the existing `files`, `issues`, `pulls`, `commits`, `stargazers` and `members` schema tables.
  - `pulls` and `issues` schema tables extended with the new columns.

## Known gap, not addressed here

The `from` table still omits `github.com/<owner>/<repo>/workflows/<file>/runs` and the `projects` paths, which predate this source PR. Left for a separate change so this one stays scoped to spiceai/spiceai#13545.

## Source PRs

- spiceai/spiceai#13545 — feat(github): add review, release, milestone, user and repo tables, plus repo/owner columns

## Test plan

- [x] `cd website && npm run build` passes (the `#identity-columns` anchor resolves from the repository-metadata section)
- [x] Versioned-docs propagation checked — vNext-only addition; no `versioned_docs/version-*/` copy touched
- [x] Files updated: 1