### PR TITLE
docs(acceleration): column references accept quoted names and optional parentheses

### DIFF
--- a/website/docs/features/data-acceleration/constraints.md
+++ b/website/docs/features/data-acceleration/constraints.md
@@ -27,12 +27,34 @@ datasets:
 
 ## Column References
 
-Column references can be used to specify which columns are part of the constraint. The column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+Column references can be used to specify which columns are part of the constraint. The column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional.
 
 Examples
 
 - `number`: Reference a constraint on the `number` column
 - `(hash, timestamp)`: Reference a constraint on the `hash` and `timestamp` columns
+- `hash, timestamp`: The same multicolumn key, written without parentheses
+
+### Column names
+
+The names in a column reference are matched against the schema's field names as written — they are not SQL identifiers, so a name that SQL would read as a qualifier chain (`service.instance.id`) or reject outright (`sentry-environment`, `2xx_count`) is a single column name here and needs no special treatment.
+
+A name may also be double-quoted the way SQL writes it. The quotes are not part of the name, and any whitespace or casing inside them is preserved:
+
+- `service.instance.id` and `"service.instance.id"` both reference the same column
+- `(time_unix_nano, "service.instance.id")`: A multicolumn key mixing both forms
+
+A column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced. Each of those characters separates fields in the strings a column reference is carried in, so such a name cannot be read back unambiguously; the runtime refuses it at load with a configuration error naming the column and the character, rather than silently splitting it.
+
+### Primary key columns must be non-null
+
+Every column named by `primary_key` must be populated in the incoming data. On the [Spice Cayenne](../../components/data-accelerators/cayenne) accelerator a batch carrying a null in any primary key column is rejected with an error naming the offending column(s), for example:
+
+```text
+Primary key column 'region' has null values. Every primary key column must be non-null: populate it in the source data, or set `primary_key` to columns that are always present.
+```
+
+Either populate the column in the source data, or choose a `primary_key` made only of columns that are always present.
 
 ## Handling conflicts
 

--- a/website/docs/features/data-acceleration/indexes.md
+++ b/website/docs/features/data-acceleration/indexes.md
@@ -23,12 +23,15 @@ datasets:
 
 ## Column References
 
-Column references can be used to specify which columns to index. The column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+Column references can be used to specify which columns to index. The column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional.
 
 Examples
 
 - `number`: Index the `number` column
 - `(hash, timestamp)`: Index the `hash` and `timestamp` columns
+- `"service.instance.id"`: Index the `service.instance.id` column, written with the quotes SQL uses
+
+A column name may be double-quoted, and the quotes are not part of the name. Names are matched against the schema's field names as written rather than parsed as SQL identifiers, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced. See [Column names](./constraints#column-names) for the full rules, which are shared by `indexes`, `primary_key` and `on_conflict`.
 
 ## Index Types
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -789,7 +789,7 @@ Optional. Specify which indexes should be applied to the locally accelerated tab
 
 The `indexes` field is a map where the key is the column reference and the value is the index type.
 
-A column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+A column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 See [Indexes](../../features/data-acceleration/indexes)
 
@@ -809,7 +809,7 @@ datasets:
 
 Optional. Specify the primary key constraint on the locally accelerated table. Not supported for in-memory Arrow acceleration engine.
 
-The `primary_key` field is a string that represents the column reference that should be used as the primary key. The column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+The `primary_key` field is a string that represents the column reference that should be used as the primary key. The column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 See [Constraints](../../features/data-acceleration/constraints)
 
@@ -829,7 +829,7 @@ Optional. Specify what should happen when a constraint is violated. Not supporte
 
 The `on_conflict` field is a map where the key is the column reference and the value is the conflict resolution strategy.
 
-A column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+A column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 Only a single `on_conflict` target can be specified, unless all `on_conflict` targets are specified with `drop`.
 

--- a/website/docs/reference/spicepod/views.md
+++ b/website/docs/reference/spicepod/views.md
@@ -252,7 +252,7 @@ Optional. Specify which indexes should be applied to the locally accelerated tab
 
 The `indexes` field is a map where the key is the column reference and the value is the index type.
 
-A column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+A column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 See [Indexes](../../features/data-acceleration/indexes)
 
@@ -272,7 +272,7 @@ views:
 
 Optional. Specify the primary key constraint on the locally accelerated table. Not supported for in-memory Arrow acceleration engine.
 
