### PR TITLE
docs(duckdb): a connector's DuckDB session is pinned to UTC

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -87,6 +87,10 @@ The `access` field controls what operations are allowed on the catalog:
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                                                                  |
 | `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**.                        |
 
+:::info[Timestamps are read in UTC]
+Spice pins the DuckDB session backing this catalog to `SET TimeZone = 'UTC'`, so a `TIMESTAMPTZ` column always reaches Spice as `Timestamp(us, "UTC")` rather than carrying the host's timezone into the dataset schema. See the [DuckDB connector](../data-connectors/duckdb/index.md) for why.
+:::
+
 ## Authentication
 
 ### AWS S3

--- a/website/docs/components/data-connectors/duckdb/index.md
+++ b/website/docs/components/data-connectors/duckdb/index.md
@@ -68,6 +68,10 @@ The DuckDB data connector can be configured by providing the following `params`:
 
 Configuration `params` are provided either in the top level `dataset` for a dataset source, or in the `acceleration` section for a data store.
 
+:::info[Timestamps are read in UTC]
+Spice pins every DuckDB session it opens to `SET TimeZone = 'UTC'`, so a `TIMESTAMPTZ` column always reaches Spice as `Timestamp(us, "UTC")` regardless of the host's timezone. Without this the Arrow schema — and therefore the instant a naive literal such as `WHERE ts > TIMESTAMP '2024-01-15 15:00:00'` denotes — would differ from machine to machine, because DuckDB labels an exported `TIMESTAMPTZ` with the connection's own `TimeZone` setting. Convert in SQL (`ts AT TIME ZONE 'Asia/Tokyo'`) if you need a local-time reading.
+:::
+
 ## Examples
 
 ### Reading from a relative path

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -64,6 +64,10 @@ The dataset name cannot be a [reserved keyword](../../reference/spicepod/keyword
 | `ducklake_aws_allow_http`          | Optional. Set to `true` to allow HTTP (non-TLS) connections to S3. Default: `false`.                           |
 | `ducklake_automatic_migration`     | Optional. Set to `true` to automatically migrate an older DuckLake catalog schema to the version required by the DuckLake extension on attach. Default: `false`. Migration rewrites catalog metadata and **cannot be undone**. |
 
+:::info[Timestamps are read in UTC]
+Spice pins the DuckDB session backing this connector to `SET TimeZone = 'UTC'`, so a `TIMESTAMPTZ` column always reaches Spice as `Timestamp(us, "UTC")` rather than carrying the host's timezone into the dataset schema. See the [DuckDB connector](./duckdb/index.md) for why.
+:::
+
 ### Connection string formats
 
 | Backend    | Example                                                             |


### PR DESCRIPTION
## Summary

`spiceai/spiceai#13903` pinned every DuckDB session Spice opens for user data to `SET TimeZone = 'UTC'`. Before it, only the DuckDB *accelerator* pinned the setting; the `duckdb` connector, the `ducklake` connector and the `ducklake` catalog connector built their pools with no setup query, so their session timezone was whatever DuckDB derived from the host.

That is user-visible in a way worth documenting: DuckDB labels a `TIMESTAMPTZ` column it exports to Arrow with the connection's own `TimeZone`, so the same file read back as `Timestamp(us, "Asia/Tokyo")` on one machine and `Timestamp(us, "UTC")` on another. DataFusion then coerces a naive literal into the column's zone, so `WHERE ts > TIMESTAMP '2024-01-15 15:00:00'` selected a different set of rows per host. Nothing in the docs said which zone a timestamp column arrives in, and now there is a definite answer.

Three `:::info` notes — the full explanation on the DuckDB connector page, and a one-line statement linking back to it on each DuckLake page.

## Verification

- `data_components::duckdb::with_utc_session_timezone` and `SET_UTC_SESSION_TIMEZONE = "SET TimeZone = 'UTC'"` — `crates/data_components/src/duckdb.rs:45,61`. The statement is quoted verbatim, not paraphrased.
- Applied at all six pools on `trunk`: `connector-duckdb/src/lib.rs:101,126` (file + memory), `connector-ducklake/src/lib.rs:137,151` (file + memory), `runtime/src/catalogconnector/ducklake.rs:232,242` (file + memory) — which is why all three pages get a note and not just the connector.
- `TimeZone` is a **session** setting, applied per connection via the pool's setup queries, so the note says "session" rather than implying a database-level change.
- The DuckDB **accelerator** page is deliberately untouched: it already pinned the same setting through its own settings registry (`accelerator-duckdb`'s `settings::TimeZone`, `DuckDBSettingScope::Local`) and the source PR left it unchanged. This is the accelerator-is-not-the-connector distinction, in the direction where the connector was the one missing the mechanism.

## Source PRs

- spiceai/spiceai#13903 — fix(duckdb): pin a connector's DuckDB session to UTC so a dataset's schema does not carry the host timezone (fixes spiceai/spiceai#13899)

## Test plan

- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] Versioned-docs propagation checked — **addition** class, vNext only. `git tag --contains` on the merge commit `b5849b79` is empty, so no released version behaves this way and the snapshots correctly describe their own behaviour by saying nothing.
- [x] Two links added, both to `data-connectors/duckdb/index.md`, depth-counted from each source file (`./duckdb/index.md` from `data-connectors/ducklake.md`, `../data-connectors/duckdb/index.md` from `catalogs/ducklake.md`) and confirmed to resolve to that page
- [x] No overlap with open #2156, which touches only the accelerator page
- [x] Files updated: 3