### PR TITLE
fix: quote placeholders in shell examples so the blocks paste safely (fixes #2196)

### DIFF
--- a/website/docs/cli/reference/chat.md
+++ b/website/docs/cli/reference/chat.md
@@ -52,13 +52,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/docs/cli/reference/cloud.md
+++ b/website/docs/cli/reference/cloud.md
@@ -102,7 +102,7 @@ Lists the organizations this identity can act on, marking the active one and whi
 ### `org`
 
 ```shell
-spice cloud org use <ORG>
+spice cloud org use "<ORG>"
 spice cloud org current
 spice cloud org clear
 ```
@@ -121,7 +121,7 @@ An enrolled directory holds an instance identity in `.spice/identity.json`, and 
 
 ```shell
 spice cloud link
-spice cloud link <org>/<project>
+spice cloud link "<org>/<project>"
 ```
 
 Enrolls the current directory as a Spice Cloud instance and attaches it to a project. Omit the argument to choose from the projects available to you.
@@ -196,8 +196,8 @@ spice cloud project delete <org>/<project> [--yes]
 `--kind` decides which kind of project is created. Either way, the command prints the new project's primary API key.
 
 ```shell
-spice cloud project create <NAME>                              # Cloud Connect project
-spice cloud project create <NAME> --kind set --region <REGION> # Spice-managed project
+spice cloud project create "<NAME>"                              # Cloud Connect project
+spice cloud project create "<NAME>" --kind set --region "<REGION>" # Spice-managed project
 ```
 
 - **Omit `--kind`** for a **Cloud Connect** project — one Spice Cloud does not run, served by your own runtime. This is the project [`spice cloud link`](#link) attaches an instance to.
@@ -354,9 +354,9 @@ Shows a project's API keys. `--regenerate <1|2>` reissues one of the two keys. T
 
 ```shell
 spice cloud secrets list
-spice cloud secrets set <NAME> <VALUE>
-spice cloud secrets get <NAME>
-spice cloud secrets delete <NAME>
+spice cloud secrets set "<NAME>" "<VALUE>"
+spice cloud secrets get "<NAME>"
+spice cloud secrets delete "<NAME>"
 ```
 
 Manages a project's secrets. Every subcommand takes `--project <ORG/PROJECT>` and `-o`. `list` has the alias `ls`.

--- a/website/docs/cli/reference/connect.md
+++ b/website/docs/cli/reference/connect.md
@@ -14,7 +14,7 @@ Adds a Spicepod dependency to the current project, and prints a deprecation warn
 ### Usage
 
 ```shell
-spice connect <org>/<pod>
+spice connect "<org>/<pod>"
 ```
 
 ### Example

--- a/website/docs/cli/reference/login.md
+++ b/website/docs/cli/reference/login.md
@@ -48,7 +48,7 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```
 
 ### Browser Login Flow
@@ -94,7 +94,7 @@ spice cloud login subscription --device
 Authenticate with a Spice Cloud access token. Alias: `pat`.
 
 ```shell
-spice cloud login token --token <TOKEN>
+spice cloud login token --token "<TOKEN>"
 ```
 
 Omit `--token` to enter the token at a secure prompt. Generate one at `/account/tokens` in the Spice Cloud portal.
@@ -102,7 +102,7 @@ Omit `--token` to enter the token at a secure prompt. Generate one at `/account/
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
-export SPICE_CLOUD_PAT=<TOKEN>
+export SPICE_CLOUD_PAT="<TOKEN>"
 spice cloud login token
 ```
 
@@ -111,14 +111,14 @@ spice cloud login token
 Authenticate using OAuth2 client credentials for CI/automation workflows.
 
 ```shell
-spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+spice cloud login api --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
 ```
 
 Credentials can also be provided via environment variables:
 
 ```shell
-export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
-export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+export SPICE_CLOUD_CLIENT_ID="<CLIENT_ID>"
+export SPICE_CLOUD_CLIENT_SECRET="<CLIENT_SECRET>"
 spice cloud login api
 ```
 

--- a/website/docs/cli/reference/nsql.md
+++ b/website/docs/cli/reference/nsql.md
@@ -59,7 +59,7 @@ The `spice nsql analyze` subcommand evaluates Text-to-SQL quality by comparing a
 ### Usage
 
 ```shell
-spice nsql analyze --query <natural-language-query> --expected <expected-sql> --model <model>
+spice nsql analyze --query "<natural-language-query>" --expected "<expected-sql>" --model "<model>"
 ```
 
 ### Flags

--- a/website/docs/cli/reference/sql.md
+++ b/website/docs/cli/reference/sql.md
@@ -88,7 +88,7 @@ gas_used               | 12500000
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/docs/components/data-connectors/snowflake.md
+++ b/website/docs/components/data-connectors/snowflake.md
@@ -68,21 +68,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -90,9 +90,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -183,7 +183,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/docs/components/data-connectors/spark.md
+++ b/website/docs/components/data-connectors/spark.md
@@ -37,15 +37,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -100,7 +100,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/docs/components/secret-stores/azure-keyvault/index.md
+++ b/website/docs/components/secret-stores/azure-keyvault/index.md
@@ -84,10 +84,10 @@ The principal used by Spice must have read access to secrets in the target Key V
 
 ```bash
 az role assignment create \
-  --assignee-object-id <PRINCIPAL_OBJECT_ID> \
+  --assignee-object-id "<PRINCIPAL_OBJECT_ID>" \
   --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
-  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
 ```
 
 The store performs a `list_secret_properties` call on startup to validate connectivity and fail fast on misconfiguration. A `403 Forbidden` on list is tolerated, so principals scoped only to per-secret `Microsoft.KeyVault/vaults/secrets/getSecret/action` (for example, **Key Vault Reader** combined with a custom role) are supported.

--- a/website/docs/deployment/azure/index.md
+++ b/website/docs/deployment/azure/index.md
@@ -80,7 +80,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 
 # 3. Federate the identity with the Kubernetes ServiceAccount
 ISSUER=$(az aks show -g $RG -n $CLUSTER --query oidcIssuerProfile.issuerUrl -o tsv)
@@ -189,7 +189,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 ```
 
 #### 3. Deploy Spice.ai

--- a/website/docs/deployment/kubernetes/argocd/index.md
+++ b/website/docs/deployment/kubernetes/argocd/index.md
@@ -195,7 +195,7 @@ Roll back to a previous revision using the Argo CD CLI or UI:
 
 ```bash
 argocd app history spiceai
-argocd app rollback spiceai <history-id>
+argocd app rollback spiceai "<history-id>"
 ```
 
 When the `Application` is managed by Git, prefer reverting the commit that introduced the change so the desired state in Git matches the live state. With `selfHeal: true` enabled, Argo CD will otherwise re-apply the Git state.

--- a/website/docs/deployment/kubernetes/flux/index.md
+++ b/website/docs/deployment/kubernetes/flux/index.md
@@ -233,7 +233,7 @@ Flux records each Helm release revision. List history and roll back with the Hel
 
 ```bash
 helm history spiceai -n spiceai
-helm rollback spiceai <revision> -n spiceai
+helm rollback spiceai "<revision>" -n spiceai
 ```
 
 For automatic rollback on failed upgrades, configure `spec.upgrade.remediation` on the `HelmRelease`:

--- a/website/docs/deployment/kubernetes/local-nvme/index.md
+++ b/website/docs/deployment/kubernetes/local-nvme/index.md
@@ -56,8 +56,8 @@ Give those nodes a label so Spice — and only Spice — schedules onto them. Th
 #   gcloud container node-pools create: --node-labels=local-nvme=true (GKE also sets cloud.google.com/gke-local-nvme-ssd=true)
 #   az aks nodepool add: --labels local-nvme=true
 # On an existing node:
-kubectl label node <node-name> local-nvme=true
-kubectl taint node <node-name> local-nvme=true:NoSchedule   # optional
+kubectl label node "<node-name>" local-nvme=true
+kubectl taint node "<node-name>" local-nvme=true:NoSchedule   # optional
 ```
 
 ## Step 2 — Format and mount the NVMe on each node

--- a/website/docs/features/large-language-models/mcp.md
+++ b/website/docs/features/large-language-models/mcp.md
@@ -250,7 +250,7 @@ See the [mcp-server cookbook](https://github.com/spiceai/cookbook/tree/trunk/mcp
 A failing MCP server does not stop the runtime. Spice logs a warning, retries the connection in the background, and reports healthy — the tool is simply absent from `tools/list`. Verify the runtime log at startup:
 
 ```bash
-grep "Unable to load tool" <log>
+grep "Unable to load tool" "<log>"
 ```
 
 A server that starts but authenticates with empty or invalid credentials is harder to spot: it registers zero tools without producing that warning. Check for `runtime_secrets` errors, which indicate a `${secrets:...}` reference that did not resolve.

--- a/website/docs/monitoring/spice-cloud/index.md
+++ b/website/docs/monitoring/spice-cloud/index.md
@@ -75,7 +75,7 @@ The output includes the app's primary API key. Treat the key as a secret — any
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --project <org>/<app>
+spice cloud api-keys --project "<org>/<app>"
 ```
 
 ## Configuration
@@ -179,7 +179,7 @@ After restarting the runtime, confirm the connection is established:
 3. **Wait 5–10 seconds**, then query the target Spice Cloud app's task history. From any client logged in to Spice Cloud:
 
    ```bash
-   spice sql --cloud <org>/<app>
+   spice sql --cloud "<org>/<app>"
    ```
 
    ```sql

--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -347,10 +347,10 @@ The REPL needs no shell, because `spiced` is itself the binary being executed.
 
 ```console
 # Docker
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 
 # Kubernetes
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 Because `spiced --repl` runs inside the container, it connects to that container's own `http://localhost:50051` Flight endpoint — attaching to the runtime already serving there. The interactive SQL prompt that follows is therefore executing queries **inside the deployment**, not locally.
@@ -375,10 +375,10 @@ This is the recommended way to debug Spice on Kubernetes.
 
 ```bash
 # List pods in the namespace
-kubectl get pods -n <namespace>
+kubectl get pods -n "<namespace>"
 
 # List the container names inside the pod
-kubectl get pod <pod_name> -n <namespace> -o jsonpath='{.spec.containers[*].name}'
+kubectl get pod "<pod_name>" -n "<namespace>" -o jsonpath='{.spec.containers[*].name}'
 ```
 
 The Helm chart names the Spice container `spiceai`. Run the second command rather than assuming, since a custom manifest may name it something else.
@@ -471,7 +471,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:latest
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:latest
 
 # Exec into the container — the shell that follows runs INSIDE the Spice container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.10.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/chat.md
@@ -54,13 +54,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-1.10.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.10.x/cli/reference/search.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/search.md
@@ -33,7 +33,7 @@ spice search [query] [flags]
 
 ```shell
 # Search with Spice Cloud
-spice search --cloud --api-key <your-api-key>
+spice search --cloud --api-key "<your-api-key>"
 
 # Search with a remote spiced instance
 spice search --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.10.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-1.10.x/cli/reference/sql.md
@@ -52,7 +52,7 @@ Welcome to the Spice.ai SQL REPL! Type 'help' for help.
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:

--- a/website/versioned_docs/version-1.10.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.10.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.10.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.10.x/troubleshooting/index.md
@@ -223,13 +223,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -269,7 +269,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.11.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/chat.md
@@ -54,13 +54,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-1.11.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.11.x/cli/reference/search.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/search.md
@@ -33,7 +33,7 @@ spice search [query] [flags]
 
 ```shell
 # Search with Spice Cloud
-spice search --cloud --api-key <your-api-key>
+spice search --cloud --api-key "<your-api-key>"
 
 # Search with a remote spiced instance
 spice search --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.11.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-1.11.x/cli/reference/sql.md
@@ -52,7 +52,7 @@ Welcome to the Spice.ai SQL REPL! Type 'help' for help.
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/snowflake.md
@@ -65,21 +65,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SECRET_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SECRET_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SECRET_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SECRET_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SECRET_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SECRET_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SECRET_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SECRET_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SECRET_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SECRET_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -87,9 +87,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -180,7 +180,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.11.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.11.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.11.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.11.x/troubleshooting/index.md
@@ -272,13 +272,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -318,7 +318,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.5.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.5.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -165,7 +165,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.5.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.5.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.5.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.5.x/troubleshooting/index.md
@@ -181,13 +181,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debugging with a shell
@@ -202,7 +202,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.6.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.6.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -165,7 +165,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.6.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.6.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.6.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.6.x/troubleshooting/index.md
@@ -181,13 +181,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debugging with a shell
@@ -202,7 +202,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.7.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.7.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -165,7 +165,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.7.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.7.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.7.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.7.x/troubleshooting/index.md
@@ -181,13 +181,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -227,7 +227,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.8.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/chat.md
@@ -54,13 +54,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-1.8.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.8.x/cli/reference/search.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/search.md
@@ -33,7 +33,7 @@ spice search [query] [flags]
 
 ```shell
 # Search with Spice Cloud
-spice search --cloud --api-key <your-api-key>
+spice search --cloud --api-key "<your-api-key>"
 
 # Search with a remote spiced instance
 spice search --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.8.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-1.8.x/cli/reference/sql.md
@@ -52,7 +52,7 @@ Welcome to the Spice.ai SQL REPL! Type 'help' for help.
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -165,7 +165,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.8.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.8.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.8.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.8.x/troubleshooting/index.md
@@ -181,13 +181,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -227,7 +227,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-1.9.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/chat.md
@@ -54,13 +54,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-1.9.x/cli/reference/login.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/login.md
@@ -43,5 +43,5 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```

--- a/website/versioned_docs/version-1.9.x/cli/reference/search.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/search.md
@@ -33,7 +33,7 @@ spice search [query] [flags]
 
 ```shell
 # Search with Spice Cloud
-spice search --cloud --api-key <your-api-key>
+spice search --cloud --api-key "<your-api-key>"
 
 # Search with a remote spiced instance
 spice search --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.9.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-1.9.x/cli/reference/sql.md
@@ -52,7 +52,7 @@ Welcome to the Spice.ai SQL REPL! Type 'help' for help.
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/snowflake.md
@@ -63,15 +63,15 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -79,9 +79,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -165,7 +165,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-1.9.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-1.9.x/components/data-connectors/spark.md
@@ -33,15 +33,15 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -96,7 +96,7 @@ Check [Secrets Stores](../../components/secret-stores) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-1.9.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-1.9.x/troubleshooting/index.md
@@ -223,13 +223,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -269,7 +269,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-2.0.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/chat.md
@@ -52,13 +52,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-2.0.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/login.md
@@ -48,7 +48,7 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```
 
 ## `spice cloud login`
@@ -76,13 +76,13 @@ spice cloud login subscription --device
 Authenticate with a personal access token.
 
 ```shell
-spice cloud login pat --token <TOKEN>
+spice cloud login pat --token "<TOKEN>"
 ```
 
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
-export SPICE_CLOUD_PAT=<TOKEN>
+export SPICE_CLOUD_PAT="<TOKEN>"
 spice cloud login pat
 ```
 
@@ -91,14 +91,14 @@ spice cloud login pat
 Authenticate using OAuth2 client credentials for CI/automation workflows.
 
 ```shell
-spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+spice cloud login api --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
 ```
 
 Credentials can also be provided via environment variables:
 
 ```shell
-export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
-export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+export SPICE_CLOUD_CLIENT_ID="<CLIENT_ID>"
+export SPICE_CLOUD_CLIENT_SECRET="<CLIENT_SECRET>"
 spice cloud login api
 ```
 

--- a/website/versioned_docs/version-2.0.x/cli/reference/nsql.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/nsql.md
@@ -59,7 +59,7 @@ The `spice nsql analyze` subcommand evaluates Text-to-SQL quality by comparing a
 ### Usage
 
 ```shell
-spice nsql analyze --query <natural-language-query> --expected <expected-sql> --model <model>
+spice nsql analyze --query "<natural-language-query>" --expected "<expected-sql>" --model "<model>"
 ```
 
 ### Flags

--- a/website/versioned_docs/version-2.0.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-2.0.x/cli/reference/sql.md
@@ -88,7 +88,7 @@ gas_used               | 12500000
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/snowflake.md
@@ -68,21 +68,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -90,9 +90,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -183,7 +183,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spark.md
@@ -37,15 +37,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -100,7 +100,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-2.0.x/components/secret-stores/azure-keyvault/index.md
+++ b/website/versioned_docs/version-2.0.x/components/secret-stores/azure-keyvault/index.md
@@ -84,10 +84,10 @@ The principal used by Spice must have read access to secrets in the target Key V
 
 ```bash
 az role assignment create \
-  --assignee-object-id <PRINCIPAL_OBJECT_ID> \
+  --assignee-object-id "<PRINCIPAL_OBJECT_ID>" \
   --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
-  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
 ```
 
 The store performs a `list_secret_properties` call on startup to validate connectivity and fail fast on misconfiguration. A `403 Forbidden` on list is tolerated, so principals scoped only to per-secret `Microsoft.KeyVault/vaults/secrets/getSecret/action` (for example, **Key Vault Reader** combined with a custom role) are supported.

--- a/website/versioned_docs/version-2.0.x/deployment/azure/index.md
+++ b/website/versioned_docs/version-2.0.x/deployment/azure/index.md
@@ -80,7 +80,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 
 # 3. Federate the identity with the Kubernetes ServiceAccount
 ISSUER=$(az aks show -g $RG -n $CLUSTER --query oidcIssuerProfile.issuerUrl -o tsv)
@@ -189,7 +189,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 ```
 
 #### 3. Deploy Spice.ai

--- a/website/versioned_docs/version-2.0.x/deployment/kubernetes/argocd/index.md
+++ b/website/versioned_docs/version-2.0.x/deployment/kubernetes/argocd/index.md
@@ -195,7 +195,7 @@ Roll back to a previous revision using the Argo CD CLI or UI:
 
 ```bash
 argocd app history spiceai
-argocd app rollback spiceai <history-id>
+argocd app rollback spiceai "<history-id>"
 ```
 
 When the `Application` is managed by Git, prefer reverting the commit that introduced the change so the desired state in Git matches the live state. With `selfHeal: true` enabled, Argo CD will otherwise re-apply the Git state.

--- a/website/versioned_docs/version-2.0.x/deployment/kubernetes/flux/index.md
+++ b/website/versioned_docs/version-2.0.x/deployment/kubernetes/flux/index.md
@@ -233,7 +233,7 @@ Flux records each Helm release revision. List history and roll back with the Hel
 
 ```bash
 helm history spiceai -n spiceai
-helm rollback spiceai <revision> -n spiceai
+helm rollback spiceai "<revision>" -n spiceai
 ```
 
 For automatic rollback on failed upgrades, configure `spec.upgrade.remediation` on the `HelmRelease`:

--- a/website/versioned_docs/version-2.0.x/monitoring/spice-cloud/index.md
+++ b/website/versioned_docs/version-2.0.x/monitoring/spice-cloud/index.md
@@ -73,7 +73,7 @@ The output includes the app's primary API key. Treat the key as a secret — any
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --app <org>/<app>
+spice cloud api-keys --app "<org>/<app>"
 ```
 
 ## Configuration
@@ -177,7 +177,7 @@ After restarting the runtime, confirm the connection is established:
 3. **Wait 5–10 seconds**, then query the target Spice Cloud app's task history. From any client logged in to Spice Cloud:
 
    ```bash
-   spice sql --cloud <org>/<app>
+   spice sql --cloud "<org>/<app>"
    ```
 
    ```sql

--- a/website/versioned_docs/version-2.0.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-2.0.x/troubleshooting/index.md
@@ -272,13 +272,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -318,7 +318,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-2.1.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/chat.md
@@ -52,13 +52,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-2.1.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/login.md
@@ -48,7 +48,7 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```
 
 ## `spice cloud login`
@@ -76,13 +76,13 @@ spice cloud login subscription --device
 Authenticate with a personal access token.
 
 ```shell
-spice cloud login pat --token <TOKEN>
+spice cloud login pat --token "<TOKEN>"
 ```
 
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
-export SPICE_CLOUD_PAT=<TOKEN>
+export SPICE_CLOUD_PAT="<TOKEN>"
 spice cloud login pat
 ```
 
@@ -91,14 +91,14 @@ spice cloud login pat
 Authenticate using OAuth2 client credentials for CI/automation workflows.
 
 ```shell
-spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+spice cloud login api --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
 ```
 
 Credentials can also be provided via environment variables:
 
 ```shell
-export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
-export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+export SPICE_CLOUD_CLIENT_ID="<CLIENT_ID>"
+export SPICE_CLOUD_CLIENT_SECRET="<CLIENT_SECRET>"
 spice cloud login api
 ```
 

--- a/website/versioned_docs/version-2.1.x/cli/reference/nsql.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/nsql.md
@@ -59,7 +59,7 @@ The `spice nsql analyze` subcommand evaluates Text-to-SQL quality by comparing a
 ### Usage
 
 ```shell
-spice nsql analyze --query <natural-language-query> --expected <expected-sql> --model <model>
+spice nsql analyze --query "<natural-language-query>" --expected "<expected-sql>" --model "<model>"
 ```
 
 ### Flags

--- a/website/versioned_docs/version-2.1.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-2.1.x/cli/reference/sql.md
@@ -88,7 +88,7 @@ gas_used               | 12500000
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/snowflake.md
@@ -68,21 +68,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -90,9 +90,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -183,7 +183,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spark.md
@@ -37,15 +37,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -100,7 +100,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-2.1.x/components/secret-stores/azure-keyvault/index.md
+++ b/website/versioned_docs/version-2.1.x/components/secret-stores/azure-keyvault/index.md
@@ -84,10 +84,10 @@ The principal used by Spice must have read access to secrets in the target Key V
 
 ```bash
 az role assignment create \
-  --assignee-object-id <PRINCIPAL_OBJECT_ID> \
+  --assignee-object-id "<PRINCIPAL_OBJECT_ID>" \
   --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
-  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
 ```
 
 The store performs a `list_secret_properties` call on startup to validate connectivity and fail fast on misconfiguration. A `403 Forbidden` on list is tolerated, so principals scoped only to per-secret `Microsoft.KeyVault/vaults/secrets/getSecret/action` (for example, **Key Vault Reader** combined with a custom role) are supported.

--- a/website/versioned_docs/version-2.1.x/deployment/azure/index.md
+++ b/website/versioned_docs/version-2.1.x/deployment/azure/index.md
@@ -80,7 +80,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 
 # 3. Federate the identity with the Kubernetes ServiceAccount
 ISSUER=$(az aks show -g $RG -n $CLUSTER --query oidcIssuerProfile.issuerUrl -o tsv)
@@ -189,7 +189,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 ```
 
 #### 3. Deploy Spice.ai

--- a/website/versioned_docs/version-2.1.x/deployment/kubernetes/argocd/index.md
+++ b/website/versioned_docs/version-2.1.x/deployment/kubernetes/argocd/index.md
@@ -195,7 +195,7 @@ Roll back to a previous revision using the Argo CD CLI or UI:
 
 ```bash
 argocd app history spiceai
-argocd app rollback spiceai <history-id>
+argocd app rollback spiceai "<history-id>"
 ```
 
 When the `Application` is managed by Git, prefer reverting the commit that introduced the change so the desired state in Git matches the live state. With `selfHeal: true` enabled, Argo CD will otherwise re-apply the Git state.

--- a/website/versioned_docs/version-2.1.x/deployment/kubernetes/flux/index.md
+++ b/website/versioned_docs/version-2.1.x/deployment/kubernetes/flux/index.md
@@ -233,7 +233,7 @@ Flux records each Helm release revision. List history and roll back with the Hel
 
 ```bash
 helm history spiceai -n spiceai
-helm rollback spiceai <revision> -n spiceai
+helm rollback spiceai "<revision>" -n spiceai
 ```
 
 For automatic rollback on failed upgrades, configure `spec.upgrade.remediation` on the `HelmRelease`:

--- a/website/versioned_docs/version-2.1.x/monitoring/spice-cloud/index.md
+++ b/website/versioned_docs/version-2.1.x/monitoring/spice-cloud/index.md
@@ -73,7 +73,7 @@ The output includes the app's primary API key. Treat the key as a secret — any
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --app <org>/<app>
+spice cloud api-keys --app "<org>/<app>"
 ```
 
 ## Configuration
@@ -177,7 +177,7 @@ After restarting the runtime, confirm the connection is established:
 3. **Wait 5–10 seconds**, then query the target Spice Cloud app's task history. From any client logged in to Spice Cloud:
 
    ```bash
-   spice sql --cloud <org>/<app>
+   spice sql --cloud "<org>/<app>"
    ```
 
    ```sql

--- a/website/versioned_docs/version-2.1.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-2.1.x/troubleshooting/index.md
@@ -272,13 +272,13 @@ The Spice sandbox container is a minimal container that doesn't include standard
 It's possible to run the SQL REPL from the container to debug SQL queries:
 
 ```console
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 ```
 
 Or from `kubectl`:
 
 ```console
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 ### Debug Kubernetes Pods with Ephemeral Containers
@@ -318,7 +318,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:1.3.0
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:1.3.0
 
 # Exec into the container
 docker exec -it spiceai-debug /busy/busybox sh

--- a/website/versioned_docs/version-2.2.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/chat.md
@@ -52,13 +52,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-2.2.x/cli/reference/cloud.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/cloud.md
@@ -102,7 +102,7 @@ Lists the organizations this identity can act on, marking the active one and whi
 ### `org`
 
 ```shell
-spice cloud org use <ORG>
+spice cloud org use "<ORG>"
 spice cloud org current
 spice cloud org clear
 ```
@@ -121,7 +121,7 @@ An enrolled directory holds an instance identity in `.spice/identity.json`, and 
 
 ```shell
 spice cloud link
-spice cloud link <org>/<project>
+spice cloud link "<org>/<project>"
 ```
 
 Enrolls the current directory as a Spice Cloud instance and attaches it to a project. Omit the argument to choose from the projects available to you.
@@ -196,8 +196,8 @@ spice cloud project delete <org>/<project> [--yes]
 `--kind` decides which kind of project is created. Either way, the command prints the new project's primary API key.
 
 ```shell
-spice cloud project create <NAME>                              # Cloud Connect project
-spice cloud project create <NAME> --kind set --region <REGION> # Spice-managed project
+spice cloud project create "<NAME>"                              # Cloud Connect project
+spice cloud project create "<NAME>" --kind set --region "<REGION>" # Spice-managed project
 ```
 
 - **Omit `--kind`** for a **Cloud Connect** project — one Spice Cloud does not run, served by your own runtime. This is the project [`spice cloud link`](#link) attaches an instance to.
@@ -349,9 +349,9 @@ Shows a project's API keys. `--regenerate <1|2>` reissues one of the two keys. T
 
 ```shell
 spice cloud secrets list
-spice cloud secrets set <NAME> <VALUE>
-spice cloud secrets get <NAME>
-spice cloud secrets delete <NAME>
+spice cloud secrets set "<NAME>" "<VALUE>"
+spice cloud secrets get "<NAME>"
+spice cloud secrets delete "<NAME>"
 ```
 
 Manages a project's secrets. Every subcommand takes `--project <ORG/PROJECT>` and `-o`. `list` has the alias `ls`.

--- a/website/versioned_docs/version-2.2.x/cli/reference/connect.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/connect.md
@@ -14,7 +14,7 @@ Adds a Spicepod dependency to the current project, and prints a deprecation warn
 ### Usage
 
 ```shell
-spice connect <org>/<pod>
+spice connect "<org>/<pod>"
 ```
 
 ### Example

--- a/website/versioned_docs/version-2.2.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/login.md
@@ -48,7 +48,7 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```
 
 ### Browser Login Flow
@@ -94,7 +94,7 @@ spice cloud login subscription --device
 Authenticate with a Spice Cloud access token. Alias: `pat`.
 
 ```shell
-spice cloud login token --token <TOKEN>
+spice cloud login token --token "<TOKEN>"
 ```
 
 Omit `--token` to enter the token at a secure prompt. Generate one at `/account/tokens` in the Spice Cloud portal.
@@ -102,7 +102,7 @@ Omit `--token` to enter the token at a secure prompt. Generate one at `/account/
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
-export SPICE_CLOUD_PAT=<TOKEN>
+export SPICE_CLOUD_PAT="<TOKEN>"
 spice cloud login token
 ```
 
@@ -111,14 +111,14 @@ spice cloud login token
 Authenticate using OAuth2 client credentials for CI/automation workflows.
 
 ```shell
-spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+spice cloud login api --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
 ```
 
 Credentials can also be provided via environment variables:
 
 ```shell
-export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
-export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+export SPICE_CLOUD_CLIENT_ID="<CLIENT_ID>"
+export SPICE_CLOUD_CLIENT_SECRET="<CLIENT_SECRET>"
 spice cloud login api
 ```
 

--- a/website/versioned_docs/version-2.2.x/cli/reference/nsql.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/nsql.md
@@ -59,7 +59,7 @@ The `spice nsql analyze` subcommand evaluates Text-to-SQL quality by comparing a
 ### Usage
 
 ```shell
-spice nsql analyze --query <natural-language-query> --expected <expected-sql> --model <model>
+spice nsql analyze --query "<natural-language-query>" --expected "<expected-sql>" --model "<model>"
 ```
 
 ### Flags

--- a/website/versioned_docs/version-2.2.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-2.2.x/cli/reference/sql.md
@@ -88,7 +88,7 @@ gas_used               | 12500000
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/snowflake.md
@@ -68,21 +68,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -90,9 +90,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -183,7 +183,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/spark.md
@@ -37,15 +37,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -100,7 +100,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-2.2.x/components/secret-stores/azure-keyvault/index.md
+++ b/website/versioned_docs/version-2.2.x/components/secret-stores/azure-keyvault/index.md
@@ -84,10 +84,10 @@ The principal used by Spice must have read access to secrets in the target Key V
 
 ```bash
 az role assignment create \
-  --assignee-object-id <PRINCIPAL_OBJECT_ID> \
+  --assignee-object-id "<PRINCIPAL_OBJECT_ID>" \
   --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
-  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
 ```
 
 The store performs a `list_secret_properties` call on startup to validate connectivity and fail fast on misconfiguration. A `403 Forbidden` on list is tolerated, so principals scoped only to per-secret `Microsoft.KeyVault/vaults/secrets/getSecret/action` (for example, **Key Vault Reader** combined with a custom role) are supported.

--- a/website/versioned_docs/version-2.2.x/deployment/azure/index.md
+++ b/website/versioned_docs/version-2.2.x/deployment/azure/index.md
@@ -80,7 +80,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 
 # 3. Federate the identity with the Kubernetes ServiceAccount
 ISSUER=$(az aks show -g $RG -n $CLUSTER --query oidcIssuerProfile.issuerUrl -o tsv)
@@ -189,7 +189,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 ```
 
 #### 3. Deploy Spice.ai

--- a/website/versioned_docs/version-2.2.x/deployment/kubernetes/argocd/index.md
+++ b/website/versioned_docs/version-2.2.x/deployment/kubernetes/argocd/index.md
@@ -195,7 +195,7 @@ Roll back to a previous revision using the Argo CD CLI or UI:
 
 ```bash
 argocd app history spiceai
-argocd app rollback spiceai <history-id>
+argocd app rollback spiceai "<history-id>"
 ```
 
 When the `Application` is managed by Git, prefer reverting the commit that introduced the change so the desired state in Git matches the live state. With `selfHeal: true` enabled, Argo CD will otherwise re-apply the Git state.

--- a/website/versioned_docs/version-2.2.x/deployment/kubernetes/flux/index.md
+++ b/website/versioned_docs/version-2.2.x/deployment/kubernetes/flux/index.md
@@ -233,7 +233,7 @@ Flux records each Helm release revision. List history and roll back with the Hel
 
 ```bash
 helm history spiceai -n spiceai
-helm rollback spiceai <revision> -n spiceai
+helm rollback spiceai "<revision>" -n spiceai
 ```
 
 For automatic rollback on failed upgrades, configure `spec.upgrade.remediation` on the `HelmRelease`:

--- a/website/versioned_docs/version-2.2.x/features/large-language-models/mcp.md
+++ b/website/versioned_docs/version-2.2.x/features/large-language-models/mcp.md
@@ -250,7 +250,7 @@ See the [mcp-server cookbook](https://github.com/spiceai/cookbook/tree/trunk/mcp
 A failing MCP server does not stop the runtime. Spice logs a warning, retries the connection in the background, and reports healthy — the tool is simply absent from `tools/list`. Verify the runtime log at startup:
 
 ```bash
-grep "Unable to load tool" <log>
+grep "Unable to load tool" "<log>"
 ```
 
 A server that starts but authenticates with empty or invalid credentials is harder to spot: it registers zero tools without producing that warning. Check for `runtime_secrets` errors, which indicate a `${secrets:...}` reference that did not resolve.

--- a/website/versioned_docs/version-2.2.x/monitoring/spice-cloud/index.md
+++ b/website/versioned_docs/version-2.2.x/monitoring/spice-cloud/index.md
@@ -75,7 +75,7 @@ The output includes the app's primary API key. Treat the key as a secret — any
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --project <org>/<app>
+spice cloud api-keys --project "<org>/<app>"
 ```
 
 ## Configuration
@@ -179,7 +179,7 @@ After restarting the runtime, confirm the connection is established:
 3. **Wait 5–10 seconds**, then query the target Spice Cloud app's task history. From any client logged in to Spice Cloud:
 
    ```bash
-   spice sql --cloud <org>/<app>
+   spice sql --cloud "<org>/<app>"
    ```
 
    ```sql

--- a/website/versioned_docs/version-2.2.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-2.2.x/troubleshooting/index.md
@@ -336,10 +336,10 @@ The REPL needs no shell, because `spiced` is itself the binary being executed.
 
 ```console
 # Docker
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 
 # Kubernetes
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 Because `spiced --repl` runs inside the container, it connects to that container's own `http://localhost:50051` Flight endpoint — attaching to the runtime already serving there. The interactive SQL prompt that follows is therefore executing queries **inside the deployment**, not locally.
@@ -364,10 +364,10 @@ This is the recommended way to debug Spice on Kubernetes.
 
 ```bash
 # List pods in the namespace
-kubectl get pods -n <namespace>
+kubectl get pods -n "<namespace>"
 
 # List the container names inside the pod
-kubectl get pod <pod_name> -n <namespace> -o jsonpath='{.spec.containers[*].name}'
+kubectl get pod "<pod_name>" -n "<namespace>" -o jsonpath='{.spec.containers[*].name}'
 ```
 
 The Helm chart names the Spice container `spiceai`. Run the second command rather than assuming, since a custom manifest may name it something else.
@@ -460,7 +460,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:latest
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:latest
 
 # Exec into the container — the shell that follows runs INSIDE the Spice container
 docker exec -it spiceai-debug /busy/busybox sh


### PR DESCRIPTION
## Summary
Fixes #2196

An unquoted `<placeholder>` inside a shell-tagged fence is shell **redirection**, not text, so a reader who copies the block does not get a command to fill in — they get a redirection from a file that does not exist. 333 lines across 95 pages were affected: 53 in `website/docs/`, 280 in the ten `website/versioned_docs/version-*/` snapshots.

## Reproduced

`spice`, `kubectl`, `docker`, `helm`, `az` and `argocd` stubbed on `PATH` to print their own argv, `PATH` set to the stub directory only, every shell fence on the affected pages extracted and executed in a fresh temp dir. Before, all three failure modes were present:

```
# 1. Abort — components/data-connectors/snowflake.md, env-var install block
/bin/bash: line 1: account-identifier: No such file or directory      exit 1
      → `spice run` is never reached

# 2. Parse error — cli/reference/login.md
/bin/bash: -c: line 0: syntax error near unexpected token `newline'   exit 2
      → `spice login --key <API_KEY>` does not tokenize

# 3. Silent skip — troubleshooting/index.md, busybox debug block        exit 0
docker ARGV: [volume] [create] [busybox]
docker ARGV: [run] [--rm] [-v] [busybox:/data] ...
docker ARGV: [exec] [-it] [spiceai-debug] [/busy/busybox] [sh]
/bin/bash: line 7: path_to_spicepod: No such file or directory
      → three docker commands ran; the one that creates the container did not,
        and the block still reported success
```

After this change, the same harness over the same pages: **31 previously-failing blocks reach the tool at exit 0 with argv intact, and no block leaves a stray file behind.**

```
spice ARGV: [login] [--key] [<API_KEY>]
spice ARGV: [run]                              # after the three env-var assignments
docker ARGV: [run] [-v] [busybox:/busy] [-v] [<path_to_spicepod>:/app/spicepod] [-d] [--name] [spiceai-debug] [spiceai/spiceai:latest]
kubectl ARGV: [get] [pod] [<pod_name>] [-n] [<namespace>] [-o] [jsonpath={.spec.containers[*].name}]
```

The remaining blocks that still error are usage synopses, REPL transcripts, query output, log excerpts, and one `/busy/busybox` path that only exists inside a container — none is a copy-paste command.

## Changes

Quoting only — `--key "<API_KEY>"`, `SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>"`, `-v "<path_to_spicepod>:/app/spicepod"`. Quoting keeps the placeholder visible *as* a placeholder, which substituting a concrete value would not, and it is one character per side. No prose, links, or frontmatter changed.

Pages: `cli/reference/{chat,cloud,connect,login,nsql,sql}.md`, `components/data-connectors/{snowflake,spark}.md`, `components/secret-stores/azure-keyvault`, `deployment/azure`, `deployment/kubernetes/{argocd,flux,local-nvme}`, `features/large-language-models/mcp.md`, `monitoring/spice-cloud`, `troubleshooting/index.md`, and the same pages in every `versioned_docs/version-*/` snapshot that has them (the defect predates versioning, so every snapshot inherited it).

## Deliberately not changed

- **Usage synopses — 55 lines.** `spice cloud <command> [flags]`, `spice cloud project create <NAME> [flags]`, `spice <component> add <name> [body flags]`, `spice.ai/<organization>/<application>[/<catalog_name>]`: there `<>` and `[]` are grammar for the command's shape, not a command to paste, and quoting them would be wrong. Rule applied: if any line in a fence carries `[...]` optional-argument notation, or a placeholder fills a command slot, the whole fence is notation and is left alone — quoting only part of such a block would leave it internally inconsistent.
- **REPL transcripts, query output, and log excerpts** in shell fences — never commands.
- `releases/v1.8.0.md` (2 lines) — a historical release note.

## Test plan
- [x] `cd website && npm run build` passes locally (Docusaurus `onBrokenLinks: throw` / `onInlineTags: throw`)
- [x] No links or frontmatter tags added or moved — `git diff` over `website/**/*.md*` has zero added lines containing `](` or `tags:`
- [x] Correction applied across all affected `website/versioned_docs/version-*/` directories: 53 unversioned + 280 versioned = 333 lines, 95 files
- [x] Re-scan after the change reports zero remaining unquoted placeholders outside the synopsis class
- [x] Blocks re-executed after the change: 31 previously-failing blocks now exit 0 with the placeholder passed through verbatim