### PR TITLE
docs(distributions): say what the data build actually contains

### DIFF
--- a/website/docs/reference/distributions.md
+++ b/website/docs/reference/distributions.md
@@ -116,6 +116,12 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
 make install-data-only
 ```
 
+:::note
+`make install-data-only` builds from `SPICED_DATA_FEATURES` in the `Makefile` — a hand-maintained list that is **not** the `spiced` default feature set with `models` removed, and that differs from it in both directions. Compared with the default distribution it omits the [ADBC](../components/data-connectors/adbc) data connector and the [AWS Secrets Manager](../components/secret-stores/aws-secrets-manager), [Azure Key Vault](../components/secret-stores/azure-keyvault) and [keyring](../components/secret-stores/keyring) secret stores, and it adds the [PostgreSQL data accelerator](../components/data-accelerators/postgres) and [acceleration snapshots](../features/data-acceleration/snapshots). The [environment](../components/secret-stores/env) and [Kubernetes](../components/secret-stores/kubernetes) secret stores are not feature-gated and are available in every build.
+
+A feature added to the default set does not reach `make install-data-only` until it is added to `SPICED_DATA_FEATURES` too, so recompute the difference from that list and the `default = [...]` array in `bin/spiced/Cargo.toml` rather than assuming the two track each other.
+:::
+
 ## GPU-Accelerated Distributions
 
 ### Metal (macOS)

--- a/website/versioned_docs/version-2.0.x/reference/distributions.md
+++ b/website/versioned_docs/version-2.0.x/reference/distributions.md
@@ -94,8 +94,8 @@ The data distribution excludes AI/ML model support, resulting in a smaller binar
 
 **Included Features:**
 
-- All data connectors
-- All data accelerators
+- The default distribution's data connectors, minus ADBC
+- All embedded data accelerators, including the PostgreSQL data accelerator and acceleration snapshots, which the released default binaries do not carry
 - Default memory allocator (snmalloc)
 
 **Excluded Features:**
@@ -115,6 +115,12 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
 ```bash
 make install-data-only
 ```
+
+:::note
+`make install-data-only` builds from `SPICED_DATA_FEATURES` in the `Makefile` — a hand-maintained list that is **not** the `spiced` default feature set with `models` removed, and that differs from it in both directions. Compared with the default distribution it omits the [ADBC](../components/data-connectors/adbc) data connector and the [AWS Secrets Manager](../components/secret-stores/aws-secrets-manager), [Azure Key Vault](../components/secret-stores/azure-keyvault) and [keyring](../components/secret-stores/keyring) secret stores, and it adds the [PostgreSQL data accelerator](../components/data-accelerators/postgres) and [acceleration snapshots](../features/data-acceleration/snapshots). The [environment](../components/secret-stores/env) and [Kubernetes](../components/secret-stores/kubernetes) secret stores are not feature-gated and are available in every build.
+
+A feature added to the default set does not reach `make install-data-only` until it is added to `SPICED_DATA_FEATURES` too, so recompute the difference from that list and the `default = [...]` array in `bin/spiced/Cargo.toml` rather than assuming the two track each other.
+:::
 
 ## GPU-Accelerated Distributions
 

--- a/website/versioned_docs/version-2.1.x/reference/distributions.md
+++ b/website/versioned_docs/version-2.1.x/reference/distributions.md
@@ -94,8 +94,8 @@ The data distribution excludes AI/ML model support, resulting in a smaller binar
 
 **Included Features:**
 
-- All data connectors
-- All data accelerators
+- The default distribution's data connectors, minus ADBC
+- All embedded data accelerators, including the PostgreSQL data accelerator and acceleration snapshots, which the released default binaries do not carry
 - Default memory allocator (snmalloc)
 
 **Excluded Features:**
@@ -115,6 +115,12 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
 ```bash
 make install-data-only
 ```
+
+:::note
+`make install-data-only` builds from `SPICED_DATA_FEATURES` in the `Makefile` — a hand-maintained list that is **not** the `spiced` default feature set with `models` removed, and that differs from it in both directions. Compared with the default distribution it omits the [ADBC](../components/data-connectors/adbc) data connector and the [AWS Secrets Manager](../components/secret-stores/aws-secrets-manager), [Azure Key Vault](../components/secret-stores/azure-keyvault) and [keyring](../components/secret-stores/keyring) secret stores, and it adds the [PostgreSQL data accelerator](../components/data-accelerators/postgres) and [acceleration snapshots](../features/data-acceleration/snapshots). The [environment](../components/secret-stores/env) and [Kubernetes](../components/secret-stores/kubernetes) secret stores are not feature-gated and are available in every build.
+
+A feature added to the default set does not reach `make install-data-only` until it is added to `SPICED_DATA_FEATURES` too, so recompute the difference from that list and the `default = [...]` array in `bin/spiced/Cargo.toml` rather than assuming the two track each other.
+:::
 
 ## GPU-Accelerated Distributions
 

--- a/website/versioned_docs/version-2.2.x/reference/distributions.md
+++ b/website/versioned_docs/version-2.2.x/reference/distributions.md
@@ -94,8 +94,8 @@ The data distribution excludes AI/ML model support, resulting in a smaller binar
 
 **Included Features:**
 
-- All data connectors
-- All data accelerators
+- The default distribution's data connectors, minus ADBC
+- All embedded data accelerators, including the PostgreSQL data accelerator and acceleration snapshots, which the released default binaries do not carry
 - Default memory allocator (snmalloc)
 
 **Excluded Features:**
@@ -115,6 +115,12 @@ docker pull ghcr.io/spiceai/spiceai-nightly:latest-data
 ```bash
 make install-data-only
 ```
+
+:::note
+`make install-data-only` builds from `SPICED_DATA_FEATURES` in the `Makefile` — a hand-maintained list that is **not** the `spiced` default feature set with `models` removed, and that differs from it in both directions. Compared with the default distribution it omits the [ADBC](../components/data-connectors/adbc) data connector and the [AWS Secrets Manager](../components/secret-stores/aws-secrets-manager), [Azure Key Vault](../components/secret-stores/azure-keyvault) and [keyring](../components/secret-stores/keyring) secret stores, and it adds the [PostgreSQL data accelerator](../components/data-accelerators/postgres) and [acceleration snapshots](../features/data-acceleration/snapshots). The [environment](../components/secret-stores/env) and [Kubernetes](../components/secret-stores/kubernetes) secret stores are not feature-gated and are available in every build.
+
+A feature added to the default set does not reach `make install-data-only` until it is added to `SPICED_DATA_FEATURES` too, so recompute the difference from that list and the `default = [...]` array in `bin/spiced/Cargo.toml` rather than assuming the two track each other.
+:::
 
 ## GPU-Accelerated Distributions
 


### PR DESCRIPTION
## Summary

[spiceai/spiceai#13738](https://github.com/spiceai/spiceai/pull/13738) corrected the `Makefile` comment that described `SPICED_DATA_FEATURES` as "default features minus models". It is not, and has not been for some time — it is an independent, hand-maintained list that differs from `default` **in both directions**. The Data Distribution page inherited exactly the assumption that comment invited, so it describes a build that does not exist.

Diffed on `trunk` (`e4c821c8`) between `SPICED_DATA_FEATURES` (`Makefile:477`) and `default` (`bin/spiced/Cargo.toml`):

| In `default`, not in `SPICED_DATA_FEATURES` | In `SPICED_DATA_FEATURES`, not in `default` |
| --- | --- |
| `adbc`, `aws-secrets-manager`, `azure-keyvault`, `keyring-secret-store`, `models` | `postgres-accel`, `snapshots` |

So the page's two "Included Features" claims are both wrong, and the "Excluded Features" list is incomplete:

- **"All data connectors"** — ADBC is not in the data feature set.
- **"All data accelerators"** — understated: the data build additionally carries the PostgreSQL accelerator and acceleration snapshots, neither of which is in `default` (`release = []` is an empty marker feature, so the released default binaries are `default` + `models` and carry neither).
- **Three secret stores are silently missing.** `aws_secrets_manager`, `azure_keyvault` and `keyring` are `#[cfg(feature = ...)]`-gated in `crates/runtime-secrets/src/stores.rs`; `env` and `kubernetes` are unconditional. A user who picks the data build and relies on AWS Secrets Manager or Azure Key Vault loses it with nothing in the docs saying so.

