### PR TITLE
docs(caching): document the always-on logical plan cache

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -110,6 +110,31 @@ Entries written with `encoding: zstd` are exempt — they keep the serialized by
 
 When a background [stale-while-revalidate](#stale-while-revalidate) revalidation is declined for this reason it is reported as `results_cache_swr_revalidations{outcome="unboundable"}`, and the previous entry is left in place to be served stale until it expires.
 
+## Logical Plan Cache
+
+Separately from the result caches above, the runtime keeps a small cache of **logical plans**, so a repeated query skips parsing and planning even when its results are not cached. It is not part of the `caching` configuration and has no `enabled` flag: it is installed on every runtime, whatever `sql_results`, `search_results` and `embeddings` are set to.
+
+| | |
+| --- | --- |
+| Configurable | No — always on |
+| Capacity | 512 plans |
+| Entry lifetime | 1 hour from insertion |
+| Key | The SQL text, plus any bound parameter values |
+| Hashing algorithm | [`sql_results.hashing_algorithm`](#choosing-a-hashing_algorithm) |
+
+Two consequences are worth knowing:
+
+- `sql_results.hashing_algorithm` is read even when `sql_results.enabled` is `false`, because the plan cache borrows it. It is the one `sql_results` setting that still has an effect with the results cache switched off.
+- Bypassing the results cache does not bypass the plan cache. A query sent with `cache-control: no-cache` re-executes, but it is still planned from the cached plan if one is present, and still populates the plan cache if one is not.
+
+The cache is dropped wholesale — every entry, not only the affected ones — whenever something a plan was built against changes:
+
+- a dataset or a view is registered, updated, or removed;
+- a spicepod hot reload changes the set of registered [`functions`](../../reference/spicepod/functions);
+- an accelerated table's schema evolves, in place or by recreation.
+
+A plan is otherwise held for its full hour, so a change made outside these paths is not picked up until the entry expires.
+
 ## Per-Principal Cache Isolation
 
 When [authentication](../api/auth) is enabled, all cache layers (SQL results, search results, and caching-mode acceleration storage) are automatically scoped per principal. Each authenticated caller has an isolated cache namespace — one caller's cached output is never served to a different caller.


### PR DESCRIPTION
## Summary

The runtime keeps a **logical plan cache** that nothing in the docs mentions — `grep -rni "plan cache\|cached plan" website/docs/` returns nothing. It is installed on **every** runtime regardless of the `caching` configuration, so it is not something a reader can find by looking at the settings they set.

[spiceai/spiceai#13911](https://github.com/spiceai/spiceai/pull/13911) is what surfaced it: it fixed a hot reload that changed `functions:` without discarding cached plans, and its root-cause analysis spells out the cache's shape. Documenting the cache is the forward-sync half of that fix.

## What changed

One new `## Logical Plan Cache` section in `website/docs/features/caching/index.md`, before "Per-Principal Cache Isolation":

- A table: not configurable, 512 plans, 1-hour entry lifetime, keyed on SQL text plus bound parameter values, hashed with `sql_results.hashing_algorithm`.
- Two consequences a reader cannot derive from the settings page: `sql_results.hashing_algorithm` still has an effect with `sql_results.enabled: false`, and `cache-control: no-cache` bypasses the *results* cache without bypassing the plan cache.
- The three events that drop the whole cache — dataset/view registration, a `functions:` change on hot reload, and accelerated-table schema evolution — plus the note that anything else waits out the hour.

## Verification

All on `origin/trunk`:

| Claim | Source |
| --- | --- |
| Installed unconditionally | `crates/runtime/src/init/caching.rs:63-76` — the `with_plans_cache` arm has no `if <config>.enabled`, unlike the `sql_results`, `search_results` and `embeddings` arms around it |
| 512 plans | `caching.rs:24` `DEFAULT_CACHED_PLANS_MAX_CAPACITY: u64 = 512`, passed as `SimpleCache::new`'s `cache_max_size` → moka `max_capacity` (entries, no weigher) |
| 1 hour from insertion | `caching.rs:68` `Duration::from_hours(1)` → `SimpleCache::new`'s `ttl` → moka `.time_to_live(ttl)` (`crates/cache/src/simple_cache.rs:80-86`) — time-to-live, not time-to-idle |
| Keyed on SQL text + bound parameters | `CacheKey::Query(sql, parameters)` hashed at `crates/cache/src/key.rs:103-124`; the plan lookup uses that key (`datafusion/query/cache.rs:174-176`, `:245-249`) |
| Borrows `sql_results.hashing_algorithm` | `caching.rs:63` `get_hash_builder(sql_results_config.hashing_algorithm)` — outside the `if sql_results_config.enabled` block above it |
| Consulted when the results cache is bypassed | `ResultsCacheMode::Bypass` routes to `get_plan_without_results_cache` (`datafusion/query.rs:1176`), which still passes a key into `get_plan` → `get_or_create_logical_plan` (`datafusion/mod.rs:5077-5106`), the only lookup/populate site |
| Whole-cache invalidation, and its three triggers | `clear_cached_plans` (`datafusion/mod.rs:5155-5160`) calls `invalidate_all`; callers are `init/dataset.rs:1179`, `init/view.rs:444`, `datafusion/udf.rs:418` (`apply_function_diff`, added by #13911), and `datafusion/mod.rs:3780` / `:3936` / `:4187` (schema evolution: in-place, recreate, OTel write) |

## Versioned docs

`website/docs/` only. The capacity and TTL are unchanged since at least `v2.2.0` (`git show v2.2.0:crates/runtime/src/init/caching.rs` → same `512` and `from_hours(1)`), but the `functions:` invalidation trigger is **vNext-only** — #13911 is in no release tag — so stamping this section into `version-2.2.x` would document a behavior that release does not have. Backfilling the rest into the older snapshots is a separate, per-version pass.

## Source PRs

- [spiceai/spiceai#13911](https://github.com/spiceai/spiceai/pull/13911) — fix(functions): discard cached plans when a hot reload changes the function set

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked — see above
- [x] Files updated: 1
