### PR TITLE
docs(caching): the pingora cache engine is Enterprise-only in v2.3.0 too

### DIFF
--- a/website/versioned_docs/version-2.3.x/features/caching/index.md
+++ b/website/versioned_docs/version-2.3.x/features/caching/index.md
@@ -51,13 +51,33 @@ Every cache type (`sql_results`, `search_results`, `embeddings`) supports the fo
 | `eviction_policy`   | Yes      | `lru`    | Cache replacement policy when the cache reaches `max_size`. Defaults to `lru`. Supports `lru` (Least Recently Used) and `tiny_lfu` (Tiny Least Frequently Used, higher hit rate for skewed access patterns). |
 | `item_ttl`          | Yes      | `1s`     | Cache entry expiration duration (Time to Live). Defaults to 1 second.                                                                                                                                        |
 | `hashing_algorithm` | Yes      | `xxh3`   | Selects which hashing algorithm is used to hash the cache keys when storing the results. Defaults to `xxh3`. Supports `xxh3`, `ahash`, `siphash`, `blake3`, `xxh32`, `xxh64`, or `xxh128`.                   |
-| `engine`            | Yes      | `moka`   | Cache backend: `moka` or `pingora`. See [Choosing an `engine`](#choosing-an-engine).                                                                                                                           |
+| `engine`            | Yes      | `moka`   | Cache backend: `moka`, or `pingora` on an [Enterprise](https://docs.spice.ai/docs/enterprise/getting-started/distributions) build. See [Choosing an `engine`](#choosing-an-engine).                            |
 
 ### Choosing an `engine`
 
 - **`moka` (default):** Supports TTL expiration and lazy table invalidation.
 - **`pingora`:** Uses a sharded LRU cache. Reads lock the key's shard; table invalidations that
-  evict entries scan the cache, with cost proportional to its size.
+  evict entries scan the cache, with cost proportional to its size. `pingora` does not implement
+  `eviction_policy: tiny_lfu`; selecting both warns
+  (`Pingora cache engine does not support TinyLFU caching policy. Falling back to LRU.`) and uses LRU.
+
+:::note[Enterprise edition]
+
+The `pingora` cache engine is available in the Spice [Enterprise edition](https://docs.spice.ai/docs/enterprise/getting-started/distributions). It is compiled behind a build feature that the published open source `spiced` binaries and images do not enable.
+
+`engine: pingora` is **not** rejected on a build without it: the value parses, the runtime logs
+
+```
+The Pingora cache engine is included in the Enterprise distribution of Spice.ai. Learn more at https://docs.spice.ai/docs/enterprise Falling back to the Moka cache engine.
+```
+
+and the cache runs on Moka instead. The engine each cache actually started on is named in its own startup line, so that is what to check rather than the configured value — the sizes and TTL in it are the ones configured for that cache:
+
+```
+Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+```
+
+:::
 
 With a non-zero [`stale_while_revalidate_ttl`](#serving-stale-after-an-acceleration-refresh), SQL
 result invalidations mark entries stale without eviction, so neither engine scans.


### PR DESCRIPTION
## Summary

The `version-2.3.x` snapshot was published on 2026-09-10 at 11:24 UTC; spiceai/docs#2188 merged at 15:07 the same day and edited `website/docs/` only. So the newest release's caching page still presents `engine: pingora` as an ordinary open source backend, and describes its sharded-LRU behaviour as what a reader who sets it will get.

On a published open source `spiced` they will not get it. `pingora` is absent from `bin/spiced`'s `default` feature list, the `CacheEngine` enum is **not** feature-gated (so the value parses and nothing fails), and the dispatch arm warns and builds a Moka backend instead. This is the edition-gating shape the hygiene reference calls out: a config enum declared in `spicepod` but implemented behind a cargo feature.

This applies #2188's text to the 2.3.x snapshot; the page is now byte-identical to trunk's vNext copy.

Scope: only `version-2.3.x`. `features/caching/index.md` in 2.0.x, 2.1.x and 2.2.x does not mention `engine`/`pingora` at all.

## Source PRs

- spiceai/docs#2188 — the vNext half of this correction

## Test plan

- [x] Docusaurus build gate — `cd website && npm run build`:

```
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- [x] Versioned-docs propagation — `diff -u website/versioned_docs/version-2.3.x/features/caching/index.md website/docs/features/caching/index.md` now prints nothing: the snapshot matches vNext exactly.
- [x] Cross-page sweep — `grep -rln 'pingora' website/docs website/versioned_docs` returns only the two caching pages plus the `acknowledgements/index.md` dependency lists; no other page carries the claim.
- [x] Files updated: 1 — `versioned_docs/version-2.3.x/features/caching/index.md`, matching the diff.

### Reproduction

Doc said (`website/versioned_docs/version-2.3.x/features/caching/index.md:54` at docs `c0f47f88`):

> `engine` … Cache backend: `moka` or `pingora`.

Code says — `pingora` is not in the default feature set at v2.3.0:

```
$ git show v2.3.0:bin/spiced/Cargo.toml | sed -n '/^default = \[/,/^\]/p' | grep -c pingora
0
```

and the non-`pingora` build arm falls back (`crates/cache/src/lru_cache.rs` at [v2.3.0](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/cache/src/lru_cache.rs#L373-L381)):

```rust
#[cfg(not(feature = "pingora"))]
{
    tracing::warn!(
        "{PINGORA_ENTERPRISE_ONLY_MESSAGE} Falling back to the Moka cache engine."
    );
    let cache = build_moka_cache(cache_max_size, ttl, hasher.clone(), caching_policy);
    CacheBackendEnum::MokaFallback(MokaBackend::from_cache(cache))
}
```

Every string the page quotes is grepped from v2.3.0 source, not paraphrased:

```
$ git grep -n 'PINGORA_ENTERPRISE_ONLY_MESSAGE\|TinyLFU caching policy' v2.3.0 -- crates/cache/src/lru_cache.rs
v2.3.0:crates/cache/src/lru_cache.rs:53:pub const PINGORA_ENTERPRISE_ONLY_MESSAGE: &str = "The Pingora cache engine is included in the Enterprise distribution of Spice.ai. Learn more at https://docs.spice.ai/docs/enterprise";
v2.3.0:crates/cache/src/lru_cache.rs:364:  "Pingora cache engine does not support TinyLFU caching policy. Falling back to LRU."
```

The startup line the page tells readers to check is the `Display` impl at `lru_cache.rs:208` (`"max size: {:.2}, item ttl: {:?}, engine: {}"`) interpolated into `tracing::info!("Initialized sql results cache; {cache_provider}")` at `crates/runtime/src/init/caching.rs:54`, and `CacheBackendEnum::MokaFallback(_) => CacheEngine::Moka` at `lru_cache.rs:177` is why it reads `Moka` rather than the configured value.

Behavior claim: **not run — reproducing the fallback warning needs a `spiced` built at the v2.3.0 tag with the default feature set.** The correction rests on the feature-list grep and the `#[cfg(not(feature = "pingora"))]` arm quoted above, so it is labeled **Unverified, code inspection only** for the runtime behaviour and **Reproduced** for the edition-gating claim itself.
