### PR TITLE
docs(ducklake): correct the embedded DuckDB version per release line

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -208,7 +208,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice embeds DuckDB **1.4.4** and supports the catalog schema required by its `ducklake` extension. For older catalogs, `ducklake_automatic_migration: true` performs an irreversible [metadata migration](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake) on attach.
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.

--- a/website/versioned_docs/version-2.1.x/components/catalogs/ducklake.md
+++ b/website/versioned_docs/version-2.1.x/components/catalogs/ducklake.md
@@ -198,7 +198,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice v2.1.2 and later embed DuckDB 1.5.5; v2.1.0 and v2.1.1 embed DuckDB 1.5.3. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/ducklake.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/ducklake.md
@@ -201,7 +201,7 @@ datasets:
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice v2.1.2 and later embed DuckDB 1.5.5; v2.1.0 and v2.1.1 embed DuckDB 1.5.3. Older DuckLake catalogs require a metadata migration before use. See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.

--- a/website/versioned_docs/version-2.2.x/components/catalogs/ducklake.md
+++ b/website/versioned_docs/version-2.2.x/components/catalogs/ducklake.md
@@ -204,7 +204,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice v2.2.1 embeds DuckDB 1.4.4; v2.2.0 embeds DuckDB 1.5.5. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/ducklake.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/ducklake.md
@@ -203,7 +203,7 @@ datasets:
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice v2.2.1 embeds DuckDB 1.4.4; v2.2.0 embeds DuckDB 1.5.5. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.


### PR DESCRIPTION
## Summary

The DuckLake pages claim **DuckDB 1.5.3**. That value is right only for the v2.0.x line; every other release line embeds a different DuckDB, and trunk embeds **1.4.4**.

`Cargo.toml` on trunk is explicit about the mapping between the `duckdb` crate version and the DuckDB library version, which is what makes this checkable — the crate versions are not the DuckDB versions:

```
duckdb = "1.4.4" # the crate version that matches DuckDB v1.4.4
duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "9d7be742…" } # branch: spiceai-1.4.4 (DuckDB v1.4.4, arrow 58; …)
```

Reading that comment at each release tag gives:

| Release line | Tags | Embedded DuckDB | Docs said | Verdict |
| --- | --- | --- | --- | --- |
| vNext (trunk) | — | **1.4.4** | 1.5.3 (catalog page) | wrong |
| v2.2.x | v2.2.1 / v2.2.0 | **1.4.4** / 1.5.5 | 1.5.3 | wrong |
| v2.1.x | v2.1.2–v2.1.5 / v2.1.0–v2.1.1 | **1.5.5** / 1.5.3 | 1.5.3 | wrong for v2.1.2+ |
| v2.0.x | v2.0.0 / v2.0.1 | 1.5.3 | 1.5.3 | **correct — left unchanged** |

The vNext *connector* page was corrected to 1.4.4 in #2186; this PR sweeps the sibling **catalog** page it missed, plus every versioned snapshot that carries the same claim.

## What changed

- `website/docs/components/catalogs/ducklake.md` — 1.5.3 → 1.4.4, wording matched to the connector page #2186 already fixed.
- `versioned_docs/version-2.2.x/` (connector + catalog) — "Spice v2.2.1 embeds DuckDB 1.4.4; v2.2.0 embeds DuckDB 1.5.5".
- `versioned_docs/version-2.1.x/` (connector + catalog) — "Spice v2.1.2 and later embed DuckDB 1.5.5; v2.1.0 and v2.1.1 embed DuckDB 1.5.3".

The version changed *inside* the 2.1.x and 2.2.x lines, so a single flat number is wrong for part of each line's readership — hence the per-patch wording rather than just swapping one digit.

## Source refs

- spiceai/spiceai#13742 — "Downgrade DuckDB to v1.4.4" (merged 2026-08-30, first shipped in v2.2.1, tagged 2026-09-02)
- [`Cargo.toml` at v2.2.1](https://github.com/spiceai/spiceai/blob/v2.2.1/Cargo.toml) / [at v2.2.0](https://github.com/spiceai/spiceai/blob/v2.2.0/Cargo.toml) / [at v2.1.5](https://github.com/spiceai/spiceai/blob/v2.1.5/Cargo.toml) / [at v2.1.1](https://github.com/spiceai/spiceai/blob/v2.1.1/Cargo.toml)
- Prior maintenance of this same claim: #1732 (→1.5.2), #1792 (→1.5.3)

## Out of scope

The versioned pages also assert "which supports DuckLake 1.0". #2186 dropped that clause from the vNext connector page rather than restate it, and I have no runnable evidence for which DuckLake catalog version each DuckDB build accepts, so I left the clause alone on the snapshots instead of guessing.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Versioned-docs propagation checked: `grep -rn "DuckDB 1.5.3" website/` now returns only the two v2.0.x files, which are correct
- [x] Files updated: 5