## Evidence

Computed per release tag rather than assumed, from each tag's own `Makefile` and `bin/spiced/Cargo.toml`:

```
=== v2.0.1 ===
in default not in DATA: ['adbc', 'aws-secrets-manager', 'azure-keyvault', 'keyring-secret-store', 'models']
in DATA not in default: ['postgres-accel', 'snapshots']
=== v2.1.5 ===
in default not in DATA: ['adbc', 'aws-secrets-manager', 'azure-keyvault', 'keyring-secret-store', 'models']
in DATA not in default: ['postgres-accel', 'snapshots']
=== v2.2.1 ===
in default not in DATA: ['adbc', 'aws-secrets-manager', 'azure-keyvault', 'keyring-secret-store', 'models']
in DATA not in default: ['postgres-accel', 'snapshots']
=== trunk (e4c821c8) ===
in default not in DATA: ['adbc', 'aws-secrets-manager', 'azure-keyvault', 'keyring-secret-store', 'models']
in DATA not in default: ['postgres-accel', 'snapshots']
```

The secret-store gating is identical at all four (`#[cfg(feature = "aws-secrets-manager")]` / `"azure-keyvault"` / `"keyring-secret-store"`; `pub mod env;` and `pub mod kubernetes;` unconditional).

## Source PRs

- spiceai/spiceai#13738 — docs(makefile): say what `SPICED_DATA_FEATURES` actually is (fixes #13678)

## Versioning

The divergence is identical at `v2.0.1`, `v2.1.5`, `v2.2.1` and `trunk`, so this is a correction that belongs in vNext plus those three snapshots.

**`version-1.11.x` is deliberately left alone**: `v1.11.6` has no `SPICED_DATA_FEATURES` and no `install-data-only` target at all (its data variants are the `install-with-models*` targets, inverted), so its page needs its own audit rather than this text. Flagging rather than guessing.

## Overlap with #2154

Open PR #2154 already rewrites the vNext `- All data connectors` line to `- The default distribution's data connectors, minus ADBC`. **This PR does not touch that line on vNext** — it only adds the `make install-data-only` note further down the page (5 lines clear of #2154's hunk), and applies the ADBC correction only to the three versioned snapshots, which #2154 does not touch. The two should merge in either order; the versioned wording was copied from #2154 so the pages stay consistent.

## Pages changed (4)

- `website/docs/reference/distributions.md` — note under **Local Build** only
- `website/versioned_docs/version-2.0.x/reference/distributions.md`
- `website/versioned_docs/version-2.1.x/reference/distributions.md`
- `website/versioned_docs/version-2.2.x/reference/distributions.md`

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags)
- [x] Every link in the new note verified to resolve in all four versions (8 targets × 4 dirs)
- [x] Files updated: 4