### PR TITLE
docs(huggingface): the v2.2.x model token is huggingface_token, and bare token never worked

### DIFF
--- a/website/docs/components/models/huggingface/deployment.md
+++ b/website/docs/components/models/huggingface/deployment.md
@@ -18,7 +18,6 @@ Production operating guide for loading models from the Hugging Face Hub and runn
 | Parameter    | Description                                                                                           |
 | ------------ | ----------------------------------------------------------------------------------------------------- |
 | `hf_token`   | Hugging Face access token. Required for private or gated repos.                                       |
-| `token`      | Alias accepted by some integrations.                                                                   |
 
 Tokens must be sourced from a [secret store](../../secret-stores/) in production. For public, non-gated models the token is optional; for private / gated repos (Llama, most Mistral checkpoints), the token is required.
 

--- a/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/models/huggingface/deployment.md
@@ -18,7 +18,6 @@ Production operating guide for loading models from the Hugging Face Hub and runn
 | Parameter    | Description                                                                                           |
 | ------------ | ----------------------------------------------------------------------------------------------------- |
 | `hf_token`   | Hugging Face access token. Required for private or gated repos.                                       |
-| `token`      | Alias accepted by some integrations.                                                                   |
 
 Tokens must be sourced from a [secret store](../../secret-stores/) in production. For public, non-gated models the token is optional; for private / gated repos (Llama, most Mistral checkpoints), the token is required.
 

--- a/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/models/huggingface/deployment.md
@@ -18,7 +18,6 @@ Production operating guide for loading models from the Hugging Face Hub and runn
 | Parameter    | Description                                                                                           |
 | ------------ | ----------------------------------------------------------------------------------------------------- |
 | `hf_token`   | Hugging Face access token. Required for private or gated repos.                                       |
-| `token`      | Alias accepted by some integrations.                                                                   |
 
 Tokens must be sourced from a [secret store](../../secret-stores/) in production. For public, non-gated models the token is optional; for private / gated repos (Llama, most Mistral checkpoints), the token is required.
 

--- a/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/models/huggingface/deployment.md
@@ -17,14 +17,27 @@ Production operating guide for loading models from the Hugging Face Hub and runn
 
 | Parameter    | Description                                                                                           |
 | ------------ | ----------------------------------------------------------------------------------------------------- |
