### PR TITLE
docs(caching): the pingora cache engine is Enterprise-only and falls back silently

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -51,13 +51,33 @@ Every cache type (`sql_results`, `search_results`, `embeddings`) supports the fo
 | `eviction_policy`   | Yes      | `lru`    | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`. Supports `lru` (Least Recently Used) and `tiny_lfu` (Tiny Least Frequently Used, higher hit rate for skewed access patterns). |
 | `item_ttl`          | Yes      | `1s`     | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                                                                                        |
 | `hashing_algorithm` | Yes      | `xxh3`   | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `xxh3`. Supports `xxh3`, `ahash`, `siphash`, `blake3`, `xxh32`, `xxh64`, or `xxh128`.                   |
-| `engine`            | Yes      | `moka`   | Cache backend: `moka` or `pingora`. See [Choosing an `engine`](#choosing-an-engine).                                                                                                                           |
+| `engine`            | Yes      | `moka`   | Cache backend: `moka`, or `pingora` on an [Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) build. See [Choosing an `engine`](#choosing-an-engine).                            |
 
 ### Choosing an `engine`
 
 - **`moka` (default):** Supports TTL expiration and lazy table invalidation.
 - **`pingora`:** Uses a sharded LRU cache. Reads lock the key's shard; table invalidations that
-  evict entries scan the cache, with cost proportional to its size.
+  evict entries scan the cache, with cost proportional to its size. `pingora` does not implement
+  `eviction_policy: tiny_lfu`; selecting both warns
+  (`Pingora cache engine does not support TinyLFU caching policy. Falling back to LRU.`) and uses LRU.
+
+:::note[Enterprise edition]
+
+The `pingora` cache engine is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is compiled behind a build feature that the published open source `spiced` binaries and images do not enable.
+
+`engine: pingora` is **not** rejected on a build without it: the value parses, the runtime logs
+
+```
+The Pingora cache engine is included in the Enterprise distribution of Spice.ai. Learn more at https://docs.spice.ai/docs/enterprise Falling back to the Moka cache engine.
+```
+
+and the cache runs on Moka instead. The engine each cache actually started on is named in its own startup line, so that is what to check rather than the configured value — the sizes and TTL in it are the ones configured for that cache:
+
+```
+Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+```
+
+:::
 
 With a non-zero [`stale_while_revalidate_ttl`](#serving-stale-after-an-acceleration-refresh), SQL
 result invalidations mark entries stale without eviction, so neither engine scans.


### PR DESCRIPTION
## Summary

#2186 added a `caching.*.engine` row and a "Choosing an `engine`" section to the OSS caching page, offering `pingora` as a plain selectable value alongside `moka`. Two things about it are missing:

**1. It is not in the open source distribution.** `pingora` is a Cargo feature, and it is absent from `spiced`'s `default` feature list. Released images build `--features release,models` on top of `default` (`release = []`), so no published open source binary or image contains the Pingora backend at all — the whole module is behind `#[cfg(feature = "pingora")]`. Per the docs convention for capabilities gated out of the default build, this needs the Enterprise callout.

**2. Selecting it on such a build is a silent downgrade, not an error.** `CacheEngine` lives in `spicepod` and is *not* feature-gated, so `engine: pingora` parses everywhere. The dispatch then does:

```rust
CacheEngine::Pingora => {
    #[cfg(feature = "pingora")] { … PingoraBackend … }
    #[cfg(not(feature = "pingora"))] {
        tracing::warn!("{PINGORA_ENTERPRISE_ONLY_MESSAGE} Falling back to the Moka cache engine.");
        … CacheBackendEnum::MokaFallback(…)
    }
}
```

A user who reads the page, sets `engine: pingora`, and sees the runtime start normally is on Moka. `MokaFallback` also reports `engine()` as `CacheEngine::Moka`, so the startup line is the honest signal, which is why the note points at it rather than at the configured value.

**3. `pingora` has no TinyLFU implementation.** The same page documents `eviction_policy: tiny_lfu`; combined with `engine: pingora` it warns and uses LRU.

## What changed

`website/docs/features/caching/index.md` only:

- `engine` row now says `pingora` requires an Enterprise build.
- The `pingora` bullet records that `eviction_policy: tiny_lfu` is not implemented there, quoting the warning.
- Added the standard `:::note[Enterprise edition]` callout with the verbatim fallback warning and the `Initialized … cache; … engine: Moka` startup line to check.

Both quoted strings are static format templates with no substituted fields, so they are greppable in a log exactly as written. The startup line does interpolate the configured size and TTL, which the text says explicitly.

## Source refs (spiceai/spiceai @ `2f10331`)

- [`crates/cache/src/lru_cache.rs#L53`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/crates/cache/src/lru_cache.rs#L53) — `PINGORA_ENTERPRISE_ONLY_MESSAGE`
- [`crates/cache/src/lru_cache.rs#L352-L382`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/crates/cache/src/lru_cache.rs#L352) — the engine dispatch, the TinyLFU warning, and the `not(feature = "pingora")` fallback arm
- [`bin/spiced/Cargo.toml`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spiced/Cargo.toml) — `pingora = ["runtime/pingora"]` is declared but not listed in `default`
- [`crates/runtime/src/init/caching.rs#L54`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/crates/runtime/src/init/caching.rs#L54) — `Initialized sql results cache; {cache_provider}`, whose `Display` ends in `engine: {}`

## Scope

vNext only — the `engine` parameter is not documented in any versioned snapshot, so there is nothing to sweep. `reference/distributions.md` was left alone: its feature-gated section is scoped to data connectors, and widening it to cache engines is a structural change rather than an accuracy fix.

## Test plan

- [x] `cd website && npm run build` passes
- [x] Cross-page grep: `grep -rn "pingora" website/docs website/versioned_docs` — the only non-`acknowledgements` hits are on this page
- [x] Files updated: 1