### PR TITLE
docs(arrow): the hash index activates from `indexes` too, and `partition_by` is supported

### DIFF
--- a/website/docs/components/data-accelerators/arrow/deployment.md
+++ b/website/docs/components/data-accelerators/arrow/deployment.md
@@ -54,9 +54,9 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 
 - **No persistence**: Every restart refreshes from the source.
 - **No traditional indexes**: Arrow does not support B-tree indexes. Hash index provides point-lookup acceleration but not range or sort-order optimization.
-- **Only primary-key hash index**: The hash index requires a `primary_key` constraint; `unique` constraints alone do not enable the index.
+- **Activation is automatic and cannot be forced**: The index activates when `primary_key` or a secondary [`indexes`](../../../features/data-acceleration/indexes) entry is configured; the `hash_index` acceleration parameter is stripped with a warning and enables nothing on its own. A `primary_key` alone does not build an index under `refresh_mode: caching`, which drops the primary-key constraint before the table is created — configure `indexes` instead.
 - **Memory pressure**: If the dataset exceeds available RAM, the runtime will OOM; no spill-to-disk mechanism exists in the Arrow accelerator itself.
-- **`partition_by`**: Not applicable — Arrow accelerator holds a single in-memory representation.
+- **`partition_by` partitions in memory only**: Setting `partition_by` on `engine: arrow` switches the dataset to the partitioned Arrow accelerator, which holds one `MemTable` per partition value — see [Partitioning](../../../features/data-acceleration/partitioning). Every partition still lives in RAM, so partitioning prunes scans but does not relieve the memory ceiling above.
 
 ## Troubleshooting
 
@@ -64,6 +64,7 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | ------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
-| `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
+| `The hash_index acceleration parameter is ignored for Arrow acceleration` warning | `hash_index` no longer activates indexing on its own. | Remove `hash_index` from `params:` and set `primary_key:` or `indexes:` instead.               |
+| No hash index despite `primary_key` being set     | `refresh_mode: caching` drops the primary-key constraint. | Configure `indexes:` on the looked-up columns, or use a non-`caching` refresh mode.            |
 | Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/docs/features/data-acceleration/hash-index.md
+++ b/website/docs/features/data-acceleration/hash-index.md
@@ -237,9 +237,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### Hash index not active despite `primary_key` being set
 
-**Cause**: `refresh_mode: caching` disables hash indexing even when `primary_key` is set; the caching path uses its own lookup strategy.
+**Cause**: `refresh_mode: caching` drops the primary-key constraint before the table is created, so a `primary_key` on its own activates nothing. It does **not** disable hash indexing as such — a secondary `indexes` entry is read from a different place and survives the drop.
 
-**Solution**: Use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) for datasets that need point-lookup acceleration via the hash index.
+**Solution**: Either configure [`indexes`](./indexes) on the looked-up columns, which activates hash indexing under `caching` as it does under any other mode, or use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) if you need the primary-key index specifically. Note that under `caching` the primary-key index stays absent even when `primary_key` and `indexes` are both set — only the secondary index is built.
 
 ### High Memory Usage
 

--- a/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-accelerators/arrow/deployment.md
@@ -54,9 +54,9 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 
 - **No persistence**: Every restart refreshes from the source.
 - **No traditional indexes**: Arrow does not support B-tree indexes. Hash index provides point-lookup acceleration but not range or sort-order optimization.
-- **Only primary-key hash index**: The hash index requires a `primary_key` constraint; `unique` constraints alone do not enable the index.
+- **Activation is automatic and cannot be forced**: The index activates when `primary_key` or a secondary [`indexes`](../../../features/data-acceleration/indexes) entry is configured; the `hash_index` acceleration parameter is stripped with a warning and enables nothing on its own. A `primary_key` alone does not build an index under `refresh_mode: caching`, which drops the primary-key constraint before the table is created — configure `indexes` instead.
 - **Memory pressure**: If the dataset exceeds available RAM, the runtime will OOM; no spill-to-disk mechanism exists in the Arrow accelerator itself.
-- **`partition_by`**: Not applicable — Arrow accelerator holds a single in-memory representation.
+- **`partition_by` partitions in memory only**: Setting `partition_by` on `engine: arrow` switches the dataset to the partitioned Arrow accelerator, which holds one `MemTable` per partition value — see [Partitioning](../../../features/data-acceleration/partitioning). Every partition still lives in RAM, so partitioning prunes scans but does not relieve the memory ceiling above.
 
 ## Troubleshooting
 
@@ -64,6 +64,7 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | ------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
-| `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
+| `The hash_index acceleration parameter is ignored for Arrow acceleration` warning | `hash_index` no longer activates indexing on its own. | Remove `hash_index` from `params:` and set `primary_key:` or `indexes:` instead.               |
+| No hash index despite `primary_key` being set     | `refresh_mode: caching` drops the primary-key constraint. | Configure `indexes:` on the looked-up columns, or use a non-`caching` refresh mode.            |
 | Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/hash-index.md