-| `hf_token`   | Hugging Face access token. Required for private or gated repos.                                       |
-| `token`      | Alias accepted by some integrations.                                                                   |
+| `huggingface_token` | Hugging Face access token. Required for private or gated repos. Spelled `huggingface_token` on this release line, not `hf_token`. |
+
+:::warning[`huggingface_token` on v2.2.0 and v2.2.1]
+
+`hf_token` is rejected on this release line: the runtime drops it with
+
+```text
+WARN runtime_parameters_typed: Ignoring parameter `hf_token`: not supported for model huggingface.
+```
+
+and downloads the repository anonymously, so a gated or private repo fails with an HTTP 401 that names no cause. A bare `token` is rejected too, with a warning that it must be prefixed with `huggingface_`. This affects `from: huggingface:` **models** only — the `hf_token` documented for [embeddings](../../embeddings/huggingface/deployment.md) and rerankers is read correctly on this release.
+
+Spelling reverted in v2.3.0: `hf_token` is the parameter again, and `huggingface_token` is kept as an alias so a Spicepod written against v2.2.x keeps loading. See [spiceai/spiceai#13932](https://github.com/spiceai/spiceai/issues/13932).
+
+:::
 
 Tokens must be sourced from a [secret store](../../secret-stores/) in production. For public, non-gated models the token is optional; for private / gated repos (Llama, most Mistral checkpoints), the token is required.
 
 ### Token Discovery Fallback
 
-When `hf_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
+When `huggingface_token` is unset, the loader falls back to the `HF_TOKEN` environment variable, then `HF_HUB_TOKEN`, then the Hugging Face token file (`$HF_HOME/token`, default `~/.cache/huggingface/token`, written by `huggingface-cli login`). This makes local development portable but should be explicitly set in production via the secret store to avoid surprise auth behavior across environments.
 
 ## Resilience Controls
 
@@ -89,7 +102,7 @@ Local inference operations emit `ai_completion` spans (and `health` spans for pr
 
 | Symptom                                                         | Likely cause                                               | Resolution                                                                                                                    |
 | --------------------------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `401 Unauthorized` on download                                  | Missing or invalid `hf_token`; gated model.                | Set `hf_token`; accept the model's license on Hugging Face; verify token has `read` scope.                                    |
+| `401 Unauthorized` on download                                  | Missing or invalid `huggingface_token`; gated model.       | Set `huggingface_token` (not `hf_token`, which this release ignores); accept the model's license on Hugging Face; verify token has `read` scope. |
 | OOM on model load                                               | Model size exceeds device memory.                          | Choose a smaller quantized variant; switch to CPU + larger system RAM; use multi-GPU if supported.                             |
 | Inference falls back to CPU unexpectedly                        | CUDA / Metal unavailable or not detected.                  | Use a CUDA-enabled Spice build on GPU hosts; verify `nvidia-smi` shows devices; for macOS, use Apple Silicon build.            |
 | Model output changes between restarts                           | Revision unpinned (default branch).                        | Pin the revision with a colon: `from: huggingface:huggingface.co/org/model:<commit_sha>`.                                       |

--- a/website/versioned_docs/version-2.2.x/components/models/huggingface/index.md
+++ b/website/versioned_docs/version-2.2.x/components/models/huggingface/index.md
@@ -38,7 +38,7 @@ The model name. This will be used as the model ID within Spice and Spice's endpo
 
 | Param           | Description                                                                                                                                                                               | Default |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `hf_token`      | The Huggingface access token.                                                                                                                                                             | -       |
+| `huggingface_token` | The Huggingface access token. Spelled `huggingface_token` on this release line — see the note under [Access Tokens](#access-tokens).                                                   | -       |
 | `model_type`    | The architecture to load the model as. Supported text architectures: `mistral`, `gemma`, `mixtral`, `llama`, `phi2`, `phi3`, `qwen2`, `gemma2`, `starcoder2`, `phi3.5moe`, `deepseekv2`, `deepseekv3`, `qwen3`, `glm4`, `glm4moelite`, `glm4moe`, `qwen3moe`, `smollm3`, `granitemoehybrid`, `gpt_oss`, `qwen3next`. Supported multimodal architectures: `phi3v`, `idefics2`, `llava_next`, `llava`, `vllama`, `qwen2vl`, `idefics3`, `minicpmo`, `phi4mm`, `qwen2_5vl`, `gemma3`, `mistral3`, `llama4`, `gemma3n`, `gemma4`, `qwen3vl`, `qwen3vlmoe`, `qwen3_5`, `qwen3_5moe`, `voxtral`. | -       |
 | `tools`         | Which [tools] should be made available to the model. Set to `auto` to use all available tools.                                                                                            | -       |
 | `system_prompt` | An additional system prompt used for all chat completions to this model.                                                                                                                  | -       |
@@ -59,6 +59,20 @@ models:
 
 ## Access Tokens
 
+:::warning[`huggingface_token` on v2.2.0 and v2.2.1]
+
+On this release line the parameter is spelled **`huggingface_token`**. `hf_token` is rejected: the runtime drops it with
+
+```text
+WARN runtime_parameters_typed: Ignoring parameter `hf_token`: not supported for model huggingface.
+```
+
+and loads the model anonymously, so a gated or private repository fails with an HTTP 401 that names no cause. A bare `token` is rejected too, with a warning that it must be prefixed with `huggingface_`. This affects `from: huggingface:` **models** only — the `hf_token` documented for [embeddings](../../embeddings/huggingface/index.md) and rerankers is read correctly on this release.
+
+Spelling reverted in v2.3.0: `hf_token` is the parameter again, and `huggingface_token` is kept as an alias so a Spicepod written against v2.2.x keeps loading. See [spiceai/spiceai#13932](https://github.com/spiceai/spiceai/issues/13932).
+
+:::
+
 Access tokens can be provided for Huggingface models in two ways:
 
 1. In the Huggingface token cache (i.e. `~/.cache/huggingface/token`). Default.
@@ -69,7 +83,7 @@ models:
   - name: llama_3.2_1B
     from: huggingface:huggingface.co/meta-llama/Llama-3.2-1B
     params:
-      hf_token: ${ secrets:HF_TOKEN }
+      huggingface_token: ${ secrets:HF_TOKEN }
 ```
 
 ## Examples
@@ -89,7 +103,7 @@ models:
   - name: llama_3.2_1B
     from: huggingface:huggingface.co/meta-llama/Llama-3.2-1B
     params:
-      hf_token: ${ secrets:HF_TOKEN }
+      huggingface_token: ${ secrets:HF_TOKEN }
 ```
 
 For more details on authentication, see [access tokens](#access-tokens).

--- a/website/versioned_docs/version-2.2.x/features/large-language-models/serving.md
+++ b/website/versioned_docs/version-2.2.x/features/large-language-models/serving.md
@@ -18,7 +18,7 @@ models:
   - name: llama_3.2_1B
     from: huggingface:huggingface.co/meta-llama/Llama-3.2-1B
     params:
-      hf_token: ${ secrets:HF_TOKEN }
+      huggingface_token: ${ secrets:HF_TOKEN } # `huggingface_token` on v2.2.x; `hf_token` from v2.3.0
 ```
 
 ## Filesystem


### PR DESCRIPTION
## Summary

Two wrong claims about the Hugging Face **model** token parameter, both measured against released binaries rather than inferred.

1. **The v2.2.x docs name a parameter that release ignores.** `HuggingFaceModelParams` was given `prefix = "huggingface"` when it moved to `#[derive(TypedParams)]`, and its token field was the component param `token` — so on v2.2.0/v2.2.1 the key is `huggingface_token`, and the documented `hf_token` is warned about and dropped. The model then downloads anonymously and a gated or private repo fails with an HTTP 401 that names no cause. Fixed in v2.3.0 (spiceai/spiceai#13946), which restores `hf_token` and keeps `huggingface_token` as an alias.
2. **`| \`token\` | Alias accepted by some integrations. |` is a fabricated row.** A bare `token` is rejected on every release measured — the runtime says it must be prefixed. Removed from vNext, 2.0.x, 2.1.x, and (as part of the rewritten table) 2.2.x.

Embeddings and rerankers are untouched: their `hf_token` is a `#[param(runtime)]` field on a different struct and is read correctly on every release, including v2.2.x. The v2.2.x notes say so explicitly, because the two spellings sitting side by side in one Spicepod is exactly the confusing part.

## Evidence — measured, not inferred

Each released `spiced` (`spiced_metal_darwin_aarch64`) was run against a one-model Spicepod pointing at a nonexistent repository, so load fails fast *after* params are read and the parameter warning is the artifact:

| Release | `hf_token` | `huggingface_token` | bare `token` |
| --- | --- | --- | --- |
| `v2.0.1+models.metal` | accepted, no warning | `Ignoring parameter \`huggingface_token\`: not supported for model huggingface.` | `Ignoring parameter token: must be prefixed with \`hf_\` for model huggingface.` |
| `v2.1.5+models.metal` | accepted, no warning | `Ignoring parameter \`huggingface_token\`: not supported for model huggingface.` | `Ignoring parameter token: must be prefixed with \`hf_\` for model huggingface.` |
| `v2.2.1+models.metal` | **`Ignoring parameter \`hf_token\`: not supported for model huggingface.`** | **accepted, no warning** | `Ignoring parameter token: must be prefixed with \`huggingface_\` for model huggingface.` |
| `v2.3.0+models.metal` | accepted, no warning | accepted, no warning (alias) | `Ignoring parameter token: must be prefixed with \`hf_\` for model huggingface.` |

An **embeddings** component with `hf_token` on `v2.2.1+models.metal` drew no parameter warning at all (it failed later, in `text_embeddings_core::download`, on the 401 for the nonexistent repo) — confirming the regression is chat-model-only and that the v2.2.x embeddings pages are correct as they stand.

Source agrees: `crates/runtime/src/model/params/huggingface.rs` is `prefix = "huggingface"` with `pub token` at `v2.2.1`, and `prefix = "hf"` with `#[param(runtime, alias = "huggingface_token")] pub hf_token` at `v2.3.0` and on `trunk`; `crates/runtime/src/embeddings/params/huggingface.rs` carries `#[param(runtime, autoload_secret)] pub hf_token` in both.

## Source PRs

- spiceai/spiceai#13946 — fix(models): read the HuggingFace chat token as hf_token again (fixes #13932)
- spiceai/spiceai#13932 — the issue, linked from both v2.2.x notes so a reader on that release can see the whole story

## Versioned-docs propagation

Two classes, deliberately scoped apart:

- **Version-specific change** — the `huggingface_token` spelling holds *only* on the v2.2.x line. v2.0.x, v2.1.x and vNext take `hf_token` and are left alone; no note is added to vNext, whose `hf_token` is correct as written.
- **Correction** — the bare `token` row is wrong wherever it appears. `grep -rn '| \`token\`' website/` returned exactly four hits (vNext, 2.0.x, 2.1.x, 2.2.x); all four are gone. No 1.x snapshot carries the row.

## Test plan

- [x] `cd website && npm run build` passes (Docusaurus throws on broken links / undefined tags) — `[SUCCESS] Generated static files in "build"`.
- [x] Behavior measured on four released binaries (table above), not read off a diff.
- [x] Quoted warnings are the runtime's rendered output, copied from the logs.
- [x] Post-edit re-grep: every remaining `hf_token` under `versioned_docs/version-2.2.x/components/models/` and `.../features/large-language-models/` is inside a version note that deliberately names it.
- [x] Files updated: 6