### PR TITLE
docs(caching): a hot reload that replaces a catalog drops the logical plan cache

### DIFF
--- a/website/docs/features/caching/index.md
+++ b/website/docs/features/caching/index.md
@@ -142,7 +142,10 @@ The cache is dropped wholesale — every entry, not only the affected ones — w
 
 - a dataset or a view is registered, updated, or removed;
 - a spicepod hot reload changes the set of registered [`functions`](../../reference/spicepod/functions);
+- a spicepod hot reload replaces a [`catalog`](../../reference/spicepod/catalogs) — one whose declaration changed, or one whose name a provider is already registered under. Re-registering a catalog builds a fresh provider under the same name, and a plan holds the table source it was planned against;
 - an accelerated table's schema evolves, in place or by recreation.
+
+A reload that adds a catalog name nothing was registered under invalidates nothing — no cached plan can have resolved a table in it — and a reload that changes no catalog leaves the cache intact.
 
 A plan is otherwise held for its full hour, so a change made outside these paths is not picked up until the entry expires.
 


### PR DESCRIPTION
## Summary

The Logical Plan Cache section lists what drops the cache: dataset/view registration, a `functions` hot reload, and accelerated-schema evolution. Catalogs were missing.

`apply_catalog_diff` now clears the plan cache when a hot reload **replaces** a catalog — one whose declaration changed, or one whose name a provider is already registered under (`crates/runtime/src/init/catalog.rs`). Re-registering builds a fresh provider under the same name, and a cached plan embeds the `Arc<dyn TableSource>` it was planned against, so without this a repeated query keeps reading through the connector the reload replaced.

Two conditions the code is deliberate about, and which the added prose states:

- a reload that registers a catalog name **nothing was registered under** invalidates nothing — no cached plan can have resolved a table in it;
- a reload that changes no catalog leaves the cache intact.

## Source PRs

- spiceai/spiceai#13914 — fix(runtime): discard cached logical plans when a hot reload replaces a catalog (fixes #13910)

## Versioned-docs propagation

**Addition, vNext only.** spiceai/spiceai#13914 merged to `trunk` after the v2.3.0 release branch point (`git merge-base origin/trunk v2.3.0` = `86e079d3`, `git tag --contains 20d8df4d` is empty), and `git show v2.3.0:crates/runtime/src/init/catalog.rs | grep -c clear_cached_plans` returns `0`. No released version behaves this way, so no `versioned_docs/` snapshot may carry it.

The sibling `functions` case (spiceai/spiceai#13911) *is* in v2.3.0 and was already documented by #2180.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags) — `[SUCCESS] Generated static files in "build"`.
- [x] Link target verified: `website/docs/reference/spicepod/catalogs.md` exists.
- [x] Versioned-docs propagation checked — 1 file changed, `website/docs/` only, by the tag evidence above.
- [x] Files updated: 1