@@ -237,9 +237,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### Hash index not active despite `primary_key` being set
 
-**Cause**: `refresh_mode: caching` disables hash indexing even when `primary_key` is set; the caching path uses its own lookup strategy.
+**Cause**: `refresh_mode: caching` drops the primary-key constraint before the table is created, so a `primary_key` on its own activates nothing. It does **not** disable hash indexing as such — a secondary `indexes` entry is read from a different place and survives the drop.
 
-**Solution**: Use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) for datasets that need point-lookup acceleration via the hash index.
+**Solution**: Either configure [`indexes`](./indexes) on the looked-up columns, which activates hash indexing under `caching` as it does under any other mode, or use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) if you need the primary-key index specifically. Note that under `caching` the primary-key index stays absent even when `primary_key` and `indexes` are both set — only the secondary index is built.
 
 ### High Memory Usage
 

--- a/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-accelerators/arrow/deployment.md
@@ -54,9 +54,9 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 
 - **No persistence**: Every restart refreshes from the source.
 - **No traditional indexes**: Arrow does not support B-tree indexes. Hash index provides point-lookup acceleration but not range or sort-order optimization.
-- **Only primary-key hash index**: The hash index requires a `primary_key` constraint; `unique` constraints alone do not enable the index.
+- **Activation is automatic and cannot be forced**: The index activates when `primary_key` or a secondary [`indexes`](../../../features/data-acceleration/indexes) entry is configured; the `hash_index` acceleration parameter is stripped with a warning and enables nothing on its own. A `primary_key` alone does not build an index under `refresh_mode: caching`, which drops the primary-key constraint before the table is created — configure `indexes` instead.
 - **Memory pressure**: If the dataset exceeds available RAM, the runtime will OOM; no spill-to-disk mechanism exists in the Arrow accelerator itself.
-- **`partition_by`**: Not applicable — Arrow accelerator holds a single in-memory representation.
+- **`partition_by` partitions in memory only**: Setting `partition_by` on `engine: arrow` switches the dataset to the partitioned Arrow accelerator, which holds one `MemTable` per partition value — see [Partitioning](../../../features/data-acceleration/partitioning). Every partition still lives in RAM, so partitioning prunes scans but does not relieve the memory ceiling above.
 
 ## Troubleshooting
 
