### PR TITLE
docs(bigquery): json_contains, json_as_text and json_get IS NULL now push down

### DIFF
--- a/website/docs/components/data-connectors/adbc.md
+++ b/website/docs/components/data-connectors/adbc.md
@@ -40,7 +40,7 @@ dbc install redshift
 
 See the [`dbc` documentation](https://docs.columnar.tech/dbc/) for other installation methods (pip, Homebrew, Windows MSI) and platform support.
 
-Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL automatically. That dialect also rewrites the Spice [JSON extraction functions](../../reference/sql/json) — `json_get_str`, `json_get_int`, `json_get_float`, `json_get_bool`, `json_length` and `json_object_keys` — into native BigQuery SQL, so a predicate over a JSON column filters at the source instead of streaming the column to Spice. See [Federation and pushdown](../../reference/sql/json#federation-and-pushdown) for the functions that stay local and why.
+Spice includes built-in SQL dialect support for BigQuery, translating federated queries into BigQuery-compatible SQL automatically. That dialect also rewrites the Spice [JSON extraction functions](../../reference/sql/json) — `json_get_str`, `json_get_int`, `json_get_float`, `json_get_bool`, `json_length`, `json_object_keys` and `json_contains`, plus `json_as_text` and `json_get(...) IS NULL` on a `STRING` document — into native BigQuery SQL, so a predicate over a JSON column filters at the source instead of streaming the column to Spice. See [Federation and pushdown](../../reference/sql/json#federation-and-pushdown) for the functions that stay local, the ones whose translation depends on how the source declares the column, and why.
 
 ## Configuration
 

--- a/website/docs/reference/sql/json.md
+++ b/website/docs/reference/sql/json.md
@@ -65,6 +65,7 @@ JSON support in Spice is based on [datafusion-functions-json](https://github.com
   - [Conditional JSON Queries](#conditional-json-queries)
   - [Using JSON Functions in Views](#using-json-functions-in-views)
 - [Federation and Pushdown](#federation-and-pushdown)
+  - [How the document column is declared matters](#how-the-document-column-is-declared-matters)
 - [Further Reading](#further-reading)
 
 ---
@@ -659,37 +660,63 @@ scan. Whether — and which — JSON functions push down is therefore connector-
 connector](../../components/data-connectors/adbc) with `adbc_driver: bigquery` uses a BigQuery
 dialect that rewrites these functions into native BigQuery SQL, so they push down to the source:
 
-| Function                                    | Pushed down to BigQuery |
-| ------------------------------------------- | ----------------------- |
-| [`json_get_str`](#json_get_str)             | Yes                     |
-| [`json_get_int`](#json_get_int)             | Yes                     |
-| [`json_get_float`](#json_get_float)         | Yes                     |
-| [`json_get_bool`](#json_get_bool)           | Yes                     |
-| [`json_length`](#json_length)               | Yes (alias `json_len`)  |
-| [`json_object_keys`](#json_object_keys)     | Yes (alias `json_keys`) |
-| [`json_get`](#json_get)                     | No                      |
-| [`json_get_json`](#json_get_json)           | No                      |
-| [`json_get_array`](#json_get_array)         | No                      |
-| [`json_as_text`](#json_as_text)             | No                      |
-| [`json_contains`](#json_contains)           | No                      |
+| Function                                | Pushed down to BigQuery                            |
+| --------------------------------------- | -------------------------------------------------- |
+| [`json_get_str`](#json_get_str)         | Yes                                                 |
+| [`json_get_int`](#json_get_int)         | Yes                                                 |
+| [`json_get_float`](#json_get_float)     | Yes                                                 |
+| [`json_get_bool`](#json_get_bool)       | Yes                                                 |
+| [`json_length`](#json_length)           | Yes (alias `json_len`)                              |
+| [`json_object_keys`](#json_object_keys) | Yes (alias `json_keys`)                             |
+| [`json_contains`](#json_contains)       | Yes, when the source declares the document's type   |
+| [`json_as_text`](#json_as_text)         | Yes, on a `STRING` document only                    |
+| [`json_get`](#json_get)                 | Only as `json_get(...) IS NULL`, on a `STRING` document |
+| [`json_get_json`](#json_get_json)       | No                                                  |
+| [`json_get_array`](#json_get_array)     | No                                                  |
 
-The five that stay local do so because BigQuery cannot reproduce their results, not because the
-translation is unwritten:
-
-- `json_get_json` and `json_as_text` return the matched node's own bytes, spacing and number
-  spelling intact, where BigQuery's `JSON_QUERY` re-renders it — a document holding `{"b": -1}`
-  comes back as `{"b":-1}`.
-- `json_contains` counts a JSON `null` as present, and BigQuery returns SQL NULL for such a node
-  exactly as it does for a missing key, so the two cannot be told apart.
-- `json_get` and `json_get_array` return the library's JSON union type, which has no SQL type to
-  unparse into.
+`json_get_json` and `json_get_array` stay local because BigQuery cannot reproduce their results,
+not because the translation is unwritten: `json_get_json` returns the matched node's own bytes,
+spacing and number spelling intact, where BigQuery's `JSON_QUERY` re-renders it — a document
+holding `{"b": -1}` comes back as `{"b":-1}` — and `json_get_array` returns the library's JSON
+union type, which has no SQL type to unparse into. `json_get` returns that same union type, so
+only its nullness crosses the boundary (below).
 
 The [operators](#json-operators) `->`, `->>` and `?` are spellings of `json_get`, `json_as_text`
-and `json_contains`, so they are not pushed down either.
+and `json_contains`, and each follows its function's row above.
 
-Pushdown also requires every path argument to be a **literal**, because BigQuery's JSON path must
+Pushdown always requires every path argument to be a **literal**, because BigQuery's JSON path must
 be a constant. `json_get_int(doc, 'id')` pushes down; `json_get_int(doc, key_column)` is legal SQL
-in Spice but is evaluated locally.
+in Spice but is evaluated locally. A key containing a quote, a backslash or a control character is
+also refused.
+
+### How the document column is declared matters
+
+BigQuery holds JSON either as a native `JSON` column or as JSON text in a `STRING` column, and both
+arrive in Spice as a string. The three rows above that are conditional are the ones whose
+translation depends on which it is, so they read the remote type the driver reports for the column
+(the Arrow `arrow.json` extension name, or the driver's own `BIGQUERY:type`). An expression the
+source did not type — a computed string, or a literal — establishes neither, and the call stays
+local.
+
+- **`json_contains`** needs the declared type in order to pick between two BigQuery expressions
+  that are *not* interchangeable: `JSON_QUERY(doc, '<path>') IS NOT NULL` on a native `JSON`
+  column, and the same test over `SAFE.PARSE_JSON(doc)` on a `STRING` column. Applied to a raw
+  string, `JSON_QUERY` returns SQL `NULL` for a JSON `null` that is genuinely present, which is
+  exactly the confusion that would make the result wrong.
+- **`json_as_text`** and **`json_get(...) IS NULL`** push down on a `STRING` column only. On a
+  native `JSON` column, BigQuery need not retain a numeric token's input spelling — `1.50` and
+  `1e+00` do not survive — so the local answer and the remote one would differ.
+
+Two values cannot be extracted from a `STRING` document without changing the result, and rather
+than return a different answer the remote query fails with an error telling you to set
+[`query_federation: disabled`](../../components/data-connectors/adbc) on the dataset:
+
+- **A container.** `json_as_text` returns the matched array or object's original serialization,
+  and BigQuery's `JSON_QUERY` re-spaces it.
+- **A UTF-16 surrogate escape.** Extracting from a `STRING` can replace a `\uD800`–`\uDFFF` escape
+  with the replacement character `U+FFFD`. An escaped `U+FFFD` that was already in the document is
+  preserved by both engines and is not affected, so only a document carrying a surrogate escape
+  *and* an extracted value containing `U+FFFD` is refused.
 
 ## Further Reading
 


### PR DESCRIPTION
## Summary

Two merged BigQuery PRs added JSON pushdown that [`reference/sql/json`](https://docs.spiceai.org/docs/reference/sql/json#federation-and-pushdown) still lists as **No**:

- [spiceai/spiceai#13905](https://github.com/spiceai/spiceai/pull/13905) added `json_contains_to_sql`.
- [spiceai/spiceai#13944](https://github.com/spiceai/spiceai/pull/13944) added `json_as_text_to_sql` and the `json_get(...) IS NULL` rewrite.

All three are conditional on how the source declares the document column, and the two `STRING`-only ones can fail at run time on a value BigQuery cannot reproduce — neither of which the page could say while it claimed they stay local.

## What changed

**`website/docs/reference/sql/json.md`** — "Federation and Pushdown":

- Pushdown table: `json_contains` → *Yes, when the source declares the document's type*; `json_as_text` → *Yes, on a `STRING` document only*; `json_get` → *Only as `json_get(...) IS NULL`, on a `STRING` document*. `json_get_json` and `json_get_array` stay **No**, and the prose explaining why now covers only those two.
- The operators note no longer says `->>` and `?` are not pushed down — each now follows its function's row.
- Literal-path requirement kept, extended with the key restriction (no quote, backslash or control character).
- New **"How the document column is declared matters"** subsection: what makes a column `Native` vs `Text`, why `json_contains` cannot use one rendering for both, why numeric-token spelling keeps the other two off native `JSON`, and the two run-time refusals (a container, and a UTF-16 surrogate escape that yields `U+FFFD`) that raise a BigQuery error pointing at `query_federation: disabled`.
- Page ToC updated with the new subsection.

**`website/docs/components/data-connectors/adbc.md`** — the BigQuery dialect sentence now lists `json_contains`, and `json_as_text` / `json_get(...) IS NULL` with their `STRING` condition.

## Verification

Every claim against `origin/trunk` (`crates/runtime-datafusion/src/dialect/bigquery.rs` unless noted):

| Claim | Source |
| --- | --- |
| `json_contains`, `json_as_text`, `__spice_json_get_is_null` have handlers | `SCALAR_OVERRIDES`, lines 372–426 |
| `json_get_json`, `json_get_array`, `json_get` have none | absent from `SCALAR_OVERRIDES`; a Spice function not carved out of the deny-list stays local |
| `json_as_text` / `IS NULL` are `STRING`-only | `json_text_is_renderable` (:803) requires `json_document_kind(...) == Some(JsonDocument::Text)`, and `text_json_arguments` (:823) re-checks it |
| `json_contains` needs a declared type, either kind | `json_contains_is_renderable` (:621) requires `json_document_kind(...).is_some()` |
| `Native` vs `Text` detection | `json_document_kind_of` (:598) — `ARROW:extension:name == arrow.json` or `BIGQUERY:type == JSON` → Native; `BIGQUERY:type == STRING` → Text; otherwise `None` |
| The two `json_contains` renderings are not interchangeable | `json_contains_to_sql` doc comment (:632–652) and body: `JSON_QUERY(doc, …) IS NOT NULL` vs the same over `SAFE.PARSE_JSON(doc)` |
| Numeric-token spelling is why the other two are `STRING`-only | `json_text_is_renderable` comment (:801) and `json_as_text_to_sql` (:688) |
| Container and surrogate-escape refusals, and the error text | `guard_json_text_escapes` (:756–799) — the `ERROR(...)` string names `query_federation` and links the ADBC page |
| Literal path + key restrictions | `json_path` (:152–174) and `key_is_renderable` (:193) |
| `->` / `->>` / `?` map to `json_get` / `json_as_text` / `json_contains` | `datafusion-functions-json` 0.54.2 `src/rewrite.rs:124-126` |
| The `IS NULL` rewrite is BigQuery-only and pre-federation | `connector-adbc/src/table_factory.rs:65-75` — `pre_federation_optimizer_rules_for_driver` installs `JsonGetNullCheckRewrite` for `BIGQUERY_DRIVER` only |

No behavior is claimed beyond what these renderings emit; the run-time refusals are read off the generated `CASE WHEN … ERROR(…)`, not inferred.

## Source PRs

- [spiceai/spiceai#13944](https://github.com/spiceai/spiceai/pull/13944) — fix(bigquery): push down JSON scalar text and null checks
- [spiceai/spiceai#13905](https://github.com/spiceai/spiceai/pull/13905) — fix(bigquery): preserve results and federation for temporal and recursive queries

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — both source commits are vNext-only (`git tag --contains` returns no release tag), and `website/versioned_docs/version-2.2.x/reference/sql/json.md` has no "Federation and Pushdown" section to correct
- [x] Files updated: 2
