### PR TITLE
docs: quote shell placeholders in the version-2.3.x snapshot too

### DIFF
--- a/website/versioned_docs/version-2.3.x/cli/reference/chat.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/chat.md
@@ -52,13 +52,13 @@ Time: 0.57s (first token 0.53s). Tokens: 18. Prompt: 8. Completion: 10 (325.04/s
 
 ```shell
 # Chat with Spice Cloud
-spice chat --cloud --api-key <your-api-key> --model <model>
+spice chat --cloud --api-key "<your-api-key>" --model "<model>"
 
 # Chat with a remote spiced instance over HTTP
-spice chat --endpoint http://my-remote-host:8090 --model <model>
+spice chat --endpoint http://my-remote-host:8090 --model "<model>"
 
 # Chat with a remote spiced instance over Arrow Flight SQL (gRPC)
-spice chat --endpoint grpc://my-remote-host:50051 --model <model>
+spice chat --endpoint grpc://my-remote-host:50051 --model "<model>"
 ```
 
 When multiple models are **ready**, the command prompts for a selection before starting the REPL:

--- a/website/versioned_docs/version-2.3.x/cli/reference/cloud.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/cloud.md
@@ -102,7 +102,7 @@ Lists the organizations this identity can act on, marking the active one and whi
 ### `org`
 
 ```shell
-spice cloud org use <ORG>
+spice cloud org use "<ORG>"
 spice cloud org current
 spice cloud org clear
 ```
@@ -121,7 +121,7 @@ An enrolled directory holds an instance identity in `.spice/identity.json`, and 
 
 ```shell
 spice cloud link
-spice cloud link <org>/<project>
+spice cloud link "<org>/<project>"
 ```
 
 Enrolls the current directory as a Spice Cloud instance and attaches it to a project. Omit the argument to choose from the projects available to you.
@@ -196,8 +196,8 @@ spice cloud project delete <org>/<project> [--yes]
 `--kind` decides which kind of project is created. Either way, the command prints the new project's primary API key.
 
 ```shell
-spice cloud project create <NAME>                              # Cloud Connect project
-spice cloud project create <NAME> --kind set --region <REGION> # Spice-managed project
+spice cloud project create "<NAME>"                              # Cloud Connect project
+spice cloud project create "<NAME>" --kind set --region "<REGION>" # Spice-managed project
 ```
 
 - **Omit `--kind`** for a **Cloud Connect** project — one Spice Cloud does not run, served by your own runtime. This is the project [`spice cloud link`](#link) attaches an instance to.
@@ -354,9 +354,9 @@ Shows a project's API keys. `--regenerate <1|2>` reissues one of the two keys. T
 
 ```shell
 spice cloud secrets list
-spice cloud secrets set <NAME> <VALUE>
-spice cloud secrets get <NAME>
-spice cloud secrets delete <NAME>
+spice cloud secrets set "<NAME>" "<VALUE>"
+spice cloud secrets get "<NAME>"
+spice cloud secrets delete "<NAME>"
 ```
 
 Manages a project's secrets. Every subcommand takes `--project <ORG/PROJECT>` and `-o`. `list` has the alias `ls`.

--- a/website/versioned_docs/version-2.3.x/cli/reference/connect.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/connect.md
@@ -14,7 +14,7 @@ Adds a Spicepod dependency to the current project, and prints a deprecation warn
 ### Usage
 
 ```shell
-spice connect <org>/<pod>
+spice connect "<org>/<pod>"
 ```
 
 ### Example

--- a/website/versioned_docs/version-2.3.x/cli/reference/login.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/login.md
@@ -48,7 +48,7 @@ spice login
 ### Additional Example
 
 ```shell
-spice login --key <API_KEY>
+spice login --key "<API_KEY>"
 ```
 
 ### Browser Login Flow
@@ -94,7 +94,7 @@ spice cloud login subscription --device
 Authenticate with a Spice Cloud access token. Alias: `pat`.
 
 ```shell
-spice cloud login token --token <TOKEN>
+spice cloud login token --token "<TOKEN>"
 ```
 
 Omit `--token` to enter the token at a secure prompt. Generate one at `/account/tokens` in the Spice Cloud portal.
@@ -102,7 +102,7 @@ Omit `--token` to enter the token at a secure prompt. Generate one at `/account/
 The token can also be provided via the `SPICE_CLOUD_PAT` environment variable:
 
 ```shell
-export SPICE_CLOUD_PAT=<TOKEN>
+export SPICE_CLOUD_PAT="<TOKEN>"
 spice cloud login token
 ```
 
@@ -111,14 +111,14 @@ spice cloud login token
 Authenticate using OAuth2 client credentials for CI/automation workflows.
 
 ```shell
-spice cloud login api --client-id <CLIENT_ID> --client-secret <CLIENT_SECRET>
+spice cloud login api --client-id "<CLIENT_ID>" --client-secret "<CLIENT_SECRET>"
 ```
 
 Credentials can also be provided via environment variables:
 
 ```shell
-export SPICE_CLOUD_CLIENT_ID=<CLIENT_ID>
-export SPICE_CLOUD_CLIENT_SECRET=<CLIENT_SECRET>
+export SPICE_CLOUD_CLIENT_ID="<CLIENT_ID>"
+export SPICE_CLOUD_CLIENT_SECRET="<CLIENT_SECRET>"
 spice cloud login api
 ```
 

--- a/website/versioned_docs/version-2.3.x/cli/reference/nsql.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/nsql.md
@@ -59,7 +59,7 @@ The `spice nsql analyze` subcommand evaluates Text-to-SQL quality by comparing a
 ### Usage
 
 ```shell
-spice nsql analyze --query <natural-language-query> --expected <expected-sql> --model <model>
+spice nsql analyze --query "<natural-language-query>" --expected "<expected-sql>" --model "<model>"
 ```
 
 ### Flags

--- a/website/versioned_docs/version-2.3.x/cli/reference/sql.md
+++ b/website/versioned_docs/version-2.3.x/cli/reference/sql.md
@@ -88,7 +88,7 @@ gas_used               | 12500000
 
 ```shell
 # Connect to Spice Cloud
-spice sql --cloud --api-key <your-api-key>
+spice sql --cloud --api-key "<your-api-key>"
 
 # Connect to a remote spiced instance over HTTP
 spice sql --endpoint http://my-remote-host:8090

--- a/website/versioned_docs/version-2.3.x/components/data-connectors/snowflake.md
+++ b/website/versioned_docs/version-2.3.x/components/data-connectors/snowflake.md
@@ -68,21 +68,21 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PASSWORD=<password> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PASSWORD="<password>" \
     spice run
     # Key-pair using private key file (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH=<path-to-private-key> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PATH="<path-to-private-key>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
-    SPICE_SNOWFLAKE_ACCOUNT=<account-identifier> \
-    SPICE_SNOWFLAKE_USERNAME=<username> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY=<private-key-pem-content> \
-    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=<private-key-passphrase> \
+    SPICE_SNOWFLAKE_ACCOUNT="<account-identifier>" \
+    SPICE_SNOWFLAKE_USERNAME="<username>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY="<private-key-pem-content>" \
+    SPICE_SNOWFLAKE_PRIVATE_KEY_PASSPHRASE="<private-key-passphrase>" \
     spice run
     ```
 
@@ -90,9 +90,9 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
 
     ```bash
     # Password-based
-    spice login snowflake -a <account-identifier> -u <username> -p <password>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -p "<password>"
     # Key-pair (the `<private-key-passphrase>` is an optional parameter and is used for encrypted private key only)
-    spice login snowflake -a <account-identifier> -u <username> -k <path-to-private-key> -s <private-key-passphrase>
+    spice login snowflake -a "<account-identifier>" -u "<username>" -k "<path-to-private-key>" -s "<private-key-passphrase>"
     ```
 
     The CLI will create or update an `.env` file that looks like:
@@ -183,7 +183,7 @@ The connector supports password-based and [key-pair](https://docs.snowflake.com/
     # Password-based
     security add-generic-password -l "Snowflake Secret" \
     -a spiced -s spice_snowflake_password\
-    -w <password>
+    -w "<password>"
 
     # Key-pair using private key content (the `<private-key-passphrase>` is optional, used for encrypted keys only)
     security add-generic-password -l "Snowflake Secret" \

--- a/website/versioned_docs/version-2.3.x/components/data-connectors/spark.md
+++ b/website/versioned_docs/version-2.3.x/components/data-connectors/spark.md
@@ -37,15 +37,15 @@ Check [Secrets Stores](../secret-stores/) for more details.
 <Tabs>
   <TabItem value="env" label="Env">
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote> \
+    SPICE_SPARK_REMOTE="<spark-remote>" \
     spice run
     # Or using the CLI to configure the secrets into an `.env` file
-    spice login spark --spark_remote <spark-remote>
+    spice login spark --spark_remote "<spark-remote>"
     ```
 
     `.env`
     ```bash
-    SPICE_SPARK_REMOTE=<spark-remote>
+    SPICE_SPARK_REMOTE="<spark-remote>"
     ```
 
     `spicepod.yaml`
@@ -100,7 +100,7 @@ Check [Secrets Stores](../secret-stores/) for more details.
     ```bash
     security add-generic-password -l "Spark Remote" \
     -a spiced -s spice_spark_remote \
-    -w <spark-remote>
+    -w "<spark-remote>"
     ```
 
     `spicepod.yaml`

--- a/website/versioned_docs/version-2.3.x/components/secret-stores/azure-keyvault/index.md
+++ b/website/versioned_docs/version-2.3.x/components/secret-stores/azure-keyvault/index.md
@@ -84,10 +84,10 @@ The principal used by Spice must have read access to secrets in the target Key V
 
 ```bash
 az role assignment create \
-  --assignee-object-id <PRINCIPAL_OBJECT_ID> \
+  --assignee-object-id "<PRINCIPAL_OBJECT_ID>" \
   --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
-  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>
+  --scope "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.KeyVault/vaults/<vault>"
 ```
 
 The store performs a `list_secret_properties` call on startup to validate connectivity and fail fast on misconfiguration. A `403 Forbidden` on list is tolerated, so principals scoped only to per-secret `Microsoft.KeyVault/vaults/secrets/getSecret/action` (for example, **Key Vault Reader** combined with a custom role) are supported.

--- a/website/versioned_docs/version-2.3.x/deployment/azure/index.md
+++ b/website/versioned_docs/version-2.3.x/deployment/azure/index.md
@@ -80,7 +80,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 
 # 3. Federate the identity with the Kubernetes ServiceAccount
 ISSUER=$(az aks show -g $RG -n $CLUSTER --query oidcIssuerProfile.issuerUrl -o tsv)
@@ -189,7 +189,7 @@ PRINCIPAL_ID=$(az identity show -g $RG -n spiceai-identity --query principalId -
 az role assignment create \
   --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal \
   --role "Storage Blob Data Reader" \
-  --scope /subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>
+  --scope "/subscriptions/<sub>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/<acct>"
 ```
 
 #### 3. Deploy Spice.ai

--- a/website/versioned_docs/version-2.3.x/deployment/kubernetes/argocd/index.md
+++ b/website/versioned_docs/version-2.3.x/deployment/kubernetes/argocd/index.md
@@ -195,7 +195,7 @@ Roll back to a previous revision using the Argo CD CLI or UI:
 
 ```bash
 argocd app history spiceai
-argocd app rollback spiceai <history-id>
+argocd app rollback spiceai "<history-id>"
 ```
 
 When the `Application` is managed by Git, prefer reverting the commit that introduced the change so the desired state in Git matches the live state. With `selfHeal: true` enabled, Argo CD will otherwise re-apply the Git state.

--- a/website/versioned_docs/version-2.3.x/deployment/kubernetes/flux/index.md
+++ b/website/versioned_docs/version-2.3.x/deployment/kubernetes/flux/index.md
@@ -233,7 +233,7 @@ Flux records each Helm release revision. List history and roll back with the Hel
 
 ```bash
 helm history spiceai -n spiceai
-helm rollback spiceai <revision> -n spiceai
+helm rollback spiceai "<revision>" -n spiceai
 ```
 
 For automatic rollback on failed upgrades, configure `spec.upgrade.remediation` on the `HelmRelease`:

--- a/website/versioned_docs/version-2.3.x/deployment/kubernetes/local-nvme/index.md
+++ b/website/versioned_docs/version-2.3.x/deployment/kubernetes/local-nvme/index.md
@@ -56,8 +56,8 @@ Give those nodes a label so Spice — and only Spice — schedules onto them. Th
 #   gcloud container node-pools create: --node-labels=local-nvme=true (GKE also sets cloud.google.com/gke-local-nvme-ssd=true)
 #   az aks nodepool add: --labels local-nvme=true
 # On an existing node:
-kubectl label node <node-name> local-nvme=true
-kubectl taint node <node-name> local-nvme=true:NoSchedule   # optional
+kubectl label node "<node-name>" local-nvme=true
+kubectl taint node "<node-name>" local-nvme=true:NoSchedule   # optional
 ```
 
 ## Step 2 — Format and mount the NVMe on each node

--- a/website/versioned_docs/version-2.3.x/features/large-language-models/mcp.md
+++ b/website/versioned_docs/version-2.3.x/features/large-language-models/mcp.md
@@ -250,7 +250,7 @@ See the [mcp-server cookbook](https://github.com/spiceai/cookbook/tree/trunk/mcp
 A failing MCP server does not stop the runtime. Spice logs a warning, retries the connection in the background, and reports healthy — the tool is simply absent from `tools/list`. Verify the runtime log at startup:
 
 ```bash
-grep "Unable to load tool" <log>
+grep "Unable to load tool" "<log>"
 ```
 
 A server that starts but authenticates with empty or invalid credentials is harder to spot: it registers zero tools without producing that warning. Check for `runtime_secrets` errors, which indicate a `${secrets:...}` reference that did not resolve.

--- a/website/versioned_docs/version-2.3.x/monitoring/spice-cloud/index.md
+++ b/website/versioned_docs/version-2.3.x/monitoring/spice-cloud/index.md
@@ -75,7 +75,7 @@ The output includes the app's primary API key. Treat the key as a secret — any
 For an existing app, retrieve the current key with:
 
 ```bash
-spice cloud api-keys --project <org>/<app>
+spice cloud api-keys --project "<org>/<app>"
 ```
 
 ## Configuration
@@ -179,7 +179,7 @@ After restarting the runtime, confirm the connection is established:
 3. **Wait 5–10 seconds**, then query the target Spice Cloud app's task history. From any client logged in to Spice Cloud:
 
    ```bash
-   spice sql --cloud <org>/<app>
+   spice sql --cloud "<org>/<app>"
    ```
 
    ```sql

--- a/website/versioned_docs/version-2.3.x/troubleshooting/index.md
+++ b/website/versioned_docs/version-2.3.x/troubleshooting/index.md
@@ -347,10 +347,10 @@ The REPL needs no shell, because `spiced` is itself the binary being executed.
 
 ```console
 # Docker
-docker exec -it <container_id> spiced --repl
+docker exec -it "<container_id>" spiced --repl
 
 # Kubernetes
-kubectl exec -it <pod_name> -- spiced --repl
+kubectl exec -it "<pod_name>" -- spiced --repl
 ```
 
 Because `spiced --repl` runs inside the container, it connects to that container's own `http://localhost:50051` Flight endpoint — attaching to the runtime already serving there. The interactive SQL prompt that follows is therefore executing queries **inside the deployment**, not locally.
@@ -375,10 +375,10 @@ This is the recommended way to debug Spice on Kubernetes.
 
 ```bash
 # List pods in the namespace
-kubectl get pods -n <namespace>
+kubectl get pods -n "<namespace>"
 
 # List the container names inside the pod
-kubectl get pod <pod_name> -n <namespace> -o jsonpath='{.spec.containers[*].name}'
+kubectl get pod "<pod_name>" -n "<namespace>" -o jsonpath='{.spec.containers[*].name}'
 ```
 
 The Helm chart names the Spice container `spiceai`. Run the second command rather than assuming, since a custom manifest may name it something else.
@@ -471,7 +471,7 @@ docker volume create busybox
 docker run --rm -v busybox:/data busybox:stable-musl sh -c "mkdir -p /data && cp /bin/busybox /data/busybox"
 
 # Run the Spice.ai container with the busybox binary mounted, ensure that any other volumes are mounted as well (i.e. for spicepod)
-docker run -v busybox:/busy -v <path_to_spicepod>:/app/spicepod -d --name spiceai-debug spiceai/spiceai:latest
+docker run -v busybox:/busy -v "<path_to_spicepod>:/app/spicepod" -d --name spiceai-debug spiceai/spiceai:latest
 
 # Exec into the container — the shell that follows runs INSIDE the Spice container
 docker exec -it spiceai-debug /busy/busybox sh


### PR DESCRIPTION
## Summary

spiceai/docs#2197 (fixes spiceai/docs#2196) quoted the `<placeholder>` tokens in shell examples so a reader can paste a block and get a runnable command rather than a redirection. It merged on 2026-09-10 at 15:08 UTC and swept every doc set that existed when its branch was cut — but `version-2.3.x` was published at 11:24 that morning, so the newest release's docs kept the unquoted form. **53 lines across 16 pages.**

The failure is not cosmetic. `<NAME>` is shell syntax: bash reads it as a redirection, so the command either dies with a `syntax error` that names nothing the reader recognises, or — the worse shape — **runs a different command, creates a file, and exits 0**.

This copies the already-reviewed vNext text onto the 16 counterparts. Every pair differs in these lines and nothing else (verified below), so the snapshot pages are now byte-identical to their vNext copies.

Scope: only `version-2.3.x` — every other doc set was swept by #2197.

## Source PRs

- spiceai/docs#2197 — the sweep this completes (fixes spiceai/docs#2196)

## Test plan

- [x] Docusaurus build gate — `cd website && npm run build`:

```
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

- [x] Versioned-docs propagation — replaying #2197's removed lines against the snapshot leaves `stale unquoted lines remaining in version-2.3.x: 1`, and that one hit is `` `spice connect <org>/<pod>` `` in *prose* at `connect.md:9`, not in a shell fence — vNext leaves it unquoted for the same reason.
- [x] Scope check — per-file `diff | grep -c '^[<>]'` over the 16 pairs sums to 106 = 2 × 53, i.e. the quoting lines are the *only* difference between each snapshot page and its vNext copy; nothing else is being dragged across.
- [x] Files updated: 16 — matching the diff (53 insertions, 53 deletions).

### Reproduction

Doc said (e.g. `website/versioned_docs/version-2.3.x/cli/reference/login.md:51` at docs `c0f47f88`, inside a ```shell fence):

```shell
spice login --key <API_KEY>
```

Code says — here the authority is the shell, not spiceai source: `<` and `>` are redirection operators, so the documented line is parsed as redirection. Run against a stub `spice` on `PATH` that only echoes its arguments, so the outcome is attributable to the shell and not to the CLI:

```
$ bash -c 'spice connect <org>/<pod>'
bash: -c: line 0: syntax error near unexpected token `newline'
bash: -c: line 0: `spice connect <org>/<pod>'
exit=2

$ bash -c 'spice connect "<org>/<pod>"'
spice invoked with: connect <org>/<pod>
exit=0
```

and the silent shape, from `cli/reference/cloud.md` — nothing is printed, `spice` runs with the wrong arguments, a file named `--kind` is created in the reader's working directory, and the exit status is 0:

```
$ ls -A
API_KEY  NAME
$ bash -c 'spice cloud project create <NAME> --kind set --region "<REGION>"'
exit=0
$ ls -A
--kind  API_KEY  NAME
$ cat -- --kind
spice invoked with: cloud project create set --region <REGION>
```

Behavior claim: **Reproduced** — the runs above are the artifact: the documented (unquoted) form fails or silently misfires, and the corrected (quoted) form invokes the command as written. They exercise the shell's parsing of the documented line, which is the whole of the defect; the stub stands in for `spice` precisely so the result cannot be attributed to the CLI.
