### PR TITLE
docs(file): the connector does support file watching, and CSV params need the csv_ prefix

### DIFF
--- a/website/docs/components/data-connectors/file/deployment.md
+++ b/website/docs/components/data-connectors/file/deployment.md
@@ -27,7 +27,7 @@ For secrets embedded in data files (credentials, tokens), encrypt at rest and re
 
 The File connector reads local files synchronously; there is no network layer, retry, or concurrency semaphore. Failures are filesystem errors (`ENOENT`, `EACCES`, `EIO`) and surface directly to the caller. Filesystem issues (e.g., an NFS mount going stale) must be handled at the infrastructure layer.
 
-For hot-reloading of updated data files, accelerate the dataset and configure a `refresh_interval` — the connector re-reads the file on each refresh.
+For hot-reloading of updated data files, accelerate the dataset and either set `file_watcher: enabled` in `acceleration.params` — the connector then registers a filesystem watcher and requests a refresh when the file is modified — or configure a `refresh_interval`, which re-reads the file on each refresh.
 
 ## Capacity & Sizing
 
@@ -41,7 +41,7 @@ For hot-reloading of updated data files, accelerate the dataset and configure a 
 See [File Formats](../../../reference/file_format) for format-specific parameters. Choose based on access pattern:
 
 - **Parquet**: Best for analytical reads. Column pruning and predicate pushdown apply.
-- **CSV**: Text-scan workloads only; set `has_header` and `delimiter` explicitly.
+- **CSV**: Text-scan workloads only; set `csv_has_header` and `csv_delimiter` explicitly. The bare `has_header` / `delimiter` names are not runtime parameters and are ignored.
 - **JSON (newline-delimited)**: Good for ad-hoc reads; schema inference cost is linear in sampled records.
 - **Arrow IPC**: Fastest for Spice-to-Spice data exchange.
 
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **No file watching**: File updates are not detected automatically; use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 
@@ -70,4 +70,4 @@ File reads participate in [task history](../../../reference/task_history) throug
 | `Permission denied`                               | Spice process user lacks read permission.        | Adjust file ACLs or mount with appropriate UID/GID.                                          |
 | Schema inference is slow for JSON                 | Large file with sparse fields sampled.           | Provide an explicit `schema`, or sample fewer records.                                       |
 | Planning time dominates for glob patterns         | Very large directory listings.                   | Prune with Hive partitioning or break the dataset into narrower prefixes.                    |
-| Query returns old data after file was replaced    | No file watch; Spice sees cached schema.         | Set `refresh_interval` on an accelerated dataset, or restart the runtime.                    |
+| Query returns old data after file was replaced    | The dataset is not accelerated, or is accelerated without `file_watcher` / `refresh_interval`. | Set `file_watcher: enabled` in `acceleration.params` to refresh on modification, or set a `refresh_interval`. |

--- a/website/docs/components/data-connectors/file/deployment.md
+++ b/website/docs/components/data-connectors/file/deployment.md
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: Change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
@@ -27,7 +27,7 @@ For secrets embedded in data files (credentials, tokens), encrypt at rest and re
 
 The File connector reads local files synchronously; there is no network layer, retry, or concurrency semaphore. Failures are filesystem errors (`ENOENT`, `EACCES`, `EIO`) and surface directly to the caller. Filesystem issues (e.g., an NFS mount going stale) must be handled at the infrastructure layer.
 
-For hot-reloading of updated data files, accelerate the dataset and configure a `refresh_interval` — the connector re-reads the file on each refresh.
+For hot-reloading of updated data files, accelerate the dataset and either set `file_watcher: enabled` in `acceleration.params` — the connector then registers a filesystem watcher and requests a refresh when the file is modified — or configure a `refresh_interval`, which re-reads the file on each refresh.
 
 ## Capacity & Sizing
 
@@ -41,7 +41,7 @@ For hot-reloading of updated data files, accelerate the dataset and configure a 
 See [File Formats](../../../reference/file_format) for format-specific parameters. Choose based on access pattern:
 
 - **Parquet**: Best for analytical reads. Column pruning and predicate pushdown apply.
-- **CSV**: Text-scan workloads only; set `has_header` and `delimiter` explicitly.
+- **CSV**: Text-scan workloads only; set `csv_has_header` and `csv_delimiter` explicitly. The bare `has_header` / `delimiter` names are not runtime parameters and are ignored.
 - **JSON (newline-delimited)**: Good for ad-hoc reads; schema inference cost is linear in sampled records.
 - **Arrow IPC**: Fastest for Spice-to-Spice data exchange.
 
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **No file watching**: File updates are not detected automatically; use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 
@@ -70,4 +70,4 @@ File reads participate in [task history](../../../reference/task_history) throug
 | `Permission denied`                               | Spice process user lacks read permission.        | Adjust file ACLs or mount with appropriate UID/GID.                                          |
 | Schema inference is slow for JSON                 | Large file with sparse fields sampled.           | Provide an explicit `schema`, or sample fewer records.                                       |
 | Planning time dominates for glob patterns         | Very large directory listings.                   | Prune with Hive partitioning or break the dataset into narrower prefixes.                    |
