### PR TITLE
docs(cli): v2.3.0 spice version always names the runtime path

### DIFF
--- a/website/versioned_docs/version-2.3.x/cli/reference/run.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/run.md
@@ -19,8 +19,13 @@ Run Spice - starts the Spice runtime, installing if necessary.
 4. Under `sudo`, the invoking user's `~/.spice/bin/spiced`.
 
 `PATH` is not searched. An invalid `$SPICED_PATH` causes an error; otherwise, `spice run` installs
-the runtime if none is found. For a runtime outside the managed install, the CLI reports
-its path and source. [`spice version`](./version) also reports these values.
+the runtime if none is found.
+
+Before launching, `spice run` logs the runtime it resolved and the rung it came from
+(`Using the Spice.ai runtime at '<path>' (<source>).`). It is logged at `info` only when the
+runtime is *not* the one [`spice install`](./install) manages — the case worth noticing — and at
+`debug` otherwise, so an ordinary managed install does not add a line to every run.
+[`spice version`](./version) reports the same path and source unconditionally.
 
 ### Usage
 

--- a/website/versioned_docs/version-2.3.x/cli/reference/version.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/version.md
@@ -43,7 +43,19 @@ CLI version:     v1.1.0
 Runtime version: v1.1.0+models
  ```
 
-For a runtime outside the managed install, the output also includes its path and source:
+**Runtime path and source**: whenever a runtime is found, the output names it and the
+[selection rung](./run#runtime-selection) it came from — including the ordinary managed install:
+
+```shell
+> spice version
+
+CLI version:     v1.1.0
+Runtime version: v1.1.0+models
+Runtime path:    /Users/me/.spice/bin/spiced (installed by spice install)
+```
+
+The parenthetical is one of `pinned by SPICED_PATH`, `beside the spice CLI`, `installed by spice install`,
+or `installed by spice install, by the sudo invoker`:
 
 ```shell
 > spice version
@@ -53,4 +65,9 @@ Runtime version: v1.1.0+models
 Runtime path:    /usr/local/bin/spiced (beside the spice CLI)
 ```
 
-JSON output includes `runtime_path` and `runtime_source`, following the same [runtime selection rules](./run#runtime-selection).
+The line is omitted only when no runtime resolves (`Runtime version: not installed`) or with
+`--cli-only`, which skips the runtime lookup entirely. A runtime that was found but could not be
+asked for its version reports `Runtime version: unavailable — the runtime at the path below did not
+report a version` and still names the path.
+
+JSON output includes `runtime_path` and `runtime_source`, following the same [runtime selection rules](./run#runtime-selection). `runtime_source` carries the enum value rather than the prose above, and both are `null` when no runtime resolves.


### PR DESCRIPTION
## Summary

`version-2.3.x` was cut on 2026-09-10 at 11:24 UTC; spiceai/docs#2190 merged at 15:07 the same day and edited `website/docs/` only. So the newest release's CLI reference still says the `Runtime path` line appears only *"for a runtime outside the managed install"*.

At v2.3.0 `spice version` prints it whenever a runtime resolves, with **no** test on the source — a reader on an ordinary `spice install` who sees the line has no reason to think anything unusual has happened, and a reader who doesn't see it has been told the wrong reason why. The conditional in the sentence is real, but it belongs to `spice run`, where it is a **log level** (`info` vs `debug`), not presence.

This applies #2190's text to the 2.3.x snapshot; both pages are now byte-identical to trunk's vNext copies. Every sentence in the swept text was re-verified against v2.3.0 rather than assumed to carry over — the four source strings, the `--cli-only` branch, the unprobeable-runtime wording and the JSON shape are quoted below.

Scope: only `version-2.3.x` — `grep -rn "For a runtime outside the managed install" website/` now returns nothing anywhere, and no older snapshot ever carried the sentence (it arrived with spiceai/docs#2186).

## Source PRs

- spiceai/docs#2190 — the vNext half of this correction

## Test plan

- [x] Docusaurus build gate — `cd website && npm run build`:

```
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- [x] Versioned-docs propagation — `diff -q website/versioned_docs/version-2.3.x/cli/reference/{run,version}.md website/docs/cli/reference/{run,version}.md` reports both pairs identical, and `grep -rn "For a runtime outside the managed install" website/` returns nothing.
- [x] Link check — the added `[spice install](./install)` target exists (`ls website/versioned_docs/version-2.3.x/cli/reference/install.md`), and the `./run#runtime-selection` anchor resolves to the `### Runtime selection` heading in the same snapshot's `run.md`; the full build above is the authoritative gate on both.
- [x] Files updated: 2 — `versioned_docs/version-2.3.x/cli/reference/version.md` and `.../run.md`, matching the diff.

### Reproduction

Doc said (`website/versioned_docs/version-2.3.x/cli/reference/version.md:46` at docs `c0f47f88`):

> For a runtime outside the managed install, the output also includes its path and source:

Code says (`bin/spice/src/commands/version.rs` at [v2.3.0](https://github.com/spiceai/spiceai/blob/v2.3.0/bin/spice/src/commands/version.rs#L199-L216)) — the only guards are `--cli-only` and "a runtime resolved at all":

```rust
OutputFormat::Table => {
    if !args.cli_only {
        println!("Runtime version: {}", describe_runtime_version(runtime.as_ref()));
        if let Some(resolved) = &resolved {
            println!("Runtime path:    {} ({})", resolved.path().display(), resolved.source.describe());
        }
    }
}
```

The conditional the sentence describes is in `spice run`, and it is a level, not presence (`bin/spice/src/runtime_launcher.rs:126-132` at [v2.3.0](https://github.com/spiceai/spiceai/blob/v2.3.0/bin/spice/src/runtime_launcher.rs#L126-L132)):

```
v2.3.0:bin/spice/src/runtime_launcher.rs:130:  tracing::debug!("Using the Spice.ai runtime at '{path}' ({source}).");
v2.3.0:bin/spice/src/runtime_launcher.rs:132:  tracing::info!("Using the Spice.ai runtime at '{path}' ({source}).");
```

Each remaining string in the replacement text is grepped from v2.3.0, not paraphrased:

```
$ git grep -n 'pinned by SPICED_PATH\|beside the spice CLI\|installed by spice install\|by the sudo invoker' v2.3.0 -- bin/spice/src/context.rs
v2.3.0:bin/spice/src/context.rs:999:   Self::Pinned => "pinned by SPICED_PATH",
v2.3.0:bin/spice/src/context.rs:1000:  Self::Sibling => "beside the spice CLI",
v2.3.0:bin/spice/src/context.rs:1001:  Self::ManagedInstall => "installed by spice install",
v2.3.0:bin/spice/src/context.rs:1002:  Self::SudoInvokerInstall => "installed by spice install, by the sudo invoker",
```

`version.rs:247` gives `None => "not installed"` and `:250` the `"unavailable — the runtime at the path below did not report a version"` wording; the JSON arm at `:218-229` maps `runtime_path`/`runtime_source` through `resolved.as_ref().map(...)` — hence `null` when nothing resolves — and serialises `found.source`, the enum, rather than `describe()`.

Behavior claim: **not run — reproducing the printed output needs a `spice` CLI built at the v2.3.0 tag.** The correction is an existence claim about a guard (`if let Some(resolved)` with no source test) plus four string literals, settled by the quoted lines, so it is labeled **Reproduced** on that basis.
