### PR TITLE
docs(snapshots): snapshot files carry the engine extension, not .db

### DIFF
--- a/website/docs/deployment/read-write-separation.md
+++ b/website/docs/deployment/read-write-separation.md
@@ -232,9 +232,11 @@ Snapshots are written to Hive-partitioned paths so retention is straightforward:
 
 ```text
 s3://spiceai-snapshots/prod/
-  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.db
-  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.db
+  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.duckdb
+  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.duckdb
 ```
+
+The extension names the engine that wrote the snapshot (`.duckdb`, `.sqlite`, `.cayenne`, or `.turso`), so the cluster and read tiers must accelerate a dataset with the same engine.
 
 Apply an object-store lifecycle rule (S3 lifecycle, GCS Object Lifecycle Management, ADLS Lifecycle) to expire old partitions. Most deployments keep 24–72 hours of refresh-triggered snapshots and a daily archive beyond that.
 

--- a/website/docs/features/data-acceleration/snapshots.md
+++ b/website/docs/features/data-acceleration/snapshots.md
@@ -41,13 +41,13 @@ Acceleration snapshots let Spice reuse a pre-built acceleration file on startup 
 - If no snapshot is available, the acceleration boots empty and refreshes from the source.
 - Spice creates new snapshots based on the configured `snapshots_trigger` mode.
 
-Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset`, Spice writes files such as:
+Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset` accelerated with DuckDB, Spice writes files such as:
 
 ```bash
-s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
+s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.duckdb
 ```
 
-The timestamp is recorded in UTC using ISO 8601 without punctuation.
+The timestamp is recorded in UTC using ISO 8601 without punctuation. The file extension names the acceleration engine that wrote the snapshot: `.duckdb`, `.sqlite`, `.cayenne`, or `.turso`. The engine is also recorded in the snapshot metadata, and a snapshot whose engine differs from the dataset's current engine is rejected at bootstrap rather than restored.
 
 :::warning Dedicated files only
 Every accelerated dataset must write to its own file (for example, `/nvme/my_dataset.db`). Sharing a single file across multiple datasets is not supported.

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/snapshots.md
@@ -37,13 +37,13 @@ Acceleration snapshots let Spice reuse a pre-built acceleration file on startup 
 - If no snapshot is available, the acceleration boots empty and refreshes from the source.
 - Spice creates new snapshots based on the configured `snapshots_trigger` mode.
 
-Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset`, Spice writes files such as:
+Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset` accelerated with DuckDB, Spice writes files such as:
 
 ```bash
-s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
+s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.duckdb
 ```
 
-The timestamp is recorded in UTC using ISO 8601 without punctuation.
+The timestamp is recorded in UTC using ISO 8601 without punctuation. The file extension names the acceleration engine that wrote the snapshot: `.duckdb`, `.sqlite`, `.cayenne`, or `.turso`. The engine is also recorded in the snapshot metadata, and a snapshot whose engine differs from the dataset's current engine is rejected at bootstrap rather than restored.
 
 :::warning Dedicated files only
 Every accelerated dataset must write to its own file (for example, `/nvme/my_dataset.db`). Sharing a single file across multiple datasets is not supported.

--- a/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.0.x/deployment/read-write-separation.md
@@ -232,9 +232,11 @@ Snapshots are written to Hive-partitioned paths so retention is straightforward:
 
 ```text
 s3://spiceai-snapshots/prod/
-  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.db
-  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.db
+  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.duckdb
+  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.duckdb
 ```
+
+The extension names the engine that wrote the snapshot (`.duckdb`, `.sqlite`, `.cayenne`, or `.turso`), so the cluster and read tiers must accelerate a dataset with the same engine.
 
 Apply an object-store lifecycle rule (S3 lifecycle, GCS Object Lifecycle Management, ADLS Lifecycle) to expire old partitions. Most deployments keep 24–72 hours of refresh-triggered snapshots and a daily archive beyond that.
 

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/snapshots.md
@@ -41,13 +41,13 @@ Acceleration snapshots let Spice reuse a pre-built acceleration file on startup 
 - If no snapshot is available, the acceleration boots empty and refreshes from the source.
 - Spice creates new snapshots based on the configured `snapshots_trigger` mode.
 
-Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset`, Spice writes files such as:
+Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset` accelerated with DuckDB, Spice writes files such as:
 
 ```bash
-s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
+s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.duckdb
 ```
 
-The timestamp is recorded in UTC using ISO 8601 without punctuation.
+The timestamp is recorded in UTC using ISO 8601 without punctuation. The file extension names the acceleration engine that wrote the snapshot: `.duckdb`, `.sqlite`, `.cayenne`, or `.turso`. The engine is also recorded in the snapshot metadata, and a snapshot whose engine differs from the dataset's current engine is rejected at bootstrap rather than restored.
 
 :::warning Dedicated files only
 Every accelerated dataset must write to its own file (for example, `/nvme/my_dataset.db`). Sharing a single file across multiple datasets is not supported.

--- a/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.1.x/deployment/read-write-separation.md
@@ -232,9 +232,11 @@ Snapshots are written to Hive-partitioned paths so retention is straightforward:
 
 ```text
 s3://spiceai-snapshots/prod/
-  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.db
-  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.db
+  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.duckdb
+  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.duckdb
 ```
+
+The extension names the engine that wrote the snapshot (`.duckdb`, `.sqlite`, `.cayenne`, or `.turso`), so the cluster and read tiers must accelerate a dataset with the same engine.
 
 Apply an object-store lifecycle rule (S3 lifecycle, GCS Object Lifecycle Management, ADLS Lifecycle) to expire old partitions. Most deployments keep 24–72 hours of refresh-triggered snapshots and a daily archive beyond that.
 

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/snapshots.md
@@ -41,13 +41,13 @@ Acceleration snapshots let Spice reuse a pre-built acceleration file on startup 
 - If no snapshot is available, the acceleration boots empty and refreshes from the source.
 - Spice creates new snapshots based on the configured `snapshots_trigger` mode.
 
-Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset`, Spice writes files such as:
+Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset` accelerated with DuckDB, Spice writes files such as:
 
 ```bash
-s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
+s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.duckdb
 ```
 
-The timestamp is recorded in UTC using ISO 8601 without punctuation.
+The timestamp is recorded in UTC using ISO 8601 without punctuation. The file extension names the acceleration engine that wrote the snapshot: `.duckdb`, `.sqlite`, `.cayenne`, or `.turso`. The engine is also recorded in the snapshot metadata, and a snapshot whose engine differs from the dataset's current engine is rejected at bootstrap rather than restored.
 
 :::warning Dedicated files only
 Every accelerated dataset must write to its own file (for example, `/nvme/my_dataset.db`). Sharing a single file across multiple datasets is not supported.

--- a/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
+++ b/website/versioned_docs/version-2.2.x/deployment/read-write-separation.md
@@ -232,9 +232,11 @@ Snapshots are written to Hive-partitioned paths so retention is straightforward:
 
 ```text
 s3://spiceai-snapshots/prod/
-  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.db
-  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.db
+  month=2026-05/day=2026-05-01/dataset=orders/orders_20260501T120000Z.duckdb
+  month=2026-05/day=2026-05-02/dataset=orders/orders_20260502T120000Z.duckdb
 ```
+
+The extension names the engine that wrote the snapshot (`.duckdb`, `.sqlite`, `.cayenne`, or `.turso`), so the cluster and read tiers must accelerate a dataset with the same engine.
 
 Apply an object-store lifecycle rule (S3 lifecycle, GCS Object Lifecycle Management, ADLS Lifecycle) to expire old partitions. Most deployments keep 24–72 hours of refresh-triggered snapshots and a daily archive beyond that.
 

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/snapshots.md
@@ -41,13 +41,13 @@ Acceleration snapshots let Spice reuse a pre-built acceleration file on startup 
 - If no snapshot is available, the acceleration boots empty and refreshes from the source.
 - Spice creates new snapshots based on the configured `snapshots_trigger` mode.
 
-Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset`, Spice writes files such as:
+Snapshots are organized with Hive-style partitioning so they are easy to retain and prune. For a dataset named `my_dataset` accelerated with DuckDB, Spice writes files such as:
 
 ```bash
