### PR TITLE
docs(sqlite): the page cache is 10x larger under the EBS storage profile

### DIFF
--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -43,11 +43,12 @@ For file-mode databases, the connection pool automatically sets the following pr
 | ---------------- | -------- | -------------------------------------------------- |
 | `journal_mode`   | `WAL`    | Enables concurrent readers during writes.          |
 | `synchronous`    | `NORMAL` | Balances durability with write performance.        |
-| `cache_size`     | `-20000` | Sets the page cache to ~20 MB.                     |
+| `cache_size`     | `-20000` | Sets the page cache to ~20 MB. Raised to `-200000` (~200 MB) when the acceleration `storage_profile` resolves to EBS-class network storage. |
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
+| `mmap_size`      | `0`      | Memory-mapped I/O is off by default. Set to `268435456` (256 MiB) when the `storage_profile` resolves to EBS-class network storage. |
 
-These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Two of them — `cache_size` and `mmap_size` — are re-applied after pool setup with larger values when the acceleration [`storage_profile`](../../../reference/spicepod/datasets#accelerationstorage_profile) resolves to EBS-class network storage, to absorb its per-I/O latency. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -56,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics
@@ -81,6 +82,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
+| Slow reads on a large file-mode database  | Page cache is small for the working set.                  | The page cache is managed by the runtime and is not directly configurable; on network-attached storage the larger EBS-profile cache applies automatically. Consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |

--- a/website/docs/components/data-accelerators/sqlite/deployment.md
+++ b/website/docs/components/data-accelerators/sqlite/deployment.md
@@ -57,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`) when the acceleration `storage_profile` resolves to EBS-class network storage. Size for the page cache: that is the anonymous memory the accelerator asks for. The 256 MiB `mmap_size` set under the same profile is a ceiling on how much of the database file may be memory-mapped at once, not a further 256 MiB to provision — mapped pages are file-backed, become resident on demand, and are reclaimable under pressure. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
@@ -43,11 +43,12 @@ For file-mode databases, the connection pool automatically sets the following pr
 | ---------------- | -------- | -------------------------------------------------- |
 | `journal_mode`   | `WAL`    | Enables concurrent readers during writes.          |
 | `synchronous`    | `NORMAL` | Balances durability with write performance.        |
-| `cache_size`     | `-20000` | Sets the page cache to ~20 MB.                     |
+| `cache_size`     | `-20000` | Sets the page cache to ~20 MB. Raised to `-200000` (~200 MB) when the acceleration `storage_profile` resolves to EBS-class network storage. |
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
+| `mmap_size`      | `0`      | Memory-mapped I/O is off by default. Set to `268435456` (256 MiB) when the `storage_profile` resolves to EBS-class network storage. |
 
-These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Two of them — `cache_size` and `mmap_size` — are re-applied after pool setup with larger values when the acceleration [`storage_profile`](../../../reference/spicepod/datasets#accelerationstorage_profile) resolves to EBS-class network storage, to absorb its per-I/O latency. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -56,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics
@@ -81,6 +82,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
+| Slow reads on a large file-mode database  | Page cache is small for the working set.                  | The page cache is managed by the runtime and is not directly configurable; on network-attached storage the larger EBS-profile cache applies automatically. Consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/sqlite/deployment.md
@@ -57,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`) when the acceleration `storage_profile` resolves to EBS-class network storage. Size for the page cache: that is the anonymous memory the accelerator asks for. The 256 MiB `mmap_size` set under the same profile is a ceiling on how much of the database file may be memory-mapped at once, not a further 256 MiB to provision — mapped pages are file-backed, become resident on demand, and are reclaimable under pressure. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
@@ -43,11 +43,12 @@ For file-mode databases, the connection pool automatically sets the following pr
 | ---------------- | -------- | -------------------------------------------------- |
 | `journal_mode`   | `WAL`    | Enables concurrent readers during writes.          |
 | `synchronous`    | `NORMAL` | Balances durability with write performance.        |
-| `cache_size`     | `-20000` | Sets the page cache to ~20 MB.                     |
+| `cache_size`     | `-20000` | Sets the page cache to ~20 MB. Raised to `-200000` (~200 MB) when the acceleration `storage_profile` resolves to EBS-class network storage. |
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
+| `mmap_size`      | `0`      | Memory-mapped I/O is off by default. Set to `268435456` (256 MiB) when the `storage_profile` resolves to EBS-class network storage. |
 
