### PR TITLE
docs(spiceai): the Flight client does not retry — the caller must

### DIFF
--- a/website/docs/components/data-connectors/spiceai/deployment.md
+++ b/website/docs/components/data-connectors/spiceai/deployment.md
@@ -56,7 +56,7 @@ On startup the connector performs a DNS + TCP reachability check against the res
 
 ### Flight Transport
 
-Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
 
 For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
 
@@ -196,7 +196,7 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 - **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
 - **Append-only changes stream.** Updates and deletes are not propagated.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. The `spiceai-retryable` metadata flag on the returned error marks the failure as safe for the *caller* to retry — it does not mean a retry has already been performed.
 - **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
@@ -210,5 +210,5 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 | TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
 | `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `runtime.flight.max_message_size` on both client and server, or narrow the query projection.                                              |
 | Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
-| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | The error surfaces on the first failure — retry the request from the application; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)). |
 | `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/docs/components/data-connectors/spiceai/index.md
+++ b/website/docs/components/data-connectors/spiceai/index.md
@@ -269,7 +269,7 @@ datasets:
 - **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
 - **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.
 - **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
 :::warning Memory considerations

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/deployment.md
@@ -56,7 +56,7 @@ On startup the connector performs a DNS + TCP reachability check against the res
 
 ### Flight Transport
 
-Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
 
 For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
 
@@ -196,7 +196,7 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 - **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
 - **Append-only changes stream.** Updates and deletes are not propagated.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. The `spiceai-retryable` metadata flag on the returned error marks the failure as safe for the *caller* to retry — it does not mean a retry has already been performed.
 - **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
@@ -210,5 +210,5 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 | TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
 | `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `runtime.flight.max_message_size` on both client and server, or narrow the query projection.                                              |
 | Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
-| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | The error surfaces on the first failure — retry the request from the application; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)). |
 | `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/index.md
+++ b/website/versioned_docs/version-2.0.x/components/data-connectors/spiceai/index.md
@@ -269,7 +269,7 @@ datasets:
 - **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
 - **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.
 - **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
 :::warning Memory considerations

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/deployment.md
@@ -56,7 +56,7 @@ On startup the connector performs a DNS + TCP reachability check against the res
 
 ### Flight Transport
 
-Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
 
 For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
 
@@ -196,7 +196,7 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 - **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
 - **Append-only changes stream.** Updates and deletes are not propagated.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. The `spiceai-retryable` metadata flag on the returned error marks the failure as safe for the *caller* to retry — it does not mean a retry has already been performed.
 - **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
@@ -210,5 +210,5 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 | TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
 | `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `runtime.flight.max_message_size` on both client and server, or narrow the query projection.                                              |
 | Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
-| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | The error surfaces on the first failure — retry the request from the application; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)). |
 | `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/index.md
+++ b/website/versioned_docs/version-2.1.x/components/data-connectors/spiceai/index.md
@@ -269,7 +269,7 @@ datasets:
 - **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
 - **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.
 - **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
 :::warning Memory considerations

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/spiceai/deployment.md
@@ -56,7 +56,7 @@ On startup the connector performs a DNS + TCP reachability check against the res
 
 ### Flight Transport
 
-Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
 
 For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
 
@@ -196,7 +196,7 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 - **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
 - **Append-only changes stream.** Updates and deletes are not propagated.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. The `spiceai-retryable` metadata flag on the returned error marks the failure as safe for the *caller* to retry — it does not mean a retry has already been performed.
 - **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
@@ -210,5 +210,5 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 | TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
 | `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `runtime.flight.max_message_size` on both client and server, or narrow the query projection.                                              |
 | Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
-| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | The error surfaces on the first failure — retry the request from the application; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)). |
 | `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/versioned_docs/version-2.2.x/components/data-connectors/spiceai/index.md
+++ b/website/versioned_docs/version-2.2.x/components/data-connectors/spiceai/index.md
@@ -269,7 +269,7 @@ datasets:
 - **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
 - **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.
 - **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
 :::warning Memory considerations

--- a/website/versioned_docs/version-2.3.x/components/data-connectors/spiceai/deployment.md
+++ b/website/versioned_docs/version-2.3.x/components/data-connectors/spiceai/deployment.md
@@ -56,7 +56,7 @@ On startup the connector performs a DNS + TCP reachability check against the res
 
 ### Flight Transport
 
-Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.
+Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
 
 For self-hosted upstreams, prefer `https://` or `grpc+tls://` in production. `http://` is supported for local development and trusted networks but transmits Flight payloads unencrypted. Plain `grpc://` is rejected at startup.
 
@@ -196,7 +196,7 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 - **Single endpoint per dataset.** A dataset binds to a single endpoint URL. Multi-endpoint failover lives at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector.
 - **Append-only changes stream.** Updates and deletes are not propagated.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. The `spiceai-retryable` metadata flag indicates the retry path.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. The `spiceai-retryable` metadata flag on the returned error marks the failure as safe for the *caller* to retry — it does not mean a retry has already been performed.
 - **No `grpc://` (clear-text gRPC).** Use `http://` for unencrypted Flight or `https://` / `grpc+tls://` for TLS.
 
 ## Troubleshooting
@@ -210,5 +210,5 @@ Queries to the upstream Spice runtime participate in [task history](../../../ref
 | TLS handshake failure with self-signed upstream cert | System cert store doesn't trust the upstream CA.              | Set `spiceai_tls_ca_certificate_file` to the upstream's CA PEM, or have the upstream present a publicly-trusted certificate.        |
 | `message size exceeded` / `ResourceExhausted`        | Row batch exceeds gRPC message limit.                         | Increase `runtime.flight.max_message_size` on both client and server, or narrow the query projection.                                              |
 | Append stream stalled; acceleration lag climbing     | Network partition or upstream dataset paused.                 | Check upstream status; verify the source dataset is healthy; restart the runtime to re-establish the stream.                        |
-| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | Flight client auto-retries; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)).  |
+| Sudden 5xx / `UNAVAILABLE` errors                    | Transient service-side issue.                                 | The error surfaces on the first failure — retry the request from the application; if persistent, check upstream runtime health (or the [Spice.ai status page](https://status.spice.ai)). |
 | `MissingRequiredParameter: api_key or token`         | Targeting a Cloud endpoint with no API key configured.        | Set `spiceai_api_key` (Cloud requires authentication; self-hosted endpoints accept anonymous if upstream auth is off).              |

--- a/website/versioned_docs/version-2.3.x/components/data-connectors/spiceai/index.md
+++ b/website/versioned_docs/version-2.3.x/components/data-connectors/spiceai/index.md
@@ -269,7 +269,7 @@ datasets:
 - **Single endpoint per dataset.** Multi-endpoint failover must be handled at the load-balancer / DNS layer.
 - **API key auth only.** OIDC / SSO is not supported at the data-plane connector. Use API keys for both Cloud and self-hosted federation.
 - **Append-only changes stream.** Updates and deletes from the upstream are not propagated; rely on `refresh_mode: full` for datasets that mutate.
-- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.
+- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.
 - **`grpc://` (without TLS) is rejected.** Use `http://` for clear-text or `https://` / `grpc+tls://` for TLS.
 
 :::warning Memory considerations


### PR DESCRIPTION
## Summary

The Spice.ai data connector pages claim the Arrow Flight client retries transient
failures on its own. It does not. `crates/flight_client` contains no retry or
backoff logic in any release line — every connection-reset path returns `Err` —
so a query that hits an `UNAVAILABLE`, `DEADLINE_EXCEEDED`, or connection-reset
condition fails on the first attempt and the error is handed to the caller.

The most misleading of the four claims is the 1000-request-cap bullet: it tells
readers that the `spiceai-retryable` metadata means "the query has been retried
already". That metadata is attached to the error the runtime *returns* — it is a
signal that the caller may safely retry, and the error string it rides on
literally reads `Please retry the request.` A reader following the current text
would build no retry of their own and silently drop queries at every connection
recycle.

This is the same false-claim class as #1849 (`docs(dremio): correct false Flight
client auto-retry claim in deployment guide`), which corrected the Dremio pages
and did not sweep the Spice.ai pages. The `version-1.11.x` snapshot still carries
the correct wording ("the query **should be retried**"); the claim was inverted
when the page was rewritten for 2.x, so this corrects vNext and every 2.x
snapshot and leaves the 1.x snapshots alone.

### Reproduction

Doc said (`website/docs/components/data-connectors/spiceai/index.md:272`, base `6ca48270`):

> **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset; the Flight client retries automatically. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata, the query has been retried already.

and (`.../spiceai/deployment.md:59`):

> Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller; retries are handled by the Flight client's default policy.

Code says (`crates/flight_client/src/lib.rs` at `v2.3.0`) — no retry/backoff anywhere;
the only occurrence of the word in the whole crate is the *message text*:

```
$ git grep -n -iE 'retry|retries|backoff' v2.3.0 -- crates/flight_client/src/
v2.3.0:crates/flight_client/src/lib.rs:206:    #[snafu(display("Connection is reset by the server. Please retry the request. {source}"))]
```

Same single hit at `v2.0.1`, `v2.1.5` and `v2.2.1`. The condition is classified
and returned, never retried
([`flight_client/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/flight_client/src/lib.rs#L655-L666)):

```rust
fn map_tonic_error_to_message(e: tonic::Status) -> Error {
    if is_connection_reset_error(&e) {
        return Error::ConnectionReset { source: TonicStatusError::from(e) };
    }
```

and the query path forwards it to DataFusion as-is, with no retry wrapper
([`data_components/src/flight.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/data_components/src/flight.rs#L576-L579)):

```rust
flight_client::Error::ConnectionReset { .. } => DataFusionError::External(Box::new(source)),
```

The `spiceai-retryable` metadata is attached to the error `Status` the runtime
*returns to its caller*
([`runtime/src/flight/mod.rs:729-733`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/flight/mod.rs#L729-L733)):

```rust
FlightClientError::ConnectionReset { source } => {
    let mut error = Status::invalid_argument(source.to_string());
    error.metadata_mut().insert("spiceai-retryable", 1.into());
    error
}
```

Behavior claim, run on the base commit (`spiced v2.3.0+models.metal`, macOS arm64). A stub
Arrow Flight server (pyarrow 21.0.0) serves the schema so the dataset registers,
then fails `DoGet`. One SQL query is issued per failure mode and the server logs
every RPC it receives:

```
$ cat spicepod.yaml
datasets:
  - from: spice.ai/spiceai/quickstart/datasets/taxi_trips
    name: taxi_trips
    params:
      spiceai_endpoint: http://127.0.0.1:58090

$ curl -s -w '\nHTTP %{http_code} in %{time_total}s\n' -XPOST http://127.0.0.1:58190/v1/sql \
    -d 'SELECT n FROM taxi_trips WHERE n = 4242'
External error: Connection is reset by the server. Please retry the request. An internal error occurred. transport error. Detail: Internal
HTTP 400 in 0.055229s
```

Stub-server log for that one query — **one** `do_get`, no second attempt:

```
[1789114845.196] get_flight_info #1
[1789114845.196]    cmd=SELECT "taxi_trips"."n" FROM "taxi_trips" WHERE ("taxi_trips"."n" = 4242) AND ("taxi_trips"."n" = 4242)
[1789114845.197] do_get #1
[1789114845.197]    -> raising FlightInternalError('transport error')
```

The other two error codes the docs name behave the same way — one upstream
attempt each, error returned in single-digit milliseconds:

```
$ curl ... -d 'SELECT n FROM taxi_trips WHERE n = 111'     # DoGet -> UNAVAILABLE
Execution error: upstream unavailable. Detail: Unavailable
HTTP 400 in 0.007564s

$ curl ... -d 'SELECT n FROM taxi_trips WHERE n = 222'     # DoGet -> DEADLINE_EXCEEDED
Execution error: deadline exceeded. Detail: TimedOut
HTTP 400 in 0.002331s

[1789114890.706] do_get #1        -> raising for mode=unavailable
[1789114890.721] do_get #2        -> raising for mode=timeout
```

A second query through spiced's own Flight endpoint produced `do_get #2` and
`grpc_status:3` (`INVALID_ARGUMENT`) at the client — i.e. exactly the
`Status::invalid_argument` + `spiceai-retryable` arm above, reached after a
single upstream attempt.

After the fix, on this branch — the same run, re-read against the corrected text. A docs change cannot
make the runtime behave differently, so the second half of the reproduction is
the corrected text re-checked against the *same* run output. On this branch the
pages now say, at `index.md:272` and `deployment.md:59`:

```
- **Cloud connections cap at 1000 requests per connection.** When the cap is hit the connection is reset and the in-flight query fails; the connector does not re-issue it. If you see `Connection is reset by the server. Please retry the request.` or the `spiceai-retryable` metadata on the error, retry the query from your application.

Data transfer uses Arrow Flight over gRPC. Transient gRPC errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`) surface to the caller on the first failure — the connector performs no automatic retry, and no per-operation retry parameters are exposed at the Spice layer. Build retry/backoff into the calling application, or accelerate the dataset so reads are served locally instead of federating upstream on every query.
```

which matches the run above on every point the old text got wrong: one upstream
attempt (`do_get #1`), the error returned to the caller (`HTTP 400`), and the
metadata riding on that returned error rather than marking a completed retry.
Grepping the branch for the six old phrasings returns nothing:

```
$ for s in "Flight client auto-retr" "Flight client's default retry" "Flight client retries automatically" \
           "retries are handled by the Flight client" "retried already" "indicates the retry path"; do
    printf '%-46s %s\n' "$s" "$(grep -rl "$s" website/ | wc -l | tr -d ' ')"; done
Flight client auto-retr                        0
Flight client's default retry                  0
Flight client retries automatically            0
retries are handled by the Flight client       0
retried already                                0
indicates the retry path                       0
```

Verdict: **Reproduced.**

## What changed

Four claims, corrected in vNext and in the `2.0.x` / `2.1.x` / `2.2.x` / `2.3.x`
snapshots (20 replacements across 10 files):

| Page | Claim | Now says |
| --- | --- | --- |
| `deployment.md` "Flight Transport" | "retries are handled by the Flight client's default policy" | no automatic retry; build retry/backoff into the caller, or accelerate the dataset |
| `deployment.md` limitations | "the Flight client retries automatically … indicates the retry path" | the query fails and is not re-issued; the metadata marks it safe for the *caller* to retry |
| `index.md` limitations | "the query has been retried already" | retry the query from your application |
| `deployment.md` troubleshooting | "Flight client auto-retries" | the error surfaces on the first failure — retry from the application |

`version-1.11.x` and older are **not** touched: they already say the query should
be retried by the caller.

## Source refs

- `spiceai/spiceai` at `v2.3.0` — [`crates/flight_client/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/flight_client/src/lib.rs#L655-L666), [`crates/data_components/src/flight.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/data_components/src/flight.rs#L576-L579), [`crates/runtime/src/flight/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/flight/mod.rs#L729-L733)
- Prior correction of the same claim class on another connector: spiceai/docs#1849

## Test plan

- [x] `cd website && npm run build` passes — `exit 0`, `[SUCCESS] Generated static files in "build"`
- [x] Versioned-docs propagation checked (grep-count gate) — 0 remaining hits for all six phrasings, 10 files changed
- [x] Files updated: 10 (1 unversioned pair + 4 versioned pairs: 2.0.x / 2.1.x / 2.2.x / 2.3.x)
- [x] Flip-flop guard run — only #1849 (same claim, other connector); no opposite-direction correction

## Verification

- `cd website && npm run build` — **passed** (`exit 0`):

```
[INFO] [en] Creating an optimized production build...
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- Versioned-docs propagation grep-count gate — every phrasing of the claim is gone from `website/`, and the changed-file count matches the diff:

```
Flight client auto-retr                        remaining hits: 0
Flight client's default retry                  remaining hits: 0
Flight client retries automatically            remaining hits: 0
retries are handled by the Flight client       remaining hits: 0
retried already                                remaining hits: 0
indicates the retry path                       remaining hits: 0
changed files: 10
```

- Branch isolation — `git diff --name-only origin/trunk..HEAD -- 'website/'` lists only the 10 Spice.ai connector pages (5 doc sets × `index.md` + `deployment.md`).
- Flip-flop guard — `gh pr list --repo spiceai/docs --state merged --search "flight retry in:title"` returns only #1849, the correction of this same claim on the Dremio pages. No prior PR moved this claim in the opposite direction.
- Behavior run — pasted in the Reproduction block above (`spiced v2.3.0+models.metal`, stub pyarrow 21.0.0 Flight server, one `do_get` per query in all three failure modes).
