### PR TITLE
docs(github): pulls pages 25 at a time, with a 25,025 pull request scan ceiling

### DIFF
--- a/website/docs/components/data-connectors/github/deployment.md
+++ b/website/docs/components/data-connectors/github/deployment.md
@@ -47,7 +47,15 @@ The connector respects GitHub's `Retry-After` and `X-RateLimit-Reset` headers an
 
 ### Pagination
 
-GitHub paginates at 100 items per page. Datasets backed by high-volume endpoints (e.g., `repos.commits` on a monorepo) may require many hours to initially hydrate. Use incremental acceleration with a `since` filter where possible.
+Page width is chosen per table, not fixed at GitHub's 100-item maximum. GitHub enforces a **per-request compute budget** that is separate from — and reached long before — its 500,000-node ceiling, and a page wide enough to exceed it is rejected outright with `Resource limits for this query exceeded`, every node in the page returned as `null`. Tables whose rows expand into many nested connections therefore request narrower pages: `pulls` is requested 25 at a time in both comment modes, while `issues` and `milestones` still use 100.
+
+Datasets backed by high-volume endpoints (e.g., `repos.commits` on a monorepo) may require many hours to initially hydrate. Use incremental acceleration with a `since` filter where possible.
+
+:::warning[`pulls` cannot scan more than 25,025 pull requests]
+A paginated scan stops after 1,000 pages and fails with `Maximum pagination iterations (1000) exceeded` rather than silently truncating, so a `pulls` dataset is bounded at `25 x 1001` = **25,025 pull requests** per refresh. Both query modes page at the same width, so `github_query_mode: search` does not raise the ceiling — but it does push filters down to GitHub, so a filtered `pulls` dataset walks far fewer pages before reaching it.
+
+The page was wider in earlier releases, putting the arithmetic ceiling at 100,100 — but on a repository large enough for that to bind, the wider page was rejected by the compute budget and returned no rows at all. The number of pull requests actually reachable went up, not down.
+:::
 
 ### Retry Behavior
 

--- a/website/docs/components/data-connectors/github/deployment.md
+++ b/website/docs/components/data-connectors/github/deployment.md
@@ -47,12 +47,12 @@ The connector respects GitHub's `Retry-After` and `X-RateLimit-Reset` headers an
 
 ### Pagination
 
-Page width is chosen per table, not fixed at GitHub's 100-item maximum. GitHub enforces a **per-request compute budget** that is separate from — and reached long before — its 500,000-node ceiling, and a page wide enough to exceed it is rejected outright with `Resource limits for this query exceeded`, every node in the page returned as `null`. Tables whose rows expand into many nested connections therefore request narrower pages: `pulls` is requested 25 at a time in both comment modes, while `issues` and `milestones` still use 100.
+Page width is chosen per table, not fixed at GitHub's 100-item maximum. GitHub enforces a **per-request compute budget** ([GraphQL API resource limits announcement](https://github.blog/changelog/2025-09-01-graphql-api-resource-limits/)) that is separate from — and reached long before — the [500,000-node ceiling](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#node-limit), and a page wide enough to exceed it is rejected outright with `Resource limits for this query exceeded`, every node in the page returned as `null`. Tables whose rows expand into many nested connections therefore request narrower pages: `pulls` is requested 25 at a time in both comment modes, while `issues` and `milestones` still use 100.
 
 Datasets backed by high-volume endpoints (e.g., `repos.commits` on a monorepo) may require many hours to initially hydrate. Use incremental acceleration with a `since` filter where possible.
 
-:::warning[`pulls` cannot scan more than 25,025 pull requests]
-A paginated scan stops after 1,000 pages and fails with `Maximum pagination iterations (1000) exceeded` rather than silently truncating, so a `pulls` dataset is bounded at `25 x 1001` = **25,025 pull requests** per refresh. Both query modes page at the same width, so `github_query_mode: search` does not raise the ceiling — but it does push filters down to GitHub, so a filtered `pulls` dataset walks far fewer pages before reaching it.
+:::warning[`pulls` scan ceilings differ by query mode]
+In `github_query_mode: auto`, the connector fails with `Maximum pagination iterations (1000) exceeded` after 1,000 pagination iterations (1,001 total page fetches counting the initial page), rather than silently truncating. At 25 rows per page, that bounds a `pulls` dataset at `25 x 1001` = **25,025 pull requests** per refresh. In `github_query_mode: search`, GitHub Search has its own [1,000-result limit](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests), which is the effective cap for a single query.
 
 The page was wider in earlier releases, putting the arithmetic ceiling at 100,100 — but on a repository large enough for that to bind, the wider page was rejected by the compute budget and returned no rows at all. The number of pull requests actually reachable went up, not down.
 :::


