### PR TITLE
docs(github): the connector has its own concurrency limiter, not the shared HTTP rate control

### DIFF
--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -113,11 +113,11 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector supports the following HTTP concurrency parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `max_concurrent_requests`   | Maximum number of concurrent GitHub HTTP requests for this authentication context. When unset, the connector falls back to `runtime.source_rate_control.github_concurrent_connections_limit`, then to the deprecated `runtime.params.github_max_concurrent_connections`, and finally to the connector default of `10`. The GitHub connector does **not** read `runtime.params.http_max_concurrent_requests`, and concurrency limiting is never disabled. |
 
 The GitHub connector uses its own rate limiter based on GitHub API `X-RateLimit-*` response headers. Multiple datasets targeting the same GitHub endpoint share this rate limiter.
 

--- a/website/docs/components/data-connectors/github/index.md
+++ b/website/docs/components/data-connectors/github/index.md
@@ -113,7 +113,7 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP/HTTPS, GraphQL and Databricks connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/docs/reference/spicepod/runtime.md
+++ b/website/docs/reference/spicepod/runtime.md
@@ -159,7 +159,7 @@ Optional. Global key-value parameters for the runtime.
 
 ### HTTP Rate Control
 
-HTTP-based connectors (HTTP/HTTPS, GraphQL, GitHub) support the following rate control defaults:
+HTTP-based connectors (HTTP/HTTPS, GraphQL, Databricks) support the following rate control defaults. The GitHub connector is **not** part of this family — it has its own limiter, configured with [`runtime.source_rate_control.github_concurrent_connections_limit`](#runtimesource_rate_control):
 
 | Parameter Name                    | Description                                                                                                                                                    |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
@@ -113,11 +113,11 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector supports the following HTTP concurrency parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `max_concurrent_requests`   | Maximum number of concurrent GitHub HTTP requests for this authentication context. When unset, the connector falls back to `runtime.source_rate_control.github_concurrent_connections_limit`, then to the deprecated `runtime.params.github_max_concurrent_connections`, and finally to the connector default of `10`. The GitHub connector does **not** read `runtime.params.http_max_concurrent_requests`, and concurrency limiting is never disabled. |
 
 The GitHub connector uses its own rate limiter based on GitHub API `X-RateLimit-*` response headers. Multiple datasets targeting the same GitHub endpoint share this rate limiter.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/github/index.md
@@ -113,7 +113,7 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP/HTTPS, GraphQL and Databricks connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.0.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-2.0.x/reference/spicepod/runtime.md
@@ -131,7 +131,7 @@ Optional. Global key-value parameters for the runtime.
 
 ### HTTP Rate Control
 
-HTTP-based connectors (HTTP/HTTPS, GraphQL, GitHub) support the following rate control defaults:
+HTTP-based connectors (HTTP/HTTPS, GraphQL, Databricks) support the following rate control defaults. The GitHub connector is **not** part of this family — it has its own limiter, configured with [`runtime.source_rate_control.github_concurrent_connections_limit`](#runtimesource_rate_control):
 
 | Parameter Name                    | Description                                                                                                                                                    |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/github/index.md
@@ -113,11 +113,11 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector supports the following HTTP concurrency parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `max_concurrent_requests`   | Maximum number of concurrent GitHub HTTP requests for this authentication context. When unset, the connector falls back to `runtime.source_rate_control.github_concurrent_connections_limit`, then to the deprecated `runtime.params.github_max_concurrent_connections`, and finally to the connector default of `10`. The GitHub connector does **not** read `runtime.params.http_max_concurrent_requests`, and concurrency limiting is never disabled. |
 
 The GitHub connector uses its own rate limiter based on GitHub API `X-RateLimit-*` response headers. Multiple datasets targeting the same GitHub endpoint share this rate limiter.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/github/index.md
@@ -113,7 +113,7 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP/HTTPS, GraphQL and Databricks connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.1.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-2.1.x/reference/spicepod/runtime.md
@@ -131,7 +131,7 @@ Optional. Global key-value parameters for the runtime.
 
 ### HTTP Rate Control
 
-HTTP-based connectors (HTTP/HTTPS, GraphQL, GitHub) support the following rate control defaults:
+HTTP-based connectors (HTTP/HTTPS, GraphQL, Databricks) support the following rate control defaults. The GitHub connector is **not** part of this family — it has its own limiter, configured with [`runtime.source_rate_control.github_concurrent_connections_limit`](#runtimesource_rate_control):
 
 | Parameter Name                    | Description                                                                                                                                                    |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/github/index.md
@@ -113,11 +113,11 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector supports the following HTTP concurrency parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `max_concurrent_requests`   | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.         |
+| `max_concurrent_requests`   | Maximum number of concurrent GitHub HTTP requests for this authentication context. When unset, the connector falls back to `runtime.source_rate_control.github_concurrent_connections_limit`, then to the deprecated `runtime.params.github_max_concurrent_connections`, and finally to the connector default of `10`. The GitHub connector does **not** read `runtime.params.http_max_concurrent_requests`, and concurrency limiting is never disabled. |
 
 The GitHub connector uses its own rate limiter based on GitHub API `X-RateLimit-*` response headers. Multiple datasets targeting the same GitHub endpoint share this rate limiter.
 

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/github/index.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/github/index.md
@@ -113,7 +113,7 @@ datasets:
 # ... other configuration ...
 ```
 
-The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP and GraphQL connectors. It reads a single parameter:
+The GitHub connector runs its own concurrency limiter, separate from the [shared HTTP rate control](../https/index.md#rate-control-parameters) used by the HTTP/HTTPS, GraphQL and Databricks connectors. It reads a single parameter:
 
 | Parameter Name              | Description                                                                                                                                                                                  |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/website/versioned_docs/version-2.2.x/reference/spicepod/runtime.md
+++ b/website/versioned_docs/version-2.2.x/reference/spicepod/runtime.md
@@ -159,7 +159,7 @@ Optional. Global key-value parameters for the runtime.
 
 ### HTTP Rate Control
 
-HTTP-based connectors (HTTP/HTTPS, GraphQL, GitHub) support the following rate control defaults:
+HTTP-based connectors (HTTP/HTTPS, GraphQL, Databricks) support the following rate control defaults. The GitHub connector is **not** part of this family — it has its own limiter, configured with [`runtime.source_rate_control.github_concurrent_connections_limit`](#runtimesource_rate_control):
 
 | Parameter Name                    | Description                                                                                                                                                    |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

The GitHub connector page documented `max_concurrent_requests` with text copy-pasted from the **shared** HTTP rate-control family (`data-http-rate-control`), which GitHub is not part of.

**What the docs said** (`components/data-connectors/github/index.md`):

> `max_concurrent_requests` | Maximum number of concurrent HTTP requests to the same upstream origin. Overrides `runtime.params.http_max_concurrent_requests`. If both are unset, concurrency limiting is disabled.

**What the code does** — three things wrong:

1. GitHub never reads `runtime.params.http_max_concurrent_requests`. `connector-github` does not even depend on the `data-http-rate-control` crate (the consumers are HTTP/HTTPS, GraphQL and Databricks); it declares its own `ParameterSpec::runtime("max_concurrent_requests")`.
2. Concurrency limiting is **never** disabled — a semaphore is always installed, at `GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS = 10` when nothing is configured.
3. The scope is the **authentication context** (token / GitHub App installation), not the upstream origin, and the fallback chain is `runtime.source_rate_control.github_concurrent_connections_limit` → deprecated `runtime.params.github_max_concurrent_connections` → `10`.

`reference/spicepod/runtime.md` carried the mirror of the same error: it listed the HTTP rate-control family as "(HTTP/HTTPS, GraphQL, **GitHub**)" and omitted **Databricks**, which does resolve those keys.

## Evidence

A temporary probe added to `connector-github`'s own test module (using the existing `github_available_permits` helper, then reverted) — `cargo test -p connector-github --lib`, `spiceai/spiceai` @ `e4c821c8a9`:

```
DOCS-AUDIT unset            -> permits = 10     # docs claimed "concurrency limiting is disabled"
DOCS-AUDIT http_max=3       -> permits = 10     # runtime.params.http_max_concurrent_requests ignored
DOCS-AUDIT dataset=7        -> permits = 7      # dataset-level override does work
test result: ok. 1 passed
```

Verified unchanged across `v2.0.1`, `v2.1.5`, `v2.2.1` and trunk (`GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS = 10`; zero occurrences of `http_max_concurrent_requests` in the GitHub connector in every one), so the correction applies to vNext and all three affected snapshots. Databricks has resolved the shared keys since v2.0.1, so naming it is correct in every snapshot too.

## Source refs

`spiceai/spiceai` @ [`e4c821c8a9`](https://github.com/spiceai/spiceai/commit/e4c821c8a9):

- [`crates/data-connectors/connector-github/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connectors/connector-github/src/lib.rs) — `GITHUB_DEFAULT_MAX_CONCURRENT_CONNECTIONS`, `resolve_runtime_github_concurrent_connections_limit`, the `ParameterSpec::runtime("max_concurrent_requests")` declaration, and the unconditional `Semaphore::new(...)`.
- [`crates/data-http-rate-control/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-http-rate-control/src/lib.rs) — `parameter_specs()`, the description GitHub's row was copied from. Consumers: `connector-graphql`, `connector-databricks`, `runtime/src/dataconnector/https.rs`.

## Test plan

- [x] `cd website && npm run build` passes (the first attempt caught a bad relative link and it was fixed)
- [x] Versioned-docs propagation checked — `grep -rln 'GraphQL, GitHub) support' website/` and the GitHub-page phrasing both return 0 remaining hits; the 8 surviving `http_max_concurrent_requests` hits are all on graphql/https pages, where the claim is correct
- [x] Files updated: 8 (vNext + 2.0.x + 2.1.x + 2.2.x × {github/index.md, reference/spicepod/runtime.md})