@@ -64,6 +64,7 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | ------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
-| `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
+| `The hash_index acceleration parameter is ignored for Arrow acceleration` warning | `hash_index` no longer activates indexing on its own. | Remove `hash_index` from `params:` and set `primary_key:` or `indexes:` instead.               |
+| No hash index despite `primary_key` being set     | `refresh_mode: caching` drops the primary-key constraint. | Configure `indexes:` on the looked-up columns, or use a non-`caching` refresh mode.            |
 | Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/hash-index.md
@@ -237,9 +237,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### Hash index not active despite `primary_key` being set
 
-**Cause**: `refresh_mode: caching` disables hash indexing even when `primary_key` is set; the caching path uses its own lookup strategy.
+**Cause**: `refresh_mode: caching` drops the primary-key constraint before the table is created, so a `primary_key` on its own activates nothing. It does **not** disable hash indexing as such — a secondary `indexes` entry is read from a different place and survives the drop.
 
-**Solution**: Use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) for datasets that need point-lookup acceleration via the hash index.
+**Solution**: Either configure [`indexes`](./indexes) on the looked-up columns, which activates hash indexing under `caching` as it does under any other mode, or use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) if you need the primary-key index specifically. Note that under `caching` the primary-key index stays absent even when `primary_key` and `indexes` are both set — only the secondary index is built.
 
 ### High Memory Usage
 

--- a/website/versioned_docs/version-2.2.x/components/data-accelerators/arrow/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-accelerators/arrow/deployment.md
@@ -54,9 +54,9 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 
 - **No persistence**: Every restart refreshes from the source.
 - **No traditional indexes**: Arrow does not support B-tree indexes. Hash index provides point-lookup acceleration but not range or sort-order optimization.
-- **Only primary-key hash index**: The hash index requires a `primary_key` constraint; `unique` constraints alone do not enable the index.
+- **Activation is automatic and cannot be forced**: The index activates when `primary_key` or a secondary [`indexes`](../../../features/data-acceleration/indexes) entry is configured; the `hash_index` acceleration parameter is stripped with a warning and enables nothing on its own. A `primary_key` alone does not build an index under `refresh_mode: caching`, which drops the primary-key constraint before the table is created — configure `indexes` instead.
 - **Memory pressure**: If the dataset exceeds available RAM, the runtime will OOM; no spill-to-disk mechanism exists in the Arrow accelerator itself.
-- **`partition_by`**: Not applicable — Arrow accelerator holds a single in-memory representation.
+- **`partition_by` partitions in memory only**: Setting `partition_by` on `engine: arrow` switches the dataset to the partitioned Arrow accelerator, which holds one `MemTable` per partition value — see [Partitioning](../../../features/data-acceleration/partitioning). Every partition still lives in RAM, so partitioning prunes scans but does not relieve the memory ceiling above.
 
 ## Troubleshooting
 
@@ -64,6 +64,7 @@ Arrow acceleration operations (refresh, query) participate in [task history](../
 | ------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | OOM on refresh                                   | Source dataset larger than RAM.                         | Switch to a durable accelerator (DuckDB / SQLite / Cayenne) that supports spill to disk.       |
 | Long startup time                                | Full-dataset refresh runs on boot.                      | Switch to a durable accelerator so refresh is incremental, not full, on restart.               |
-| `hash_index` ignored                             | No primary-key constraint on the dataset.               | Add `primary_key:` to the dataset definition; hash index activates automatically.              |
+| `The hash_index acceleration parameter is ignored for Arrow acceleration` warning | `hash_index` no longer activates indexing on its own. | Remove `hash_index` from `params:` and set `primary_key:` or `indexes:` instead.               |
+| No hash index despite `primary_key` being set     | `refresh_mode: caching` drops the primary-key constraint. | Configure `indexes:` on the looked-up columns, or use a non-`caching` refresh mode.            |
 | Query slow for point lookups                     | No primary key/index, or wrong key column.              | Add a `primary_key:` (or secondary `indexes:` entry); ensure the query filter matches the indexed columns. |
 | Accelerator refuses to start with file mode      | Arrow rejects file-mode acceleration.                   | Switch `engine:` to `duckdb`, `sqlite`, `postgres`, or `cayenne`.                              |

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/hash-index.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/hash-index.md
@@ -237,9 +237,9 @@ Uses XXH3_64 with a fixed seed (`0x5370_6963_6541_4920` = "SpiceAI ") for:
 
 ### Hash index not active despite `primary_key` being set
 
-**Cause**: `refresh_mode: caching` disables hash indexing even when `primary_key` is set; the caching path uses its own lookup strategy.
+**Cause**: `refresh_mode: caching` drops the primary-key constraint before the table is created, so a `primary_key` on its own activates nothing. It does **not** disable hash indexing as such — a secondary `indexes` entry is read from a different place and survives the drop.
 
-**Solution**: Use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) for datasets that need point-lookup acceleration via the hash index.
+**Solution**: Either configure [`indexes`](./indexes) on the looked-up columns, which activates hash indexing under `caching` as it does under any other mode, or use a non-caching `refresh_mode` (e.g. `full`, `append`, `changes`) if you need the primary-key index specifically. Note that under `caching` the primary-key index stays absent even when `primary_key` and `indexes` are both set — only the secondary index is built.
 
 ### High Memory Usage
 


### PR DESCRIPTION
## Summary

Two Known-Limitations bullets on the Arrow accelerator **deployment guide** are wrong, and both contradict other Arrow pages in the same doc set.

### 1. Hash-index activation

> **Only primary-key hash index**: The hash index requires a `primary_key` constraint; `unique` constraints alone do not enable the index.

The runtime enables the index on `has_primary_key || has_indexes` — `crates/runtime/src/dataaccelerator/arrow.rs:63-84` (`enable_hash_index_for_primary_key_or_indexes`) — so a secondary `indexes` entry **alone**, `unique` included, builds the index with no `primary_key` at all. `crates/data_components/src/arrow.rs:160-215` then constructs the `IndexedMemTable`, erroring only when *both* are absent ("hash_index requires a primary_key or indexes to be specified"), and builds each `unique` entry as a secondary hash index via `HashIndexBuilder::allow_duplicates(!is_unique)`.

The same page's Capacity & Sizing section already said "Activated automatically when a `primary_key` (**or secondary `indexes` entry**) is configured", so the page contradicted itself; `features/data-acceleration/hash-index.md` and `components/data-accelerators/arrow/index.md` are both already correct. The deployment guide was the lone outlier.

What the bullet *should* have warned about is the reverse case it missed: `refresh_mode: caching` strips the primary-key constraints before the table is created (`dataaccelerator/arrow.rs:108-117`), so under caching a `primary_key` alone builds nothing — `indexes` is required. `Acceleration::is_hash_index_enabled` (`crates/runtime-acceleration/src/acceleration.rs:626-631`) encodes the same rule.

### 2. `partition_by`

> **`partition_by`**: Not applicable — Arrow accelerator holds a single in-memory representation.

Setting `partition_by` on `engine: arrow` remaps the engine: `Engine::Arrow if !acceleration.partition_by.is_empty() => Engine::PartitionedArrow` (`crates/runtime-acceleration/src/acceleration.rs:901`). `crates/runtime/src/dataaccelerator/partitioned_arrow.rs` builds one `ArrowFactory` `MemTable` per partition value behind a `PartitionTableProvider`. `features/data-acceleration/partitioning.md` documents this fully ("`arrow` … Yes … One Arrow `MemTable` per partition value") and `components/data-accelerators/duckdb/index.md:125` tells readers to "use the `arrow` or `cayenne` engine for partitioned acceleration" — again, the deployment guide was the outlier.

## Runnable evidence

`crates/data_components/src/arrow.rs` already carries the negative case as a test (`test_factory_hash_index_enabled_requires_primary_key_or_indexes`, which asserts the error when neither is set). A temporary probe added alongside it — `hash_index: enabled` + `indexes: "name:unique"` + **no** primary-key constraint — was run and confirms the positive case:

```
$ cargo test -p data_components --lib probe_docs_audit_unique_index_alone -- --nocapture
running 1 test
indexes-only (no primary_key) provider: IndexedMemTable { schema: Schema { fields: [Field { name: "id", data_type: Int64 }, Field { name: "name", data_type: Utf8 }], metadata: {} }, indexed: false, primary_key_columns: [], secondary_indexes_count: 1, dirty: false }
test arrow::tests::probe_docs_audit_unique_index_alone_enables_hash_index ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 571 filtered out
```

`primary_key_columns: []` with `secondary_indexes_count: 1` is the point: an `IndexedMemTable` with a live secondary hash index and no primary key at all — exactly the configuration the old bullet said could not enable the index. The probe was reverted after the run; no `spiceai/spiceai` change is proposed here.

The `hash_index`-is-ignored warning quoted in the new troubleshooting row was grepped verbatim, not paraphrased: `crates/runtime-acceleration/src/acceleration.rs:909` — "The hash_index acceleration parameter is ignored for Arrow acceleration; …".

## Version scope

Both facts hold in every doc set that has this page:

- `indexes`-enables-hash-index arrived in `spiceai/spiceai@5a99cd3001` ("Add Arrow primary key upserts", #10749) → first tag `v2.0.0`.
- The `caching`-strips-primary-key behaviour arrived in `89d3ed74c3` (#8237) → first tag `v1.10.0`.
- `PartitionedArrow` arrived in `baf8c13a60` ("Support partitioning in Arrow accelerator", #9571) → first tag `v2.0.0`.

`git grep` at `v2.0.1`, `v2.1.3` and `v2.2.1` confirms the identical `arrow.rs` structure (caching strip at :114, `enable_hash_index_for_primary_key_or_indexes` at :127) and the identical `Engine::PartitionedArrow` remap, so the correction applies to vNext + `2.0.x` + `2.1.x` + `2.2.x`. The page does not exist in `1.x` snapshots.

Cross-page grep (`grep -rn "hash_index\|hash index" website/docs/reference/ website/docs/features/data-acceleration/` and `grep -rn "partition_by" website/docs/components/data-accelerators/`) found no other stale copy — the other pages already state both facts correctly.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — 4 files, `grep -rn "Only primary-key hash index" website/` and `grep -rn '\*\*`partition_by`\*\*: Not applicable' website/` now return 0 hits
- [x] Files updated: 4