-| Query returns old data after file was replaced    | No file watch; Spice sees cached schema.         | Set `refresh_interval` on an accelerated dataset, or restart the runtime.                    |
+| Query returns old data after file was replaced    | The dataset is not accelerated, or is accelerated without `file_watcher` / `refresh_interval`. | Set `file_watcher: enabled` in `acceleration.params` to refresh on modification, or set a `refresh_interval`. |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/file/deployment.md
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: Change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
@@ -27,7 +27,7 @@ For secrets embedded in data files (credentials, tokens), encrypt at rest and re
 
 The File connector reads local files synchronously; there is no network layer, retry, or concurrency semaphore. Failures are filesystem errors (`ENOENT`, `EACCES`, `EIO`) and surface directly to the caller. Filesystem issues (e.g., an NFS mount going stale) must be handled at the infrastructure layer.
 
-For hot-reloading of updated data files, accelerate the dataset and configure a `refresh_interval` — the connector re-reads the file on each refresh.
+For hot-reloading of updated data files, accelerate the dataset and either set `file_watcher: enabled` in `acceleration.params` — the connector then registers a filesystem watcher and requests a refresh when the file is modified — or configure a `refresh_interval`, which re-reads the file on each refresh.
 
 ## Capacity & Sizing
 
@@ -41,7 +41,7 @@ For hot-reloading of updated data files, accelerate the dataset and configure a 
 See [File Formats](../../../reference/file_format) for format-specific parameters. Choose based on access pattern:
 
 - **Parquet**: Best for analytical reads. Column pruning and predicate pushdown apply.
-- **CSV**: Text-scan workloads only; set `has_header` and `delimiter` explicitly.
+- **CSV**: Text-scan workloads only; set `csv_has_header` and `csv_delimiter` explicitly. The bare `has_header` / `delimiter` names are not runtime parameters and are ignored.
 - **JSON (newline-delimited)**: Good for ad-hoc reads; schema inference cost is linear in sampled records.
 - **Arrow IPC**: Fastest for Spice-to-Spice data exchange.
 
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **No file watching**: File updates are not detected automatically; use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 
@@ -70,4 +70,4 @@ File reads participate in [task history](../../../reference/task_history) throug
 | `Permission denied`                               | Spice process user lacks read permission.        | Adjust file ACLs or mount with appropriate UID/GID.                                          |
 | Schema inference is slow for JSON                 | Large file with sparse fields sampled.           | Provide an explicit `schema`, or sample fewer records.                                       |
 | Planning time dominates for glob patterns         | Very large directory listings.                   | Prune with Hive partitioning or break the dataset into narrower prefixes.                    |
-| Query returns old data after file was replaced    | No file watch; Spice sees cached schema.         | Set `refresh_interval` on an accelerated dataset, or restart the runtime.                    |
+| Query returns old data after file was replaced    | The dataset is not accelerated, or is accelerated without `file_watcher` / `refresh_interval`. | Set `file_watcher: enabled` in `acceleration.params` to refresh on modification, or set a `refresh_interval`. |

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/file/deployment.md
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: Change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/file/deployment.md
@@ -27,7 +27,7 @@ For secrets embedded in data files (credentials, tokens), encrypt at rest and re
 
 The File connector reads local files synchronously; there is no network layer, retry, or concurrency semaphore. Failures are filesystem errors (`ENOENT`, `EACCES`, `EIO`) and surface directly to the caller. Filesystem issues (e.g., an NFS mount going stale) must be handled at the infrastructure layer.
 
-For hot-reloading of updated data files, accelerate the dataset and configure a `refresh_interval` — the connector re-reads the file on each refresh.
+For hot-reloading of updated data files, accelerate the dataset and either set `file_watcher: enabled` in `acceleration.params` — the connector then registers a filesystem watcher and requests a refresh when the file is modified — or configure a `refresh_interval`, which re-reads the file on each refresh.
 
 ## Capacity & Sizing
 
@@ -41,7 +41,7 @@ For hot-reloading of updated data files, accelerate the dataset and configure a 
 See [File Formats](../../../reference/file_format) for format-specific parameters. Choose based on access pattern:
 
 - **Parquet**: Best for analytical reads. Column pruning and predicate pushdown apply.
-- **CSV**: Text-scan workloads only; set `has_header` and `delimiter` explicitly.
+- **CSV**: Text-scan workloads only; set `csv_has_header` and `csv_delimiter` explicitly. The bare `has_header` / `delimiter` names are not runtime parameters and are ignored.
 - **JSON (newline-delimited)**: Good for ad-hoc reads; schema inference cost is linear in sampled records.
 - **Arrow IPC**: Fastest for Spice-to-Spice data exchange.
 
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **No file watching**: File updates are not detected automatically; use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 
@@ -70,4 +70,4 @@ File reads participate in [task history](../../../reference/task_history) throug
 | `Permission denied`                               | Spice process user lacks read permission.        | Adjust file ACLs or mount with appropriate UID/GID.                                          |
 | Schema inference is slow for JSON                 | Large file with sparse fields sampled.           | Provide an explicit `schema`, or sample fewer records.                                       |
 | Planning time dominates for glob patterns         | Very large directory listings.                   | Prune with Hive partitioning or break the dataset into narrower prefixes.                    |