-s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
+s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.duckdb
 ```
 
-The timestamp is recorded in UTC using ISO 8601 without punctuation.
+The timestamp is recorded in UTC using ISO 8601 without punctuation. The file extension names the acceleration engine that wrote the snapshot: `.duckdb`, `.sqlite`, `.cayenne`, or `.turso`. The engine is also recorded in the snapshot metadata, and a snapshot whose engine differs from the dataset's current engine is rejected at bootstrap rather than restored.
 
 :::warning Dedicated files only
 Every accelerated dataset must write to its own file (for example, `/nvme/my_dataset.db`). Sharing a single file across multiple datasets is not supported.


### PR DESCRIPTION
## Summary

The snapshot path examples show a `.db` suffix on the snapshot filename:

```
s3://some_bucket/some_folder/month=2025-09/day=2025-09-30/dataset=my_dataset/my_dataset_20250919T134522Z.db
```

Since v1.11.1 the filename ends in the acceleration engine's own extension. `SnapshotPathLayout::snapshot_filename` composes `{dataset}_{timestamp}{engine.snapshot_extension()}`, and `AccelerationEngine::snapshot_extension()` returns `.duckdb`, `.sqlite`, `.cayenne` or `.turso` — never `.db`. Anyone writing an object-store lifecycle rule, a prefix filter, or a bucket-inventory query against `*.db` matches nothing.

The engine is also carried in the snapshot metadata, and `download_snapshot_entry` rejects an entry whose `snapshot_engine` differs from the dataset's current engine, so the extension is not cosmetic — it tells an operator which snapshots a given read tier can actually restore. Both pages now say so.

## Version scoping

This is a version-specific change, not a typo that predates versioning:

- `spiceai/spiceai` before v1.11.1 hardcoded `format!("{}_{}.db", …)` — `.db` is **correct** in the 1.8.x, 1.9.x and 1.10.x doc sets, and those are left alone.
- spiceai/spiceai#9318 ("Snapshots Improvements", 2026-02-07) introduced `snapshot_extension()`. `git tag --contains` puts it in v1.11.1 onward, and `version-1.11.x` tracks v1.11.6, so 1.11.x needs the fix.
- Fixed in vNext + 1.11.x + 2.0.x + 2.1.x + 2.2.x. All four extensions have been identical since v1.11.1, verified at v1.11.6, v2.0.0, v2.1.0 and v2.2.1, so one wording is correct for every affected snapshot.

## Verified source refs

- v2.2.1: [`crates/runtime-acceleration/src/snapshot/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime-acceleration/src/snapshot/mod.rs#L543-L582) — `snapshot_filename` + `snapshot_extension`
- v2.1.0: [same file](https://github.com/spiceai/spiceai/blob/v2.1.0/crates/runtime-acceleration/src/snapshot/mod.rs#L543-L582)
- v2.0.0: [same file](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/runtime-acceleration/src/snapshot/mod.rs#L503-L541)
- v1.11.6: [same file](https://github.com/spiceai/spiceai/blob/v1.11.6/crates/runtime-acceleration/src/snapshot/mod.rs#L467-L505)
- v1.10.4 (unchanged by this PR, for contrast): [`.db` hardcoded](https://github.com/spiceai/spiceai/blob/v1.10.4/crates/runtime-acceleration/src/snapshot/mod.rs#L375-L381)
- trunk @ `5dbe86427d`: [engine-mismatch rejection in `download_snapshot_entry`](https://github.com/spiceai/spiceai/blob/5dbe86427d5df9d0f92ff30d5b1a3fd1e42e6b1e/crates/runtime-acceleration/src/snapshot/mod.rs#L1833-L1848)

`SNAPSHOT_TIMESTAMP_FORMAT` is `%Y%m%dT%H%M%SZ`, so the timestamp portion of the examples was already right and is unchanged.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rln '134522Z.db\|120000Z.db' website/` before → 12 files; after → 3, all of them 1.8.x/1.9.x/1.10.x where `.db` is correct
- [x] Both page types swept: `features/data-acceleration/snapshots.md` and `deployment/read-write-separation.md` (the retention-path example)
- [x] Files updated: 9