### PR TITLE
docs(retention): retention_sql alone satisfies an enabled policy

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -549,7 +549,17 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
+
+:::warning[An incomplete policy is reported, not silently dropped]
+A dataset that enables retention but leaves out one of these settings gets **no scheduled retention pass**, and the runtime logs a `[retention]` error naming the dataset and the missing setting rather than starting nothing quietly. There are three such refusals:
+
+- Neither `retention_period` nor `retention_sql` is set to a valid value, so nothing says which rows to delete.
+- `retention_period` is set but `time_column` is not, so there is nothing to compare against the cutoff.
+- `retention_check_interval` is missing or is not a valid duration. It has **no default**, so this is one unset field away from any otherwise-complete policy.
+
+`retention_check_enabled: false` stays silent — asking for no retention is not a policy that failed to assemble.
+:::
 
 Example:
 

--- a/website/versioned_docs/version-1.10.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.10.x/features/data-acceleration/data-refresh.md
@@ -498,7 +498,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/data-refresh.md
@@ -497,7 +497,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.5.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.5.x/features/data-acceleration/data-refresh.md
@@ -478,7 +478,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.6.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.6.x/features/data-acceleration/data-refresh.md
@@ -478,7 +478,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets.md#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets.md#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets.md#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets.md#time_column) and [`time_format`](../../reference/spicepod/datasets.md#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.7.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.7.x/features/data-acceleration/data-refresh.md
@@ -478,7 +478,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.8.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.8.x/features/data-acceleration/data-refresh.md
@@ -486,7 +486,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-1.9.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-1.9.x/features/data-acceleration/data-refresh.md
@@ -486,7 +486,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/data-refresh.md
@@ -549,7 +549,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/data-refresh.md
@@ -549,7 +549,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/data-refresh.md
@@ -549,7 +549,7 @@ Automatically evict time-series data exceeding a retention period by setting a r
 
 The policy is set using the [`acceleration.retention_check_enabled`](../../reference/spicepod/datasets#accelerationretention_check_enabled), [`acceleration.retention_period`](../../reference/spicepod/datasets#accelerationretention_period) and [`acceleration.retention_check_interval`](../../reference/spicepod/datasets#accelerationretention_check_interval) parameters, along with the [`time_column`](../../reference/spicepod/datasets#time_column) and [`time_format`](../../reference/spicepod/datasets#time_format) dataset parameters.
 
-When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.
+When `retention_check_enabled` is set to `true`, `retention_check_interval` is required, along with **either** `retention_period` (with a `time_column`) **or** `retention_sql`. Setting both applies both policies on every check.
 
 Example:
 


### PR DESCRIPTION
## Summary

Two changes to the Data Retention section of `features/data-acceleration/data-refresh.md`.

**1. A wrong required-parameter claim, corrected in all 11 doc sets.** The page said:

> When `retention_check_enabled` is set to `true`, `retention_check_interval` and `retention_period` are required parameters.

`retention_period` is not required. `retention_sql` alone assembles a working policy, and has since at least `v1.5.2`. Following this sentence, a reader who wants only soft-delete eviction sets a `retention_period` they do not want — or concludes SQL-based retention needs a `time_column` it does not need. The page's own [Custom SQL-based Retention](https://docs.spiceai.org/docs/features/data-acceleration/data-refresh) section two paragraphs down contradicts it, and so do `reference/spicepod/datasets.md` and `views.md`, which both already say "`retention_period` or `retention_sql` must be specified". `data-refresh.md` was the lone outlier.

**2. What happens when a policy is incomplete (vNext only).** `spiceai/spiceai#13857` turned the builder's silent refusal into a reported one. Before it, a dataset that set `retention_check_enabled: true`, a `retention_period` and a `time_column` — everything an operator would think constitutes a policy — but no `retention_check_interval` got **no retention task and no diagnostic**: the measured difference is 0 `[retention]` log lines on `trunk` before, 1 error after, same config, same 6 rows loaded. The new admonition lists all three refusals and notes that `retention_check_enabled: false` stays silent.

## Verification

- Refusal arms read from `RetentionBuilder::assemble` (`crates/runtime-table/src/accelerated/mod.rs:2519-2560`): `TimeColumnUnset` when a `time_period` is set with no `time_column` (:2525), `NothingToDelete` when `filters.is_empty()` (:2545), `Unscheduled` from `self.check_interval.ok_or(...)` (:2552). The doc's three bullets are those three arms, in the order the code evaluates them.
- The interval check is deliberately **last**, so a config missing both a filter and an interval reports the filter — which is why the admonition leads with `NothingToDelete` rather than the interval.
- The correction is not a flip: at `v1.5.2`, `RetentionBuilder::build` already pushed a filter from `delete_expr` independently of `time_period` (`crates/runtime/src/accelerated_table/mod.rs:793,811`), so `retention_period` was never required in any released version. Searched merged docs PRs for a prior correction in the opposite direction — nothing but #1067, which added `retention_sql` and never touched this sentence.
- The vNext note does **not** quote the log message verbatim or claim the table "grows without limit". The runtime's own message stops at "nothing deletes rows on a schedule" because two callers still evict — `create_accelerated_table` copies `retention_sql` into `refresh.write_retention_sql_delete_expr` for Arrow engines before the builder runs, and caching mode derives its own policy afterwards — so the docs make the same narrower claim.
- Cross-page grep run: `reference/spicepod/datasets.md`, `views.md`, `runtime.md` and `task_history.md` all mention retention and were checked; only `data-refresh.md` carried the wrong claim, so this is a complete sweep rather than a one-file fix.

## Propagation

**Correction** class — the sentence predates versioning and every snapshot inherited it, so all 11 are fixed in this PR (vNext + `1.5.x` through `2.2.x`). Grep-and-assert: remaining hits `0`, changed files `11`.

The vNext-only admonition lands in `website/docs/` alone: `git tag --contains` on `spiceai/spiceai#13857`'s merge commit is empty, so no released version reports these refusals and the snapshots correctly say nothing about them.

## Source PRs

- spiceai/spiceai#13857 — fix(acceleration): report a retention policy that cannot start instead of silently building none (fixes spiceai/spiceai#13804)

## Test plan

- [x] `cd website && npm run build` passes (exit 0, `[SUCCESS] Generated static files`)
- [x] Versioned-docs propagation checked — grep-and-assert gate above
- [x] No links or frontmatter tags added
- [x] Files updated: 11