### PR TITLE
docs(read/write separation): snapshot polling on read instances needs refresh_mode: snapshot

### DIFF
--- a/website/docs/deployment/read-write-separation.md
+++ b/website/docs/deployment/read-write-separation.md
@@ -147,7 +147,7 @@ Read instances run alongside applications — typically as Kubernetes pod sideca
 Read Spicepod responsibilities:
 
 - Bootstrap each accelerated dataset from the latest snapshot on startup. No source connection required.
-- Optionally refresh from newer snapshots on a schedule (`bootstrap_only` mode polls for new snapshots without writing them).
+- Optionally pick up newer snapshots on a schedule with [`refresh_mode: snapshot`](../features/data-acceleration/data-refresh#snapshot), which polls the snapshot store instead of the federated source.
 - Optionally delegate queries that fall outside the materialized working set to the cluster over Arrow Flight.
 
 ```yaml
@@ -168,6 +168,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot # reload from the snapshot store; never query the source
+      refresh_check_interval: 1m # poll the snapshot store every minute
       snapshots: bootstrap_only # download only; never write back
       params:
         duckdb_file: /local/orders.db
@@ -178,12 +180,14 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot
+      refresh_check_interval: 1m
       snapshots: bootstrap_only
       params:
         duckdb_file: /local/customers.db
 ```
 
-`snapshots: bootstrap_only` is the key setting — read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. Combine with a periodic refresh trigger to pick up new snapshots without re-querying the source.
+Two settings make the read tier read-only. `snapshots: bootstrap_only` means read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. `refresh_mode: snapshot` makes every steady-state refresh a snapshot reload — the federated source is never queried, so a read instance stays functional with no source credentials at all. `refresh_mode: snapshot` also rejects `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` against the accelerated table.
 
 ### Live delegation for the long tail
 
@@ -220,11 +224,12 @@ Steady-state refresh on read instances is configured per dataset:
 
 ```yaml
 acceleration:
-  refresh_check_interval: 1m # check the snapshot bucket every minute
+  refresh_mode: snapshot # refresh by reloading snapshots, not by querying the source
+  refresh_check_interval: 1m # poll the snapshot store every minute (default: 60s)
   snapshots: bootstrap_only
 ```
 
-When a newer snapshot is available, the dataset hot-swaps without restarting the pod.
+`refresh_mode: snapshot` is what turns `refresh_check_interval` into a snapshot-store poll. Without it the dataset keeps its normal refresh mode (`full` by default) and `refresh_check_interval` refreshes **from the federated source** — which a read instance holding no source credentials cannot do. When a newer snapshot is found, its schema is validated against the current acceleration and the accelerator file is swapped atomically, so queries keep being served from the previous snapshot until the swap completes; no pod restart is needed. See [Snapshot refresh mode](../features/data-acceleration/data-refresh#snapshot) for the full requirements.
 
 ### Snapshot retention and storage
 

--- a/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
@@ -147,7 +147,7 @@ Read instances run alongside applications — typically as Kubernetes pod sideca
 Read Spicepod responsibilities:
 
 - Bootstrap each accelerated dataset from the latest snapshot on startup. No source connection required.
-- Optionally refresh from newer snapshots on a schedule (`bootstrap_only` mode polls for new snapshots without writing them).
+- Optionally pick up newer snapshots on a schedule with [`refresh_mode: snapshot`](../features/data-acceleration/data-refresh#snapshot), which polls the snapshot store instead of the federated source.
 - Optionally delegate queries that fall outside the materialized working set to the cluster over Arrow Flight.
 
 ```yaml
@@ -168,6 +168,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot # reload from the snapshot store; never query the source
+      refresh_check_interval: 1m # poll the snapshot store every minute
       snapshots: bootstrap_only # download only; never write back
       params:
         duckdb_file: /local/orders.db
@@ -178,12 +180,14 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot
+      refresh_check_interval: 1m
       snapshots: bootstrap_only
       params:
         duckdb_file: /local/customers.db
 ```
 
-`snapshots: bootstrap_only` is the key setting — read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. Combine with a periodic refresh trigger to pick up new snapshots without re-querying the source.
+Two settings make the read tier read-only. `snapshots: bootstrap_only` means read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. `refresh_mode: snapshot` makes every steady-state refresh a snapshot reload — the federated source is never queried, so a read instance stays functional with no source credentials at all. `refresh_mode: snapshot` also rejects `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` against the accelerated table.
 
 ### Live delegation for the long tail
 
@@ -220,11 +224,12 @@ Steady-state refresh on read instances is configured per dataset:
 
 ```yaml
 acceleration:
-  refresh_check_interval: 1m # check the snapshot bucket every minute
+  refresh_mode: snapshot # refresh by reloading snapshots, not by querying the source
+  refresh_check_interval: 1m # poll the snapshot store every minute (default: 60s)
   snapshots: bootstrap_only
 ```
 
-When a newer snapshot is available, the dataset hot-swaps without restarting the pod.
+`refresh_mode: snapshot` is what turns `refresh_check_interval` into a snapshot-store poll. Without it the dataset keeps its normal refresh mode (`full` by default) and `refresh_check_interval` refreshes **from the federated source** — which a read instance holding no source credentials cannot do. When a newer snapshot is found, its schema is validated against the current acceleration and the accelerator file is swapped atomically, so queries keep being served from the previous snapshot until the swap completes; no pod restart is needed. See [Snapshot refresh mode](../features/data-acceleration/data-refresh#snapshot) for the full requirements.
 
 ### Snapshot retention and storage
 

--- a/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
@@ -147,7 +147,7 @@ Read instances run alongside applications — typically as Kubernetes pod sideca
 Read Spicepod responsibilities:
 
 - Bootstrap each accelerated dataset from the latest snapshot on startup. No source connection required.
-- Optionally refresh from newer snapshots on a schedule (`bootstrap_only` mode polls for new snapshots without writing them).
+- Optionally pick up newer snapshots on a schedule with [`refresh_mode: snapshot`](../features/data-acceleration/data-refresh#snapshot), which polls the snapshot store instead of the federated source.
 - Optionally delegate queries that fall outside the materialized working set to the cluster over Arrow Flight.
 
 ```yaml
@@ -168,6 +168,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot # reload from the snapshot store; never query the source
+      refresh_check_interval: 1m # poll the snapshot store every minute
       snapshots: bootstrap_only # download only; never write back
       params:
         duckdb_file: /local/orders.db
@@ -178,12 +180,14 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot
+      refresh_check_interval: 1m
       snapshots: bootstrap_only
       params:
         duckdb_file: /local/customers.db
 ```
 
-`snapshots: bootstrap_only` is the key setting — read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. Combine with a periodic refresh trigger to pick up new snapshots without re-querying the source.
+Two settings make the read tier read-only. `snapshots: bootstrap_only` means read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. `refresh_mode: snapshot` makes every steady-state refresh a snapshot reload — the federated source is never queried, so a read instance stays functional with no source credentials at all. `refresh_mode: snapshot` also rejects `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` against the accelerated table.
 
 ### Live delegation for the long tail
 
@@ -220,11 +224,12 @@ Steady-state refresh on read instances is configured per dataset:
 
 ```yaml
 acceleration:
-  refresh_check_interval: 1m # check the snapshot bucket every minute
+  refresh_mode: snapshot # refresh by reloading snapshots, not by querying the source
+  refresh_check_interval: 1m # poll the snapshot store every minute (default: 60s)
   snapshots: bootstrap_only
 ```
 
-When a newer snapshot is available, the dataset hot-swaps without restarting the pod.
+`refresh_mode: snapshot` is what turns `refresh_check_interval` into a snapshot-store poll. Without it the dataset keeps its normal refresh mode (`full` by default) and `refresh_check_interval` refreshes **from the federated source** — which a read instance holding no source credentials cannot do. When a newer snapshot is found, its schema is validated against the current acceleration and the accelerator file is swapped atomically, so queries keep being served from the previous snapshot until the swap completes; no pod restart is needed. See [Snapshot refresh mode](../features/data-acceleration/data-refresh#snapshot) for the full requirements.
 
 ### Snapshot retention and storage
 

--- a/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
@@ -147,7 +147,7 @@ Read instances run alongside applications — typically as Kubernetes pod sideca
 Read Spicepod responsibilities:
 
 - Bootstrap each accelerated dataset from the latest snapshot on startup. No source connection required.
-- Optionally refresh from newer snapshots on a schedule (`bootstrap_only` mode polls for new snapshots without writing them).
+- Optionally pick up newer snapshots on a schedule with [`refresh_mode: snapshot`](../features/data-acceleration/data-refresh#snapshot), which polls the snapshot store instead of the federated source.
 - Optionally delegate queries that fall outside the materialized working set to the cluster over Arrow Flight.
 
 ```yaml
@@ -168,6 +168,8 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot # reload from the snapshot store; never query the source
+      refresh_check_interval: 1m # poll the snapshot store every minute
       snapshots: bootstrap_only # download only; never write back
       params:
         duckdb_file: /local/orders.db
@@ -178,12 +180,14 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_mode: snapshot
+      refresh_check_interval: 1m
       snapshots: bootstrap_only
       params:
         duckdb_file: /local/customers.db
 ```
 
-`snapshots: bootstrap_only` is the key setting — read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. Combine with a periodic refresh trigger to pick up new snapshots without re-querying the source.
+Two settings make the read tier read-only. `snapshots: bootstrap_only` means read instances **read** snapshots but never **write** them, so multiple replicas don't race to upload. `refresh_mode: snapshot` makes every steady-state refresh a snapshot reload — the federated source is never queried, so a read instance stays functional with no source credentials at all. `refresh_mode: snapshot` also rejects `INSERT`, `UPDATE`, `DELETE`, and `TRUNCATE` against the accelerated table.
 
 ### Live delegation for the long tail
 
@@ -220,11 +224,12 @@ Steady-state refresh on read instances is configured per dataset:
 
 ```yaml
 acceleration:
-  refresh_check_interval: 1m # check the snapshot bucket every minute
+  refresh_mode: snapshot # refresh by reloading snapshots, not by querying the source
+  refresh_check_interval: 1m # poll the snapshot store every minute (default: 60s)
   snapshots: bootstrap_only
 ```
 
-When a newer snapshot is available, the dataset hot-swaps without restarting the pod.
+`refresh_mode: snapshot` is what turns `refresh_check_interval` into a snapshot-store poll. Without it the dataset keeps its normal refresh mode (`full` by default) and `refresh_check_interval` refreshes **from the federated source** — which a read instance holding no source credentials cannot do. When a newer snapshot is found, its schema is validated against the current acceleration and the accelerator file is swapped atomically, so queries keep being served from the previous snapshot until the swap completes; no pod restart is needed. See [Snapshot refresh mode](../features/data-acceleration/data-refresh#snapshot) for the full requirements.
 
 ### Snapshot retention and storage
 


### PR DESCRIPTION
## Summary

The Read/Write Separation deployment guide attributes periodic snapshot polling and atomic hot-swap on read instances to `snapshots: bootstrap_only` combined with `refresh_check_interval`. Those are the semantics of `refresh_mode: snapshot`, which the page never mentions.

**What the docs said**

- "Optionally refresh from newer snapshots on a schedule (`bootstrap_only` mode polls for new snapshots without writing them)."
- Read-instance Spicepod examples with `snapshots: bootstrap_only` and no `refresh_mode`.
- ```yaml
  acceleration:
    refresh_check_interval: 1m # check the snapshot bucket every minute
    snapshots: bootstrap_only
  ```
  … "When a newer snapshot is available, the dataset hot-swaps without restarting the pod."

**What the code does**

- `bootstrap_only` satisfies `SnapshotBehavior::bootstrap_enabled()`, which is consumed by `download_snapshot_if_needed` in the accelerator's `init` — a one-time bootstrap that returns early when `primary_path.exists()`. It never polls.
- Snapshot polling, schema validation and the atomic provider swap are built only when `matches!(refresh_mode, RefreshMode::Snapshot)` (`build_snapshot_refresh_state` / `refresh_from_snapshot`).
- With any other refresh mode, `refresh_check_interval` drives a refresh **from the federated source**. The default refresh mode is `full`, so the documented read-tier config — advertised on the same page as having "No source credentials" — would attempt a source refresh every minute.

So the guide's read-tier snippets are not just imprecise: as written they configure the one behavior the page says the read tier must not have.

## What changed

- Added `refresh_mode: snapshot` (and an explicit `refresh_check_interval`) to both read-instance dataset examples and to the steady-state refresh snippet.
- Rewrote the "key setting" paragraph to name both settings and their distinct jobs, and to note that `refresh_mode: snapshot` rejects `INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`.
- Replaced the hot-swap sentence with the actual sequence (poll → schema validation → atomic file swap, previous snapshot served until the swap completes), plus a link to [Snapshot refresh mode](https://docs.spiceai.org/docs/features/data-acceleration/data-refresh#snapshot).
- The `refresh_check_interval` default for snapshot mode is stated as 60s, matching `DEFAULT_SNAPSHOT_REFRESH_CHECK_INTERVAL`.

## Verified source refs

`spiceai/spiceai` @ `5dbe86427d`:

- [`crates/data-accelerator-api/src/snapshots.rs#L58-L90`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/data-accelerator-api/src/snapshots.rs#L58-L90) — `download_snapshot_if_needed`, the `primary_path.exists()` early return
- [`crates/runtime/src/datafusion/mod.rs#L3033-L3055`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/datafusion/mod.rs#L3033-L3055) — snapshot refresh state built only for `RefreshMode::Snapshot`
- [`crates/runtime/src/datafusion/mod.rs#L3110-L3122`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/datafusion/mod.rs#L3110-L3122) — `DEFAULT_SNAPSHOT_REFRESH_CHECK_INTERVAL` fallback (`Duration::from_mins(1)`, line 732)
- [`crates/runtime-table/src/accelerated/refresh_task.rs#L1248-L1262`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime-table/src/accelerated/refresh_task.rs#L1248-L1262) — `refresh_from_snapshot`: "The federated source is never queried by this code path"
- [`crates/runtime-table/src/accelerated/mod.rs#L2070`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime-table/src/accelerated/mod.rs#L2070) — `insert_into` rejection (`delete_from`/`update`/`truncate` gate the same way at L2136/L2182/L2238)

`refresh_mode: snapshot` shipped in v2.0.0 (spiceai/spiceai#10651), so this correction applies to vNext plus every versioned snapshot that carries the page — 2.0.x, 2.1.x, 2.2.x. The page does not exist in 1.x.

## Test plan

- [x] `cd website && npm run build` passes (new `#snapshot` anchor resolves in vNext and all three snapshots)
- [x] Versioned-docs propagation checked: `grep -rln 'read-write-separation' website/` → 4 files, all 4 updated
- [x] Files updated: 4