### PR TITLE
docs(troubleshooting): explain the S3 read retry warning and where its full diagnostic goes

### DIFF
--- a/website/docs/troubleshooting/index.md
+++ b/website/docs/troubleshooting/index.md
@@ -41,6 +41,24 @@ Review the `task_history` table for detailed error messages:
 SELECT task, error_message FROM runtime.task_history WHERE error_message IS NOT NULL ORDER BY start_time DESC LIMIT 5;
 ```
 
+### `opendal::layers::retry` warnings on S3 reads
+
+An S3 read whose connection closes before the response completes is retried, and each retry logs one warning at the default verbosity:
+
+```console
+2026-09-10T19:16:30.158989Z  WARN opendal::layers::retry: Reading file 'https://my-bucket.s3.us-east-1.amazonaws.com/warehouse/metadata/1-m0.avro' (S3) was interrupted, so Spice will retry in 1s (attempt 1). Cause: The connection closed before the response completed. If this continues, check network access to S3 and any proxy timeouts. See: https://spiceai.org/docs/troubleshooting
+```
+
+The line names the object, the scheduled backoff, and which attempt this is — so an isolated warning followed by no further attempts for that object means the retry succeeded. A rising `attempt` count, or the same object retrying repeatedly, points at the network path rather than at the data: check egress and VPC endpoint reachability to S3, and any proxy or load balancer idle timeout between the runtime and the bucket. Credentials, query strings, and fragments are stripped from the logged URL, so a presigned URL's signature is not written to the log.
+
+The full underlying object-store diagnostic is emitted at `DEBUG` on the same target, labeled `S3 read retry diagnostic` and escaped onto a single line. It is above the default and `--verbose` levels; reach it with `--very-verbose`, or with a targeted filter that leaves everything else alone:
+
+```bash
+SPICED_LOG="WARN,opendal::layers::retry=DEBUG" spice run
+```
+
+`SPICED_LOG` applies only when neither `--verbose` nor `--very-verbose` is set — see [Tracing](../cli/tracing.md).
+
 ### Slow query performance
 
 - **Check if acceleration is enabled**: Unaccelerated datasets query the remote source directly, adding network latency. Add `acceleration: enabled: true` to the dataset configuration.


### PR DESCRIPTION
## Summary

`spiced` now translates OpenDAL's multiline S3 connection-closure diagnostic into a single
WARN line, and that line ends with `See: https://spiceai.org/docs/troubleshooting` — which
resolves to this page, where nothing explained the warning. This adds the entry the message
sends readers to.

New `### opendal::layers::retry warnings on S3 reads` under **Common Issues**, covering:
the warning itself and that it is emitted at the *default* verbosity; how to read `attempt N`
and the backoff; that the logged URL is stripped of credentials, query string, and fragment;
and where the full diagnostic goes (`DEBUG` on the same target, above both the default and
`--verbose` levels).

## Source PRs

- spiceai/spiceai#14040 — fix: clarify OpenDAL S3 retry warnings

## Pages changed

- `website/docs/troubleshooting/index.md`

vNext only. The message rewrite is in no release — `git tag --contains ecd92a5122` on
`spiceai/spiceai` returns nothing — and on v2.3.0 and earlier the raw multiline OpenDAL
diagnostic is what a reader sees, so stamping this text into `versioned_docs/version-2.3.x/`
would describe output that release does not produce.

## Verification

Runtime read at `spiceai/spiceai` `origin/trunk` = `ecd92a5122` (2026-09-11 15:54:34 +0000).

**The message template** — `bin/spiced/src/tracing/dependency_log.rs:190-193`. The doc's
example line is this template with a representative bucket URL substituted for `{url}`:

```rust
Some(format!(
    "Reading file '{url}' (S3) was interrupted, so Spice will retry in {delay}s (attempt {attempt}). Cause: The connection closed before the response completed. If this continues, check network access to S3 and any proxy timeouts. See: https://spiceai.org/docs/troubleshooting"
))
```

**Target and level** — `dependency_log.rs:118` and `:124`:

```rust
const OPENDAL_RETRY_TARGET: &str = "opendal::layers::retry";
...
if record.target() != OPENDAL_RETRY_TARGET || record.level() != Level::Warn {
    return None;
}
```

**URL stripping** (the "signature is not written to the log" sentence) — `dependency_log.rs:181-186`:

```rust
url.set_username("").ok()?;
url.set_password(None).ok()?;
url.set_query(None);
url.set_fragment(None);
```

**The diagnostic's level and label** — `dependency_log.rs:41-44` and `:104-108`:

```rust
/// Optional detail emitted at DEBUG, with the message escaped onto one line.
struct LogDiagnostic { label: &'static str, message: String }
...
self.forward(record, Level::Debug, format_args!("{}: {:?}", diagnostic.label, diagnostic.message));
```

with `label: "S3 read retry diagnostic"` at `:135`.

**Why the doc says DEBUG is above `--verbose`** — `bin/spiced/src/tracing.rs:119-131`. The
default filter ends in `WARN` (so the warning shows by default), `--verbose` ends in `INFO`,
and only `--very-verbose` ends in `DEBUG`; `opendal::layers::retry` is not in
`INTERNAL_COMPONENTS` and not in `OFF_FILTERS`, so no per-target directive raises it:

```rust
LogVerbosity::Default => format!("{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},WARN", internal_components("INFO")),
LogVerbosity::Verbose => format!("{},{OFF_FILTERS},{OFF_UNLESS_VERY_VERBOSE_FILTERS},INFO", internal_components("DEBUG")),
LogVerbosity::VeryVerbose => format!("{},{OFF_FILTERS},DEBUG", internal_components("TRACE")),
LogVerbosity::Specific(filter) => specific_env_filter(filter),
```

**Why the doc says `SPICED_LOG` applies only without the flags** — `tracing.rs:63-73` returns
`VeryVerbose`/`Verbose` before it reads the variable, and `bin/spiced/src/lib.rs:859-863`
passes `"SPICED_LOG"` as that variable.

**Not run — no S3 repro of my own.** I did not run `spiced` against a bucket or reproduce a
connection closure; the behavior claims above are read off the quoted code, and the exact
warning text is the source PR's own captured probe output. The end-to-end emission is covered
by `bin/spiced/tests/dependency_logging.rs` on trunk (a loopback TCP server that closes the
first GET before headers), which I read but did not execute.

Propagation grep (vNext-only addition — one file expected):

```
$ grep -rln "opendal::layers::retry" website/ | sort
website/docs/troubleshooting/index.md
```

Build gate:

```
$ cd website && NODE_OPTIONS=--max-old-space-size=8192 npm run build
[SUCCESS] [docusaurus-plugin-llms-txt] Plugin completed successfully - processed 488 documents
[SUCCESS] Generated static files in "build".
```

## Test plan

- [x] `cd website && npm run build` passes — tail pasted above (`onBrokenLinks: 'throw'`; the one added link, `../cli/tracing.md`, resolves to `website/docs/cli/tracing.md`, the same target this page already links at line 129)
- [x] Versioned-docs propagation checked — vNext-only addition, grep output above shows 1 file
- [x] Files updated: 1 (matches `git diff --name-only origin/trunk..HEAD -- website/`)
