### PR TITLE
docs(embeddings): the chunk offset column is `<column>_offset`, not `_offsets`

### DIFF
--- a/website/docs/components/embeddings/index.md
+++ b/website/docs/components/embeddings/index.md
@@ -255,7 +255,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/docs/features/search/multi-vector.md
+++ b/website/docs/features/search/multi-vector.md
@@ -23,7 +23,7 @@ Chunking splits one long string (such as a document body) into pieces and embeds
 | `Utf8` + chunking  | Chunked                | `List<FixedSizeList<Float32, N>>` |
 | `List<Utf8>`       | Multi-vector (default) | `List<FixedSizeList<Float32, N>>` |
 
-Multi-vector and chunked columns share the same Arrow type, but the per-element offsets column (`<column>_offsets`) is only produced for chunked columns.
+Multi-vector and chunked columns share the same Arrow type, but the per-element offset column (`<column>_offset`) is only produced for chunked columns.
 
 ## Configuring a Multi-Vector Column
 

--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -173,7 +173,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -253,7 +253,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.10.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.10.x/components/embeddings/index.md
@@ -253,7 +253,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.10.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.10.x/features/search/vector-search.md
@@ -164,7 +164,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -247,7 +247,7 @@ sql> describe sales;
      2. If the column is [**chunked**(../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.11.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.11.x/components/embeddings/index.md
@@ -255,7 +255,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.11.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.11.x/features/search/vector-search.md
@@ -169,7 +169,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -249,7 +249,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.5.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.5.x/components/embeddings/index.md
@@ -257,7 +257,7 @@ To ensure compatibility, these table columns must adhere to the following constr
      2. If the column is [**chunked**](#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.5.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.5.x/features/search/vector-search.md
@@ -142,7 +142,7 @@ Datasets that already include embeddings can utilize the same functionalities (e
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.6.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.6.x/components/embeddings/index.md
@@ -253,7 +253,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.6.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.6.x/features/search/vector-search.md
@@ -156,7 +156,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -236,7 +236,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings/index.md#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.7.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.7.x/components/embeddings/index.md
@@ -253,7 +253,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.7.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.7.x/features/search/vector-search.md
@@ -156,7 +156,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -236,7 +236,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings/index.md#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.8.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.8.x/components/embeddings/index.md
@@ -253,7 +253,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.8.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.8.x/features/search/vector-search.md
@@ -164,7 +164,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -247,7 +247,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-1.9.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-1.9.x/components/embeddings/index.md
@@ -253,7 +253,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-1.9.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-1.9.x/features/search/vector-search.md
@@ -164,7 +164,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -247,7 +247,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-2.0.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-2.0.x/components/embeddings/index.md
@@ -255,7 +255,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-2.0.x/features/search/multi-vector.md
+++ b/website/versioned_docs/version-2.0.x/features/search/multi-vector.md
@@ -23,7 +23,7 @@ Chunking splits one long string (such as a document body) into pieces and embeds
 | `Utf8` + chunking  | Chunked                | `List<FixedSizeList<Float32, N>>` |
 | `List<Utf8>`       | Multi-vector (default) | `List<FixedSizeList<Float32, N>>` |
 
-Multi-vector and chunked columns share the same Arrow type, but the per-element offsets column (`<column>_offsets`) is only produced for chunked columns.
+Multi-vector and chunked columns share the same Arrow type, but the per-element offset column (`<column>_offset`) is only produced for chunked columns.
 
 ## Configuring a Multi-Vector Column
 

--- a/website/versioned_docs/version-2.0.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-2.0.x/features/search/vector-search.md
@@ -173,7 +173,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -253,7 +253,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-2.1.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-2.1.x/components/embeddings/index.md
@@ -255,7 +255,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-2.1.x/features/search/multi-vector.md
+++ b/website/versioned_docs/version-2.1.x/features/search/multi-vector.md
@@ -23,7 +23,7 @@ Chunking splits one long string (such as a document body) into pieces and embeds
 | `Utf8` + chunking  | Chunked                | `List<FixedSizeList<Float32, N>>` |
 | `List<Utf8>`       | Multi-vector (default) | `List<FixedSizeList<Float32, N>>` |
 
-Multi-vector and chunked columns share the same Arrow type, but the per-element offsets column (`<column>_offsets`) is only produced for chunked columns.
+Multi-vector and chunked columns share the same Arrow type, but the per-element offset column (`<column>_offset`) is only produced for chunked columns.
 
 ## Configuring a Multi-Vector Column
 

--- a/website/versioned_docs/version-2.1.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-2.1.x/features/search/vector-search.md
@@ -173,7 +173,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -253,7 +253,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 

--- a/website/versioned_docs/version-2.2.x/components/embeddings/index.md
+++ b/website/versioned_docs/version-2.2.x/components/embeddings/index.md
@@ -255,7 +255,7 @@ To ensure compatibility, embedding columns must meet these requirements:
      - `FixedSizeList[Float32 or Float64, N]` for unchunked data, where `N` is the embedding vector size.
      - `List[FixedSizeList[Float32 or Float64, N]]` for chunked data.
 4. **Offset Column (for chunked data):**
-   - If chunked, an offset column `<column_name>_offsets` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
+   - If chunked, an offset column `<column_name>_offset` must exist with type `List[FixedSizeList[Int32, 2]]`, where each pair `[start, end]` maps a chunk to its text segment.
    - Example: `[[0, 100], [101, 200]]` means two chunks covering indices 0–100 and 101–200.
 
 Following these guidelines ensures that the dataset's pre-existing embeddings are fully compatible with Spice.

--- a/website/versioned_docs/version-2.2.x/features/search/multi-vector.md
+++ b/website/versioned_docs/version-2.2.x/features/search/multi-vector.md
@@ -23,7 +23,7 @@ Chunking splits one long string (such as a document body) into pieces and embeds
 | `Utf8` + chunking  | Chunked                | `List<FixedSizeList<Float32, N>>` |
 | `List<Utf8>`       | Multi-vector (default) | `List<FixedSizeList<Float32, N>>` |
 
-Multi-vector and chunked columns share the same Arrow type, but the per-element offsets column (`<column>_offsets`) is only produced for chunked columns.
+Multi-vector and chunked columns share the same Arrow type, but the per-element offset column (`<column>_offset`) is only produced for chunked columns.
 
 ## Configuring a Multi-Vector Column
 

--- a/website/versioned_docs/version-2.2.x/features/search/vector-search.md
+++ b/website/versioned_docs/version-2.2.x/features/search/vector-search.md
@@ -173,7 +173,7 @@ Spice supports vector searches on datasets with pre-existing embeddings. Ensure 
 2. **Data Types**: Embedding columns must use Arrow types:
    - Non-chunked: `FixedSizeList[Float32|Float64, N]`
    - Chunked: `List[FixedSizeList[Float32|Float64, N]]`
-3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offsets`) is required:
+3. **Offset Columns**: For chunked embeddings, an additional offset column (`<column_name>_offset`) is required:
    - Type: `List[FixedSizeList[Int32, 2]]`, indicating chunk boundaries.
 
 Example dataset structure (`sales` table):
@@ -253,7 +253,7 @@ sql> describe sales;
      2. If the column is [**chunked**](../../components/embeddings#chunking), use `List[FixedSizeList[Float32 or Float64, N]]`.
 
 4. **Offset Column for Chunked Data:**
-   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offsets` with the following Arrow data type:
+   - If the underlying column is chunked, there must be an additional offset column named `<column_name>_offset` with the following Arrow data type:
      1. `List[FixedSizeList[Int32, 2]]`, where each element is a pair of integers `[start, end]` representing the start and end indices of the chunk in the underlying text column. This offset column maps each chunk in the embeddings back to the corresponding segment in the underlying text column.
      - _For instance, `[[0, 100], [101, 200]]` indicates two chunks covering indices 0–100 and 101–200, respectively._
 


### PR DESCRIPTION
## Summary

Every page that documents bring-your-own (precomputed) **chunked** embeddings named the required sibling column `<column_name>_offsets`. The runtime looks for `<column>_offset` — singular.

A reader following the docs names their column `body_offsets`, and the failure is silent. `EmbeddingTable::base_table_has_embedding_column` looks the column up by that exact name and — unlike the two early-returns immediately above it, which both `tracing::warn!` — logs nothing when it is absent. It just returns `false`, so the column is not recognised as precomputed and Spice re-embeds the text itself. The user pays for embeddings they already had, with no diagnostic pointing at the column name.

The vector-search page already disagreed with itself: its `describe sales` output for the chunked case shows `address_offset`, matching the code, roughly one screen below the constraint asking for `_offsets`.

## Verified source refs

`spiceai/spiceai` at `origin/trunk` (`2e6499061f`):

- `crates/runtime-search/src/embeddings/common.rs:41-45` — `offset_col!` → `format!("{}_offset", $col)`; `:60-64` — `base_col` strips `_embedding` or `_offset`.
- `crates/search/src/index/chunking.rs:297-301` — `ChunkedSearchIndex::chunking_offset_col` → `format!("{search_column}_offset")`, the same spelling from the other direction.
- `crates/runtime-search/src/embeddings/table.rs:481-492` — the precomputed-embedding gate: `base_schema.column_with_name(offset_col!(column).as_str())`, `else { return false; }` with **no** log line. `:328-331` shows the consequence — the `true` branch logs "has needed embeddings in base table. Will not augment", so `false` means Spice augments (re-embeds).
- `crates/runtime-search/src/candidate/vector.rs:264-267` — the chunked-scalar scan projects `offset_col!(self.embedding_column)`, so the query path reads the same name.

Note for a follow-up in `spiceai/spiceai` (not blocking this PR): the doc comment on `base_table_has_embedding_column` (`table.rs:425-429`) itself writes `c_offsets`, which is very likely where the docs picked the plural up. The code below it uses `offset_col!`.

## Runnable evidence

The singular spelling is the only one in the source, in every release from the oldest snapshot to trunk:

```
$ git grep -n 'format!("{}_offset"' origin/trunk v2.2.1 v2.0.1 v1.11.4 v1.5.2 -- '*.rs'
origin/trunk:crates/runtime-search/src/embeddings/common.rs:43:        format!("{}_offset", $col)
v2.2.1:crates/runtime-search/src/embeddings/common.rs:43:        format!("{}_offset", $col)
v2.0.1:crates/runtime/src/embeddings/common.rs:43:        format!("{}_offset", $col)
v1.11.4:crates/runtime/src/embeddings/common.rs:43:        format!("{}_offset", $col)
v1.5.2:crates/runtime/src/embeddings/common.rs:43:        format!("{}_offset", $col)
```

(The crate moved from `crates/runtime/src/embeddings/` to `crates/runtime-search/src/embeddings/` in #11391; the literal did not change.)

`git grep -n '_offsets' origin/trunk v2.2.1 v1.5.2 -- crates/runtime-search crates/search` returns only unrelated Arrow/chunker locals (`list.value_offsets()`, `chunk_with_char_offsets`, `chunk_offsets`) — never a column name.

The repo also already asserts the name in a unit test: `crates/runtime-search/src/candidate/vector.rs:853` — `assert_eq!(offset_col!("embedding"), "embedding_offset");`.

## Version scope

Correction: the error predates versioning, so every snapshot inherited it. Swept all 11 doc sets and all three page types that carry the claim — 26 files:

- `features/search/vector-search.md` — vNext + `2.2.x` … `1.6.x` (2 hits each), `1.5.x` (1 hit)
- `features/search/multi-vector.md` — vNext + `2.2.x`, `2.1.x`, `2.0.x` (the page does not exist in `1.x`)
- `components/embeddings/index.md` — vNext + all 10 snapshots

`grep -rn "_offsets" website/docs/ website/versioned_docs/` returned 36 hits before this change and **0** after. On the multi-vector pages the surrounding prose was also adjusted from "the per-element offsets column" to "the per-element offset column" so the sentence agrees with the name.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — 26 files, 0 remaining `_offsets` hits
- [x] Files updated: 26