### PR TITLE
docs(cayenne): v2.2 preserves timestamp units; the 2.2.x snapshot still says microseconds

### DIFF
--- a/website/versioned_docs/version-2.2.x/components/data-accelerators/cayenne/index.md
+++ b/website/versioned_docs/version-2.2.x/components/data-accelerators/cayenne/index.md
@@ -645,7 +645,7 @@ Cayenne (via Vortex) supports most Arrow data types with the following considera
 - Boolean
 - Utf8 and LargeUtf8 strings
 - Binary and LargeBinary
-- Timestamps (normalized to Microsecond precision)
+- Timestamps, preserving the source unit and timezone
 - Date32 and Date64
 - Lists and FixedSizeLists
 - Maps
@@ -653,10 +653,17 @@ Cayenne (via Vortex) supports most Arrow data types with the following considera
 
 ### Automatically Converted Types
 
-| Original Type               | Converted To             | Notes                                         |
-| --------------------------- | ------------------------ | --------------------------------------------- |
-| `Float16`                   | `Float32`                | Automatic conversion for Vortex compatibility |
-| `Timestamp(Nanosecond/...)` | `Timestamp(Microsecond)` | Precision normalized                          |
+| Original Type | Converted To | Notes                                         |
+| ------------- | ------------ | --------------------------------------------- |
+| `Float16`     | `Float32`    | Automatic conversion for Vortex compatibility |
+
+:::note Tables created before v2.2.0
+
+These tables continue to normalize timestamps to microseconds. Preserving the source unit requires
+recreating the table with `mode: file_create` in an empty directory. The
+[`on_schema_change`](../../reference/spicepod/datasets#on_schema_change) setting does not migrate existing timestamps.
+
+:::
 
 ### Unsupported Types
 


### PR DESCRIPTION
## Summary

The `version-2.2.x` Cayenne page still documents unconditional timestamp normalization:

- Fully Supported Types: "Timestamps (normalized to Microsecond precision)"
- Automatically Converted Types: a `Timestamp(Nanosecond/...)` → `Timestamp(Microsecond)` row, "Precision normalized"

Cayenne stopped doing that **in v2.2.0**. spiceai/spiceai#13180 split the rewrite lists in two and dropped `TimestampToMicrosecond` from the creation rules:

```rust
static CAYENNE_CREATION_REWRITE_RULES: TypeRewriteRules = &[&Float16ToFloat32];

// superset, because a table keeps the types it was created with
pub static CAYENNE_TYPE_REWRITE_RULES: TypeRewriteRules =
    &[&Float16ToFloat32, &TimestampToMicrosecond];
```

`TimestampToMicrosecond` survives only in the *write-path recognition* list, so an existing microsecond table fed by a nanosecond source is not misread as a schema change — it is not applied when creating a table. A table created on v2.2.0 or v2.2.1 keeps its source unit and timezone.

This is the "current-release behavioral change lands only in `website/docs/`" case: #2186 fixed vNext and left the snapshot the change shipped in stale.

## Version scoping

| Snapshot | Latest tag | Creation rewrite | Docs | Action |
| --- | --- | --- | --- | --- |
| vNext | — | preserves unit | preserves unit (#2186) | — |
| version-2.2.x | v2.2.1 | **preserves unit** | normalized | **fixed here** |
| version-2.1.x | v2.1.5 | normalizes unconditionally | normalized | correct, untouched |
| version-2.0.x, 1.11.x | — | normalizes unconditionally | normalized | correct, untouched |

At v2.1.5 `schema.rs` still has the unconditional arm, which is why the older snapshots are right as they stand:

```rust
if let DataType::Timestamp(unit, tz) = data_type && !matches!(unit, TimeUnit::Microsecond) {
    return Some(DataType::Timestamp(TimeUnit::Microsecond, tz.clone()));
}
```

## What changed

`website/versioned_docs/version-2.2.x/components/data-accelerators/cayenne/index.md` only — the two claims above, replaced with the vNext wording, including the "Tables created before v2.2.0" note (the boundary is correct for this snapshot as written, since the change shipped in v2.2.0). `mode: file_create` is a real mode at v2.2.1.

## Source refs

- spiceai/spiceai#13180 — "fix(cayenne): keep Arrow timestamp units (Vortex supports ns)", merged 2026-08-17; `git tag --contains` → `v2.2.0`, `v2.2.1`
- [`crates/cayenne/src/schema.rs` at v2.2.1](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/cayenne/src/schema.rs) — the split rewrite lists
- [`crates/cayenne/src/schema.rs` at v2.1.5](https://github.com/spiceai/spiceai/blob/v2.1.5/crates/cayenne/src/schema.rs) — the unconditional normalization the older snapshots document

## Test plan

- [x] `cd website && npm run build` passes (`#on_schema_change` exists in the 2.2.x `datasets.md`)
- [x] Cross-page grep: `grep -rln "normalized to Microsecond" website/` now returns only 2.1.x, 2.0.x and 1.11.x, all correct
- [x] Files updated: 1