### PR TITLE
docs(huggingface): correct the model revision separator and download cache

### DIFF
--- a/website/docs/components/models/huggingface/deployment.md
+++ b/website/docs/components/models/huggingface/deployment.md
@@ -38,7 +38,7 @@ Model IDs support explicit revision pinning by appending a **colon** and the rev
 
 ### Retry Behavior
 
-Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI to avoid first-request latency.
+Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. Models are downloaded and instantiated during startup, so a slow or large download delays the model reaching `Ready` rather than slowing the first request. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI (passing `--revision` when the `from` pins one).
 
 ## Capacity & Sizing
 
@@ -93,5 +93,5 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
 | Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model stays `Initializing` for a long time after startup       | First-run download. Models are fetched and instantiated during startup (`load_models`), not lazily on the first inference request, so the model is unavailable until the download completes. | Pre-warm the Hub cache with `huggingface-cli download <org>/<model> --revision <revision>` — passing the same revision the `from` pins — and point `HF_HOME` / `HF_HUB_CACHE` at the directory Spice uses. |
 | Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/docs/components/models/huggingface/deployment.md
+++ b/website/docs/components/models/huggingface/deployment.md
@@ -24,17 +24,17 @@ Tokens must be sourced from a [secret store](../../secret-stores/) in production
 
 ### Token Discovery Fallback
 
