### PR TITLE
docs(cli): spice version always names the runtime path, managed install included

### DIFF
--- a/website/docs/cli/reference/run.md
+++ b/website/docs/cli/reference/run.md
@@ -19,8 +19,13 @@ Run Spice - starts the Spice runtime, installing if necessary.
 4. Under `sudo`, the invoking user's `~/.spice/bin/spiced`.
 
 `PATH` is not searched. An invalid `$SPICED_PATH` causes an error; otherwise, `spice run` installs
-the runtime if none is found. For a runtime outside the managed install, the CLI reports
-its path and source. [`spice version`](./version) also reports these values.
+the runtime if none is found.
+
+Before launching, `spice run` logs the runtime it resolved and the rung it came from
+(`Using the Spice.ai runtime at '<path>' (<source>).`). It is logged at `info` only when the
+runtime is *not* the one [`spice install`](./install) manages — the case worth noticing — and at
+`debug` otherwise, so an ordinary managed install does not add a line to every run.
+[`spice version`](./version) reports the same path and source unconditionally.
 
 ### Usage
 

--- a/website/docs/cli/reference/version.md
+++ b/website/docs/cli/reference/version.md
@@ -43,7 +43,19 @@ CLI version:     v1.1.0
 Runtime version: v1.1.0+models
  ```
 
-For a runtime outside the managed install, the output also includes its path and source:
+**Runtime path and source**: whenever a runtime is found, the output names it and the
+[selection rung](./run#runtime-selection) it came from — including the ordinary managed install:
+
+```shell
+> spice version
+
+CLI version:     v1.1.0
+Runtime version: v1.1.0+models
+Runtime path:    /Users/me/.spice/bin/spiced (installed by spice install)
+```
+
+The parenthetical is one of `pinned by SPICED_PATH`, `beside the spice CLI`, `installed by spice install`,
+or `installed by spice install, by the sudo invoker`:
 
 ```shell
 > spice version
@@ -53,4 +65,9 @@ Runtime version: v1.1.0+models
 Runtime path:    /usr/local/bin/spiced (beside the spice CLI)
 ```
 
-JSON output includes `runtime_path` and `runtime_source`, following the same [runtime selection rules](./run#runtime-selection).
+The line is omitted only when no runtime resolves (`Runtime version: not installed`) or with
+`--cli-only`, which skips the runtime lookup entirely. A runtime that was found but could not be
+asked for its version reports `Runtime version: unavailable — the runtime at the path below did not
+report a version` and still names the path.
+
+JSON output includes `runtime_path` and `runtime_source`, following the same [runtime selection rules](./run#runtime-selection). `runtime_source` carries the enum value rather than the prose above, and both are `null` when no runtime resolves.


### PR DESCRIPTION
## Summary

#2186 added runtime-path reporting to the `spice version` and `spice run` pages, both gated on the same condition:

> **`version.md`**: "For a runtime outside the managed install, the output also includes its path and source"
> **`run.md`**: "For a runtime outside the managed install, the CLI reports its path and source. `spice version` also reports these values."

`spice version` does not test the source. It prints the line whenever a runtime resolves:

```rust
if !args.cli_only {
    println!("Runtime version: {}", describe_runtime_version(runtime.as_ref()));
    if let Some(resolved) = &resolved {
        println!("Runtime path:    {} ({})", resolved.path().display(), resolved.source.describe());
    }
}
```

So a reader on the ordinary `spice install` layout — the commonest one — is told they will not see a line they do see, and the "sample output" blocks above it show a two-line output that no longer matches.

The conditional is real, but it belongs to **`spice run`**, and it is a log *level*, not presence:

```rust
if resolved.source.is_expected_default() {
    tracing::debug!("Using the Spice.ai runtime at '{path}' ({source}).");
} else {
    tracing::info!("Using the Spice.ai runtime at '{path}' ({source}).");
}
```

`is_expected_default()` is true only for `ManagedInstall`, and its doc comment is explicit that this is "what keeps `spice run` from announcing its runtime". The two commands were collapsed into one sentence that is right for neither.

## What changed

- `version.md` — the line is described as unconditional, with the managed install as the shown example; enumerates the four `describe()` strings verbatim (`pinned by SPICED_PATH`, `beside the spice CLI`, `installed by spice install`, `installed by spice install, by the sudo invoker`); names the two cases where it *is* absent (no runtime resolves, or `--cli-only`); and records the located-but-unprobeable case, whose `Runtime version:` text is quoted from source. Notes that `runtime_source` in JSON is the enum, not the prose — the code comments that this deliberately, so docs describing it as the same string would be wrong.
- `run.md` — replaces the shared sentence with `spice run`'s own behavior, quoting the log message and saying which level each case gets, then states that `spice version` reports the same values unconditionally.

Every quoted string is a static template with no substituted fields except the path and source, which the text identifies as such.

## Source refs (spiceai/spiceai @ `2f10331`)

- [`bin/spice/src/commands/version.rs#L198-L235`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spice/src/commands/version.rs#L198) — unconditional table output; `runtime_path` / `runtime_source` in JSON
- [`bin/spice/src/commands/version.rs#L250`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spice/src/commands/version.rs#L250) — the `unavailable — …did not report a version` string
- [`bin/spice/src/runtime_launcher.rs#L118-L133`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spice/src/runtime_launcher.rs#L118) — `report_resolved_runtime`, the info/debug split
- [`bin/spice/src/context.rs#L994-L1012`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spice/src/context.rs#L994) — `SpicedSource::describe()` and `is_expected_default()`

The four-rung selection order #2186 documented is accurate as written — [`context.rs#L518-L527`](https://github.com/spiceai/spiceai/blob/2f1033102e85f0436258bdcd8204edb12179a95d/bin/spice/src/context.rs#L518) lists the same four, and `PATH` really is excluded by design.

## Scope

vNext only — neither claim exists in any versioned snapshot (`grep -rn "Runtime path" website/versioned_docs/` is empty), and the reporting itself is newer than v2.2.1.

## Test plan

- [x] `cd website && npm run build` passes (`./run#runtime-selection` and `./install` both resolve)
- [x] Files updated: 2