### PR DESCRIPTION
## Summary

The GitHub connector's deployment guide said, flatly, "GitHub paginates at 100 items per page." That was already over-broad — the connector picks a page width per table — and `spiceai/spiceai#13938` made it wrong in the way that matters most: `pulls` now requests **25** per page, not 100, and that gives the table a hard scan ceiling nothing in the docs mentioned.

Two things this section now says that it did not:

1. **Why the pages are narrow.** GitHub enforces a per-request *compute budget* separate from its 500,000-node ceiling. A page of 100 pull requests is only ~26,000 nodes — about 5% of the node limit — yet it is rejected outright with `Resource limits for this query exceeded`, with every node in the page returned as `null`. So the width is chosen against the compute budget, not validated against the node one.
2. **`pulls` is bounded at 25,025 pull requests per refresh.** A paginated scan stops after 1,000 pages and *errors* rather than truncating, so the reachable set is `page_size x 1001`. A reader planning a `pulls` dataset against a large repository needs that number, and it was nowhere in the docs at either page width.

The warning also says the ceiling is not a regression: it was 100,100 on paper before, but on any repository large enough for it to bind the wider page returned no rows at all.

## Verification

- `DEFAULT_PAGE_SIZE: u32 = 25` — `crates/data-connectors/connector-github/src/pull_requests.rs:271`, and `COMMENTS_PAGE_SIZE = 25` at :285. `outer_page_size()` (:338) returns 25 for **every** `PullRequestCommentType` variant, which is why the page says "in both comment modes" rather than singling one out.
- Both query modes page at that width: `outer_page_size()` feeds the `search(query:"repo:... type:pr", first:{page_size}, type:ISSUE)` form at :407 **and** the `pullRequests(first: {page_size}, ...)` form at :434. So the note that `github_query_mode: search` does not raise the ceiling is read off the code, not assumed.
- `issues` and `milestones` are still 100 — `ISSUES_PAGE_SIZE`/`MILESTONES_PAGE_SIZE`, both `= 100` — which is what makes the blanket "100 items per page" wrong rather than merely stale.
- Both quoted error strings were grepped before being pasted: `Maximum pagination iterations (1000) exceeded` is emitted verbatim by `execute_paginated` (`crates/data-connectors/connector-graphql/src/graphql/client.rs`, `MAX_PAGINATION_ITERATIONS: usize = 1000`), and it is an `Err`, not a truncation — which is the whole reason the ceiling is worth documenting.

## Source PRs

- spiceai/spiceai#13938 — fix(github): bound the pull request page to GitHub's per-request compute budget (refs spiceai/spiceai#13762)

## Versioned docs — deliberately not swept

`git tag --contains` on the merge commit `b75bad43` is empty, so this is vNext-only. The identical sentence does exist in the `2.0.x`/`2.1.x`/`2.2.x` snapshots and is over-broad there too, but with **different** values: `DEFAULT_PAGE_SIZE` is `100` at `v2.0.1`, `v2.1.5` and `v2.2.1`, and those releases predate the per-table `*_PAGE_SIZE` constants entirely (only `pull_requests.rs` declares one; the rest are inline `first: N`). Stamping trunk's numbers across them would replace an over-broad claim with a wrong one, so those snapshots are left for a per-release pass rather than swept here.

## Test plan

- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] Versioned-docs propagation checked — version-specific change, vNext only; reasoning above
- [x] No links or frontmatter tags added
- [x] No overlap with open #2161, which touches `github/index.md` and `reference/spicepod/runtime.md`, not `github/deployment.md`
- [x] Files updated: 1