-When `hf_token` is unset, the local loader falls back to the Hugging Face token cache (typically `~/.cache/huggingface/token` or `HF_TOKEN_PATH`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
+When `hf_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
 
 ## Resilience Controls
 
 ### Download & Cache
 
-Models are downloaded on first use into `~/.spice/models/<name>/<revision>/`. Existing files are skipped on subsequent starts (cache-by-file-existence). Download requests use bearer auth when a token is configured. Path-traversal protections ensure all downloaded files stay within the model directory.
+Models are downloaded on first use into the standard Hugging Face Hub cache, resolved in this order: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then `~/.cache/huggingface/hub`. Blobs already present in that cache are reused on subsequent starts. Download requests use bearer auth when a token is configured. Set `HF_HUB_CACHE` (or `HF_HOME`) to place the cache on a volume with enough space and to share it between restarts or replicas.
 
 ### Revision Pinning
 
-Model IDs support explicit revision pinning (e.g. `org/model@revision`). `latest` maps to `main`. Revisions are sanitized for path safety before use. Pin revisions in production to guarantee reproducibility — `main` is a moving target.
+Model IDs support explicit revision pinning by appending a **colon** and the revision to the `from` value — `from: huggingface:huggingface.co/<org>/<model>:<revision>` (see [`from` format](./index.md#from)). The revision is passed to the Hub verbatim, so it must name a real branch, tag or commit SHA on the repo; `latest` is *not* translated to `main` and fails unless the repo actually has a `latest` ref. An `@` is not a valid separator: `org/model@revision` fails the `from` pattern and the model does not load. Pin revisions to a commit SHA in production to guarantee reproducibility — the default branch is a moving target.
 
 ### Retry Behavior
 
@@ -83,7 +83,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 - **No hot reload**: Switching model revisions requires a spicepod reload.
 - **Limited Responses API support**: Responses API routing is currently tied to specific providers (OpenAI, xAI); a local HF-loaded model does not serve the Responses API.
 - **Quantized formats**: Support depends on the local loader (mistral / candle). Verify the format is supported before production deployment.
-- **Disk-space requirements**: First-run downloads can be multi-GB; ensure `~/.spice/models/` has adequate space.
+- **Disk-space requirements**: First-run downloads can be multi-GB; ensure the Hub cache directory (`HF_HUB_CACHE`, `$HF_HOME/hub`, or `~/.cache/huggingface/hub`) has adequate space.
 
 ## Troubleshooting
 
@@ -92,6 +92,6 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | `401 Unauthorized` on download                                  | Missing or invalid `hf_token`; gated model.                | Set `hf_token`; accept the model's license on Hugging Face; verify token has `read` scope.                                    |
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
-| Model output changes between restarts                           | Revision unpinned (`main`).                                | Pin the revision: `org/model@revision_hash`.                                                                                    |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm with `huggingface-cli download` into the Spice model cache, or start with `initial_load: true` if supported.           |
-| Path traversal error on startup                                 | Malformed revision string.                                 | Use a clean revision: alphanumeric + underscores + dashes only; commit SHAs are safe.                                          |
+| Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
+| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
@@ -24,17 +24,17 @@ Tokens must be sourced from a [secret store](../../secret-stores/) in production
 
 ### Token Discovery Fallback
 
-When `hf_token` is unset, the local loader falls back to the Hugging Face token cache (typically `~/.cache/huggingface/token` or `HF_TOKEN_PATH`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
+When `hf_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
 
 ## Resilience Controls
 
 ### Download & Cache
 
-Models are downloaded on first use into `~/.spice/models/<name>/<revision>/`. Existing files are skipped on subsequent starts (cache-by-file-existence). Download requests use bearer auth when a token is configured. Path-traversal protections ensure all downloaded files stay within the model directory.
+Models are downloaded on first use into the standard Hugging Face Hub cache, resolved in this order: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then `~/.cache/huggingface/hub`. Blobs already present in that cache are reused on subsequent starts. Download requests use bearer auth when a token is configured. Set `HF_HUB_CACHE` (or `HF_HOME`) to place the cache on a volume with enough space and to share it between restarts or replicas.
 
 ### Revision Pinning
 
-Model IDs support explicit revision pinning (e.g. `org/model@revision`). `latest` maps to `main`. Revisions are sanitized for path safety before use. Pin revisions in production to guarantee reproducibility — `main` is a moving target.
+Model IDs support explicit revision pinning by appending a **colon** and the revision to the `from` value — `from: huggingface:huggingface.co/<org>/<model>:<revision>` (see [`from` format](./index.md#from)). The revision is passed to the Hub verbatim, so it must name a real branch, tag or commit SHA on the repo; `latest` is *not* translated to `main` and fails unless the repo actually has a `latest` ref. An `@` is not a valid separator: `org/model@revision` fails the `from` pattern and the model does not load. Pin revisions to a commit SHA in production to guarantee reproducibility — the default branch is a moving target.
 
 ### Retry Behavior
 
@@ -83,7 +83,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 - **No hot reload**: Switching model revisions requires a spicepod reload.
 - **Limited Responses API support**: Responses API routing is currently tied to specific providers (OpenAI, xAI); a local HF-loaded model does not serve the Responses API.
 - **Quantized formats**: Support depends on the local loader (mistral / candle / ONNX). Verify the format is supported before production deployment.
-- **Disk-space requirements**: First-run downloads can be multi-GB; ensure `~/.spice/models/` has adequate space.
+- **Disk-space requirements**: First-run downloads can be multi-GB; ensure the Hub cache directory (`HF_HUB_CACHE`, `$HF_HOME/hub`, or `~/.cache/huggingface/hub`) has adequate space.
 
 ## Troubleshooting
 
@@ -92,6 +92,6 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | `401 Unauthorized` on download                                  | Missing or invalid `hf_token`; gated model.                | Set `hf_token`; accept the model's license on Hugging Face; verify token has `read` scope.                                    |
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
-| Model output changes between restarts                           | Revision unpinned (`main`).                                | Pin the revision: `org/model@revision_hash`.                                                                                    |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm with `huggingface-cli download` into the Spice model cache, or start with `initial_load: true` if supported.           |
-| Path traversal error on startup                                 | Malformed revision string.                                 | Use a clean revision: alphanumeric + underscores + dashes only; commit SHAs are safe.                                          |
+| Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
+| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
@@ -38,7 +38,7 @@ Model IDs support explicit revision pinning by appending a **colon** and the rev
 
 ### Retry Behavior
 
-Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI to avoid first-request latency.
+Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. Models are downloaded and instantiated during startup, so a slow or large download delays the model reaching `Ready` rather than slowing the first request. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI (passing `--revision` when the `from` pins one).
 
 ## Capacity & Sizing
 
@@ -93,5 +93,5 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
 | Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model stays `Initializing` for a long time after startup       | First-run download. Models are fetched and instantiated during startup (`load_models`), not lazily on the first inference request, so the model is unavailable until the download completes. | Pre-warm the Hub cache with `huggingface-cli download <org>/<model> --revision <revision>` — passing the same revision the `from` pins — and point `HF_HOME` / `HF_HUB_CACHE` at the directory Spice uses. |
 | Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
@@ -24,17 +24,17 @@ Tokens must be sourced from a [secret store](../../secret-stores/) in production
 
 ### Token Discovery Fallback
 
-When `hf_token` is unset, the local loader falls back to the Hugging Face token cache (typically `~/.cache/huggingface/token` or `HF_TOKEN_PATH`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
+When `hf_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
 
 ## Resilience Controls
 
 ### Download & Cache
 
-Models are downloaded on first use into `~/.spice/models/<name>/<revision>/`. Existing files are skipped on subsequent starts (cache-by-file-existence). Download requests use bearer auth when a token is configured. Path-traversal protections ensure all downloaded files stay within the model directory.
+Models are downloaded on first use into the standard Hugging Face Hub cache, resolved in this order: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then `~/.cache/huggingface/hub`. Blobs already present in that cache are reused on subsequent starts. Download requests use bearer auth when a token is configured. Set `HF_HUB_CACHE` (or `HF_HOME`) to place the cache on a volume with enough space and to share it between restarts or replicas.
 
 ### Revision Pinning
 
-Model IDs support explicit revision pinning (e.g. `org/model@revision`). `latest` maps to `main`. Revisions are sanitized for path safety before use. Pin revisions in production to guarantee reproducibility — `main` is a moving target.
+Model IDs support explicit revision pinning by appending a **colon** and the revision to the `from` value — `from: huggingface:huggingface.co/<org>/<model>:<revision>` (see [`from` format](./index.md#from)). The revision is passed to the Hub verbatim, so it must name a real branch, tag or commit SHA on the repo; `latest` is *not* translated to `main` and fails unless the repo actually has a `latest` ref. An `@` is not a valid separator: `org/model@revision` fails the `from` pattern and the model does not load. Pin revisions to a commit SHA in production to guarantee reproducibility — the default branch is a moving target.
 
 ### Retry Behavior
 
@@ -83,7 +83,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 - **No hot reload**: Switching model revisions requires a spicepod reload.
 - **Limited Responses API support**: Responses API routing is currently tied to specific providers (OpenAI, xAI); a local HF-loaded model does not serve the Responses API.
 - **Quantized formats**: Support depends on the local loader (mistral / candle / ONNX). Verify the format is supported before production deployment.
-- **Disk-space requirements**: First-run downloads can be multi-GB; ensure `~/.spice/models/` has adequate space.
+- **Disk-space requirements**: First-run downloads can be multi-GB; ensure the Hub cache directory (`HF_HUB_CACHE`, `$HF_HOME/hub`, or `~/.cache/huggingface/hub`) has adequate space.
 
 ## Troubleshooting
 
@@ -92,6 +92,6 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | `401 Unauthorized` on download                                  | Missing or invalid `hf_token`; gated model.                | Set `hf_token`; accept the model's license on Hugging Face; verify token has `read` scope.                                    |
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
-| Model output changes between restarts                           | Revision unpinned (`main`).                                | Pin the revision: `org/model@revision_hash`.                                                                                    |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm with `huggingface-cli download` into the Spice model cache, or start with `initial_load: true` if supported.           |
-| Path traversal error on startup                                 | Malformed revision string.                                 | Use a clean revision: alphanumeric + underscores + dashes only; commit SHAs are safe.                                          |
+| Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
+| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
@@ -38,7 +38,7 @@ Model IDs support explicit revision pinning by appending a **colon** and the rev
 
 ### Retry Behavior
 
-Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI to avoid first-request latency.
+Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. Models are downloaded and instantiated during startup, so a slow or large download delays the model reaching `Ready` rather than slowing the first request. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI (passing `--revision` when the `from` pins one).
 
 ## Capacity & Sizing
 
@@ -93,5 +93,5 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
 | Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model stays `Initializing` for a long time after startup       | First-run download. Models are fetched and instantiated during startup (`load_models`), not lazily on the first inference request, so the model is unavailable until the download completes. | Pre-warm the Hub cache with `huggingface-cli download <org>/<model> --revision <revision>` — passing the same revision the `from` pins — and point `HF_HOME` / `HF_HUB_CACHE` at the directory Spice uses. |
 | Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
@@ -38,7 +38,7 @@ Model IDs support explicit revision pinning by appending a **colon** and the rev
 
 ### Retry Behavior
 
-Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI to avoid first-request latency.
+Download retries follow the shared HTTP-client policy with exponential/fibonacci backoff on transient failures. Models are downloaded and instantiated during startup, so a slow or large download delays the model reaching `Ready` rather than slowing the first request. For very large models over slow networks, pre-download into the cache directory with the Hugging Face CLI (passing `--revision` when the `from` pins one).
 
 ## Capacity & Sizing
 
@@ -93,5 +93,5 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
 | Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model stays `Initializing` for a long time after startup       | First-run download. Models are fetched and instantiated during startup (`load_models`), not lazily on the first inference request, so the model is unavailable until the download completes. | Pre-warm the Hub cache with `huggingface-cli download <org>/<model> --revision <revision>` — passing the same revision the `from` pins — and point `HF_HOME` / `HF_HUB_CACHE` at the directory Spice uses. |
 | Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |

--- a/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
@@ -24,17 +24,17 @@ Tokens must be sourced from a [secret store](../../secret-stores/) in production
 
 ### Token Discovery Fallback
 
-When `hf_token` is unset, the local loader falls back to the Hugging Face token cache (typically `~/.cache/huggingface/token` or `HF_TOKEN_PATH`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
+When `hf_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
 
 ## Resilience Controls
 
 ### Download & Cache
 
-Models are downloaded on first use into `~/.spice/models/<name>/<revision>/`. Existing files are skipped on subsequent starts (cache-by-file-existence). Download requests use bearer auth when a token is configured. Path-traversal protections ensure all downloaded files stay within the model directory.
+Models are downloaded on first use into the standard Hugging Face Hub cache, resolved in this order: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then `~/.cache/huggingface/hub`. Blobs already present in that cache are reused on subsequent starts. Download requests use bearer auth when a token is configured. Set `HF_HUB_CACHE` (or `HF_HOME`) to place the cache on a volume with enough space and to share it between restarts or replicas.
 
 ### Revision Pinning
 
-Model IDs support explicit revision pinning (e.g. `org/model@revision`). `latest` maps to `main`. Revisions are sanitized for path safety before use. Pin revisions in production to guarantee reproducibility — `main` is a moving target.
+Model IDs support explicit revision pinning by appending a **colon** and the revision to the `from` value — `from: huggingface:huggingface.co/<org>/<model>:<revision>` (see [`from` format](./index.md#from)). The revision is passed to the Hub verbatim, so it must name a real branch, tag or commit SHA on the repo; `latest` is *not* translated to `main` and fails unless the repo actually has a `latest` ref. An `@` is not a valid separator: `org/model@revision` fails the `from` pattern and the model does not load. Pin revisions to a commit SHA in production to guarantee reproducibility — the default branch is a moving target.
 
 ### Retry Behavior
 
@@ -83,7 +83,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 - **No hot reload**: Switching model revisions requires a spicepod reload.
 - **Limited Responses API support**: Responses API routing is currently tied to specific providers (OpenAI, xAI); a local HF-loaded model does not serve the Responses API.
 - **Quantized formats**: Support depends on the local loader (mistral / candle). Verify the format is supported before production deployment.
-- **Disk-space requirements**: First-run downloads can be multi-GB; ensure `~/.spice/models/` has adequate space.
+- **Disk-space requirements**: First-run downloads can be multi-GB; ensure the Hub cache directory (`HF_HUB_CACHE`, `$HF_HOME/hub`, or `~/.cache/huggingface/hub`) has adequate space.
 
 ## Troubleshooting
 
@@ -92,6 +92,6 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 | `401 Unauthorized` on download                                  | Missing or invalid `hf_token`; gated model.                | Set `hf_token`; accept the model's license on Hugging Face; verify token has `read` scope.                                    |
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
-| Model output changes between restarts                           | Revision unpinned (`main`).                                | Pin the revision: `org/model@revision_hash`.                                                                                    |
-| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm with `huggingface-cli download` into the Spice model cache, or start with `initial_load: true` if supported.           |
-| Path traversal error on startup                                 | Malformed revision string.                                 | Use a clean revision: alphanumeric + underscores + dashes only; commit SHAs are safe.                                          |
+| Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |
+| First request extremely slow                                    | Model downloading on first run.                            | Pre-warm the Hub cache with `huggingface-cli download <org>/<model>`, pointing `HF_HOME` / `HF_HUB_CACHE` at the same directory Spice uses. |
+| Model fails to load with an invalid-`from` error                | `from` does not match the HuggingFace pattern — most often an `@` used as the revision separator, or a character outside `[A-Za-z0-9_.-]` in the revision. | Use `from: huggingface:huggingface.co/<org>/<model>:<revision>`; the revision accepts word characters, digits, dashes and dots, so commit SHAs are safe. |


### PR DESCRIPTION
## Summary

The HuggingFace model **Deployment Guide** describes the old `crates/model_components/src/modelsource/` downloader — the ONNX / `/v1/predict` path, removed after v2.1.1 — rather than the loader that actually serves `from: huggingface:` chat and embedding models. Four claims are wrong, in every snapshot:

| What the docs said | What the code does |
| --- | --- |
| "Model IDs support explicit revision pinning (e.g. `org/model@revision`)" | The separator is a **colon**. `HUGGINGFACE_PATH_REGEX` matches `(:(?<revision>[\w\d\-\.]+))?`; an `@` fails the pattern outright and the model does not load. The connector's own index page already documents this correctly. |
| "`latest` maps to `main`" | No such mapping exists on this path. `MistralLlama::from_hf` does `model_id.split(':')` and forwards `model_parts.get(1)` straight into `load_model_from_hf(revision, …)`, so `:latest` asks the Hub for a ref literally named `latest`. |
| "downloaded … into `~/.spice/models/<name>/<revision>/`" … "Path-traversal protections …" | That directory and its `sanitize_filename` guard belonged to the removed `modelsource` layer. Downloads land in the Hugging Face Hub cache: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then `~/.cache/huggingface/hub`. |
| Token fallback "typically `~/.cache/huggingface/token` or `HF_TOKEN_PATH`" | `TokenSource::CacheToken` reads `HF_TOKEN`, then `HF_HUB_TOKEN`, then `$HF_HOME/token`. `HF_TOKEN_PATH` is read by neither `hf-hub` nor `mistralrs-core`. |

Also drops the fabricated `initial_load: true` knob from the troubleshooting table (no such identifier exists in `spiceai/spiceai`), and replaces the now-impossible "Path traversal error on startup" row with the invalid-`from` error a reader will actually hit.

## Evidence

A temporary probe added to `spicepod`'s own test module and then reverted — `cargo test -p spicepod --lib`, `spiceai/spiceai` @ `e4c821c8a9`:

```
DOCS-AUDIT huggingface:huggingface.co/BAAI/bge-base-en-v1.5@a5beb1e       -> model_id = None
DOCS-AUDIT huggingface:BAAI/bge-base-en-v1.5@a5beb1e                      -> model_id = None
DOCS-AUDIT huggingface:huggingface.co/BAAI/bge-base-en-v1.5:a5beb1e       -> model_id = Some("BAAI/bge-base-en-v1.5:a5beb1e")
DOCS-AUDIT huggingface:huggingface.co/BAAI/bge-base-en-v1.5:latest        -> model_id = Some("BAAI/bge-base-en-v1.5:latest")
DOCS-AUDIT huggingface:huggingface.co/BAAI/bge-base-en-v1.5               -> model_id = Some("BAAI/bge-base-en-v1.5")
DOCS-AUDIT split_hf_model_id("BAAI/bge-base-en-v1.5:a5beb1e") = ("BAAI/bge-base-en-v1.5", Some("a5beb1e"))
DOCS-AUDIT split_hf_model_id("BAAI/bge-base-en-v1.5:latest") = ("BAAI/bge-base-en-v1.5", Some("latest"))
test result: ok. 1 passed
```

`@` yields `None` — no model id parses, so the `from` is rejected. `:latest` comes back as the revision `latest`, unmapped.

Version scoping: `MistralLlama::from_hf` has used `model_id.split(':')` in `v2.0.1`, `v2.1.5`, `v2.2.1` and trunk, and none of those tags contains a `"latest" =>` arm anywhere under `crates/llms/` or `crates/runtime/src/model/`. The `~/.spice/models` path existed only under `crates/model_components/src/modelsource/` (gone at v2.2.1), and at v2.1.5 it was reachable only from `http/v1/inference.rs` — the ML predict endpoint, never the LLM loader. So all four claims are wrong in vNext and in all three snapshots that carry this page.

## Source refs

`spiceai/spiceai` @ [`e4c821c8a9`](https://github.com/spiceai/spiceai/commit/e4c821c8a9):

- [`crates/spicepod/src/component/model.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/component/model.rs) — `HUGGINGFACE_PATH_REGEX`, `huggingface_model_id`, `split_hf_model_id`
- [`crates/llms/src/chat/mistral.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/chat/mistral.rs) — `from_hf`: `model_id.split(':')`, `TokenSource::CacheToken`, `load_model_from_hf(model_parts.get(1), …)`
- [`crates/llms/src/embeddings/candle/util.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/llms/src/embeddings/candle/util.rs) — `hf_api_builder`, `HF_HUB_CACHE`
- `mistralrs-core/src/pipeline/hf.rs` (`hf_home_dir`, `hf_hub_cache_dir`, `hf_token_path`) and `mistralrs-core/src/utils/tokens.rs` (`TokenSource::CacheToken`) for the cache and token precedence

## Test plan

- [x] `cd website && npm run build` passes (the added `./index.md#from` link resolves; the `### \`from\`` heading is present in all four snapshots)
- [x] Versioned-docs propagation checked — `grep -rn 'spice/models\|@revision\|latest.*maps to\|initial_load\|Path-traversal' website/docs/components/models/ website/versioned_docs/*/components/models/` returns only the four intentional mentions of `@` as the *wrong* form
- [x] Files updated: 4 (vNext + 2.0.x + 2.1.x + 2.2.x)