### PR TITLE
docs(spicepod): acceleration.ready_state is honoured on views, and deprecated on both

### DIFF
--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -313,6 +313,18 @@ datasets:
       enabled: true
 ```
 
+:::warning[`acceleration.ready_state` is deprecated]
+`ready_state` also parses inside the `acceleration` block. When it is set there it **takes precedence** over the dataset's own top-level `ready_state`, and it applies whether or not `acceleration.enabled` is `true` — which is why it is never listed among the settings the [`enabled: false` warning](#accelerationenabled) reports as discarded.
+
+It is deprecated and will be removed. The runtime warns at load, naming the dataset:
+
+```
+Dataset 'api_data' sets `acceleration.ready_state`, which is deprecated and will be removed. Move the setting to the dataset's own `ready_state` to keep it working. See: https://spiceai.org/docs/reference/spicepod/datasets
+```
+
+Move the setting to the top-level `ready_state` shown above.
+:::
+
 ## `check_availability`
 
 Spice can monitor whether the source backing a non-accelerated dataset is still reachable, marking the dataset `Error` while it is not. Availability monitoring is **opt-in**: it runs only for datasets that set [`check_availability_interval`](#check_availability_interval). Note that probing may trigger the startup of compute resources (for example, Databricks or Snowflake), potentially incurring additional costs.

--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -79,6 +79,18 @@ views:
       enabled: true
 ```
 
+:::warning[`acceleration.ready_state` is deprecated]
+`ready_state` also parses inside the `acceleration` block. When it is set there it **takes precedence** over the view's own top-level `ready_state`, and it applies whether or not `acceleration.enabled` is `true` — which is why it is never listed among the settings the [`enabled: false` warning](#accelerationenabled) reports as discarded.
+
+It is deprecated and will be removed. The runtime warns at load, naming the view:
+
+```
+View 'daily_totals' sets `acceleration.ready_state`, which is deprecated and will be removed. Move the setting to the view's own `ready_state` to keep it working. See: https://spiceai.org/docs/reference/spicepod/views
+```
+
+Move the setting to the top-level `ready_state` shown above.
+:::
+
 ## `acceleration`
 
 Optional. Accelerate queries to the view by caching data locally.
@@ -97,7 +109,7 @@ The runtime warns at load naming the view and the settings it discarded:
 View 'my_view' sets `acceleration.enabled: false`, so these settings in its acceleration block are read and then ignored: `engine`, `mode`, `refresh_mode`. Remove `enabled: false` to apply them, or remove them to keep the view unaccelerated. See: https://spiceai.org/docs/reference/spicepod/views#acceleration
 ```
 
-`enabled: false` on its own — with nothing else in the block — is a complete configuration and is not warned about.
+`enabled: false` on its own — with nothing else in the block — is a complete configuration and is not warned about. The deprecated [`acceleration.ready_state`](#ready_state) is also never reported, because a view applies it whether or not acceleration is enabled.
 
 :::
 


### PR DESCRIPTION
## Summary

`acceleration.ready_state` parsed cleanly on a view and then did nothing: `ViewBuilder::try_from` built `ready_state` from the view's own top-level field unconditionally. The identical key in the identical position on a **dataset** was read out of the block and honoured. spiceai/spiceai#13750 makes the view resolve it the same way and deprecates the key on both components.

Verified against `origin/trunk`:

- `crates/runtime/src/component/view.rs:148-157` and `crates/runtime/src/component/dataset/builder.rs:78-88` — identical `match` on `acceleration.ready_state`: when `Some(Some(_))` it warns and uses that value, otherwise it falls back to the component's own top-level `ready_state`. So the acceleration-block spelling **takes precedence** over the top-level one, on both components.
- Neither match is gated on `acceleration.enabled`, so the setting applies to a disabled acceleration block too — which is why `ready_state` is excluded from `CONSUMED_WHEN_DISABLED` (`component/mod.rs:134`) and never appears in the `enabled: false` discard warning. `datasets.md` already stated this; `views.md` needed the same sentence now that a view honours the key.
- `component/mod.rs:97-114` — the warning text, asserted by `the_ready_state_deprecation_names_the_replacement_and_the_components_reference` and `the_ready_state_deprecation_calls_a_view_a_view`. The example messages in the docs are transcribed from that `format!` and those two tests' fixture names (`api_data`, `daily_totals`), including the unanchored reference URL — `reference_url()` deliberately drops the `#acceleration` anchor because the remedy is a field *outside* the acceleration block.

`git tag --contains c981dd0dbe` is empty, so this is vNext-only. On `v2.2.x` and earlier a view's `acceleration.ready_state` really is silently ignored, so the versioned snapshots stay as they are.

## Changes

- `reference/spicepod/views.md` — a deprecation warning admonition under `## ready_state`, and the "never reported by the `enabled: false` warning" sentence added to the acceleration-disabled admonition.
- `reference/spicepod/datasets.md` — the matching deprecation warning admonition under `## ready_state` (the page previously mentioned the deprecation only in passing, inside the `acceleration.enabled` admonition).

## Source PRs

- spiceai/spiceai#13750 — fix(views): apply a view's acceleration.ready_state instead of dropping it

## Test plan

- [x] `cd website && npm run build` passes (`onBrokenAnchors: throw`, so the new `#accelerationenabled` and `#ready_state` links are checked)
- [x] Versioned-docs propagation checked — vNext-only; older snapshots correctly describe the pre-change behaviour
- [x] Files updated: 2