### PR TITLE
docs(ducklake): v2.3.0 embeds DuckDB 1.4.4, not 1.5.3

### DIFF
--- a/website/versioned_docs/version-2.3.x/components/catalogs/ducklake.md
+++ b/website/versioned_docs/version-2.3.x/components/catalogs/ducklake.md
@@ -208,7 +208,7 @@ Spice integrates with multiple secret stores to help manage sensitive data secur
 
 :::warning[Limitations]
 
-- Spice uses DuckDB 1.5.3, which supports DuckLake 1.0. Older DuckLake catalogs require a metadata migration before use — set `ducklake_automatic_migration: true` to perform it on attach (this rewrites catalog metadata and cannot be undone). See [DuckLake migration guide](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
+- Spice embeds DuckDB **1.4.4** and supports the catalog schema required by its `ducklake` extension. For older catalogs, `ducklake_automatic_migration: true` performs an irreversible [metadata migration](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake) on attach.
 - The DuckLake DuckDB extension is downloaded at runtime on first use, requiring network connectivity.
 - The `information_schema` and `pg_catalog` system schemas are automatically filtered out during discovery.
 - Catalog refresh is non-incremental — a full re-query of `information_schema` is performed on each refresh cycle.


### PR DESCRIPTION
## Summary

The `version-2.3.x` snapshot was published on 2026-09-10 at 11:24 UTC; spiceai/docs#2187 — which corrected the embedded DuckDB version per release line — merged the same day and swept vNext, 2.1.x and 2.2.x only. So the DuckLake **catalog** page in the newest snapshot still says *"Spice uses DuckDB 1.5.3, which supports DuckLake 1.0"*, while the DuckLake **connector** page in that same snapshot already says 1.4.4 — a doc-vs-doc contradiction inside one release's documentation.

v2.3.0 embeds DuckDB **1.4.4** (the downgrade landed in v2.2.1, spiceai/spiceai#13742). The stale line matters because the number is what a reader checks before pointing an existing DuckLake catalog at Spice — 1.5.3 and 1.4.4 are on opposite sides of a catalog-metadata migration.

This applies the wording #2187 settled on, which is also verbatim what the connector page in this snapshot already carries.

Scope: only `version-2.3.x`. 2.0.x (1.5.3), 2.1.x (1.5.3 → 1.5.5 mid-line) and 2.2.x (1.5.5 → 1.4.4 mid-line) are correct as written.

## Source PRs

- spiceai/spiceai#13742 — "Downgrade DuckDB to v1.4.4"
- spiceai/docs#2187 — the vNext + 2.1.x + 2.2.x half of this correction

## Test plan

- [x] Docusaurus build gate — `cd website && npm run build`:

```
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- [x] Versioned-docs propagation grep-count gate — `grep -rl 'DuckDB 1\.5\.3' website/versioned_docs/version-2.3.x/ | wc -l` vs the staged file count:

```
$ grep -rl 'DuckDB 1\.5\.3' website/versioned_docs/version-2.3.x/ | wc -l
0
$ git diff --cached --name-only -- website/ | wc -l
1
```

- [x] Cross-page audit — `grep -rn -E 'DuckDB \*?\*?1\.[0-9]+\.[0-9]+|DuckDB v1\.[0-9]+\.[0-9]+' website/docs website/versioned_docs` returns 10 lines; after this change every one names the version its release line actually embeds (vNext 1.4.4, 2.0.x 1.5.3, 2.1.x 1.5.3/1.5.5, 2.2.x 1.5.5/1.4.4, 2.3.x 1.4.4 on both pages).
- [x] Files updated: 1 — `versioned_docs/version-2.3.x/components/catalogs/ducklake.md`, matching the diff.

### Reproduction

Doc said (`website/versioned_docs/version-2.3.x/components/catalogs/ducklake.md:211` at docs `c0f47f88`):

> Spice uses DuckDB 1.5.3, which supports DuckLake 1.0.

Code says (`Cargo.toml` at `v2.3.0` — the comment on the dependency line is the authority, because spiceai's `duckdb-rs` fork encodes DuckDB's version into the crate version differently per branch):

```
$ git grep -n 'duckdb' v2.3.0 -- Cargo.toml
v2.3.0:Cargo.toml:284:duckdb = "1.4.4" # the crate version that matches DuckDB v1.4.4
v2.3.0:Cargo.toml:572:duckdb = { git = "https://github.com/spiceai/duckdb-rs.git", rev = "9d7be742..." } # branch: spiceai-1.4.4 (DuckDB v1.4.4, arrow 58; ...)
```

Behavior claim: none — this is a version-identifier claim, **Reproduced** by the quoted dependency line at the v2.3.0 tag ([Cargo.toml#L284](https://github.com/spiceai/spiceai/blob/v2.3.0/Cargo.toml#L284)).
