### PR TITLE
docs(read/write separation): spiceai delegation params need the spiceai_ prefix

### DIFF
--- a/website/docs/deployment/read-write-separation.md
+++ b/website/docs/deployment/read-write-separation.md
@@ -195,9 +195,11 @@ datasets:
   - from: spiceai:orders_history
     name: orders_history
     params:
-      endpoint: grpcs://cluster.spice.svc.cluster.local:50051
-      api_key: ${ secrets:CLUSTER_API_KEY }
+      spiceai_endpoint: grpc+tls://cluster.spice.svc.cluster.local:50051
+      spiceai_api_key: ${ secrets:CLUSTER_API_KEY }
 ```
+
+Both params carry the connector's `spiceai_` prefix — an unprefixed `endpoint:` or `api_key:` is dropped at load time with a warning, leaving the connector with no endpoint at all. Use `grpc+tls://` (or `https://`) for TLS; plaintext Flight is `http://`.
 
 The application sees a single SQL surface — accelerated tables and delegated tables compose normally in joins and CTEs. See [Cluster-Sidecar Architecture](architectures/cluster-sidecar) for the conceptual model.
 

--- a/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
@@ -195,9 +195,11 @@ datasets:
   - from: spiceai:orders_history
     name: orders_history
     params:
-      endpoint: grpcs://cluster.spice.svc.cluster.local:50051
-      api_key: ${ secrets:CLUSTER_API_KEY }
+      spiceai_endpoint: grpc+tls://cluster.spice.svc.cluster.local:50051
+      spiceai_api_key: ${ secrets:CLUSTER_API_KEY }
 ```
+
+Both params carry the connector's `spiceai_` prefix — an unprefixed `endpoint:` or `api_key:` is dropped at load time with a warning, leaving the connector with no endpoint at all. Use `grpc+tls://` (or `https://`) for TLS; plaintext Flight is `http://`.
 
 The application sees a single SQL surface — accelerated tables and delegated tables compose normally in joins and CTEs. See [Cluster-Sidecar Architecture](architectures/cluster-sidecar) for the conceptual model.
 

--- a/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
@@ -195,9 +195,11 @@ datasets:
   - from: spiceai:orders_history
     name: orders_history
     params:
-      endpoint: grpcs://cluster.spice.svc.cluster.local:50051
-      api_key: ${ secrets:CLUSTER_API_KEY }
+      spiceai_endpoint: grpc+tls://cluster.spice.svc.cluster.local:50051
+      spiceai_api_key: ${ secrets:CLUSTER_API_KEY }
 ```
+
+Both params carry the connector's `spiceai_` prefix — an unprefixed `endpoint:` or `api_key:` is dropped at load time with a warning, leaving the connector with no endpoint at all. Use `grpc+tls://` (or `https://`) for TLS; plaintext Flight is `http://`.
 
 The application sees a single SQL surface — accelerated tables and delegated tables compose normally in joins and CTEs. See [Cluster-Sidecar Architecture](architectures/cluster-sidecar) for the conceptual model.
 

--- a/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
@@ -195,9 +195,11 @@ datasets:
   - from: spiceai:orders_history
     name: orders_history
     params:
-      endpoint: grpcs://cluster.spice.svc.cluster.local:50051
-      api_key: ${ secrets:CLUSTER_API_KEY }
+      spiceai_endpoint: grpc+tls://cluster.spice.svc.cluster.local:50051
+      spiceai_api_key: ${ secrets:CLUSTER_API_KEY }
 ```
+
+Both params carry the connector's `spiceai_` prefix — an unprefixed `endpoint:` or `api_key:` is dropped at load time with a warning, leaving the connector with no endpoint at all. Use `grpc+tls://` (or `https://`) for TLS; plaintext Flight is `http://`.
 
 The application sees a single SQL surface — accelerated tables and delegated tables compose normally in joins and CTEs. See [Cluster-Sidecar Architecture](architectures/cluster-sidecar) for the conceptual model.
 


### PR DESCRIPTION
## Summary

The "Live delegation for the long tail" example on the Read/Write Separation guide configures the `spiceai` connector with unprefixed params:

```yaml
  - from: spiceai:orders_history
    name: orders_history
    params:
      endpoint: grpcs://cluster.spice.svc.cluster.local:50051
      api_key: ${ secrets:CLUSTER_API_KEY }
```

Two problems:

1. **Missing connector prefix.** Both are declared `ParameterSpec::component("endpoint")` / `ParameterSpec::component("api_key")`, and the connector's `prefix()` is `spiceai`, so the user-facing keys are `spiceai_endpoint` and `spiceai_api_key`. `Parameters::validate_and_format_key` drops an unprefixed key for a prefixed spec with `Ignoring parameter {key}: must be prefixed with 'spiceai_' for {component}` — the config looks valid and silently loses both values. With no endpoint and no `spiceai_region`, `get_endpoint` then falls through to `require_valid_region`, so the dataset fails to load rather than delegating.
2. **`grpcs://` is not a recognized scheme.** The string appears nowhere in `spiceai/spiceai`. The connector recognizes `http://`, `https://` and `grpc+tls://` — its own error text spells this out: "Use http:// for plaintext Flight or https:// or grpc+tls:// for TLS."

This page is the only place in the docs that used either form; the [`spiceai` connector reference](https://docs.spiceai.org/docs/components/data-connectors/spiceai) already documents `spiceai_endpoint` / `spiceai_api_key` and the three schemes correctly, so this was a single-page drift.

## What changed

- `endpoint:` → `spiceai_endpoint:`, `api_key:` → `spiceai_api_key:`
- `grpcs://` → `grpc+tls://`
- One sentence naming the prefix requirement and the accepted schemes, so a reader adapting the snippet doesn't reintroduce the bare form.

## Verified source refs

`spiceai/spiceai` @ `5dbe86427d`:

- [`crates/runtime/src/dataconnector/spiceai.rs#L243-L259`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/dataconnector/spiceai.rs#L243-L259) — `PARAMETERS`, all `ParameterSpec::component(...)`
- [`crates/runtime/src/dataconnector/spiceai.rs#L464-L466`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/dataconnector/spiceai.rs#L464-L466) — `fn prefix() -> "spiceai"`
- [`crates/runtime-parameters/src/lib.rs#L106-L111`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime-parameters/src/lib.rs#L106-L111) — the "must be prefixed with" drop
- [`crates/runtime/src/dataconnector/spiceai.rs#L327-L334`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/dataconnector/spiceai.rs#L327-L334) — `get_endpoint` falling through to `require_valid_region`
- [`crates/runtime/src/dataconnector/spiceai.rs#L111`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/dataconnector/spiceai.rs#L111) and [`#L282-L287`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime/src/dataconnector/spiceai.rs#L282-L287) — the recognized endpoint schemes

The `spiceai_`-prefixed spelling predates every version that carries this page, so this is a straight correction across vNext + 2.0.x + 2.1.x + 2.2.x. The page does not exist in 1.x.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rn 'grpcs://' website/` → 4 hits, all 4 fixed; `grep -rn '^      endpoint:' website/docs/` shows no other `spiceai` connector example using the bare form
- [x] Files updated: 4