-| Query returns old data after file was replaced    | No file watch; Spice sees cached schema.         | Set `refresh_interval` on an accelerated dataset, or restart the runtime.                    |
+| Query returns old data after file was replaced    | The dataset is not accelerated, or is accelerated without `file_watcher` / `refresh_interval`. | Set `file_watcher: enabled` in `acceleration.params` to refresh on modification, or set a `refresh_interval`. |

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/file/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/file/deployment.md
@@ -58,7 +58,7 @@ File reads participate in [task history](../../../reference/task_history) throug
 ## Known Limitations
 
 - **Read-only**: The File connector cannot write.
-- **File watching is opt-in**: change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
+- **File watching is opt-in**: Change detection is off unless `file_watcher: enabled` is set in the dataset's `acceleration.params` (see [Trigger data refresh on file change](./index.md#trigger-data-refresh-on-file-change)). Without it, use `refresh_interval` on an accelerated dataset to pick up changes.
 - **Container portability**: Hard-coded `file://` paths in a spicepod are non-portable across environments; parameterize via env vars or use network-mounted paths with consistent mount points.
 - **Large CSVs**: CSV reads are single-threaded; prefer Parquet for datasets larger than a few GB.
 


### PR DESCRIPTION
## Summary

Two corrections to the File connector deployment guide, both found by the cheapest tell there is — the page contradicts the connector's own reference page.

**1. "No file watching" is false.** Known Limitations said:

> **No file watching**: File updates are not detected automatically; use `refresh_interval` on an accelerated dataset to pick up changes.

The connector's own `index.md` documents the opposite, under "Trigger data refresh on file change": set `file_watcher: enabled` in the dataset's `acceleration.params`. The code agrees — `FileConnector::on_accelerated_table_registration` gates on `dataset.acceleration.params.get("file_watcher") == "enabled"`, then spawns a filesystem watcher wired to the accelerated table's refresh requester (`refresh_requester()`). The Resilience Controls paragraph and the "Query returns old data after file was replaced" troubleshooting row repeated the same omission and are corrected too.

**2. The CSV parameters need the `csv_` prefix.** The guide said "set `has_header` and `delimiter` explicitly". Those bare names are not declared anywhere — `LISTING_TABLE_PARAMETERS` (`crates/data-connector-api/src/listing/mod.rs`), which is the File connector's entire parameter list, declares `csv_has_header` and `csv_delimiter`, and `reference/file_format.md` in this repo already documents them under those names. A user copying the guide sets keys the runtime filters out and silently keeps the defaults.

## Evidence

`file_watcher` is not a recent addition and has not lapsed. It landed in `spiceai/spiceai` [`c86b7ff5e5`](https://github.com/spiceai/spiceai/commit/c86b7ff5e5) ("Add ability to refresh when file data connector detects changes", spiceai/spiceai#2787), first tagged `v1.0.0`, and `git grep -c file_watcher <tag> -- crates/runtime/src/dataconnector/file.rs` returns 2 at `v2.0.1`, `v2.1.5` and `v2.2.1` — so the false limitation is wrong in vNext and in every snapshot that carries this page.

The `has_header` / `delimiter` names have no source referent: `grep -rn '"has_header"\|"delimiter"' crates/ --include='*.rs'` over `spiceai/spiceai` @ `e4c821c8a9` returns exactly one hit, `dataconnector/glue.rs` reading a **Glue table property** from the AWS catalog — not a Spice parameter, and not on the File connector's path.

## Source refs

`spiceai/spiceai` @ [`e4c821c8a9`](https://github.com/spiceai/spiceai/commit/e4c821c8a9):

- [`crates/runtime/src/dataconnector/file.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/file.rs) — `on_accelerated_table_registration`, the `file_watcher` gate, and `fn parameters()` returning `LISTING_TABLE_PARAMETERS`
- [`crates/data-connector-api/src/listing/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/data-connector-api/src/listing/mod.rs) — `LISTING_TABLE_PARAMETERS`: `csv_has_header`, `csv_delimiter`

## Test plan

- [x] `cd website && npm run build` passes (the added `./index.md#trigger-data-refresh-on-file-change` link resolves; that heading is present in all four snapshots)
- [x] Versioned-docs propagation checked — `grep -rn 'No file watch\|\`has_header\`' website/` returns 0 remaining hits of the old wording
- [x] Files updated: 4 (vNext + 2.0.x + 2.1.x + 2.2.x; no older snapshot carries this page)