### PR TITLE
docs(cayenne): refresh_append_overlap is supported in v2.3.0

### DIFF
--- a/website/versioned_docs/version-2.3.x/reference/spicepod/datasets.md
+++ b/website/versioned_docs/version-2.3.x/reference/spicepod/datasets.md
@@ -762,8 +762,6 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
-Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
-
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated dataset should retry data refresh in the event of transient errors. The default setting is true.

--- a/website/versioned_docs/version-2.3.x/reference/spicepod/views.md
+++ b/website/versioned_docs/version-2.3.x/reference/spicepod/views.md
@@ -193,8 +193,6 @@ Example: If the latest timestamp in the accelerated data table is `2020-01-01T02
 
 See [Duration](../duration)
 
-Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne view that sets this fails to load. See [Cayenne limitations](../../components/data-accelerators/cayenne#limitations).
-
 ## `acceleration.refresh_retry_enabled`
 
 Optional. Specifies whether an accelerated view should retry data refresh in the event of transient errors. The default setting is true.


### PR DESCRIPTION
## Summary

The `version-2.3.x` snapshot was published on 2026-09-10 at 11:24 UTC. spiceai/docs#2191 — which retired the Cayenne `refresh_append_overlap` limitation — merged on 2026-09-11 and swept `website/docs/` and `version-2.2.x` only. The freshly-cut snapshot therefore still carries the pre-correction text, so the v2.3.0 docs tell readers a supported knob fails to load. This is the "a freshly-cut snapshot arrives already-stale" case in the docs PR hygiene reference.

A false *negative* capability claim is the costly kind: it reads as a limitation, so nothing flags it and the reader's remedy is to stop using a feature that works.

`website/versioned_docs/version-2.3.x/components/data-accelerators/cayenne/index.md` already lacks the limitation bullet (spiceai/docs#2186 removed it in vNext before the cut), so within the snapshot the accelerator page and these two reference pages contradict each other today.

Scope: only `version-2.3.x`. The 1.9.x–2.1.x snapshots correctly keep the limitation (the rejection is in their source), and `version-2.2.x` correctly carries the per-patch wording ("from v2.2.1").

## Source PRs

- spiceai/spiceai#13574 — removed the rejection and made the engine honour the window (`git tag --contains` → v2.2.1, v2.3.0)
- spiceai/docs#2191 — the vNext + 2.2.x half of this correction

## Test plan

- [x] Docusaurus build gate — `cd website && npm run build`:

```
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- [x] Versioned-docs propagation grep-count gate — `grep -rln "Not supported by the Spice Cayenne" website/versioned_docs/version-2.3.x/ | wc -l` vs `git diff --cached --name-only -- website/ | wc -l`:

```
$ grep -rln "Not supported by the Spice Cayenne" website/versioned_docs/version-2.3.x/ | wc -l
0
$ git diff --cached --name-only -- website/ | wc -l
2
```

- [x] Class-wide sweep over every snapshot — `grep -rn "file-mode Cayenne\|does not yet support refresh_append_overlap\|Not supported by the Spice Cayenne" website/` leaves the claim standing only where it is true: 1.9.x, 1.10.x, 1.11.x, 2.0.x, 2.1.x, plus the "from v2.2.1" wording in 2.2.x.
- [x] Files updated: 2 — `versioned_docs/version-2.3.x/reference/spicepod/datasets.md` and `.../views.md`, matching the diff.

### Reproduction

Doc said (`website/versioned_docs/version-2.3.x/reference/spicepod/datasets.md:765` at docs `c0f47f88`; identical sentence at `views.md:196`):

> Not supported by the Spice Cayenne (`cayenne`) acceleration engine: a file-mode Cayenne dataset that sets this fails to load.

Code says — the rejection is present at v2.2.0 and absent at v2.3.0:

```
$ git grep -rn 'refresh_append_overlap' v2.2.0 -- crates/ | grep -i 'not supported\|does not yet'
v2.2.0:crates/runtime/src/dataaccelerator/cayenne/mod.rs:3142:  "Cayenne data accelerator does not yet support refresh_append_overlap. Please remove this configuration",

$ git grep -rn 'does not yet support refresh_append_overlap' v2.3.0
(no output)
```

and v2.3.0 applies the window with no engine test — `crates/runtime/src/datafusion/mod.rs:3126` ([v2.3.0](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/datafusion/mod.rs#L3126)):

```rust
if let Some(append_overlap) = acceleration_settings.refresh_append_overlap {
    refresh = refresh.append_overlap(append_overlap);
}
```

Behavior claim: **not run — establishing the absence of a load-time rejection needs a `spiced` build at the v2.3.0 tag plus an object store for a file-mode Cayenne dataset.** The corrected claim is an existence claim about a rejection arm, settled by the two greps above, so this correction is **Reproduced** on that basis.
