### PR TITLE
docs(caching): a declared primary_key is a row constraint, not the cache key (fixes #2183)

### DIFF
--- a/website/docs/features/data-acceleration/refresh-modes/caching.md
+++ b/website/docs/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -479,22 +479,22 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema:
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+- **A key over response fields** (for example an API's own record id) declares that stored rows are unique on those fields. Response fields are not columns unless the dataset projects them, so this requires a [`columns:` block](../../../components/data-connectors/https#metadata-columns-with-json-schema-decomposition) — an HTTP dataset's schema is otherwise the request/response metadata plus `content`.
+- **A key over the request columns** asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-Example with custom primary key:
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: id` or `primary_key: '(id, season, number)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
+
+Example with a key over response fields, projecting them with a `columns:` block:
 
 ```yaml
 datasets:
@@ -503,12 +503,20 @@ datasets:
     params:
       file_format: json
       allowed_request_paths: '/shows/*/episodes'
+    columns:
+      - name: request_path # HTTP request metadata, kept queryable
+      - name: id # decomposed from the JSON response body
+      - name: season
+      - name: number
+      - name: details # catch-all for the remaining JSON keys
+        metadata:
+          json_object: '*'
     acceleration:
       enabled: true
       refresh_mode: caching
       engine: duckdb
       mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
+      primary_key: '(id, season, number)' # stored rows are unique per episode
       params:
         caching_ttl: 15s
         caching_stale_while_revalidate_ttl: 10s
@@ -517,6 +525,8 @@ datasets:
         SELECT * FROM tv_episodes_custom_key
         WHERE request_path = '/shows/82/episodes'
 ```
+
+Entries are still addressed by `request_path` here — the key only deduplicates episodes across refreshes of the same endpoint. Declaring a `columns:` block replaces the default schema, so every metadata field the dataset needs to stay queryable (`request_path` above, and anything a `refresh_sql` filters on) must be listed in it.
 
 ### HTTP Date Header
 
@@ -712,7 +722,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation

--- a/website/versioned_docs/version-1.10.x/features/data-acceleration/refresh-modes/caching.md
+++ b/website/versioned_docs/version-1.10.x/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -472,44 +472,19 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema. An HTTP dataset's schema is the request and response metadata plus `content` — the fields inside a JSON response body are not columns — so the only columns a key can name are metadata fields, and a key over the request columns asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+A `caching` dataset therefore normally leaves `primary_key` unset, which is the default described above.
 
-Example with custom primary key:
-
-```yaml
-datasets:
-  - from: https://api.tvmaze.com
-    name: tv_episodes_custom_key
-    params:
-      file_format: json
-      allowed_request_paths: '/shows/*/episodes'
-    acceleration:
-      enabled: true
-      refresh_mode: caching
-      engine: duckdb
-      mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
-      params:
-        caching_ttl: 15s
-        caching_stale_while_revalidate_ttl: 10s
-      refresh_check_interval: 30s
-      refresh_sql: |
-        SELECT * FROM tv_episodes_custom_key
-        WHERE request_path = '/shows/82/episodes'
-```
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: request_path` or `primary_key: '(request_path, request_query)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
 
 ### HTTP Date Header
 
@@ -637,7 +612,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation

--- a/website/versioned_docs/version-1.11.x/features/data-acceleration/refresh-modes/caching.md
+++ b/website/versioned_docs/version-1.11.x/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -474,44 +474,19 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema. An HTTP dataset's schema is the request and response metadata plus `content` — the fields inside a JSON response body are not columns — so the only columns a key can name are metadata fields, and a key over the request columns asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+A `caching` dataset therefore normally leaves `primary_key` unset, which is the default described above.
 
-Example with custom primary key:
-
-```yaml
-datasets:
-  - from: https://api.tvmaze.com
-    name: tv_episodes_custom_key
-    params:
-      file_format: json
-      allowed_request_paths: '/shows/*/episodes'
-    acceleration:
-      enabled: true
-      refresh_mode: caching
-      engine: duckdb
-      mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
-      params:
-        caching_ttl: 15s
-        caching_stale_while_revalidate_ttl: 10s
-      refresh_check_interval: 30s
-      refresh_sql: |
-        SELECT * FROM tv_episodes_custom_key
-        WHERE request_path = '/shows/82/episodes'
-```
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: request_path` or `primary_key: '(request_path, request_query)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
 
 ### HTTP Date Header
 
@@ -639,7 +614,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation

--- a/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/caching.md
+++ b/website/versioned_docs/version-2.0.x/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -474,22 +474,22 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema:
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+- **A key over response fields** (for example an API's own record id) declares that stored rows are unique on those fields. Response fields are not columns unless the dataset projects them, so this requires a [`columns:` block](../../../components/data-connectors/https#metadata-columns-with-json-schema-decomposition) — an HTTP dataset's schema is otherwise the request/response metadata plus `content`.
+- **A key over the request columns** asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-Example with custom primary key:
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: id` or `primary_key: '(id, season, number)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
+
+Example with a key over response fields, projecting them with a `columns:` block:
 
 ```yaml
 datasets:
@@ -498,12 +498,20 @@ datasets:
     params:
       file_format: json
       allowed_request_paths: '/shows/*/episodes'
+    columns:
+      - name: request_path # HTTP request metadata, kept queryable
+      - name: id # decomposed from the JSON response body
+      - name: season
+      - name: number
+      - name: details # catch-all for the remaining JSON keys
+        metadata:
+          json_object: '*'
     acceleration:
       enabled: true
       refresh_mode: caching
       engine: duckdb
       mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
+      primary_key: '(id, season, number)' # stored rows are unique per episode
       params:
         caching_ttl: 15s
         caching_stale_while_revalidate_ttl: 10s
@@ -512,6 +520,8 @@ datasets:
         SELECT * FROM tv_episodes_custom_key
         WHERE request_path = '/shows/82/episodes'
 ```
+
+Entries are still addressed by `request_path` here — the key only deduplicates episodes across refreshes of the same endpoint. Declaring a `columns:` block replaces the default schema, so every metadata field the dataset needs to stay queryable (`request_path` above, and anything a `refresh_sql` filters on) must be listed in it.
 
 ### HTTP Date Header
 
@@ -648,7 +658,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation

--- a/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/caching.md
+++ b/website/versioned_docs/version-2.1.x/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -474,22 +474,22 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema:
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+- **A key over response fields** (for example an API's own record id) declares that stored rows are unique on those fields. Response fields are not columns unless the dataset projects them, so this requires a [`columns:` block](../../../components/data-connectors/https#metadata-columns-with-json-schema-decomposition) — an HTTP dataset's schema is otherwise the request/response metadata plus `content`.
+- **A key over the request columns** asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-Example with custom primary key:
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: id` or `primary_key: '(id, season, number)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
+
+Example with a key over response fields, projecting them with a `columns:` block:
 
 ```yaml
 datasets:
@@ -498,12 +498,20 @@ datasets:
     params:
       file_format: json
       allowed_request_paths: '/shows/*/episodes'
+    columns:
+      - name: request_path # HTTP request metadata, kept queryable
+      - name: id # decomposed from the JSON response body
+      - name: season
+      - name: number
+      - name: details # catch-all for the remaining JSON keys
+        metadata:
+          json_object: '*'
     acceleration:
       enabled: true
       refresh_mode: caching
       engine: duckdb
       mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
+      primary_key: '(id, season, number)' # stored rows are unique per episode
       params:
         caching_ttl: 15s
         caching_stale_while_revalidate_ttl: 10s
@@ -512,6 +520,8 @@ datasets:
         SELECT * FROM tv_episodes_custom_key
         WHERE request_path = '/shows/82/episodes'
 ```
+
+Entries are still addressed by `request_path` here — the key only deduplicates episodes across refreshes of the same endpoint. Declaring a `columns:` block replaces the default schema, so every metadata field the dataset needs to stay queryable (`request_path` above, and anything a `refresh_sql` filters on) must be listed in it.
 
 ### HTTP Date Header
 
@@ -648,7 +658,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation

--- a/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/caching.md
+++ b/website/versioned_docs/version-2.2.x/features/data-acceleration/refresh-modes/caching.md
@@ -30,7 +30,7 @@ While currently designed for HTTP-based datasets, future versions of Spice will 
 
 The `caching` mode uses HTTP request filter values as cache keys rather than enforcing primary key constraints. When a refresh occurs:
 
-1. **Cache Key Generation**: By default, the combination of `request_path`, `request_query`, and `request_body` acts as the cache key. If a `primary_key` is explicitly specified in the acceleration configuration, it will be used instead of the metadata fields.
+1. **Cache Key Generation**: The combination of `request_path`, `request_query`, and `request_body` acts as the cache key. A declared `acceleration.primary_key` does not replace it — see [Cache Key Behavior](#cache-key-behavior).
 2. **Row Replacement**: All existing rows matching the cache key are removed before inserting new data
 3. **Multiple Results**: Multiple rows with identical request metadata can coexist, representing different content items from the same API response
 4. **Timestamp Tracking**: Each row includes a `fetched_at` timestamp indicating when the data was retrieved
@@ -474,22 +474,22 @@ This behavior differs from other modes:
 
 ### Cache Key Behavior
 
-The `caching` mode determines cache keys based on the acceleration configuration:
+A cache entry is **always** addressed by HTTP request metadata — `request_path`, `request_query`, and `request_body` — whether or not a `primary_key` is declared. A lookup is built from the request alone, because that is all a query supplies before the response exists.
 
-**Default (No Primary Key Specified)**:
-
-- Uses HTTP request metadata fields as the cache key: `request_path`, `request_query`, and `request_body`
 - Multiple result rows can share the same request metadata
 - The cache key serves as the logical grouping mechanism for row replacement
 - Content within a response may have duplicate values across different requests
 
-**With Primary Key Specified**:
+A declared `primary_key` does not change how entries are addressed. It is a uniqueness constraint on the rows the accelerator stores, and it must name columns that exist in the dataset schema:
 
-- Uses the explicitly configured `primary_key` columns as the cache key
-- Provides fine-grained control over cache key composition
-- Useful when caching requires uniqueness based on response content fields rather than request metadata
+- **A key over response fields** (for example an API's own record id) declares that stored rows are unique on those fields. Response fields are not columns unless the dataset projects them, so this requires a [`columns:` block](../../../components/data-connectors/https#metadata-columns-with-json-schema-decomposition) — an HTTP dataset's schema is otherwise the request/response metadata plus `content`.
+- **A key over the request columns** asserts one row per request. That contradicts the multiple-rows-per-request shape `caching` mode is built for: a response holding several rows is refused rather than partially cached, the entry is not written, and every query for it goes to the origin.
 
-Example with custom primary key:
+:::warning
+`primary_key` takes a string naming one or more columns, optionally parenthesized — `primary_key: id` or `primary_key: '(id, season, number)'`. A YAML list (`primary_key: [id, season, number]`) is not a valid value and fails to parse, so the whole Spicepod is rejected at load.
+:::
+
+Example with a key over response fields, projecting them with a `columns:` block:
 
 ```yaml
 datasets:
@@ -498,12 +498,20 @@ datasets:
     params:
       file_format: json
       allowed_request_paths: '/shows/*/episodes'
+    columns:
+      - name: request_path # HTTP request metadata, kept queryable
+      - name: id # decomposed from the JSON response body
+      - name: season
+      - name: number
+      - name: details # catch-all for the remaining JSON keys
+        metadata:
+          json_object: '*'
     acceleration:
       enabled: true
       refresh_mode: caching
       engine: duckdb
       mode: file
-      primary_key: [id, season, number] # Use episode fields as cache key
+      primary_key: '(id, season, number)' # stored rows are unique per episode
       params:
         caching_ttl: 15s
         caching_stale_while_revalidate_ttl: 10s
@@ -512,6 +520,8 @@ datasets:
         SELECT * FROM tv_episodes_custom_key
         WHERE request_path = '/shows/82/episodes'
 ```
+
+Entries are still addressed by `request_path` here — the key only deduplicates episodes across refreshes of the same endpoint. Declaring a `columns:` block replaces the default schema, so every metadata field the dataset needs to stay queryable (`request_path` above, and anything a `refresh_sql` filters on) must be listed in it.
 
 ### HTTP Date Header
 
@@ -648,7 +658,7 @@ Choose one approach:
 
 - Currently only available for HTTP-based datasets using the [HTTPS connector](../../../components/data-connectors/https). Future releases will extend support to arbitrary queries from any data source.
 - Requires `acceleration.enabled: true`
-- When no `primary_key` is specified, cache keys default to request metadata fields (`request_path`, `request_query`, `request_body`)
+- Cache keys are always the request metadata fields (`request_path`, `request_query`, `request_body`); a declared `primary_key` constrains stored-row uniqueness, not entry addressing
 - On-demand refresh via `/v1/datasets/:name/acceleration/refresh` API triggers a new refresh for all cache keys defined in `refresh_sql`
 
 ## Related Documentation


### PR DESCRIPTION
## Summary

Fixes #2183

The caching refresh-mode page's `primary_key` section was wrong on two counts, and its worked example could not be run.

**1. The example never parsed.** It passed `primary_key: [id, season, number]`. `acceleration.primary_key` deserializes as `Option<String>` in every release from v1.10 through trunk, so a YAML sequence is rejected before schema validation — and the failure is fatal to the whole Spicepod, not just the dataset:

```
$ spiced --version
v2.2.1+models.metal
$ spiced   # spicepod.yaml copied verbatim from the page
ERROR spiced: Failed to start Spice runtime: Unable to load spicepod ...:
Failed to parse spicepod.yaml: Invalid type sequence. Expected a string
```

Same on `v1.11.6`, with the offending line named:

```
Failed to parse spicepod.yaml: datasets[0]: Invalid type sequence. Expected a string at line 5 column 5
```

Even written as a string the example would not have loaded: `id`, `season` and `number` are not columns of an HTTP dataset unless it projects them.

**2. A declared key is not the cache key.** The page said a `primary_key` is "used instead of the metadata fields". A lookup is built from the request alone, so a key over response fields could not serve one even in principle — the values would have to be known before the request that produces them. What the key actually does is constrain row uniqueness in the accelerator.

## Changes

`features/data-acceleration/refresh-modes/caching.md`, in the unversioned docs and all five `versioned_docs/version-*` copies:

- **Cache Key Behavior** — rewritten. Entries are *always* addressed by `request_path` / `request_query` / `request_body`; a `primary_key` is a uniqueness constraint on stored rows. Both consequences are spelled out: a key over response fields needs a `columns:` block, and a key over the request columns asserts one row per request, which a multi-row response fails.
- **How It Works** step 1 and the **Limitations** bullet — both repeated the "used instead" claim; both corrected.
- **The example** — now declares the response fields it keys on via a `columns:` block and passes the key as a parenthesized string.
- A `:::warning` giving the accepted `primary_key` syntax, since the list form is an easy thing to reach for.

**Version split.** JSON schema decomposition (`metadata.json_object`) reached the HTTP connector in v2.0.0 — `crates/runtime/src/dataconnector/https.rs` has no `json_object` at `v1.11.6` or `v1.10.2`. On v1.11.6 the corrected example is accepted as YAML but the `columns:` block is ignored and the dataset still fails:

```
WARN runtime::init::dataset: Failed to setup the dataset tv_episodes_custom_key (https).
Unable to create dataset acceleration: Invalid configuration: Primary key column 'id' was
not found in the schema. Valid columns: request_path, request_query, request_body, content,
response_status, response_headers, entries, keys, values, fetched_at
```

So there is no working response-field key in 1.10.x/1.11.x. Those two copies drop the example rather than publish a second one that does not run, and say what a key can name there instead.

## Verification

Every claim below was run, not only read.

**The corrected example loads and serves rows** (v2.2.1):

```
INFO runtime::init::dataset: Dataset tv_episodes_custom_key registered
     (https://api.tvmaze.com), acceleration (duckdb:file, caching, 30s refresh)
INFO runtime: All components are loaded. Spice runtime is ready!

$ curl -s -XPOST $SPICE/v1/sql -d "SELECT request_path, id, season, number
    FROM tv_episodes_custom_key WHERE request_path = '/shows/82/episodes'
    ORDER BY season, number LIMIT 3"
[{"request_path":"/shows/82/episodes","id":"4952","season":"1","number":"1"},
 {"request_path":"/shows/82/episodes","id":"4961","season":"1","number":"10"},
 {"request_path":"/shows/82/episodes","id":"4953","season":"1","number":"2"}]
```

An earlier attempt omitted `request_path` from the `columns:` block and failed with `Schema error: No field named request_path` — which is why the fix says a `columns:` block replaces the default schema and every field a `refresh_sql` filters on must be listed. That sentence is there because leaving it out broke the example.

**A key over the request columns refuses a multi-row response.** With `primary_key: '(request_path, request_query, request_body)'` and a 73-element JSON array response, on both v2.2.1 and v1.11.6:

```
WARN runtime_table::accelerated::caching: Failed to flush cache updates for dataset
tv_episodes_req_key: External error: Constraint Violation: Incoming data violates
uniqueness constraint on column(s): request_body, request_path, request_query
```

The query still answers `[{"n":73}]` — correctly, from the origin — and nothing is cached, so the next query goes to the origin too. This is the behaviour the new bullet describes.

**Entry addressing is request-only.** `compute_cache_key_from_filters` builds the key from the filter expressions (plus the namespace tag) and takes no constraint input; it is filter-derived in every tag checked, `v1.10.2` through trunk. The declared key reaches the write path instead, where `has_constraints` selects it — a store decision, not a lookup one.

## Reference

Verified against `spiceai/spiceai` at `origin/trunk` (`2341623962`) plus tags `v1.10.2`, `v1.11.6`, `v2.0.1`, `v2.1.5`, `v2.2.1`; runtimes exercised were `v2.2.1+models.metal` and `v1.11.6`.

- [`crates/spicepod/src/acceleration/mod.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/spicepod/src/acceleration/mod.rs) — `pub primary_key: Option<String>`
- [`crates/runtime-table/src/accelerated/caching.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime-table/src/accelerated/caching.rs) — `compute_cache_key_from_filters`, and the `has_constraints` write branch
- [`crates/runtime/src/dataconnector/https.rs`](https://github.com/spiceai/spiceai/blob/trunk/crates/runtime/src/dataconnector/https.rs) — `json_object` decomposition, present from v2.0.0

spiceai/spiceai#13992 (open) fixes two runtime defects reachable from a declared key on a caching dataset. It restates the same three-way split this PR documents and does not change it, so these corrections hold either way.

## Test plan

- [x] `cd website && npm run build` passes locally
- [x] Links valid — no broken-link or broken-anchor failures
- [x] Correction applied across all five `website/versioned_docs/version-*/` copies, split by whether `json_object` decomposition exists in that release
- [x] Published example executed against a running `spiced`, before and after