### PR TITLE
docs(acceleration): a subquery predicate does not take part in the on_zero_results decision

### DIFF
--- a/website/docs/features/data-acceleration/data-refresh.md
+++ b/website/docs/features/data-acceleration/data-refresh.md
@@ -373,6 +373,7 @@ In this example a query against `accelerated_dataset` within Spice like `SELECT 
 :::warning
 
 - It is possible that even though an accelerated table returns some results, it may not contain all the data that would be returned by the federated table. `on_zero_results` only controls the behavior in the simple case where no data is returned by the acceleration for a given query.
+- **A subquery predicate does not take part in the zero-results decision.** The fallback check runs at the accelerator's scan, below the join that a subquery is rewritten into, so a filter containing `IN (SELECT …)`, `EXISTS (…)`, `ANY`/`ALL`, a correlated column reference, or `UNNEST` is left above the scan and the decision is made without it. When the acceleration is a subset of the source and holds any rows at all, the unfiltered scan is non-empty, fallback does not fire, and a query whose only filter is such a subquery can return an empty result even though the source has a matching row. Adding a filter the scan can evaluate itself (for example `WHERE id = 2 AND id IN (SELECT …)`) restores the fallback.
 
 :::
 

--- a/website/docs/reference/spicepod/datasets.md
+++ b/website/docs/reference/spicepod/datasets.md
@@ -939,6 +939,8 @@ The following values are supported:
 - `return_empty` - Default. Return an empty result set when the accelerated query returns no rows.
 - `use_source` - Fall back to querying the original data source when the accelerated query returns no rows.
 
+The fallback check runs at the accelerator's scan, so a subquery predicate (`IN (SELECT …)`, `EXISTS (…)`, `ANY`/`ALL`, a correlated column reference, or `UNNEST`) does not take part in the zero-results decision. See [Behavior on Zero Results](../../features/data-acceleration/data-refresh#behavior-on-zero-results) for what that means for a partially-populated acceleration.
+
 ```yaml
 datasets:
   - from: spice.ai/eth.recent_blocks


### PR DESCRIPTION
## Summary

`on_zero_results: use_source` decides whether to fall back to the source at the
accelerator's **scan**. A subquery is rewritten into a join *above* that scan, so a
predicate containing one never reaches the fallback check — and on a partially-populated
acceleration the unfiltered scan is non-empty, so fallback does not fire and the query
returns empty even though the source has a matching row.

Nothing on either page said this. The `Behavior on Zero Results` warning covered only the
adjacent case ("returns some results, but not all of them"); this one returns *zero* rows
and still does not fall back.

spiceai/spiceai#14022 is what made this observable: before it, the same queries failed
outright at physical planning (`Physical plan does not support logical expression …`).
The fix makes them plan and run; the residual limit is what this documents.

## Source PRs

- spiceai/spiceai#14022 — Fix subqueries with use_source acceleration (closes spiceai/spiceai#14010)

## Pages changed

- `website/docs/features/data-acceleration/data-refresh.md` — new bullet in the `Behavior on Zero Results` warning
- `website/docs/reference/spicepod/datasets.md` — one-line caveat under `acceleration.on_zero_results`, linking to the above

vNext only: `git tag --contains 48f47f6b9d` on `spiceai/spiceai` returns no tags, so the
change is in no release and no `versioned_docs/version-*/` snapshot describes it. In
v2.3.0 and earlier these queries error rather than silently returning empty, so stamping
this text into a snapshot would be wrong.

## Verification

Runtime read at `spiceai/spiceai` `origin/trunk` = `ecd92a5122` (2026-09-11 15:54:34 +0000).

The declining arm — `crates/runtime-table/src/accelerated/mod.rs:2061-2069`:

```rust
ZeroResultsAction::UseSource => {
    // ... Consequence: such a predicate is absent from the fallback check, so
    // the zero-results decision is made without it.
    Ok(filters
        .iter()
        .map(|filter| {
            if util::expr::cannot_be_evaluated_at_scan(filter) {
                TableProviderFilterPushDown::Unsupported
            } else {
                TableProviderFilterPushDown::Inexact
            }
        })
        .collect())
}
```

The variant set the doc enumerates — `crates/util/src/expr.rs:170-185`:

```rust
pub fn cannot_be_evaluated_at_scan(expr: &Expr) -> bool {
    expr.exists(|e| {
        Ok(match e {
            Expr::Exists(_)
            | Expr::InSubquery(_)
            | Expr::ScalarSubquery(_)
            | Expr::SetComparison(_)
            | Expr::OuterReferenceColumn(_, _)
            | Expr::Unnest(_) => true,
```

The behavior claim is pinned by a test on trunk rather than by a run of mine —
`crates/runtime/tests/acceleration/on_zero_results_subqueries.rs:143-163`, which asserts
the empty result for the two subquery-only shapes under `Contents::Partial` and asserts the
*non*-empty control right beside it:

```rust
const SUBQUERY_ONLY_PARTIAL_QUERIES: Cases = &[
    ("SELECT id FROM items WHERE id IN (SELECT item_id FROM details WHERE val = 5)", &[]),
    ("SELECT id FROM items WHERE EXISTS (SELECT 1 FROM details WHERE item_id = id AND val = 5)", &[]),
];

const PARTIAL_FALLBACK_CONTROLS: Cases = &[
    ("SELECT id FROM items WHERE id = 2", &[2]),
    ("SELECT id FROM items WHERE id = 2 AND id IN (SELECT item_id FROM details WHERE val = 5)", &[2]),
];
```

That control pair is the source of the doc's last sentence (adding a scan-evaluable filter
restores the fallback). **I did not run `spiced` myself** — the artifact here is the
committed test plus the quoted arms, so the end-to-end behavior claim is *unverified by my
own run*; the test was measured on DuckDB and SQLite by the source PR's author.

Propagation grep (a vNext-only addition, so exactly one file is expected to carry it):

```
$ grep -rln "subquery predicate does not take part" website/ | sort
website/docs/features/data-acceleration/data-refresh.md
```

Build gate:

```
$ cd website && NODE_OPTIONS=--max-old-space-size=8192 npm run build
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

## Test plan

- [x] `cd website && npm run build` passes — tail pasted above (`onBrokenLinks: 'throw'`; the new `../../features/data-acceleration/data-refresh#behavior-on-zero-results` link and its anchor both resolve; the anchor is `## Behavior on Zero Results` at `data-refresh.md:338`)
- [x] Versioned-docs propagation checked — vNext-only addition, grep output above shows 1 file
- [x] Files updated: 2 (matches `git diff --name-only origin/trunk..HEAD -- website/`)