-These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Two of them — `cache_size` and `mmap_size` — are re-applied after pool setup with larger values when the acceleration [`storage_profile`](../../../reference/spicepod/datasets#accelerationstorage_profile) resolves to EBS-class network storage, to absorb its per-I/O latency. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -56,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics
@@ -81,6 +82,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
+| Slow reads on a large file-mode database  | Page cache is small for the working set.                  | The page cache is managed by the runtime and is not directly configurable; on network-attached storage the larger EBS-profile cache applies automatically. Consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/sqlite/deployment.md
@@ -57,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`) when the acceleration `storage_profile` resolves to EBS-class network storage. Size for the page cache: that is the anonymous memory the accelerator asks for. The 256 MiB `mmap_size` set under the same profile is a ceiling on how much of the database file may be memory-mapped at once, not a further 256 MiB to provision — mapped pages are file-backed, become resident on demand, and are reclaimable under pressure. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics

--- a/website/versioned_docs/version-2.2.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-accelerators/sqlite/deployment.md
@@ -43,11 +43,12 @@ For file-mode databases, the connection pool automatically sets the following pr
 | ---------------- | -------- | -------------------------------------------------- |
 | `journal_mode`   | `WAL`    | Enables concurrent readers during writes.          |
 | `synchronous`    | `NORMAL` | Balances durability with write performance.        |
-| `cache_size`     | `-20000` | Sets the page cache to ~20 MB.                     |
+| `cache_size`     | `-20000` | Sets the page cache to ~20 MB. Raised to `-200000` (~200 MB) when the acceleration `storage_profile` resolves to EBS-class network storage. |
 | `foreign_keys`   | `true`   | Enables foreign key constraint enforcement.        |
 | `temp_store`     | `memory` | Stores temporary tables and indices in memory.     |
+| `mmap_size`      | `0`      | Memory-mapped I/O is off by default. Set to `268435456` (256 MiB) when the `storage_profile` resolves to EBS-class network storage. |
 
-These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Use the `busy_timeout` parameter to tune concurrent-writer handling.
+These are no-ops for in-memory databases and are set by the runtime; the SQLite accelerator does not expose a connection string for overriding them. Two of them — `cache_size` and `mmap_size` — are re-applied after pool setup with larger values when the acceleration [`storage_profile`](../../../reference/spicepod/datasets#accelerationstorage_profile) resolves to EBS-class network storage, to absorb its per-I/O latency. Use the `busy_timeout` parameter to tune concurrent-writer handling.
 
 ### Federation Across Files
 
@@ -56,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) and is managed by the runtime; it is not directly configurable. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics
@@ -81,6 +82,6 @@ SQLite acceleration operations participate in [task history](../../../reference/
 | Symptom                                   | Likely cause                                              | Resolution                                                                                        |
 | ----------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `database is locked`                      | Concurrent writer contention exceeds `busy_timeout`.   | Raise `busy_timeout`; reduce concurrent refreshes; or switch to DuckDB/Postgres.               |
-| Slow reads on a large file-mode database  | Default page cache is small for the working set.          | The page cache is managed by the runtime and is not directly configurable; consider DuckDB for large-scan workloads. |
+| Slow reads on a large file-mode database  | Page cache is small for the working set.                  | The page cache is managed by the runtime and is not directly configurable; on network-attached storage the larger EBS-profile cache applies automatically. Consider DuckDB for large-scan workloads. |
 | Acceleration rejects `partition_by`       | Feature not supported.                                    | Remove `partition_by` or switch engines.                                                          |
 | Queries return stale data after refresh   | Readers using long-lived transactions hold an old snapshot. | Ensure read paths do not keep connections open across refresh boundaries (runtime handles this, but custom SQL in pre/post refresh hooks can affect it). |

--- a/website/versioned_docs/version-2.2.x/components/data-accelerators/sqlite/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-accelerators/sqlite/deployment.md
@@ -57,7 +57,7 @@ File-mode SQLite datasets on the same runtime can be federated using SQLite's `A
 ## Capacity & Sizing
 
 - **Single writer**: SQLite serializes writes globally per file. High-concurrency write workloads (e.g., very short refresh intervals on many datasets) hit the write mutex — prefer [DuckDB](../duckdb/deployment) or [PostgreSQL](../postgres/deployment) for those cases.
-- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`, plus a 256 MiB `mmap_size`) when the acceleration `storage_profile` resolves to EBS-class network storage. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
+- **Memory**: The page cache is managed by the runtime and is not directly configurable: ~20 MB (`cache_size = -20000`) on local/tmpfs storage, and ~200 MB (`cache_size = -200000`) when the acceleration `storage_profile` resolves to EBS-class network storage. Size for the page cache: that is the anonymous memory the accelerator asks for. The 256 MiB `mmap_size` set under the same profile is a ceiling on how much of the database file may be memory-mapped at once, not a further 256 MiB to provision — mapped pages are file-backed, become resident on demand, and are reclaimable under pressure. For large read-heavy workloads, prefer [DuckDB](../duckdb/deployment).
 - **Disk**: Plan for 1.2–1.5× the raw data size (SQLite uses row-oriented storage with no strong compression by default).
 
 ## Metrics


### PR DESCRIPTION
## Summary

The SQLite accelerator deployment guide documented the runtime-managed page cache as an unconditional value:

> | `cache_size` | `-20000` | Sets the page cache to ~20 MB. |
>
> **Memory**: The default page cache is ~20 MB (`cache_size = -20000`) … not directly configurable.

That is only the local/tmpfs case. After the connection pool's own `setup()` runs, `SqliteAccelerator::get_shared_pool` calls `apply_sqlite_pragmas(&pool, Self::storage_setup_pragmas(storage))`, and for `ResolvedAccelerationStorage::Ebs` that issues `PRAGMA cache_size=-200000` and `PRAGMA mmap_size=268435456` — a **~200 MB** page cache plus **256 MiB** of memory-mapped I/O, ten times the documented figure. `mmap_size` was not documented at all.

The page already documents the sibling storage-profile conditional correctly for `busy_timeout` (`5000` local, `15000` EBS), so this just brings `cache_size` and `mmap_size` into line with it.

## Evidence

A temporary probe added to `accelerator-sqlite`'s own test module and then reverted. It builds a real file-mode pool, applies `storage_setup_pragmas` exactly as `get_shared_pool` does, and reads the values back out of SQLite — `cargo test -p accelerator-sqlite --lib`, `spiceai/spiceai` @ `e4c821c8a9`:

```
DOCS-AUDIT storage=local_ssd extra pragmas = []
DOCS-AUDIT storage=local_ssd PRAGMA cache_size      -> | -20000     |
DOCS-AUDIT storage=local_ssd PRAGMA mmap_size       -> | 0         |
DOCS-AUDIT storage=local_ssd PRAGMA journal_mode    -> | wal          |
DOCS-AUDIT storage=ebs       extra pragmas = ["PRAGMA cache_size=-200000", "PRAGMA mmap_size=268435456"]
DOCS-AUDIT storage=ebs       PRAGMA cache_size      -> | -200000    |
DOCS-AUDIT storage=ebs       PRAGMA mmap_size       -> | 268435456 |
DOCS-AUDIT storage=ebs       PRAGMA journal_mode    -> | wal          |
test result: ok. 1 passed
```

So the documented `-20000` / implied `mmap_size = 0` are right for local SSD and wrong for EBS, and the table's other rows (`journal_mode = WAL` among them) are confirmed unchanged in both profiles.

Version scoping: `storage_setup_pragmas` arrived with `spiceai/spiceai` [`9f6cfd149f`](https://github.com/spiceai/spiceai/commit/9f6cfd149f) ("Tune accelerators by storage profile", spiceai/spiceai#10913), whose earliest release tag is **v2.0.0**. Snapshots at 1.11.x and older correctly describe a flat ~20 MB cache and are left alone.

## Source refs

`spiceai/spiceai` @ [`e4c821c8a9`](https://github.com/spiceai/spiceai/commit/e4c821c8a9):

- [`crates/accelerators/accelerator-sqlite/src/lib.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/accelerators/accelerator-sqlite/src/lib.rs) — `storage_setup_pragmas`, `get_shared_pool`, `apply_sqlite_pragmas`, and `effective_busy_timeout` (the already-documented sibling conditional)
- `datafusion-table-providers` `core/src/sql/db_connection_pool/sqlitepool.rs` — the pool-level `journal_mode` / `synchronous` / `cache_size` / `foreign_keys` / `temp_store` pragmas the storage profile then overrides

## Test plan

- [x] `cd website && npm run build` passes (the added `storage_profile` link uses the same `../../../reference/spicepod/datasets#accelerationstorage_profile` form already proven on the DuckDB deployment guide)
- [x] Versioned-docs propagation checked — `grep -rn 'cache_size' website/**/data-accelerators/sqlite/` shows the four pages carrying the claim, all updated; no 1.11.x-or-older snapshot has this page
- [x] Files updated: 4 (vNext + 2.0.x + 2.1.x + 2.2.x)