### PR TITLE
docs(duckdb): regexp_match, regexp_instr and regexp_count are never sent to DuckDB

### DIFF
--- a/website/docs/components/catalogs/ducklake.md
+++ b/website/docs/components/catalogs/ducklake.md
@@ -213,5 +213,6 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.
 - If a table fails to load during catalog refresh, it is skipped with a warning and does not fail the entire catalog.
+- This catalog uses the DuckDB SQL dialect, so the `regexp_match`, `regexp_instr` and `regexp_count` functions are evaluated in Spice rather than pushed down. See [Regular Expression Functions and Federation](../data-connectors/duckdb#regular-expression-functions-and-federation).
 
 :::

--- a/website/docs/components/data-accelerators/duckdb/index.md
+++ b/website/docs/components/data-accelerators/duckdb/index.md
@@ -124,6 +124,7 @@ Consider the following limitations when using DuckDB acceleration:
 - Hot-reloading dataset configurations while the Spice Runtime is active disables DuckDB query federation until the runtime restarts.
 - `on_refresh_sort_columns` is not currently supported with primary keys or indexes.
 - DuckDB acceleration does not support [`partition_by`](../../../features/data-acceleration/partitioning.md). Configuring it is rejected at load time. Use the `arrow` or `cayenne` engine for partitioned acceleration.
+- The `regexp_match`, `regexp_instr` and `regexp_count` functions are never sent to DuckDB and are evaluated in Spice instead, so a query using one does not push down to the acceleration. See [Regular Expression Functions and Federation](../../data-connectors/duckdb/index.md#regular-expression-functions-and-federation).
 
 ## Resource Considerations
 

--- a/website/docs/components/data-connectors/duckdb/index.md
+++ b/website/docs/components/data-connectors/duckdb/index.md
@@ -143,6 +143,22 @@ SELECT * FROM read_json('todos.json');
 
 :::
 
+## Regular Expression Functions and Federation
+
+Three of DataFusion's regular-expression built-ins are never sent to DuckDB, because DuckDB cannot answer them the way Spice does. A query using one of them is still valid — the call is evaluated in Spice, above the federated scan — but a plan containing it does not federate, so the scan under it reads its columns out of DuckDB instead of filtering there.
+
+| Function | Why it is not sent to DuckDB |
+| --- | --- |
+| `regexp_match` | It returns the first match's *capture groups* as a list, and `NULL` when nothing matches. DuckDB has no function with those semantics: `regexp_extract(s, p, 0)` returns the whole match as a plain string, and the empty string — not `NULL` — when nothing matches. |
+| `regexp_instr` | DuckDB has no function of that name, so a federated call failed outright with `Catalog Error: Scalar Function with name regexp_instr does not exist!`. |
+| `regexp_count` | Its DuckDB rendering, `len(regexp_extract_all(x, p))`, is `NULL` for a `NULL` input, where DataFusion counts zero matches and answers `0`. A `NULL` rather than `0` propagates differently through `SUM`, through `= 0`, and through a `WHERE` built on it. |
+
+**The "does it match at all" idiom still pushes down.** `regexp_match(col, pattern) IS NULL` and `IS NOT NULL` are rewritten into `regexp_like` before the capability check, and `regexp_like` the DuckDB dialect does render natively (as `regexp_matches`), so that shape stays a boolean and federates either way. Prefer it over comparing a `regexp_match` list whenever the question is only whether the pattern matches.
+
+`regexp_like` and `regexp_replace` are the two remaining DataFusion regexp built-ins, and both federate — except when their optional flags argument is a string literal containing `U` or `R`, which DuckDB's regex engine does not support. Such a call is evaluated in Spice instead.
+
+The same rules apply wherever the DuckDB dialect is used: this connector, the [DuckDB data accelerator](../../data-accelerators/duckdb/index.md), the [DuckLake data connector](../ducklake.md) and the [DuckLake catalog connector](../../catalogs/ducklake.md).
+
 ## Cookbook
 
 - A cookbook recipe to configure DuckDB as a data connector in Spice. [DuckDB Data Connector](https://github.com/spiceai/cookbook/tree/trunk/duckdb/connector#readme)

--- a/website/docs/components/data-connectors/ducklake.md
+++ b/website/docs/components/data-connectors/ducklake.md
@@ -212,5 +212,6 @@ datasets:
 - The `ducklake_connection_string` parameter is required — unlike the catalog connector, it cannot be omitted.
 - Each dataset creates its own DuckDB connection pool. For querying many tables from the same catalog, consider using the [DuckLake Catalog Connector](../catalogs/ducklake) instead, which shares a single connection pool.
 - Writes are limited to `INSERT INTO`. `UPDATE`, `DELETE FROM`, and DDL (`CREATE TABLE`, `DROP TABLE`) are not supported on the data connector — use the [DuckLake Catalog Connector](../catalogs/ducklake) for schema operations.
+- This connector uses the DuckDB SQL dialect, so the `regexp_match`, `regexp_instr` and `regexp_count` functions are evaluated in Spice rather than pushed down. See [Regular Expression Functions and Federation](./duckdb#regular-expression-functions-and-federation).
 
 :::


### PR DESCRIPTION
## Summary

Nothing in the docs said which regular-expression calls reach DuckDB. spiceai/spiceai#13871 gives every component that installs the DuckDB SQL dialect one deny-list, `DUCKDB_DENIED_BUILTINS`, holding `regexp_match`, `regexp_instr` and `regexp_count`: each is evaluated in Spice above the federated scan rather than unparsed into DuckDB SQL, because DuckDB answers it differently or has no function for it at all.

A new **Regular Expression Functions and Federation** section on the DuckDB data connector page states the three, the reason for each, the `regexp_match(...) IS NULL` idiom that still pushes down, and the `U`/`R` flags gate on the two built-ins that do federate. The DuckDB accelerator, the DuckLake data connector and the DuckLake catalog connector each get a one-line limitation pointing at it, because all four install this dialect.

Distinctions the code makes and the prose keeps:

- **Local evaluation is not the same as "the filter still runs at the source".** `SQLExecutor::can_execute_plan` refuses to federate *any* plan containing an unsupported function, projections included — not only the filters `supports_filters_pushdown` screens. So the section says a plan containing one of these calls does not federate, and the scan under it reads its columns out of DuckDB, rather than the weaker "the function runs locally".
- **Each of the three is denied for a different reason**, and a single "DuckDB does not support these" sentence would lose all three: `regexp_match` has a DuckDB function that answers a *different question* (whole match vs capture groups, empty string vs `NULL`); `regexp_instr` has no DuckDB function at all and failed remotely; `regexp_count`'s rendering is only wrong on a `NULL` input, where `len(regexp_extract_all(NULL, p))` is `NULL` and DataFusion answers `0`.
- **`regexp_count` keeps its dialect handler while being denied**, so "denied" here means "not sent", not "not renderable" — the table column is headed *Why it is not sent to DuckDB* for that reason.
- **The `U`/`R` gate is a separate, older mechanism** (a per-call check, not the deny-list) and it only fires when the flags argument is a string *literal*; the sentence says so rather than implying the flags are rejected however they arrive.

## Source PRs

- spiceai/spiceai#13871 — fix(duckdb): deny the regexp built-ins DuckDB cannot answer faithfully (fixes #13809)

## Verification

Read from today's `origin/trunk` @ `4c7b254d6c17ee7124618d37553dc0f5aa852e90`, not from the merged diff.

```
$ git show origin/trunk:crates/runtime-datafusion/src/function_support.rs | grep -n "pub const DUCKDB_DENIED_BUILTINS" -A 5
103:pub const DUCKDB_DENIED_BUILTINS: &[&str] = &[
104-    crate::dialect::REGEXP_MATCH_NAME,
105-    crate::dialect::REGEXP_INSTR_NAME,
106-    crate::dialect::REGEXP_COUNT_NAME,
107-];

$ git grep -nE "REGEXP_(MATCH|INSTR|COUNT|LIKE)_NAME: &str" origin/trunk -- crates/runtime-datafusion/src/dialect/mod.rs crates/runtime-datafusion/src/dialect/duckdb.rs
dialect/mod.rs:40:    REGEXP_LIKE_NAME   = "regexp_like"          # the DataFusion name
dialect/mod.rs:41:    REGEXP_MATCH_NAME  = "regexp_match"
dialect/mod.rs:42:    REGEXP_INSTR_NAME  = "regexp_instr"
dialect/mod.rs:44:    REGEXP_COUNT_NAME  = "regexp_count"
dialect/duckdb.rs:27:    REGEXP_LIKE_NAME   = "regexp_matches"       # what DuckDB is sent
dialect/duckdb.rs:29:    REGEXP_COUNT_NAME  = "regexp_extract_all"

$ git grep -n 'wrap_in_call(ast_fn, "len")' origin/trunk -- crates/runtime-datafusion/src/dialect/duckdb.rs
675:            ast_fn = wrap_in_call(ast_fn, "len");       # the len(regexp_extract_all(...)) rendering

$ git grep -n "contains('U')" origin/trunk -- crates/runtime-datafusion/src/dialect/duckdb.rs
718:                if string.contains('U') || string.contains('R') {

$ git grep -n "pub struct RegexpMatchNullCheckRewrite" origin/trunk -- crates/runtime-datafusion/src/optimizer_rule/regexp_match_null_check.rs
61:pub struct RegexpMatchNullCheckRewrite;

$ git grep -ln "duckdb_function_support|deny_spice_functions_for_duckdb" origin/trunk -- crates
crates/accelerators/accelerator-duckdb/src/lib.rs
crates/data-connectors/connector-duckdb/src/lib.rs
crates/data-connectors/connector-ducklake/src/lib.rs
crates/runtime/src/catalogconnector/ducklake.rs
(+ the two definition sites in runtime-datafusion, and runtime/src/datafusion/udf.rs)
```

The four consumer crates above are exactly the four pages this PR touches.

Behavior claims beyond the symbols are **unverified, code inspection only** — no runtime reproduction was run here. The source PR measured the defect it fixes (`regexp_match('ab', '(a)(b)')` returning `['ab']` federated against `['a','b']` locally, and `['']` instead of `NULL` for a non-matching row); this PR quotes only what the deny-list and the dialect show. The one error string in the page, `Catalog Error: Scalar Function with name regexp_instr does not exist!`, is DuckDB's own and is stated in the past tense as the failure the deny-list now prevents — it is not a message a reader will see on current trunk.

## Versioned-docs propagation

**Addition, `website/docs/` only.** `DUCKDB_DENIED_BUILTINS` does not exist in the latest release:

```
$ git show v2.3.0:crates/runtime-datafusion/src/function_support.rs | grep -c "DUCKDB_DENIED_BUILTINS"
0
```

In v2.3.0 and earlier, `deny_spice_functions_for_duckdb_table_providers()` installed only the native carve-out and the per-call check, and a DataFusion built-in federates unless denied — which is why `regexp_match` answered wrongly and `regexp_instr` failed remotely (spiceai/spiceai#13809, #10703). Stamping the new behavior into a `versioned_docs/version-*/` snapshot would describe a release that does not have it.

```
$ git diff --name-only origin/trunk..HEAD -- website/ | wc -l
4
```

## Test plan

- [x] `cd website && npm run build` — `[SUCCESS] Generated static files in "build".` (an earlier draft failed the gate on four extensionless relative links; they are now `.md`-relative and the rebuild is clean, anchors included — `onBrokenAnchors: 'throw'` is set in `docusaurus.config.ts:118`).
- [x] Versioned-docs propagation checked — vNext only, by the v2.3.0 evidence above; 4 files changed, 4 expected.
- [x] Files updated: 4 — `website/docs/components/data-connectors/duckdb/index.md` (the section), plus a one-line pointer each on `data-accelerators/duckdb/index.md`, `data-connectors/ducklake.md` and `catalogs/ducklake.md`.