-The `primary_key` field is a string that represents the column reference that should be used as the primary key. The column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+The `primary_key` field is a string that represents the column reference that should be used as the primary key. The column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 See [Constraints](../../features/data-acceleration/constraints)
 
@@ -292,7 +292,7 @@ Optional. Specify what should happen when a constraint is violated. Not supporte
 
 The `on_conflict` field is a map where the key is the column reference and the value is the conflict resolution strategy.
 
-A column reference can be a single column name or a multicolumn key. The column reference must be enclosed in parentheses if it is a multicolumn key.
+A column reference can be a single column name or a multicolumn key. A multicolumn key is a comma-separated list of column names, and the enclosing parentheses are optional. A column name may be double-quoted the way SQL writes it, and a column whose name contains `,`, `;`, `:`, `(`, `)` or `"` cannot be referenced — see [Column names](../../features/data-acceleration/constraints#column-names).
 
 Only a single `on_conflict` target can be specified, unless all `on_conflict` targets are specified with `drop`.
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#13845](https://github.com/spiceai/spiceai/pull/13845) moved `acceleration.primary_key`, `acceleration.indexes` and `acceleration.on_conflict` onto a single parser, `util::column_reference` (`crates/util/src/column_reference.rs`), reached from `crates/runtime-acceleration/src/acceleration.rs:854-889`. Three user-facing rules changed, and the docs stated the opposite of the first one on 8 lines across 4 pages:

| Claim | Before | On `trunk` today |
| --- | --- | --- |
| Compound key | "must be enclosed in parentheses" | Parentheses are **optional** — `primary_key: a, b` is the same key as `(a, b)`. Previously the un-parenthesised form was read as one column name and failed as missing. |
| Quoted names | undocumented | A name may be double-quoted the way SQL writes it; the quotes are stripped. Previously they were kept in the name, so `"service.instance.id"` was reported missing while the schema listed `service.instance.id`. |
| Unsupported names | undocumented | A name containing `,` `;` `:` `(` `)` or `"` is refused at load with a typed configuration error naming the column and the character, rather than being silently split by a later consumer. |

The names are literal Arrow field names, not SQL identifiers (`sqlparser` is deliberately not used), so `service.instance.id`, `sentry-environment` and `2xx_count` are each a single column name.

Also documents the **non-null primary key requirement**. The same source PR added a Cayenne error that names the offending column and links to this page for details (`crates/cayenne/src/provider/pk_validation.rs:24`) — the page had nothing to say about it.

## Evidence

The parser's own tests on `trunk` (`e4c821c8`) pin every rule above:

```
$ cargo test -p util --lib column_reference
running 5 tests
test column_reference::tests::parses_names_that_are_not_sql_identifiers ... ok
test column_reference::tests::rejects_names_that_cannot_round_trip ... ok
test column_reference::tests::parses_single_and_compound_references ... ok
test column_reference::tests::parses_quoted_names ... ok
test column_reference::tests::rejects_malformed_references ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 179 filtered out
```

`parses_single_and_compound_references` asserts `parse("foo, bar") == ["foo", "bar"]` (optional parentheses); `parses_quoted_names` asserts `parse(r#"(time_unix_nano, "service.instance.id")"#) == ["time_unix_nano", "service.instance.id"]`; `rejects_names_that_cannot_round_trip` asserts the `UnsupportedCharacterInName` error.

## Source PRs

- spiceai/spiceai#13845 — fix(acceleration,cayenne): Resolve quoted columns in keys, name which primary key columns are null

## Versioning

vNext only. `git tag --contains 9dcf95ca` is empty — the change is not in any release, so the versioned snapshots correctly document the parentheses-required behaviour.

## Pages changed (4)

- `website/docs/features/data-acceleration/constraints.md` — new `### Column names` and `### Primary key columns must be non-null` subsections
- `website/docs/features/data-acceleration/indexes.md` — corrected sentence + pointer to the shared rules
- `website/docs/reference/spicepod/datasets.md` — `acceleration.indexes`, `acceleration.primary_key`, `acceleration.on_conflict`
- `website/docs/reference/spicepod/views.md` — same three fields

`grep -rn "must be enclosed in parentheses" website/docs/` now returns 0 hits (was 8).

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Versioned-docs propagation checked — addition class, vNext only
- [x] Files updated: 4