### PR TITLE
docs(search): document the vectors a vector index will not store

### DIFF
--- a/website/docs/features/search/vector-search.md
+++ b/website/docs/features/search/vector-search.md
@@ -165,6 +165,25 @@ ORDER BY score DESC;
 
 :::
 
+## Vectors an Index Will Not Store
+
+A vector is indexable only if it has a defined direction under the metrics the index offers. Two shapes do not, and a row carrying one is skipped instead of stored:
+
+| Shape | Examples | Why |
+| --- | --- | --- |
+| **No direction** — every component is `0` or `NaN` | `[0, 0, 0]`, `[NaN, NaN]`, `[0, NaN]` | The vector points nowhere, so a cosine distance to it is undefined. |
+| **Non-finite** — at least one component is `NaN` or `±Inf` | `[1.0, NaN]`, `[0.0, Inf]` | Every metric the index offers answers `NaN` or `Inf` for it, whatever it is compared against. |
+
+A vector that is both is reported as the first.
+
+Skipping is neither silent nor passive:
+
+- **The skip is logged, and the two reasons are reported apart.** The in-memory and `s3_vectors` write paths warn once per record, naming it and its reason — `its embedding has no direction — every component is zero or NaN`, or `its embedding has a NaN or infinite component, so every distance to it is undefined`. The `elasticsearch` path aggregates instead: one warning per reason per write, carrying the count of records skipped for it and a sample of their row indices.
+- **A skipped row evicts whatever its primary key already holds.** Within a write, the last row for a repeated key decides that key, so a key whose deciding row is skipped is removed from the index rather than left answering at the vector its previous text produced. The same applies to a row whose search text is `NULL` or empty.
+- A row whose primary key is `NULL` is skipped too, with its own warning, but evicts nothing — there is no key with which to address an earlier entry.
+
+This criterion is applied by the [`elasticsearch`](../../components/vectors/elasticsearch) and [`s3_vectors`](../../components/vectors/s3_vectors) engines, and by the in-memory warm index written through to alongside them. The [`duckdb`](../../components/vectors/duckdb) engine's write path applies no such criterion and stores the vector as it arrives; it screens the **query** vector instead, failing a search whose query embedding has a non-finite component with `DuckDB vector query contains a non-finite value.`
+
 ## Using Existing Embeddings
 
 Spice supports vector searches on datasets with pre-existing embeddings. Ensure the dataset meets these requirements:


### PR DESCRIPTION
## Summary

Nothing in the docs said which embedding vectors an index refuses, what a refusal does to the key that carried it, or that the engines differ. A new **Vectors an Index Will Not Store** section on the Vector Search page states the criterion, the two rejection shapes, the logging, the eviction consequence, and the per-engine scope.

The criterion is stated once in source as `write_util::classify_vector` (`crates/search/src/index/write_util.rs`): a vector must have a defined direction under the metrics the index offers. Its two `VectorRejection` variants are the two table rows, and `NoDirection` is tested first, which is the "a vector that is both is reported as the first" sentence.

Distinctions the code makes and the prose keeps:

- **Logging differs by engine.** The in-memory and `s3_vectors` paths warn per record with `VectorRejection::reason()`; `elasticsearch` aggregates `zero_or_nan_skips` / `non_finite_skips` into one warning per reason per write with sample row indices. Both reason strings are quoted verbatim from `reason()` — they carry no substituted fields, so they are greppable as written.
- **Eviction follows the deciding row.** `write_util::keys_to_evict` inserts into a map keyed by primary key, so the *last* row for a repeated key decides it; a rejected deciding row evicts the entry rather than leaving it answering at its previous vector. A `None` embedding (NULL/empty search text) is `RowOutcome::Rejected` on all three paths; a NULL primary key is skipped and evicts nothing, since there is no key to address an earlier entry with.
- **`duckdb` is not in scope.** `wrap_table_as_index_duckdb` gets no warm index and calls no classifier; `validate_vector` is invoked only with `context = "query"` (`duckdb/mod.rs:345`, `duckdb/query_exec.rs:70`), so it screens the query vector, not the stored one. The quoted failure string is that function's rendered `Display` — `context` substitutes to `query`, and no other field is interpolated.

## Source PRs

- spiceai/spiceai#13902 — fix(search): classify a partially non-finite embedding as unindexable on every backend (fixes #13872)
- spiceai/spiceai#13859 — fix(search): evict a key whose deciding row the index rejected (fixes #13848) — the eviction half, already released in v2.3.0

## Versioned-docs propagation

**Addition, vNext only.** spiceai/spiceai#13902 merged to `trunk` after the v2.3.0 release branch point (`git merge-base origin/trunk v2.3.0` = `86e079d3`; `git tag --contains 1d2cc08b` is empty). Before it, only the Elasticsearch path tested the non-finite limb — the in-memory and S3 Vectors paths spelled the `all(zero or NaN)` test alone, so a partially non-finite vector was stored on them. Writing the criterion as backend-wide into any `versioned_docs/` snapshot would document behavior no release has.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags) — `[SUCCESS] Generated static files in "build"`.
- [x] Three added links resolve: `website/docs/components/vectors/{elasticsearch,s3_vectors,duckdb}.md` all exist.
- [x] Every quoted string grepped in source, not paraphrased.
- [x] Versioned-docs propagation checked — `website/docs/` only, by the tag evidence above.
- [x] Files updated: 1